### PR TITLE
SFTSRV-594  Create a template for ARecord with 2 IPs

### DIFF
--- a/wpengine.com.arecord-cdn.json
+++ b/wpengine.com.arecord-cdn.json
@@ -1,0 +1,25 @@
+{
+   "providerId":"wpengine.com",
+   "providerName":"WPEngine.com",
+   "serviceId":"arecord-cdn",
+   "serviceName":"WP Engine Digital Experience Platform",
+   "version": 1,
+   "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2018/03/LGO-WPEngine-Horiz-reg-RGB-768x146.png",
+   "description":"Configure ip address for the domain A record.",
+   "syncBlock":false,
+   "syncPubKeyDomain": "landmark.wpesvc.net",
+   "records":[
+      {
+         "type":"A",
+         "host":"@",
+         "pointsTo":"%ip%",
+         "ttl":3600
+      },
+      {
+         "type":"A",
+         "host":"@",
+         "pointsTo":"%fallbackip%",
+         "ttl":3600
+      }
+   ]
+}


### PR DESCRIPTION
Create a new template wpengine.com.arecord-cdn.json

The template supports 2 IPs as a parameter:
%ip%
%fallbackip%