### PR TITLE
Remove spf

### DIFF
--- a/aweber.com.email-web.json
+++ b/aweber.com.email-web.json
@@ -7,16 +7,9 @@
    "syncRedirectDomain": "aweber.com, optin.com",
    "syncPubKeyDomain": "optin.com",
    "logoUrl":"https://assets.aweber-static.com/page-templates/assets/img/powered_by.png",
-   "description":"Configure AWeber's SPF and DKIM records to improve sender reputation and deliverability. Connect AWeber landing pages to your domain",
+   "description":"Configure AWeber's DKIM records to improve sender reputation and deliverability. Connect AWeber landing pages to your domain",
    "variableDescription":"account-subdomain refers to an AWeber account subdomain.",
    "records":[
-      {
-         "groupId": "email-aweber",
-         "type": "SPFM",
-         "host": "@",
-         "spfRules": "include:send.aweber.com",
-         "ttl": 3600
-      },
       {
          "groupId": "email-aweber",
          "type": "CNAME",
@@ -38,13 +31,6 @@
          "pointsTo": "aweber_key_c.send.aweber.com.",
          "ttl": 3600
        },
-       {
-         "groupId": "email-optin",
-         "type": "SPFM",
-         "host": "@",
-         "spfRules": "include:%account-subdomain%.optin.com",
-         "ttl": 3600
-      },
       {
          "groupId": "email-optin",
          "type": "CNAME",

--- a/aweber.com.email-web.json
+++ b/aweber.com.email-web.json
@@ -3,7 +3,7 @@
    "providerName":"AWeber",
    "serviceId":"email-web",
    "serviceName":"AWeber Email Authentication and Landing Pages",
-   "version": 1.01,
+   "version": 2,
    "syncRedirectDomain": "aweber.com, optin.com",
    "syncPubKeyDomain": "optin.com",
    "logoUrl":"https://assets.aweber-static.com/page-templates/assets/img/powered_by.png",

--- a/aweber.com.email-web.json
+++ b/aweber.com.email-web.json
@@ -3,7 +3,7 @@
    "providerName":"AWeber",
    "serviceId":"email-web",
    "serviceName":"AWeber Email Authentication and Landing Pages",
-   "version": 1,
+   "version": 1.01,
    "syncRedirectDomain": "aweber.com, optin.com",
    "syncPubKeyDomain": "optin.com",
    "logoUrl":"https://assets.aweber-static.com/page-templates/assets/img/powered_by.png",


### PR DESCRIPTION
AWeber does not require an SPF record moving forward. Once merged, these may be installed at IONOS, GoDaddy, Google Domains coordinated with myself, please.
@rphilip, @pawel-kow 