### PR TITLE
Remove the sync block on hubspot-template-3

### DIFF
--- a/hubspot.com.hubspot-template-3.json
+++ b/hubspot.com.hubspot-template-3.json
@@ -3,6 +3,8 @@
     "providerName": "HubSpot",
     "serviceId": "hubspot-template-3",
     "serviceName": "HubSpot CMS Site",
+    "syncPubKeyDomain": "domainconnect.hubspot.com",
+    "syncRedirectDomain": "app.hubspot.com, app.hubspotqa.com, api.hubspot.com, api.hubspotqa.com",
     "version": 1,
     "logoUrl": "https://domainconnect.org/wp-content/uploads/2017/02/HubSpot-768x223.png",
     "description": "Enables an apex domain to work with the HubSpot CMS",

--- a/hubspot.com.hubspot-template-3.json
+++ b/hubspot.com.hubspot-template-3.json
@@ -5,7 +5,7 @@
     "serviceName": "HubSpot CMS Site",
     "syncPubKeyDomain": "domainconnect.hubspot.com",
     "syncRedirectDomain": "app.hubspot.com, app.hubspotqa.com, api.hubspot.com, api.hubspotqa.com",
-    "version": 1,
+    "version": 2,
     "logoUrl": "https://domainconnect.org/wp-content/uploads/2017/02/HubSpot-768x223.png",
     "description": "Enables an apex domain to work with the HubSpot CMS",
     "variableDescription": "IPs: HubSpot CMS IPs",

--- a/hubspot.com.hubspot-template-3.json
+++ b/hubspot.com.hubspot-template-3.json
@@ -4,7 +4,6 @@
     "serviceId": "hubspot-template-3",
     "serviceName": "HubSpot CMS Site",
     "version": 1,
-    "syncBlock": true,
     "logoUrl": "https://domainconnect.org/wp-content/uploads/2017/02/HubSpot-768x223.png",
     "description": "Enables an apex domain to work with the HubSpot CMS",
     "variableDescription": "IPs: HubSpot CMS IPs",


### PR DESCRIPTION
We're looking to start using this template for the Domain Connect sync flow, therefore we're removing the `syncBlock` on it. For our sync requests, we will digitally sign the requests to still maintain the security aspect of the flow.