### PR TITLE
Twilio Sendgrid Domain Auth Manual Security Template

### DIFF
--- a/sendgrid.com.domain-auth-manual.json
+++ b/sendgrid.com.domain-auth-manual.json
@@ -1,0 +1,31 @@
+{
+  "providerId":"sendgrid.com",
+  "providerName":"Twilio SendGrid",
+  "serviceId":"domain-auth-manual",
+  "serviceName":"Twilio SendGrid Domain Authentication (Manual)",
+  "version": 1,
+  "logoUrl":"https://sendgrid.com/brand/sg-twilio/SG_Twilio_Lockup_RGBx1.png",
+  "syncPubKeyDomain": "domainconnect.sendgrid.net",
+  "syncRedirectDomain": "sendgrid.com",
+  "hostRequired": true,
+  "records":[
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx.sendgrid.net.",
+      "ttl": 1800
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "pointsTo": "%SPF%",
+      "ttl": 1800
+    },
+    {
+      "type": "TXT",
+      "host": "%SUBDOMAIN_DKIM%.%domain%.",
+      "pointsTo": "%DKIM%",
+      "ttl": 1800
+    }
+  ]
+}


### PR DESCRIPTION
I am back with another template.
Pre answering the common feedback section:

> 1. Misnamed templates

I don't think its misnamed

> 2. Variables too broad in scope (i.e. possible to be misused to set any arbitrary record and conflict with other template). Too broad scope example: @ TXT "%verification%". Better usage: @ TXT "foo-verification=%verification%".

We need these unique per user so variables are required

> 3. Variables as a host name. These are highly discouraged unless explicitly needed

I learnt from last time and used host required and @ where I could.

> 4. Not using digital signatures (or warnPhishing) on “insecure templates”


We will be signing

> 5. not specifying syncRedirectDomain when intended to use redirect_uri parameter in the synchronous flow


We do

> 6. not specifying syncBlock for a template only intended for asynchronous flow


N/A

> 7. not specifying hostRequired on the templates not applicable to domain APEX (with CNAME on @ host)

hostRequired = true

> 8. specifying a TXT record with SPF content (i.e. "v=spf1 ...") instead of using SPFM record type

We have to use TXT.