### PR TITLE
Create ARecord Flywheel Service Provider Template

### DIFF
--- a/getflywheel.com.arecord.json
+++ b/getflywheel.com.arecord.json
@@ -4,6 +4,7 @@
    "serviceId":"arecord",
    "serviceName":"Managed WordPress Hosting",
    "version": 1,
+   "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2021/06/flywheel-logo.png",
    "description":"Configure ip address for the domain A record.",
    "syncBlock":false,
    "syncPubKeyDomain":"domainconnect.getflywheel.com",

--- a/getflywheel.com.arecord.json
+++ b/getflywheel.com.arecord.json
@@ -2,7 +2,7 @@
    "providerId":"getflywheel.com",
    "providerName":"Flywheel",
    "serviceId":"arecord",
-   "serviceName":"Delightfully Managed WordPress Hosting",
+   "serviceName":"Managed WordPress Hosting",
    "version": 1,
    "description":"Configure ip address for the domain A record.",
    "syncBlock":false,

--- a/getflywheel.com.arecord.json
+++ b/getflywheel.com.arecord.json
@@ -1,0 +1,18 @@
+{
+   "providerId":"getflywheel.com",
+   "providerName":"Flywheel",
+   "serviceId":"arecord",
+   "serviceName":"Delightfully Managed WordPress Hosting",
+   "version": 1,
+   "description":"Configure ip address for the domain A record.",
+   "syncBlock":false,
+   "syncPubKeyDomain":"domainconnect.getflywheel.com",
+   "records":[
+      {
+         "type":"A",
+         "host":"@",
+         "pointsTo":"%ip%",
+         "ttl":3600
+      }
+   ]
+}


### PR DESCRIPTION
Creates an ARecord Domain Connect Service Provider Template for Flywheel.

We would like to add a `logoUrl`. Could we have the logo shown below hosted at DomainConnect.org?

![horz-blue](https://user-images.githubusercontent.com/58700985/122613965-59a45a80-d04b-11eb-895c-24ba6d154314.png)