### PR TITLE
Fix issues with use of %HOST%

### DIFF
--- a/leadpages.net.custom-domain-prod.json
+++ b/leadpages.net.custom-domain-prod.json
@@ -10,7 +10,7 @@
    "hostRequired": true,
    "records": [{
       "type": "CNAME",
-      "host": "%HOST%",
+      "host": "@",
       "pointsTo": "custom-proxy.leadpages.net",
       "ttl": "600"
    }]

--- a/leadpages.net.custom-domain-test.json
+++ b/leadpages.net.custom-domain-test.json
@@ -10,7 +10,7 @@
    "hostRequired": true,
    "records": [{
       "type": "CNAME",
-      "host": "%HOST%",
+      "host": "@",
       "pointsTo": "custom-proxy.leadpagestest.net",
       "ttl": "600"
    }]


### PR DESCRIPTION
Hi @timothy-hart, I think I provided misleading information and now the template is incorrect.

Instead of "%HOST%" in the record you should have "@", as host coming from query parameter is appended anyway automatically - so in this case would be doubled if we leave it as it was.
