### PR TITLE
WP Engine Logo and pubkey template updates

### DIFF
--- a/wpengine.com.arecord.json
+++ b/wpengine.com.arecord.json
@@ -4,15 +4,14 @@
    "serviceId":"arecord",
    "serviceName":"WP Engine Digital Experience Platform",
    "version": 1,
-   "logoUrl":"https://wpengine.com/logo.png",
+   "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2018/03/LGO-WPEngine-Horiz-reg-RGB-768x146.png",
    "description":"Configure ip address for the domain A record.",
    "syncBlock":false,
-   "syncPubKeyDomain": "landmark.wpengine.io",
+   "syncPubKeyDomain": "landmark.wpesvc.net",
    "syncRedirectDomain": "my.wpengine.com",
    "records":[
       {
          "type":"A",
-         "host":"@",
          "pointsTo":"%ip%",
          "ttl":"3600"
       }

--- a/wpengine.com.arecord.json
+++ b/wpengine.com.arecord.json
@@ -12,6 +12,7 @@
    "records":[
       {
          "type":"A",
+         "host":"@",
          "pointsTo":"%ip%",
          "ttl":"3600"
       }

--- a/wpengine.com.cname.json
+++ b/wpengine.com.cname.json
@@ -4,15 +4,14 @@
    "serviceId":"cname",
    "serviceName":"WP Engine Digital Experience Platform",
    "versoin": 1,
-   "logoUrl":"https://wpengine.com/logo.png",
+   "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2018/03/LGO-WPEngine-Horiz-reg-RGB-768x146.png",
    "description":"Configure domain record for CNAME entry.",
    "syncBlock":false,
-   "syncPubKeyDomain": "landmark.wpengine.io",
+   "syncPubKeyDomain": "landmark.wpesvc.net",
    "syncRedirectDomain": "my.wpengine.com",
    "records":[
       {
          "type":"CNAME",
-         "host":"@",
          "pointsTo":"%site%.wpengine.com",
          "ttl":"3600"
       }

--- a/wpengine.com.cname.json
+++ b/wpengine.com.cname.json
@@ -12,6 +12,7 @@
    "records":[
       {
          "type":"CNAME",
+         "host":"@",
          "pointsTo":"%site%.wpengine.com",
          "ttl":"3600"
       }


### PR DESCRIPTION
Two things happening here across both WP Engine templates:

1. Updated our `logoUrl` to reflect an existing asset (from a placeholder value).
2. Updated the `syncPubKeyDomain` value to the domain we're actually populating the pubkey to. Existing value was simply a placeholder as well.

cc: @markkelnar, @quaintcabeza (for viz and double checking my values here!)