### PR TITLE
Create goentri.com.toast.json

### DIFF
--- a/goentri.com.toast.json
+++ b/goentri.com.toast.json
@@ -3,7 +3,7 @@
   "providerName": "Entri",
   "serviceId": "toast",
   "serviceName": "Toast",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://cdn.goentri.com/logo.svg",
   "description": "Allows user to easily set up domain using Entri",
   "syncPubKeyDomain": "goentri.com",
@@ -34,34 +34,27 @@
       "ttl": 3600
     },
     {
-      "type": "CNAME",
-      "host": "%onlineOrdeingSubdomain%",
+      "type": "TXT",
+      "host": "%txtHost%",
       "groupId": "a2",
-      "pointsTo": "%cnamePointsTo%",
-      "ttl": 3600
-    },
-    {
-      "type": "A",
-      "host": "@",
-      "groupId": "a3",
-      "pointsTo": "%ipaddress%",
+      "data": "%txt%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a3",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain2%",
+      "groupId": "a2",
+      "pointsTo": "%cnamePointsToSubdomain2%",
       "ttl": 3600
     },
     {
       "type": "TXT",
-      "host": "%txtHost%",
+      "host": "%txtHost3%",
       "groupId": "a3",
-      "data": "%txt%",
+      "data": "%txt3%",
       "ttl": 3600
     },
-  {
+    {
       "type": "CNAME",
       "host": "%subdomain3%",
       "groupId": "a3",
@@ -69,17 +62,17 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a4",
-      "pointsTo": "%ipaddress%",
+      "type": "TXT",
+      "host": "%txtHost31%",
+      "groupId": "a3",
+      "data": "%txt31%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a4",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain31%",
+      "groupId": "a3",
+      "pointsTo": "%cnamePointsToSubdomain31%",
       "ttl": 3600
     },
     {
@@ -89,11 +82,18 @@
       "data": "%txt%",
       "ttl": 3600
     },
-  {
+    {
       "type": "CNAME",
       "host": "%subdomain4%",
       "groupId": "a4",
       "pointsTo": "%cnamePointsToSubdomain4%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost41%",
+      "groupId": "a4",
+      "data": "%txt41%",
       "ttl": 3600
     },
     {
@@ -104,17 +104,17 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a5",
-      "pointsTo": "%ipaddress%",
+      "type": "TXT",
+      "host": "%txtHost42%",
+      "groupId": "a4",
+      "data": "%txt42%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a5",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain42%",
+      "groupId": "a4",
+      "pointsTo": "%cnamePointsToSubdomain42%",
       "ttl": 3600
     },
     {
@@ -124,11 +124,18 @@
       "data": "%txt%",
       "ttl": 3600
     },
-  {
+    {
       "type": "CNAME",
       "host": "%subdomain5%",
       "groupId": "a5",
       "pointsTo": "%cnamePointsToSubdomain5%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost51%",
+      "groupId": "a5",
+      "data": "%txt51%",
       "ttl": 3600
     },
     {
@@ -139,6 +146,13 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost52%",
+      "groupId": "a5",
+      "data": "%txt52%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain52%",
       "groupId": "a5",
@@ -146,17 +160,17 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a6",
-      "pointsTo": "%ipaddress%",
+      "type": "TXT",
+      "host": "%txtHost53%",
+      "groupId": "a5",
+      "data": "%txt53%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a6",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain53%",
+      "groupId": "a5",
+      "pointsTo": "%cnamePointsToSubdomain53%",
       "ttl": 3600
     },
     {
@@ -166,11 +180,18 @@
       "data": "%txt%",
       "ttl": 3600
     },
-  {
+    {
       "type": "CNAME",
       "host": "%subdomain6%",
       "groupId": "a6",
       "pointsTo": "%cnamePointsToSubdomain6%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost61%",
+      "groupId": "a6",
+      "data": "%txt61%",
       "ttl": 3600
     },
     {
@@ -181,10 +202,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost62%",
+      "groupId": "a6",
+      "data": "%txt62%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain62%",
       "groupId": "a6",
       "pointsTo": "%cnamePointsToSubdomain62%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost63%",
+      "groupId": "a6",
+      "data": "%txt62%",
       "ttl": 3600
     },
     {
@@ -195,17 +230,17 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a7",
-      "pointsTo": "%ipaddress%",
+      "type": "TXT",
+      "host": "%txtHost64%",
+      "groupId": "a6",
+      "data": "%txt64%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a7",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain64%",
+      "groupId": "a6",
+      "pointsTo": "%cnamePointsToSubdomain64%",
       "ttl": 3600
     },
     {
@@ -215,11 +250,18 @@
       "data": "%txt%",
       "ttl": 3600
     },
-  {
+    {
       "type": "CNAME",
       "host": "%subdomain7%",
       "groupId": "a7",
       "pointsTo": "%cnamePointsToSubdomain7%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost71%",
+      "groupId": "a7",
+      "data": "%txt71%",
       "ttl": 3600
     },
     {
@@ -230,10 +272,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost72%",
+      "groupId": "a7",
+      "data": "%txt72%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain72%",
       "groupId": "a7",
       "pointsTo": "%cnamePointsToSubdomain72%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost73%",
+      "groupId": "a7",
+      "data": "%txt73%",
       "ttl": 3600
     },
     {
@@ -243,7 +299,14 @@
       "pointsTo": "%cnamePointsToSubdomain73%",
       "ttl": 3600
     },
-  {
+    {
+      "type": "TXT",
+      "host": "%txtHost74%",
+      "groupId": "a7",
+      "data": "%txt74%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain74%",
       "groupId": "a7",
@@ -251,17 +314,17 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a8",
-      "pointsTo": "%ipaddress%",
+      "type": "TXT",
+      "host": "%txtHost75%",
+      "groupId": "a7",
+      "data": "%txt75%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a8",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain75%",
+      "groupId": "a7",
+      "pointsTo": "%cnamePointsToSubdomain75%",
       "ttl": 3600
     },
     {
@@ -271,11 +334,18 @@
       "data": "%txt%",
       "ttl": 3600
     },
-  {
+    {
       "type": "CNAME",
       "host": "%subdomain8%",
       "groupId": "a8",
       "pointsTo": "%cnamePointsToSubdomain8%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost81%",
+      "groupId": "a8",
+      "data": "%txt81%",
       "ttl": 3600
     },
     {
@@ -286,10 +356,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost82%",
+      "groupId": "a8",
+      "data": "%txt82%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain82%",
       "groupId": "a8",
       "pointsTo": "%cnamePointsToSubdomain82%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost83%",
+      "groupId": "a8",
+      "data": "%txt83%",
       "ttl": 3600
     },
     {
@@ -299,11 +383,25 @@
       "pointsTo": "%cnamePointsToSubdomain83%",
       "ttl": 3600
     },
-  {
+    {
+      "type": "TXT",
+      "host": "%txtHost84%",
+      "groupId": "a8",
+      "data": "%txt84%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain84%",
       "groupId": "a8",
       "pointsTo": "%cnamePointsToSubdomain84%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost85%",
+      "groupId": "a8",
+      "data": "%txt85%",
       "ttl": 3600
     },
     {
@@ -314,17 +412,17 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a9",
-      "pointsTo": "%ipaddress%",
+      "type": "TXT",
+      "host": "%txtHost86%",
+      "groupId": "a8",
+      "data": "%txt86%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a9",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain86%",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsToSubdomain86%",
       "ttl": 3600
     },
     {
@@ -342,10 +440,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost91%",
+      "groupId": "a9",
+      "data": "%txt91%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain91%",
       "groupId": "a9",
       "pointsTo": "%cnamePointsToSubdomain91%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost92%",
+      "groupId": "a9",
+      "data": "%txt92%",
       "ttl": 3600
     },
     {
@@ -356,17 +468,38 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost93%",
+      "groupId": "a9",
+      "data": "%txt93%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain93%",
       "groupId": "a9",
       "pointsTo": "%cnamePointsToSubdomain93%",
       "ttl": 3600
     },
-  {
+    {
+      "type": "TXT",
+      "host": "%txtHost94%",
+      "groupId": "a9",
+      "data": "%txt94%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain94%",
       "groupId": "a9",
       "pointsTo": "%cnamePointsToSubdomain94%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost95%",
+      "groupId": "a9",
+      "data": "%txt95%",
       "ttl": 3600
     },
     {
@@ -377,24 +510,31 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost96%",
+      "groupId": "a9",
+      "data": "%txt96%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain96%",
       "groupId": "a9",
       "pointsTo": "%cnamePointsToSubdomain96%",
       "ttl": 3600
     },
-     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a10",
-      "pointsTo": "%ipaddress%",
+    {
+      "type": "TXT",
+      "host": "%txtHost97%",
+      "groupId": "a9",
+      "data": "%txt97%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a10",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain97%",
+      "groupId": "9",
+      "pointsTo": "%cnamePointsToSubdomain97%",
       "ttl": 3600
     },
     {
@@ -412,10 +552,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost101%",
+      "groupId": "a10",
+      "data": "%txt101%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain101%",
       "groupId": "a10",
       "pointsTo": "%cnamePointsToSubdomain101%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost102%",
+      "groupId": "a10",
+      "data": "%txt102%",
       "ttl": 3600
     },
     {
@@ -426,17 +580,38 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost103%",
+      "groupId": "a10",
+      "data": "%txt103%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain103%",
       "groupId": "a10",
       "pointsTo": "%cnamePointsToSubdomain103%",
       "ttl": 3600
     },
-  {
+    {
+      "type": "TXT",
+      "host": "%txtHost104%",
+      "groupId": "a10",
+      "data": "%txt104%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain104%",
       "groupId": "a10",
       "pointsTo": "%cnamePointsToSubdomain104%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost105%",
+      "groupId": "a10",
+      "data": "%txt105%",
       "ttl": 3600
     },
     {
@@ -447,10 +622,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost106%",
+      "groupId": "a10",
+      "data": "%txt106%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain106%",
       "groupId": "a10",
       "pointsTo": "%cnamePointsToSubdomain106%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost107%",
+      "groupId": "a10",
+      "data": "%txt107%",
       "ttl": 3600
     },
     {
@@ -461,17 +650,17 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a11",
-      "pointsTo": "%ipaddress%",
+      "type": "TXT",
+      "host": "%txtHost108%",
+      "groupId": "a10",
+      "data": "%txt108%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "www",
-      "groupId": "a11",
-      "pointsTo": "%cnamePointsTo%",
+      "host": "%subdomain108%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain108%",
       "ttl": 3600
     },
     {
@@ -489,10 +678,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost111%",
+      "groupId": "a11",
+      "data": "%txt111%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain111%",
       "groupId": "a11",
       "pointsTo": "%cnamePointsToSubdomain111%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost112%",
+      "groupId": "a11",
+      "data": "%txt112%",
       "ttl": 3600
     },
     {
@@ -503,17 +706,38 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost113%",
+      "groupId": "a11",
+      "data": "%txt113%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain113%",
       "groupId": "a11",
       "pointsTo": "%cnamePointsToSubdomain113%",
       "ttl": 3600
     },
-  {
+    {
+      "type": "TXT",
+      "host": "%txtHost114%",
+      "groupId": "a11",
+      "data": "%txt114%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain114%",
       "groupId": "a11",
       "pointsTo": "%cnamePointsToSubdomain114%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost115%",
+      "groupId": "a11",
+      "data": "%txt115%",
       "ttl": 3600
     },
     {
@@ -524,10 +748,24 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost116%",
+      "groupId": "a11",
+      "data": "%txt116%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain116%",
       "groupId": "a11",
       "pointsTo": "%cnamePointsToSubdomain116%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost117%",
+      "groupId": "a11",
+      "data": "%txt117%",
       "ttl": 3600
     },
     {
@@ -538,6 +776,13 @@
       "ttl": 3600
     },
     {
+      "type": "TXT",
+      "host": "%txtHost118%",
+      "groupId": "a11",
+      "data": "%txt118%",
+      "ttl": 3600
+    },
+    {
       "type": "CNAME",
       "host": "%subdomain118%",
       "groupId": "a11",
@@ -545,95 +790,18 @@
       "ttl": 3600
     },
     {
-      "type": "A",
-      "host": "@",
-      "groupId": "a12",
-      "pointsTo": "%ipaddress%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "www",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsTo%",
-      "ttl": 3600
-    },
-    {
       "type": "TXT",
-      "host": "%txtHost%",
-      "groupId": "a12",
-      "data": "%txt%",
+      "host": "%txtHost119%",
+      "groupId": "a11",
+      "data": "%txt119%",
       "ttl": 3600
     },
     {
       "type": "CNAME",
-      "host": "%subdomain12%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain12%",
+      "host": "%subdomain119%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain119%",
       "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain121%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain121%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain122%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain122%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain123%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain123%",
-      "ttl": 3600
-    },
-  {
-      "type": "CNAME",
-      "host": "%subdomain124%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain124%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain125%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain125%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain126%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain126%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain127%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain127%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain128%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain128%",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%subdomain129%",
-      "groupId": "a12",
-      "pointsTo": "%cnamePointsToSubdomain129%",
-      "ttl": 3600
-    }                           
+    }
   ]
 }

--- a/goentri.com.toast.json
+++ b/goentri.com.toast.json
@@ -1,0 +1,639 @@
+{
+  "providerId": "goentri.com",
+  "providerName": "Entri",
+  "serviceId": "toast",
+  "serviceName": "Toast",
+  "version": 1,
+  "logoUrl": "https://cdn.goentri.com/logo.svg",
+  "description": "Allows user to easily set up domain using Entri",
+  "syncPubKeyDomain": "goentri.com",
+  "syncRedirectDomain": "api.goentri.com, goentri.com, entri.com, app.entri.com,app.goentri.com",
+  "variableDescription": "ipaddress is the IP, cnamePointsTo is to where the domain is pointed, txt is the text domain verification, txtHost is the host for the TXT, onlineOrdeingSubdomain is the subdomain of the website hosting, subdomain is the subdomain user is creating, cnamePointsToSubdomain is to where the subdomain is pointed",
+  "hostRequired": false,
+  "sharedProviderName": true,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a1",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a1",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a1",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%onlineOrdeingSubdomain%",
+      "groupId": "a2",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a3",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a3",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a3",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain3%",
+      "groupId": "a3",
+      "pointsTo": "%cnamePointsToSubdomain3%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a4",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a4",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a4",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain4%",
+      "groupId": "a4",
+      "pointsTo": "%cnamePointsToSubdomain4%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain41%",
+      "groupId": "a4",
+      "pointsTo": "%cnamePointsToSubdomain41%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a5",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a5",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a5",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain5%",
+      "groupId": "a5",
+      "pointsTo": "%cnamePointsToSubdomain5%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain51%",
+      "groupId": "a5",
+      "pointsTo": "%cnamePointsToSubdomain51%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain52%",
+      "groupId": "a5",
+      "pointsTo": "%cnamePointsToSubdomain52%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a6",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a6",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a6",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain6%",
+      "groupId": "a6",
+      "pointsTo": "%cnamePointsToSubdomain6%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain61%",
+      "groupId": "a6",
+      "pointsTo": "%cnamePointsToSubdomain61%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain62%",
+      "groupId": "a6",
+      "pointsTo": "%cnamePointsToSubdomain62%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain63%",
+      "groupId": "a6",
+      "pointsTo": "%cnamePointsToSubdomain63%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a7",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a7",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a7",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain7%",
+      "groupId": "a7",
+      "pointsTo": "%cnamePointsToSubdomain7%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain71%",
+      "groupId": "a7",
+      "pointsTo": "%cnamePointsToSubdomain71%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain72%",
+      "groupId": "a7",
+      "pointsTo": "%cnamePointsToSubdomain72%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain73%",
+      "groupId": "a7",
+      "pointsTo": "%cnamePointsToSubdomain73%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain74%",
+      "groupId": "a7",
+      "pointsTo": "%cnamePointsToSubdomain74%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a8",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a8",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain8%",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsToSubdomain8%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain81%",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsToSubdomain81%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain82%",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsToSubdomain82%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain83%",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsToSubdomain83%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain84%",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsToSubdomain84%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain85%",
+      "groupId": "a8",
+      "pointsTo": "%cnamePointsToSubdomain85%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a9",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a9",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain9%",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsToSubdomain9%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain91%",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsToSubdomain91%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain92%",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsToSubdomain92%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain93%",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsToSubdomain93%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain94%",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsToSubdomain94%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain95%",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsToSubdomain95%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain96%",
+      "groupId": "a9",
+      "pointsTo": "%cnamePointsToSubdomain96%",
+      "ttl": 3600
+    },
+     {
+      "type": "A",
+      "host": "@",
+      "groupId": "a10",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a10",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain10%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain10%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain101%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain101%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain102%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain102%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain103%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain103%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain104%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain104%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain105%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain105%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain106%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain106%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain107%",
+      "groupId": "a10",
+      "pointsTo": "%cnamePointsToSubdomain107%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a11",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a11",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain11%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain11%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain111%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain111%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain112%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain112%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain113%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain113%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain114%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain114%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain115%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain115%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain116%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain116%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain117%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain117%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain118%",
+      "groupId": "a11",
+      "pointsTo": "%cnamePointsToSubdomain118%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "groupId": "a12",
+      "pointsTo": "%ipaddress%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%txtHost%",
+      "groupId": "a12",
+      "data": "%txt%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain12%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain12%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain121%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain121%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain122%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain122%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain123%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain123%",
+      "ttl": 3600
+    },
+  {
+      "type": "CNAME",
+      "host": "%subdomain124%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain124%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain125%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain125%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain126%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain126%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain127%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain127%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain128%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain128%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%subdomain129%",
+      "groupId": "a12",
+      "pointsTo": "%cnamePointsToSubdomain129%",
+      "ttl": 3600
+    }                           
+  ]
+}


### PR DESCRIPTION
Taost has a use case in which the user can add until 10 subdomains besides the standard configuration, this is the reason I created 12 groups separately.