### PR TITLE
Adobe Portfolio

### DIFF
--- a/portfolio.adobe.com.prod.json
+++ b/portfolio.adobe.com.prod.json
@@ -2,7 +2,7 @@
   "providerId":"portfolio.adobe.com",
   "providerName":"Adobe Portfolio",
   "serviceId":"prod",
-  "serviceName":"Adobe Portfolio Websites",
+  "serviceName":"Portfolio Site",
   "version":1,
   "description":"Enables a domain to work with Adobe Portfolio",
   "records":[

--- a/portfolio.adobe.com.prod.json
+++ b/portfolio.adobe.com.prod.json
@@ -1,0 +1,40 @@
+{
+  "providerId":"portfolio.adobe.com",
+  "providerName":"Adobe Portfolio",
+  "serviceId":"prod",
+  "serviceName":"Adobe Portfolio Websites",
+  "version":1,
+  "description":"Enables a domain to work with Adobe Portfolio",
+  "records":[
+    {
+      "type":"CNAME",
+      "host": "www",
+      "pointsTo":"@",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.0.119",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.64.119",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.128.119",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.192.119",
+      "ttl":3600
+    }
+  ]
+}

--- a/portfolio.adobe.com.stage.json
+++ b/portfolio.adobe.com.stage.json
@@ -2,7 +2,7 @@
   "providerId":"portfolio.adobe.com",
   "providerName":"Adobe Portfolio",
   "serviceId":"stage",
-  "serviceName":"Adobe Portfolio Stage Websites",
+  "serviceName":"Portfolio Stage Site",
   "version":1,
   "description":"Enables a domain to work with Adobe Portfolio",
   "records":[

--- a/portfolio.adobe.com.stage.json
+++ b/portfolio.adobe.com.stage.json
@@ -1,0 +1,40 @@
+{
+  "providerId":"portfolio.adobe.com",
+  "providerName":"Adobe Portfolio",
+  "serviceId":"stage",
+  "serviceName":"Adobe Portfolio Stage Websites",
+  "version":1,
+  "description":"Enables a domain to work with Adobe Portfolio",
+  "records":[
+    {
+      "type":"CNAME",
+      "host": "www",
+      "pointsTo":"@",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.0.118",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.64.118",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.128.118",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.192.118",
+      "ttl":600
+    }
+  ]
+}


### PR DESCRIPTION
Initial version of templates for Adobe Portfolio. We use both a production and a stage environment.

We plan to make some additions later, including adding a `logoUrl` once we have that hosted somewhere.