### PR TITLE
Titan Email w/ cPanel GD templates

### DIFF
--- a/godaddy.com.cpanel_titanemail.json
+++ b/godaddy.com.cpanel_titanemail.json
@@ -1,0 +1,39 @@
+{
+  "providerId": "godaddy.com",
+  "providerName": "GoDaddy",
+  "serviceId": "cpanel_titanemail",
+  "serviceName": "cPanel TitanEmail",
+  "version": 1,
+  "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
+  "description": "Enables a domain to work with TitanEmail",
+  "variableDescription": "",
+  "syncPubKeyDomain": "domain-attach.api.godaddy.com",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.titan.email",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx2.titan.email",
+      "priority": 20,
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "v=spf1 include:spf.titan.email ~all",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1;p=none;sp=none;adkim=r;aspf=r;pct=100",
+      "ttl": 3600
+    }
+  ]
+}

--- a/godaddy.com.cpanel_titanemail.json
+++ b/godaddy.com.cpanel_titanemail.json
@@ -24,10 +24,9 @@
       "ttl": 3600
     },
     {
-      "type": "TXT",
-      "host": "@",
-      "data": "v=spf1 include:spf.titan.email ~all",
-      "ttl": 3600
+      "type": "SPFM",
+      "spfRules": "include:spf.titan.email",
+      "host": "@"
     },
     {
       "type": "TXT",

--- a/secureserver.net.cpanel_titanemail.json
+++ b/secureserver.net.cpanel_titanemail.json
@@ -1,0 +1,39 @@
+{
+  "providerId": "secureserver.net",
+  "providerName": "SecureServer",
+  "serviceId": "cpanel_titanemail",
+  "serviceName": "cPanel TitanEmail",
+  "version": 1,
+  "logoUrl": "https://domainconnect.org/wp-content/uploads/2016/06/godaddy-logo-300x79.png",
+  "description": "Enables a domain to work with TitanEmail",
+  "variableDescription": "",
+  "syncPubKeyDomain": "domain-attach.api.godaddy.com",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.titan.email",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx2.titan.email",
+      "priority": 20,
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "v=spf1 include:spf.titan.email ~all",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1;p=none;sp=none;adkim=r;aspf=r;pct=100",
+      "ttl": 3600
+    }
+  ]
+}

--- a/secureserver.net.cpanel_titanemail.json
+++ b/secureserver.net.cpanel_titanemail.json
@@ -24,10 +24,9 @@
       "ttl": 3600
     },
     {
-      "type": "TXT",
-      "host": "@",
-      "data": "v=spf1 include:spf.titan.email ~all",
-      "ttl": 3600
+      "type": "SPFM",
+      "spfRules": "include:spf.titan.email",
+      "host": "@"
     },
     {
       "type": "TXT",


### PR DESCRIPTION
Titan Email replaces FlockMail; see secureserver.net.cpanel_flockmail.json + godaddy.com.cpanel_flockmail.json.