### PR TITLE
Short.io templates

### DIFF
--- a/short.io.arecord.json
+++ b/short.io.arecord.json
@@ -1,0 +1,25 @@
+{
+   "providerId":"short.io",
+   "providerName":"Short.io",
+   "serviceId":"arecord",
+   "serviceName":"White label link shortener",
+   "version": 2,
+   "logoUrl":"",
+   "description":"Configure ip address for the domain A record.",
+   "syncBlock":false,
+   "syncPubKeyDomain": "pubkey.short.io",
+   "records":[
+      {
+         "type":"A",
+         "host":"@",
+         "pointsTo":"%ip%",
+         "ttl":3600
+      },
+      {
+         "type":"A",
+         "host":"@",
+         "pointsTo":"%fallbackip%",
+         "ttl":3600
+      }
+   ]
+}

--- a/short.io.cname.json
+++ b/short.io.cname.json
@@ -1,0 +1,19 @@
+{
+   "providerId":"short.io",
+   "providerName":"Short.io",
+   "serviceId":"arecord",
+   "serviceName":"White label link shortener",
+   "version": 2,
+   "logoUrl":"",
+   "description":"Configure ip address for the domain A record.",
+   "syncBlock":false,
+   "syncPubKeyDomain": "pubkey.short.io",
+   "records":[
+      {
+         "type":"CNAME",
+         "host":"@",
+         "pointsTo":"%cname%",
+         "ttl":3600
+      }
+   ]
+}

--- a/short.io.cname.json
+++ b/short.io.cname.json
@@ -1,7 +1,7 @@
 {
    "providerId":"short.io",
    "providerName":"Short.io",
-   "serviceId":"arecord",
+   "serviceId":"cname",
    "serviceName":"White label link shortener",
    "version": 2,
    "logoUrl":"",

--- a/short.io.cname.json
+++ b/short.io.cname.json
@@ -5,9 +5,10 @@
    "serviceName":"White label link shortener",
    "version": 2,
    "logoUrl":"",
-   "description":"Configure ip address for the domain A record.",
+   "description":"Configure ip address for the domain CNAME record.",
    "syncBlock":false,
-   "syncPubKeyDomain": "pubkey.short.io",
+   "hostRequired":true,
+   "syncPubKeyDomain":"pubkey.short.io",
    "records":[
       {
          "type":"CNAME",


### PR DESCRIPTION
These templates are for connecting clients' domains to Short.io link shortener. We have 2 IPs in case of routing or network issues and latency-aware CNAME record if it is possible