### PR TITLE
Changed domain variable to spdomain

### DIFF
--- a/websitetoolbox.com.forum.json
+++ b/websitetoolbox.com.forum.json
@@ -17,13 +17,13 @@
     },
     {
       "type": "SPFM",
-      "host": "%domain%.",
+      "host": "%spdomain%.",
       "spfRules": "a:mailers.websitetoolbox.com",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "websitetoolbox._domainkey.%domain%.",
+      "host": "websitetoolbox._domainkey.%spdomain%.",
       "pointsTo": "websitetoolbox._domainkey.websitetoolbox.com",
       "ttl": 3600
     }


### PR DESCRIPTION
A domain provider already internally uses the %domain% variable, so we have changed it to %spdomain%.