### PR TITLE
Template for Crisp Watch feature.

### DIFF
--- a/goentri.com.crisp-watch.json
+++ b/goentri.com.crisp-watch.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "goentri.com",
+  "providerName": "Entri",
+  "serviceId": "crisp-watch",
+  "serviceName": "Crisp",
+  "version": 1,
+  "logoUrl": "https://cdn.goentri.com/logo.svg",
+  "description": "Allows user to easily set up domain using Entri",
+  "syncPubKeyDomain": "goentri.com",
+  "syncRedirectDomain": "api.goentri.com, goentri.com",
+  "variableDescription": "txt is the text domain verification.",
+  "hostRequired": true,
+  "sharedProviderName": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_crisp",
+      "data": "%txt%",
+      "ttl": 14400
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "custom.crisp.watch.",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Template for Crisp Watch users to easily set up DNS records needed to integrate.