### PR TITLE
Add Canva Website Template 

### DIFF
--- a/canva.com.website.json
+++ b/canva.com.website.json
@@ -1,0 +1,37 @@
+{  
+   "providerId":"canva.com",
+   "providerName":"Canva",
+   "serviceId":"website",
+   "serviceName":"Canva Websites",
+   "syncPubKeyDomain":"domainconnect.canva.com",
+   "version": 1,
+   "logoUrl": "https://static.canva.com/static/images/canva_logo_100x100@2x.png",
+   "description":"Enables a domain to work with Canva",
+   "variableDescription":"verify is the verification value for the site and ssl is the certificate verification value",
+   "records":[  
+      {  
+         "type":"A",
+         "host":"@",
+         "pointsTo":"103.169.142.0",
+         "ttl":300
+      },
+      {  
+         "type":"A",
+         "host":"www",
+         "pointsTo":"103.169.142.0",
+         "ttl":300
+      },
+      {
+         "type":"TXT",
+         "host": "_canva-domain-verify",
+         "data": "%verify%",
+         "ttl":300
+      },
+      {
+         "type":"TXT",
+         "host": "@",
+         "data": "%ssl%",
+         "ttl":300
+      }
+   ]
+}


### PR DESCRIPTION
This PR adds a `canva.com.website.json` template to support website hosting on `canva.com` 