### PR TITLE
Add syncPubKeyDomain to Shopify template

### DIFF
--- a/shopify.com.website.json
+++ b/shopify.com.website.json
@@ -3,7 +3,7 @@
    "providerName":"Shopify",
    "serviceId":"website",
    "serviceName":"Shopify Site",
-   "version": 1,
+   "version": 2,
    "syncPubKeyDomain" : "shopify.com",
    "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/08/shopify.png",
    "description":"Enables a domain to work with Shopify",

--- a/shopify.com.website.json
+++ b/shopify.com.website.json
@@ -4,6 +4,7 @@
    "serviceId":"website",
    "serviceName":"Shopify Site",
    "version": 1,
+   "syncPubKeyDomain" : "shopify.com",
    "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/08/shopify.png",
    "description":"Enables a domain to work with Shopify",
    "variableDescription":"v1 is the shopify hosted domain name and verification is the verification code for the site",


### PR DESCRIPTION
Shopify will start digitally signing domain connect requests. Adding `syncPubKeyDomain` to support it.