### PR TITLE
Split WordPress.com template into three separate template

### DIFF
--- a/wordpress.com.email-forwarding.json
+++ b/wordpress.com.email-forwarding.json
@@ -1,0 +1,19 @@
+{
+   "providerId":"WordPress.com",
+   "providerName":"WordPress.com",
+   "serviceId":"email-forwarding",
+   "serviceName":"WordPress services",
+   "logoUrl":"https://automattic.files.wordpress.com/2005/12/wpcom-horiz.png",
+   "description":"This can be used to set up email forwarding at WordPress.com",
+   "syncBlock":true,
+   "records":[
+      {
+         "groupId":"email-forwarding-mx",
+         "type":"MX",
+         "host":"@",
+         "pointsTo":"smtp-fwd.wordpress.com.",
+         "priority":"1",
+         "ttl":"3600"
+      }
+   ]
+}

--- a/wordpress.com.g-suite.json
+++ b/wordpress.com.g-suite.json
@@ -2,53 +2,11 @@
    "providerId":"WordPress.com",
    "providerName":"WordPress.com",
    "serviceId":"wordpress-services",
-   "serviceName":"WordPress services",
+   "serviceName":"G-Suite",
    "logoUrl":"https://automattic.files.wordpress.com/2005/12/wpcom-horiz.png",
-   "description":"This can be used to set up various services at WordPress.com",
+   "description":"This can be used to set up G-Suite at WordPress.com",
    "syncBlock":true,
    "records":[
-      {
-         "groupId":"mapping-apexcname",
-         "type":"APEXCNAME",
-         "pointsTo":"%sitename%.wordpress.com.",
-         "ttl":"3600"
-      },
-      {
-         "groupId":"mapping-a",
-         "type":"A",
-         "host":"@",
-         "pointsTo":"192.0.78.24",
-         "ttl":"3600"
-      },
-      {
-         "groupId":"mapping-a",
-         "type":"A",
-         "host":"www",
-         "pointsTo":"192.0.78.24",
-         "ttl":"3600"
-      },
-      {
-         "groupId":"mapping-a",
-         "type":"A",
-         "host":"@",
-         "pointsTo":"192.0.78.25",
-         "ttl":"3600"
-      },
-      {
-         "groupId":"mapping-a",
-         "type":"A",
-         "host":"www",
-         "pointsTo":"192.0.78.25",
-         "ttl":"3600"
-      },
-      {
-         "groupId":"email-forwarding-mx",
-         "type":"MX",
-         "host":"@",
-         "pointsTo":"smtp-fwd.wordpress.com.",
-         "priority":"1",
-         "ttl":"3600"
-      },
       {
          "groupId":"g-suite-verification",
          "type":"TXT",
@@ -103,6 +61,5 @@
          "priority":"10",
          "ttl":"3600"
       }
-
    ]
 }

--- a/wordpress.com.hosting.json
+++ b/wordpress.com.hosting.json
@@ -1,0 +1,45 @@
+{
+   "providerId":"WordPress.com",
+   "providerName":"WordPress.com",
+   "serviceId":"hosting",
+   "serviceName":"WordPress services",
+   "logoUrl":"https://automattic.files.wordpress.com/2005/12/wpcom-horiz.png",
+   "description":"This can be used to set up website hosting at WordPress.com",
+   "syncBlock":true,
+   "records":[
+      {
+         "groupId":"mapping-apexcname",
+         "type":"APEXCNAME",
+         "pointsTo":"%sitename%.wordpress.com.",
+         "ttl":"3600"
+      },
+      {
+         "groupId":"mapping-a",
+         "type":"A",
+         "host":"@",
+         "pointsTo":"192.0.78.24",
+         "ttl":"3600"
+      },
+      {
+         "groupId":"mapping-a",
+         "type":"A",
+         "host":"www",
+         "pointsTo":"192.0.78.24",
+         "ttl":"3600"
+      },
+      {
+         "groupId":"mapping-a",
+         "type":"A",
+         "host":"@",
+         "pointsTo":"192.0.78.25",
+         "ttl":"3600"
+      },
+      {
+         "groupId":"mapping-a",
+         "type":"A",
+         "host":"www",
+         "pointsTo":"192.0.78.25",
+         "ttl":"3600"
+      }
+   ]
+}


### PR DESCRIPTION
In order to provider more fine grained control on the permissions users will be asked to grant when applying a template, the original template which included services for hosting, G-Suite and email forwarding is being broken into three separate templates.