### PR TITLE
Update Shopify A record IP address

### DIFF
--- a/shopify.com.website.json
+++ b/shopify.com.website.json
@@ -3,7 +3,7 @@
    "providerName":"Shopify",
    "serviceId":"website",
    "serviceName":"Shopify Site",
-   "version": 2,
+   "version": 3,
    "syncPubKeyDomain" : "shopify.com",
    "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/08/shopify.png",
    "description":"Enables a domain to work with Shopify",


### PR DESCRIPTION
This updates the IP address to the currently used one (also in [the documentation](https://help.shopify.com/en/manual/online-store/domains/add-a-domain/connecting-domains/connect-domain-manual#before-you-begin)).