### PR TITLE
Submit Pear Commerce template

### DIFF
--- a/pearcommerce.com.cname.json
+++ b/pearcommerce.com.cname.json
@@ -15,7 +15,7 @@
          "type":"CNAME",
          "host":"@",
          "pointsTo":"%cname%.pearcommerce.com",
-         "ttl":3600
+         "ttl":60
       }
    ]
 }


### PR DESCRIPTION
Making it easier for our customers to use custom subdomains such as https://shop.fosterfarms.com/picker/1809066080428224?zip=94553 vs https://offers.pearcommerce.com/picker/1809066080428224?zip=94553