### PR TITLE
Add Shopify verification template as a service provider

### DIFF
--- a/shopify.com.verification.json
+++ b/shopify.com.verification.json
@@ -1,0 +1,37 @@
+{  
+   "providerId":"Shopify.com",
+   "providerName":"Shopify",
+   "serviceId":"verification",
+   "serviceName":"Shopify Site",
+   "version": 1,
+   "syncPubKeyDomain" : "shopify.com",
+   "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/08/shopify.png",
+   "description":"Verifies the proof of domain ownership to work with Shopify",
+   "variableDescription":"v1 is the shopify hosted domain name, verification is the verification code for the site and uuid is the unique verification code for proof of domain ownership",
+   "records":[  
+      {  
+         "type":"A",
+         "host":"@",
+         "pointsTo":"23.227.38.65",
+         "ttl":3600
+      },
+      {
+         "type":"CNAME",
+         "host":"www",
+         "pointsTo":"%v1%",
+         "ttl":3600
+      },
+      {  
+         "type":"CNAME",
+         "host":"%verification%",
+         "pointsTo":"dns-verification.shopify.com",
+         "ttl":3600
+      },
+      {
+         "type":"TXT",
+         "host":"@",
+         "data":"shopify_verification_%uuid%",
+         "ttl":3600
+      }
+   ]
+}

--- a/shopify.com.verification.json
+++ b/shopify.com.verification.json
@@ -2,7 +2,7 @@
    "providerId":"Shopify.com",
    "providerName":"Shopify",
    "serviceId":"verification",
-   "serviceName":"Shopify Site",
+   "serviceName":"Shopify Site and Domain Verification",
    "version": 1,
    "syncPubKeyDomain" : "shopify.com",
    "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/08/shopify.png",

--- a/shopify.com.verification.json
+++ b/shopify.com.verification.json
@@ -29,7 +29,7 @@
       },
       {
          "type":"TXT",
-         "host":"@",
+         "host":"shopify_verification",
          "data":"shopify_verification_%uuid%",
          "ttl":3600
       }

--- a/shopify.com.verification.json
+++ b/shopify.com.verification.json
@@ -7,7 +7,7 @@
    "syncPubKeyDomain" : "shopify.com",
    "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/08/shopify.png",
    "description":"Verifies the proof of domain ownership to work with Shopify",
-   "variableDescription":"v1 is the shopify hosted domain name, verification is the verification code for the site and uuid is the unique verification code for proof of domain ownership",
+   "variableDescription":"v1 is the shopify hosted domain name, verification is the verification code for the site and ulid is the unique verification code for proof of domain ownership",
    "records":[  
       {  
          "type":"A",
@@ -30,7 +30,7 @@
       {
          "type":"TXT",
          "host":"shopify_verification",
-         "data":"shopify_verification=%uuid%",
+         "data":"%ulid%",
          "ttl":3600
       }
    ]

--- a/shopify.com.verification.json
+++ b/shopify.com.verification.json
@@ -4,7 +4,7 @@
    "serviceId":"verification",
    "serviceName":"Shopify Site and Domain Verification",
    "version": 1,
-   "syncPubKeyDomain" : "shopify.com",
+   "syncPubKeyDomain":"shopify.com",
    "logoUrl":"https://domainconnect.org/wp-content/uploads/2016/08/shopify.png",
    "description":"Verifies the proof of domain ownership to work with Shopify",
    "variableDescription":"v1 is the shopify hosted domain name, verification is the verification code for the site and ulid is the unique verification code for proof of domain ownership",

--- a/shopify.com.verification.json
+++ b/shopify.com.verification.json
@@ -30,7 +30,7 @@
       {
          "type":"TXT",
          "host":"shopify_verification",
-         "data":"shopify_verification_%uuid%",
+         "data":"shopify_verification=%uuid%",
          "ttl":3600
       }
    ]


### PR DESCRIPTION
Adding a new template for Shopify proof of domain ownership verification.

Based on [shopify.com.website.json](https://github.com/Domain-Connect/Templates/blob/master/shopify.com.website.json)

Let me know if there's anything.