### PR TITLE
Template for Twilio Sendgrid

### DIFF
--- a/sendgrid.com.domain-auth.json
+++ b/sendgrid.com.domain-auth.json
@@ -10,19 +10,19 @@
   "records":[
     {
       "type": "CNAME",
-      "host": "%host%",
+      "host": "@",
       "pointsTo": "%POINTS_TO%",
       "ttl": 1800
     },
     {
       "type": "CNAME",
-      "host": "%SUBDOMAIN_DKIM1%",
+      "host": "%SUBDOMAIN_DKIM1%.%domain%.",
       "pointsTo": "%POINTS_TO_DKIM1%",
       "ttl": 1800
     },
     {
       "type": "CNAME",
-      "host": "%SUBDOMAIN_DKIM2%",
+      "host": "%SUBDOMAIN_DKIM2%.%domain%.",
       "pointsTo": "%POINTS_TO_DKIM2%",
       "ttl": 1800
     }

--- a/sendgrid.com.domain-auth.json
+++ b/sendgrid.com.domain-auth.json
@@ -7,6 +7,7 @@
   "logoUrl":"https://sendgrid.com/brand/sg-twilio/SG_Twilio_Lockup_RGBx1.png",
   "syncPubKeyDomain": "domainconnect.sendgrid.net",
   "syncRedirectDomain": "sendgrid.com",
+  "hostRequired": true,
   "records":[
     {
       "type": "CNAME",

--- a/sendgrid.com.domain-auth.json
+++ b/sendgrid.com.domain-auth.json
@@ -1,0 +1,30 @@
+{
+  "providerId":"sendgrid.com",
+  "providerName":"Twilio SendGrid",
+  "serviceId":"domain-auth",
+  "serviceName":"Twilio SendGrid Domain Authentication",
+  "version": 1,
+  "logoUrl":"https://sendgrid.com/brand/sg-twilio/SG_Twilio_Lockup_RGBx1.png",
+  "syncPubKeyDomain": "domainconnect.sendgrid.net",
+  "syncRedirectDomain": "sendgrid.com",
+  "records":[
+    {
+      "type": "CNAME",
+      "host": "%SUBDOMAIN%",
+      "pointsTo": "%POINTS_TO%",
+      "ttl": 1800
+    },
+    {
+      "type": "CNAME",
+      "host": "%SUBDOMAIN_DKIM1%",
+      "pointsTo": "%POINTS_TO_DKIM1%",
+      "ttl": 1800
+    },
+    {
+      "type": "CNAME",
+      "host": "%SUBDOMAIN_DKIM2%",
+      "pointsTo": "%POINTS_TO_DKIM2%",
+      "ttl": 1800
+    }
+  ]
+}

--- a/sendgrid.com.domain-auth.json
+++ b/sendgrid.com.domain-auth.json
@@ -10,7 +10,7 @@
   "records":[
     {
       "type": "CNAME",
-      "host": "%SUBDOMAIN%",
+      "host": "%host%",
       "pointsTo": "%POINTS_TO%",
       "ttl": 1800
     },


### PR DESCRIPTION


Pre answering the common feedback section:

> 1. Misnamed templates

I don't think its misnamed

> 2. Variables too broad in scope (i.e. possible to be misused to set any arbitrary record and conflict with other template). Too broad scope example: @ TXT "%verification%". Better usage: @ TXT "foo-verification=%verification%".

We need these unique per user so variables are required

> 3. Variables as a host name. These are highly discouraged unless explicitly needed


Again needs to be unique per user

> 4. Not using digital signatures (or warnPhishing) on “insecure templates”


We will be signing

> 5. not specifying syncRedirectDomain when intended to use redirect_uri parameter in the synchronous flow


We do

> 6. not specifying syncBlock for a template only intended for asynchronous flow


N/A

> 7. not specifying hostRequired on the templates not applicable to domain APEX (with CNAME on @ host)

N/A

> 8. specifying a TXT record with SPF content (i.e. "v=spf1 ...") instead of using SPFM record type


N/A