### PR TITLE
added syncRedirectDomain and syncPubKeyDomain to AWeber templates

### DIFF
--- a/aweber.com.email-authentication-optin.json
+++ b/aweber.com.email-authentication-optin.json
@@ -3,15 +3,17 @@
    "providerName":"AWeber",
    "serviceId":"email-authentication-optin",
    "serviceName":"AWeber Email Authentication for Optin.com",
+   "syncRedirectDomain": "aweber.com, optin.com",
+   "syncPubKeyDomain": "optin.com",
    "version": 1,
    "logoUrl":"https://assets.aweber-static.com/page-templates/assets/img/powered_by.png",
    "description":"Configure AWeber's SPF and DKIM records to improve sender reputation and deliverability.",
-   "variableDescription":"%account-subdomain% is the AWeber customer's unique subdomain",
+   "variableDescription":"%subdomain% is the AWeber customer's unique subdomain",
    "records":[
       {
          "type": "SPFM",
          "host": "@",
-         "spfRules": "include:%account-subdomain%.optin.com"
+         "spfRules": "include:%subdomain%.optin.com"
       },
       {
          "type": "CNAME",

--- a/aweber.com.email-authentication.json
+++ b/aweber.com.email-authentication.json
@@ -3,6 +3,8 @@
    "providerName":"AWeber",
    "serviceId":"email-authentication",
    "serviceName":"AWeber Email Authentication",
+   "syncRedirectDomain": "aweber.com, optin.com",
+   "syncPubKeyDomain": "aweber.com",
    "version": 1,
    "logoUrl":"https://assets.aweber-static.com/page-templates/assets/img/powered_by.png",
    "description":"Configure AWeber's SPF and DKIM records to improve sender reputation and deliverability.",

--- a/aweber.com.landing-pages-default.json
+++ b/aweber.com.landing-pages-default.json
@@ -3,6 +3,8 @@
    "providerName":"AWeber",
    "serviceId":"landing-pages-default",
    "serviceName":"AWeber Landing Pages",
+   "syncRedirectDomain": "aweber.com",
+   "syncPubKeyDomain": "aweber.com",
    "version": 1,
    "logoUrl":"https://assets.aweber-static.com/page-templates/assets/img/powered_by.png",
    "description":"Configure a domain to AWeber Landing Pages",

--- a/aweber.com.landing-pages-subdomain.json
+++ b/aweber.com.landing-pages-subdomain.json
@@ -3,6 +3,8 @@
    "providerName":"AWeber",
    "serviceId":"landing-pages-subdomain",
    "serviceName":"AWeber Landing Pages",
+   "syncRedirectDomain": "aweber.com",
+   "syncPubKeyDomain": "aweber.com",
    "version": 1,
    "logoUrl":"https://assets.aweber-static.com/page-templates/assets/img/powered_by.png",
    "description":"Configure a domain to AWeber Landing Pages",


### PR DESCRIPTION
Added the following fields to AWeber templates:

- syncRedirectDomain
- syncPubKeyDomain

Renamed variable %account-subdomain% to %subdomain% because hyphen not supported by one of the DNS providers.