### PR TITLE
Add Leadpages templates for apex+www domains

### DIFF
--- a/leadpages.net.custom-domain-apex-prod.json
+++ b/leadpages.net.custom-domain-apex-prod.json
@@ -1,0 +1,24 @@
+{
+   "providerId": "leadpages.net",
+   "providerName": "Leadpages",
+   "serviceId": "custom-domain-apex-prod",
+   "serviceName": "Leadpages Custom Domain",
+   "version": 1,
+   "logoUrl": "https://my.leadpages.net/static/current/img/logos/logo_icon.svg",
+   "description": "Enables a domain to work with Leadpages",
+   "hostRequired": false,
+   "records": [
+      {
+         "type": "A",
+         "host": "@",
+         "pointsTo": "35.202.21.90",
+         "ttl": "600"
+      },
+      {
+         "type": "CNAME",
+         "host": "www",
+         "pointsTo": "custom-proxy.leadpages.net",
+         "ttl": "600"
+      }
+   ]
+}

--- a/leadpages.net.custom-domain-apex-test.json
+++ b/leadpages.net.custom-domain-apex-test.json
@@ -1,0 +1,24 @@
+{
+   "providerId": "leadpages.net",
+   "providerName": "Leadpages Test",
+   "serviceId": "custom-domain-apex-test",
+   "serviceName": "Leadpages Custom Domain (Test)",
+   "version": 1,
+   "logoUrl": "https://my.leadpagestest.net/static/current/img/logos/logo_icon.svg",
+   "description": "Enables a domain to work with Leadpages",
+   "hostRequired": false,
+   "records": [
+      {
+         "type": "A",
+         "host": "@",
+         "pointsTo": "35.192.151.53",
+         "ttl": "600"
+      },
+      {
+         "type": "CNAME",
+         "host": "www",
+         "pointsTo": "custom-proxy.leadpagestest.net",
+         "ttl": "600"
+      }
+   ]
+}


### PR DESCRIPTION
To support more providers that can't do CNAMEs on the root this
introduces a template that points both the root of the domain and the
"www" subdomain to Leadpages.