### PR TITLE
unbounce template for domain connect

### DIFF
--- a/unbounce.com.website.json
+++ b/unbounce.com.website.json
@@ -1,0 +1,17 @@
+{
+   "providerId":"app.unbounce.com",
+   "providerName": "Unbounce",
+   "serviceId":"site",
+   "serviceName":"Unbounce Public Web Application",
+   "logoUrl":"https://app.unbounce.com/app_assets/sign_up_funnel/unbounce-logo-2017-6c9556be74767c10c9992c13898b84f1.svg",
+   "description":"Enables a Domain to work with Unbounce",
+   "variableDescription":"HOST is the subdomain for the domain.",
+   "records":[
+      {
+        "type": "CNAME",
+        "host": "%HOST%",
+        "pointsTo": "unbouncepages.com",
+        "ttl": "600"
+       }
+   ]
+}


### PR DESCRIPTION
Create template for Unbounce to use Domain Connect. 

Creates CNAME record pointing at unbounce pages and accepts a host variable to set sub domains on root domain. 