### PR TITLE
edits to split DKIM key

### DIFF
--- a/goentri.com.clickfunnels-alt.json
+++ b/goentri.com.clickfunnels-alt.json
@@ -33,7 +33,7 @@
     },
     {
       "type": "TXT",
-      "host": "%websiteId%._domainkey",
+      "host": "%websiteId%._domainkey.%websitehost%",
       "data": "%keyValue2%",
       "ttl": 3600
     }

--- a/goentri.com.clickfunnels-alt.json
+++ b/goentri.com.clickfunnels-alt.json
@@ -1,35 +1,41 @@
 {
-    "providerId": "goentri.com",
-    "providerName": "Entri",
-    "serviceId": "clickfunnels-alt",
-    "serviceName": "ClickFunnels",
-    "version": 1,
-    "logoUrl": "https://cdn.goentri.com/logo.svg",
-    "description": "Allows user to easily set up domain using Entri",
-    "syncPubKeyDomain": "goentri.com",
-    "syncRedirectDomain": "api.goentri.com, goentri.com, entri.com",
-    "variableDescription": "verificationValue is the value that is used to verify domain ownership,clusterValue is the cluster assigned to the domain,websiteId is the id of website, keyValue is the generated key value, websitehost is the website host value",
-    "sharedProviderName": true,
-    "hostRequired":true,
-    "multiInstance": true,
-    "records": [
-      {
-        "type": "TXT",
-        "host": "@",
-        "data": "clickfunnels-domain-verification=%verificationValue%",
-        "ttl": 3600
-      },
-      {
-        "type": "CNAME",
-        "host": "%websitehost%",
-        "pointsTo": "%clusterValue%",
-        "ttl": 3600
-      },
-      {
-        "type": "TXT",
-        "host": "%websiteId%._domainkey.%websitehost%",
-        "data": "%keyValue%",
-        "ttl": 3600
-      }
-    ]
-  }
+  "providerId": "goentri.com",
+  "providerName": "Entri",
+  "serviceId": "clickfunnels-alt",
+  "serviceName": "ClickFunnels",
+  "version": 1,
+  "logoUrl": "https://cdn.goentri.com/logo.svg",
+  "description": "Allows user to easily set up domain using Entri",
+  "syncPubKeyDomain": "goentri.com",
+  "syncRedirectDomain": "api.goentri.com, goentri.com, entri.com",
+  "variableDescription": "verificationValue is the value that is used to verify domain ownership,clusterValue is the cluster assigned to the domain,websiteId is the id of website, keyValue is the first 255 characters of generated key value, keyValue2 is the remaining characters in the generated key value, websitehost is the website host value",
+  "sharedProviderName": true,
+  "hostRequired": true,
+  "multiInstance": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "clickfunnels-domain-verification=%verificationValue%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%websitehost%",
+      "pointsTo": "%clusterValue%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%websiteId%._domainkey.%websitehost%",
+      "data": "%keyValue%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%websiteId%._domainkey",
+      "data": "%keyValue2%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/goentri.com.clickfunnels.json
+++ b/goentri.com.clickfunnels.json
@@ -8,7 +8,7 @@
   "description": "Allows user to easily set up domain using Entri",
   "syncPubKeyDomain": "goentri.com",
   "syncRedirectDomain": "api.goentri.com, goentri.com, entri.com",
-  "variableDescription": "verificationValue is the value that is used to verify domain ownership,clusterValue is the cluster assigned to the domain,websiteId is the id of website, keyValue is the generated key value",
+  "variableDescription": "verificationValue is the value that is used to verify domain ownership,clusterValue is the cluster assigned to the domain,websiteId is the id of website, keyValue is the first 255 characters of generated key value, keyValue2 is the remaining characters in the generated key value",
   "sharedProviderName": true,
   "hostRequired": true,
   "records": [
@@ -28,6 +28,12 @@
       "type": "TXT",
       "host": "%websiteId%._domainkey",
       "data": "%keyValue%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%websiteId%._domainkey",
+      "data": "%keyValue2%",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
The DKIM key clickfunnels is using is greater than 255 characters in length which is causing some issues on google-domains and as per the suggestion from google-domains we are making some changes to split the DKIM key into multiple values with same host