### PR TITLE
Editing the DKIM key naming convention

### DIFF
--- a/aweber.com.email-authentication-optin.json
+++ b/aweber.com.email-authentication-optin.json
@@ -15,20 +15,20 @@
       },
       {
          "type": "CNAME",
-         "host":"optin_key_a._domainkey",
-         "pointsTo": "optin_key_a.%account-subdomain%.optin.com",
+         "host":"k1._domainkey",
+         "pointsTo": "k1.%account-subdomain%.optin.com",
          "ttl": 3600
        },
        {
          "type": "CNAME",
-         "host": "aweber_key_b._domainkey",
-         "pointsTo": "aweber_key_b.%account-subdomain%.optin.com",
+         "host": "k2._domainkey",
+         "pointsTo": "k2.%account-subdomain%.optin.com",
          "ttl": 3600
        },
        {
          "type": "CNAME",
-         "host": "aweber_key_c._domainkey",
-         "pointsTo": "aweber_key_c.%account-subdomain%.optin.com",
+         "host": "k3._domainkey",
+         "pointsTo": "k3.%account-subdomain%.optin.com",
          "ttl": 3600
        }
    ]


### PR DESCRIPTION
Changes based on AWeber's final decision on naming convention for the Optin.com mail sending domains.