### PR TITLE
canva: Remove SSL verification record from canva.com.website.json

### DIFF
--- a/canva.com.website.json
+++ b/canva.com.website.json
@@ -7,7 +7,7 @@
    "version": 1,
    "logoUrl": "https://static.canva.com/static/images/canva_logo_100x100@2x.png",
    "description":"Enables a domain to work with Canva",
-   "variableDescription":"verify is the verification value for the site and ssl is the certificate verification value",
+   "variableDescription":"verify is the verification value for the site",
    "records":[  
       {  
          "type":"A",
@@ -25,12 +25,6 @@
          "type":"TXT",
          "host": "_canva-domain-verify",
          "data": "%verify%",
-         "ttl":300
-      },
-      {
-         "type":"TXT",
-         "host": "@",
-         "data": "%ssl%",
          "ttl":300
       }
    ]

--- a/canva.com.website.json
+++ b/canva.com.website.json
@@ -4,7 +4,7 @@
    "serviceId":"website",
    "serviceName":"Canva Websites",
    "syncPubKeyDomain":"domainconnect.canva.com",
-   "version": 1,
+   "version": 2,
    "logoUrl": "https://static.canva.com/static/images/canva_logo_100x100@2x.png",
    "description":"Enables a domain to work with Canva",
    "variableDescription":"verify is the verification value for the site",


### PR DESCRIPTION
This PR removes the `ssl verification` record from the `canva.com.website.json` template. 

