### PR TITLE
Revert "Changed domain variable to spdomain"

### DIFF
--- a/websitetoolbox.com.forum.json
+++ b/websitetoolbox.com.forum.json
@@ -17,13 +17,13 @@
     },
     {
       "type": "SPFM",
-      "host": "%spdomain%.",
+      "host": "%domain%.",
       "spfRules": "a:mailers.websitetoolbox.com",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "websitetoolbox._domainkey.%spdomain%.",
+      "host": "websitetoolbox._domainkey.%domain%.",
       "pointsTo": "websitetoolbox._domainkey.websitetoolbox.com",
       "ttl": 3600
     }


### PR DESCRIPTION
Reverts Domain-Connect/Templates#142

Reverting this change as per Pawel's feedback. GoDaddy confirmed that there was confusion and that the original variable is in fact better. Sorry about that.