### PR TITLE
Create mailchimp.com.email-signing.json

### DIFF
--- a/mailchimp.com.email-signing.json
+++ b/mailchimp.com.email-signing.json
@@ -1,0 +1,34 @@
+{
+    "providerId": "mailchimp.com",
+    "providerName": "Intuit Mailchimp",
+    "serviceId": "email-signing",
+    "serviceName": "Intuit Mailchimp Email Signing",
+    "version": "1",
+    "logoUrl": "https://cdn-images.mailchimp.com/product/brand_assets/logos/mc-freddie-dark.svg",
+    "syncPubKeyDomain": "mailchimp.com",
+    "description": "Configures DNS records for Mailchimp email signing",
+    "variableDescription": "sel1/sel2 are selector values; host1/host2 are the hosts we want the CNAMEs to point to. data is what the DMARC TXT is set to.",
+    "records": [
+        {
+            "groupId": "dkim",
+            "type": "CNAME",
+            "host": "%sel1%._domainkey",
+            "pointsTo": "%host1%",
+            "ttl": 3600
+        },
+        {
+            "groupId": "dkim",
+            "type": "CNAME",
+            "host": "%sel2%._domainkey",
+            "pointsTo": "%host2%",
+            "ttl": 3600
+        },
+        {
+            "groupId": "dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "%data%",
+            "ttl": 3600
+        }
+    ]
+}

--- a/mailchimp.com.email-signing.json
+++ b/mailchimp.com.email-signing.json
@@ -28,7 +28,8 @@
             "type": "TXT",
             "host": "_dmarc",
             "data": "%data%",
-            "ttl": 3600
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All"
         }
     ]
 }

--- a/mailchimp.com.email-signing.json
+++ b/mailchimp.com.email-signing.json
@@ -3,7 +3,7 @@
     "providerName": "Intuit Mailchimp",
     "serviceId": "email-signing",
     "serviceName": "Intuit Mailchimp Email Signing",
-    "version": "1",
+    "version": 1,
     "logoUrl": "https://cdn-images.mailchimp.com/product/brand_assets/logos/mc-freddie-dark.svg",
     "syncPubKeyDomain": "mailchimp.com",
     "description": "Configures DNS records for Mailchimp email signing",


### PR DESCRIPTION
For proper email signing on a user's behalf, we prompt them to add specific records to the DNS. The hope is by using this protocol, we can perform more of the heavy lifting on their behalf.

It's grouped in two parts:
- `dkim` configuration
- `dmarc` configuration

By checking beforehand, we can determine whether the user needs both groups, or just DKIM (because a DMARC record is already present).

Any and all feedback welcome. Thanks.