### PR TITLE
Create ARecord Flywheel Service Provider Template

### DIFF
--- a/getflywheel.com.arecord.json
+++ b/getflywheel.com.arecord.json
@@ -1,0 +1,19 @@
+{
+   "providerId":"getflywheel.com",
+   "providerName":"Flywheel",
+   "serviceId":"arecord",
+   "serviceName":"Delightfully Managed WordPress Hosting",
+   "version": 1,
+   "logoUrl":"https://need-image-url.org",
+   "description":"Configure ip address for the domain A record.",
+   "syncBlock":false,
+   "syncPubKeyDomain":"domainconnect.getflywheel.com",
+   "records":[
+      {
+         "type":"A",
+         "host":"@",
+         "pointsTo":"%ip%",
+         "ttl":3600
+      }
+   ]
+}


### PR DESCRIPTION
Creates an ARecord Domain Connect Service Provider Template for Flywheel.

Logo provided below.

![horz-blue](https://user-images.githubusercontent.com/58700985/122597048-6ff0ed00-d030-11eb-909b-805d7bf9a6f0.png)
