### PR TITLE
Add GoDaddy template for WAF resellers

### DIFF
--- a/godaddy.com.waf-reseller.json
+++ b/godaddy.com.waf-reseller.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "godaddy.com",
+  "providerName": "Security Provider",
+  "serviceId": "waf",
+  "serviceName": "Web Application Firewall",
+  "version": 2,
+  "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
+  "description": "Enables web application firewall.",
+  "variableDescription": "",
+  "syncPubKeyDomain": "godaddy.com",
+  "shared": true,
+  "sharedProviderName": true,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    }
+  ]
+}

--- a/secureserver.net.waf.json
+++ b/secureserver.net.waf.json
@@ -6,7 +6,7 @@
   "version": 2,
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
   "description": "Enables web application firewall.",
-  "variableDescription": "",
+  "variableDescription": "ip is the IP address of the WAF.",
   "syncPubKeyDomain": "secureserver.net",
   "shared": true,
   "sharedProviderName": true,

--- a/secureserver.net.waf.json
+++ b/secureserver.net.waf.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
   "description": "Enables web application firewall.",
   "variableDescription": "ip is the IP address of the WAF.",
-  "syncPubKeyDomain": "secureserver.net",
+  "syncPubKeyDomain": "sucuri.net",
   "shared": true,
   "sharedProviderName": true,
   "records": [

--- a/secureserver.net.waf.json
+++ b/secureserver.net.waf.json
@@ -1,5 +1,5 @@
 {
-  "providerId": "godaddy.com",
+  "providerId": "secureserver.net",
   "providerName": "Security Provider",
   "serviceId": "waf",
   "serviceName": "Web Application Firewall",
@@ -7,7 +7,7 @@
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
   "description": "Enables web application firewall.",
   "variableDescription": "",
-  "syncPubKeyDomain": "godaddy.com",
+  "syncPubKeyDomain": "secureserver.net",
   "shared": true,
   "sharedProviderName": true,
   "records": [


### PR DESCRIPTION
This PR adds a new template for GoDaddy WAF resellers.