### PR TITLE
examples: tidy example templates json format

### DIFF
--- a/exampleservice.domainconnect.org.template1.json
+++ b/exampleservice.domainconnect.org.template1.json
@@ -1,28 +1,28 @@
-{  
-   "providerId":"exampleservice.domainconnect.org",
-   "providerName":"Example Domain Connect Service",
-   "serviceId":"template1",
-   "serviceName":"Stateless Hosting Primary",
-   "version": 3,
-   "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2018/11/DomainConnectSquareBlack.png",
-   "description":"Example service for stateless hosting",
-   "syncRedirectDomain": "exampleservice.domainconnect.org",
-   "warnPhishing": true,
-   "variableDescription":"IP is the IP address of the service A record. RANDOMTEXT is the value for a TXT record in DNS. Should be prefixed with shm:",
-   "records":[  
-      {  
-         "type":"A",
-         "host":"@",
-         "pointsTo":"%IP%",
-         "ttl":1800
-      },
-      {  
-         "type":"TXT",
-         "host":"@",
-         "data":"%RANDOMTEXT%",
-         "ttl":1800,
-         "txtConflictMatchingMode": "Prefix",
-         "txtConflictMatchingPrefix" : "shm:"
-      }
-   ]
+{
+    "providerId": "exampleservice.domainconnect.org",
+    "providerName": "Example Domain Connect Service",
+    "serviceId": "template1",
+    "serviceName": "Stateless Hosting Primary",
+    "version": 3,
+    "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2018/11/DomainConnectSquareBlack.png",
+    "description": "Example service for stateless hosting",
+    "variableDescription": "IP is the IP address of the service A record. RANDOMTEXT is the value for a TXT record in DNS. Should be prefixed with shm:",
+    "syncRedirectDomain": "exampleservice.domainconnect.org",
+    "warnPhishing": true,
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%IP%",
+            "ttl": 1800
+        },
+        {
+            "type": "TXT",
+            "host": "@",
+            "ttl": 1800,
+            "data": "%RANDOMTEXT%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "shm:"
+        }
+    ]
 }

--- a/exampleservice.domainconnect.org.template2.json
+++ b/exampleservice.domainconnect.org.template2.json
@@ -1,34 +1,34 @@
-{  
-   "providerId":"exampleservice.domainconnect.org",
-   "providerName":"Example Domain Connect Service",
-   "serviceId":"template2",
-   "serviceName":"Stateless Hosting Secondary",
-   "version": 3,
-   "syncPubKeyDomain" : "exampleservice.domainconnect.org",
-   "syncRedirectDomain": "exampleservice.domainconnect.org",
-   "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2018/11/DomainConnectSquareBlack.png",
-   "description":"Example service for stateless hosting, alternative template",
-   "variableDescription":"IP is the IP address of the service A record. RANDOMTEXT is the value for a TXT record in DNS. Should be prefixed with shm:",
-   "records":[  
-      {  
-         "type":"A",
-         "host":"@",
-         "pointsTo":"%IP%",
-         "ttl":1800
-      },
-      {  
-         "type":"TXT",
-         "host":"@",
-         "data":"%RANDOMTEXT%",
-         "ttl":1800,
-         "txtConflictMatchingMode": "Prefix",
-         "txtConflictMatchingPrefix" : "shm:"
-      },
-      {
-        "type": "CNAME",
-        "host": "whd",
-        "pointsTo": "@",
-        "ttl": 600
-       }
-   ]
+{
+    "providerId": "exampleservice.domainconnect.org",
+    "providerName": "Example Domain Connect Service",
+    "serviceId": "template2",
+    "serviceName": "Stateless Hosting Secondary",
+    "version": 3,
+    "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2018/11/DomainConnectSquareBlack.png",
+    "description": "Example service for stateless hosting, alternative template",
+    "variableDescription": "IP is the IP address of the service A record. RANDOMTEXT is the value for a TXT record in DNS. Should be prefixed with shm:",
+    "syncPubKeyDomain": "exampleservice.domainconnect.org",
+    "syncRedirectDomain": "exampleservice.domainconnect.org",
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%IP%",
+            "ttl": 1800
+        },
+        {
+            "type": "TXT",
+            "host": "@",
+            "ttl": 1800,
+            "data": "%RANDOMTEXT%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "shm:"
+        },
+        {
+            "type": "CNAME",
+            "host": "whd",
+            "pointsTo": "@",
+            "ttl": 600
+        }
+    ]
 }


### PR DESCRIPTION
Spacing in these files is a bit here and there.  The tidying was done using template linter:

    Templates $ dc-template-linter --inplace ./exampleservice.domainconnect.org.template*