### PR TITLE
Fix use of %HOST%

### DIFF
--- a/app.unbounce.com.site.json
+++ b/app.unbounce.com.site.json
@@ -11,7 +11,7 @@
    "records":[
       {
         "type": "CNAME",
-        "host": "%HOST%",
+        "host": "@",
         "pointsTo": "unbouncepages.com",
         "ttl": "600"
        }


### PR DESCRIPTION
Hi,
Use of `%HOST%` variable in this template is in fact incorrect.

As per spec it should be either `"@"` or `"%fqdn%"`, because `host` query parameter will be added automatically:
https://github.com/Domain-Connect/spec/blob/master/Domain%20Connect%20Spec%20Draft.adoc#65-variables-and-host

Leaving it like this would mean creating subdomains with double label: `%host%.%host%.%domain%`