### PR TITLE
[Houzz] Add syncPubKeyDomain for Houzz Website services

### DIFF
--- a/houzz.com.website-services.json
+++ b/houzz.com.website-services.json
@@ -8,6 +8,7 @@
 	"description":"Set up website hosting at houzz.com",
 	"syncRedirectDomain": "houzz.com",
 	"syncBlock": false,
+	"syncPubKeyDomain": "houzz.com",
 	"records":[
 		{
 			"type": "CNAME",


### PR DESCRIPTION
Houzz will start signing domain connect requests. This PR adds syncPubKeyDomain to the corresponding template accordingly.