### PR TITLE
change syncPubKeyDomain

### DIFF
--- a/squarespace.com.website.json
+++ b/squarespace.com.website.json
@@ -7,7 +7,7 @@
    "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/04/squarespace-logo-horizontal-white-300x109.jpg",
    "description":"Enables a domain to work with Squarespace",
    "variableDescription":"v1 is the verification code for the site",
-   "syncPubKeyDomain":"domainconnect-squarespace.com",
+   "syncPubKeyDomain":"domainconnect.squarespace.com",
    "syncRedirectDomain":"oauth.squarespace.com,oauth.stage.sqsp.net,oauth.qa1.sqsp.net,oauth.qa2.sqsp.net,oauth.qa10.sqsp.net,oauth.qa11.sqsp.net,oauth.qa15.sqsp.net,oauth.dev.squarespace.net",
    "records":[
       {


### PR DESCRIPTION
Changes syncPubKeyDomain from domainconnect-squarespace.com to domainconnect.squarespace.com
(changes "-" to ".")

Squarespace has CNAME aliases in domainconnect.squarespace.com pointing to public key TXT records in domainconnect.squarespace.com

$ host -t TXT _dcpubkeyv1.domainconnect-squarespace.com
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=3,a=RS256,t=x509,d=HbTYPq3Sx/h0ZsSbMHd+vaWxyJV0OAmvwAq1lBsQYYo7WYNe05/js5fmubqyzAXQ/GQ5yNIPeSogr1owStBoKk5A/ih4lXvxzDgQCrcftBxks7qE/5pyOIk0jIjCrGHv"
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=1,a=RS256,t=x509,d=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuaSHChK5k3nIhMqGRLx11gzXyT80mXsh99pkyLGflK9lO5Qiy1EjEcbOpmYeygsupRnthFgTpZ49pOaJjWgu"
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=2,a=RS256,t=x509,d=GheanmbZ5iUp9LThv05CFZ8jskcVd8gVUCzH6cW93ypsuJMbabS0SfeEOauo7F7wqmprY/asWn0fJczqHqPOKvQJ+pkNPW2mqwzT6f4ts9IdOXXYnYlWOpQ5UTSnSunP"
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=4,a=RS256,t=x509,d=wQIDAQAB"

$ host -t TXT _dcpubkeyv1.domainconnect.squarespace.com
_dcpubkeyv1.domainconnect.squarespace.com is an alias for _dcpubkeyv1.domainconnect-squarespace.com.
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=2,a=RS256,t=x509,d=GheanmbZ5iUp9LThv05CFZ8jskcVd8gVUCzH6cW93ypsuJMbabS0SfeEOauo7F7wqmprY/asWn0fJczqHqPOKvQJ+pkNPW2mqwzT6f4ts9IdOXXYnYlWOpQ5UTSnSunP"
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=3,a=RS256,t=x509,d=HbTYPq3Sx/h0ZsSbMHd+vaWxyJV0OAmvwAq1lBsQYYo7WYNe05/js5fmubqyzAXQ/GQ5yNIPeSogr1owStBoKk5A/ih4lXvxzDgQCrcftBxks7qE/5pyOIk0jIjCrGHv"
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=4,a=RS256,t=x509,d=wQIDAQAB"
_dcpubkeyv1.domainconnect-squarespace.com descriptive text "p=1,a=RS256,t=x509,d=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuaSHChK5k3nIhMqGRLx11gzXyT80mXsh99pkyLGflK9lO5Qiy1EjEcbOpmYeygsupRnthFgTpZ49pOaJjWgu"