### PR TITLE
Update hubspot.com.hubspot-template-2.json

### DIFF
--- a/hubspot.com.hubspot-template-2.json
+++ b/hubspot.com.hubspot-template-2.json
@@ -10,14 +10,14 @@
   "records": [
     {
       "type": "CNAME",
-      "host": "hs1",
-      "pointsTo": "%cname0targetprefix%.dkim.hubspotemail.net",
+      "host": "%cname0host%",
+      "pointsTo": "%cname0targetprefix%.dkim.hubspotemail%envsuffix%",
       "ttl": 3600
      },
      {
        "type": "CNAME",
-       "host": "hs2",
-       "pointsTo": "%cname1targetprefix%.dkim.hubspotemail.net",
+       "host": "%cname1host%",
+       "pointsTo": "%cname1targetprefix%.dkim.hubspotemail%envsuffix%",
        "ttl": 3600
      },
      {

--- a/hubspot.com.hubspot-template-2.json
+++ b/hubspot.com.hubspot-template-2.json
@@ -10,13 +10,13 @@
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "%DESTINATION0%",
+      "pointsTo": "%cnamedestination0%",
       "ttl": 3600
      },
      {
        "type": "CNAME",
        "host": "@",
-       "pointsTo": "%DESTINATION1%",
+       "pointsTo": "%cnamedestination1%",
        "ttl": 3600
      },
      {

--- a/hubspot.com.hubspot-template-2.json
+++ b/hubspot.com.hubspot-template-2.json
@@ -10,13 +10,13 @@
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "%cnamedestination0%",
+      "pointsTo": "%destination0%",
       "ttl": 3600
      },
      {
        "type": "CNAME",
        "host": "@",
-       "pointsTo": "%cnamedestination1%",
+       "pointsTo": "%destination1%",
        "ttl": 3600
      },
      {

--- a/hubspot.com.hubspot-template-2.json
+++ b/hubspot.com.hubspot-template-2.json
@@ -6,18 +6,17 @@
   "version": 1,
   "logoUrl":"https://domainconnect.org/wp-content/uploads/2017/02/HubSpot-768x223.png",
   "description":"Enables a domain to work with HubSpot",
-  "variableDescription":"v1 is the customer id.",
   "records": [
     {
       "type": "CNAME",
-      "host": "%cname0host%",
-      "pointsTo": "%cname0targetprefix%.dkim.hubspotemail%envsuffix%",
+      "host": "@",
+      "pointsTo": "%DESTINATION0%",
       "ttl": 3600
      },
      {
        "type": "CNAME",
-       "host": "%cname1host%",
-       "pointsTo": "%cname1targetprefix%.dkim.hubspotemail%envsuffix%",
+       "host": "@",
+       "pointsTo": "%DESTINATION1%",
        "ttl": 3600
      },
      {


### PR DESCRIPTION
Update the hubspot-template-2 to add variables for the CNAME hosts and CNAME value suffixes

@moxlive 


Our goal is to support the following patterns in a single template for CNAME hosts. 

Pattern 1 PROD:
hs1-\<id\>
hs2-\<id\>

Pattern 2 PROD:
hs1
hs2

Pattern 1 QA:
hs-qa1-\<id\>
hs-qa2-\<id\>

Pattern 2 QA:
hs-qa1
hs-qa2