### PR TITLE
Update getreadydigital.com.cname-record.json

### DIFF
--- a/getreadydigital.com.cname-record.json
+++ b/getreadydigital.com.cname-record.json
@@ -7,14 +7,14 @@
   "version": 1,
   "logoUrl": "https://getreadydigital.com/wp-content/uploads/2023/04/cropped-GR-Logo-Favicon-192x192.png",
   "description": "Enable root domain to work with the GetReadyDigital",
-  "variableDescription": "CNAMEs: GetReadyDigital connection",
+  "variableDescription": "CNAME subdomain and destination for GetReadyDigital connection",
   "syncPubKeyDomain": "getreadydigital.com",
   "hostRequired": true,
   "records": [
     {
       "groupId": "cname",
       "type": "CNAME",
-      "host": "@",
+      "host": "%subdomain%",
       "pointsTo": "%cnameValue%",
       "ttl": 3600
     }


### PR DESCRIPTION
Following review of the Template Record section of the spec, this change reflects a fix based on the Description for Type CNAME to change the host to a variable from '@' - "CNAME: host, pointsTo, TTL (host must not be null or @)" (https://github.com/Domain-Connect/spec/blob/master/Domain%20Connect%20Spec%20Draft.adoc#53-template-record). This is also highlighted as an error in the template linter tool for our template.