### PR TITLE
Update pointsTo and warnPhishing for O365 and DPOO

### DIFF
--- a/microsoft.com.dpoo.json
+++ b/microsoft.com.dpoo.json
@@ -8,6 +8,7 @@
   "variableDescription": "Self explanatory in the variable names.",
   "syncBlock": false,
   "shared": false,
+  "warnPhishing": false,
   "syncPubKeyDomain": "portal.office.com",
   "syncRedirectDomain": "",
   "records": [

--- a/microsoft.com.o365.json
+++ b/microsoft.com.o365.json
@@ -56,7 +56,7 @@
       "weight": "1",
       "priority": "100",
       "host": "@",
-      "pointsTo": "%sipdir%",
+      "target": "%sipdir%",
       "ttl": "3600"
     },
     {
@@ -68,7 +68,7 @@
       "weight": "1",
       "priority": "100",
       "host": "@",
-      "pointsTo": "%sipfed%",
+      "target": "%sipfed%",
       "ttl": "3600"
     },
     {

--- a/microsoft.com.o365.json
+++ b/microsoft.com.o365.json
@@ -8,6 +8,7 @@
   "variableDescription": "Self explanatory in the variable names.",
   "syncBlock": false,
   "shared": false,
+  "warnPhishing": false,
   "syncPubKeyDomain": "portal.office.com",
   "syncRedirectDomain": "",
   "records": [


### PR DESCRIPTION
Change pointsTo for SRV records into target. Add missing warnPhishing for both DPOO and O365.