### PR TITLE
AWeber template 'A' record renamed to CNAME

### DIFF
--- a/aweber.com.landing-pages-subdomain.json
+++ b/aweber.com.landing-pages-subdomain.json
@@ -9,7 +9,7 @@
    "variableDescription":"",
    "records":[
        {
-         "type": "A",
+         "type": "CNAME",
          "host": "@",
          "pointsTo": "hosted-content.aweber.com",
          "ttl": 3600


### PR DESCRIPTION
The 'A' record was intended to be a CNAME record. Typo fixed.