### PR TITLE
Hubspot templates 4

### DIFF
--- a/hubspot.com.hubspot-template-4.json
+++ b/hubspot.com.hubspot-template-4.json
@@ -1,0 +1,48 @@
+{
+  "providerId": "hubspot.com",
+  "providerName": "HubSpot",
+  "serviceId": "hubspot-template-4",
+  "serviceName": "HubSpot CMS Site",
+  "version": 1,
+  "logoUrl": "https://domainconnect.org/wp-content/uploads/2017/02/HubSpot-768x223.png",
+  "description": "Enables a domain to work with HubSpot",
+  "variableDescription": "txtData: txt data; a1, a2: destination for A records; cnameDestination1, cnameDestination2: destination for CNAME record; cNameHost: host for CNAME record",
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "a1",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP1%",
+      "ttl": 600
+    },
+    {
+      "groupId": "a2",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP2%",
+      "ttl": 600
+    },
+    {
+      "groupId": "txt",
+      "type": "TXT",
+      "host": "@",
+      "data": "%txtData%",
+      "ttl": 600
+    },
+    {
+      "groupId": "cname1",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cnameDestination1%",
+      "ttl": 600
+    },
+    {
+      "groupId": "cname2",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cnameDestination2%",
+      "ttl": 600
+    }
+  ]
+}

--- a/hubspot.com.hubspot-template-4.json
+++ b/hubspot.com.hubspot-template-4.json
@@ -6,42 +6,49 @@
   "version": 1,
   "logoUrl": "https://domainconnect.org/wp-content/uploads/2017/02/HubSpot-768x223.png",
   "description": "Enables a domain to work with HubSpot",
-  "variableDescription": "txtData: txt data; a1, a2: destination for A records; cnameDestination1, cnameDestination2: destination for CNAME record; cNameHost: host for CNAME record",
+  "variableDescription": "txt1Data, txt2Data: txt data; a1PointsTo, a1PointsTo, cname1PointsTo, cname2PointsTo: destinations",
   "hostRequired": true,
   "records": [
     {
       "groupId": "a1",
       "type": "A",
       "host": "@",
-      "pointsTo": "%IP1%",
+      "pointsTo": "%a1PointsTo%",
       "ttl": 600
     },
     {
       "groupId": "a2",
       "type": "A",
       "host": "@",
-      "pointsTo": "%IP2%",
+      "pointsTo": "%a2PointsTo%",
       "ttl": 600
     },
     {
-      "groupId": "txt",
+      "groupId": "txt1",
       "type": "TXT",
       "host": "@",
-      "data": "%txtData%",
+      "data": "%txt1Data%",
+      "ttl": 600
+    },
+    {
+      "groupId": "txt2",
+      "type": "TXT",
+      "host": "@",
+      "data": "%txt2Data%",
       "ttl": 600
     },
     {
       "groupId": "cname1",
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "%cnameDestination1%",
+      "pointsTo": "%cname1PointsTo%",
       "ttl": 600
     },
     {
       "groupId": "cname2",
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "%cnameDestination2%",
+      "pointsTo": "%cname2PointsTo%",
       "ttl": 600
     }
   ]


### PR DESCRIPTION
Our service uses several workflows and it will use even more.

For example
 * workflow 1 - add 2 A records
 * workflow 2 - add 1 CNAME
 * workflow 3 - add 1 CNAME and 1 TXT records
 * workflow 4 - add 2 CNAMEs

We want to create a flexible template which we could use for all existing and future workflows.

In the PR I define a template with 6 records. Each record has a unique groupId. So, we'd be able to provide any combination of groupId.
