### PR TITLE
Update templates to include domain ownership verification

### DIFF
--- a/getflywheel.com.arecord.json
+++ b/getflywheel.com.arecord.json
@@ -3,18 +3,28 @@
    "providerName":"Flywheel",
    "serviceId":"arecord",
    "serviceName":"Managed WordPress Hosting",
-   "version": 2,
+   "version": 3,
    "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2021/06/flywheel-logo.png",
    "description":"Configure ip address for the domain A record.",
+   "variableDescription":"ip is the IP address of the server, verification is the domain ownership verification code",
    "syncBlock":false,
    "syncPubKeyDomain":"domainconnect.getflywheel.com",
    "syncRedirectDomain":"getflywheel.com,staging.getflywheel.com,flywheel.localhost",
    "records":[
       {
+         "groupId":"arecord",
          "type":"A",
          "host":"@",
          "pointsTo":"%ip%",
          "ttl":3600
+      },
+      {
+         "groupId":"verify",
+         "type":"TXT",
+         "host":"flywheel-domain-verification",
+         "data":"%verification%",
+         "ttl":3600,
+         "txtConflictMatchingMode": "All"
       }
    ]
 }

--- a/getflywheel.com.cname.json
+++ b/getflywheel.com.cname.json
@@ -3,20 +3,29 @@
    "providerName":"Flywheel",
    "serviceId":"cname",
    "serviceName":"Managed WordPress Hosting",
-   "version": 1,
+   "version": 2,
    "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2021/06/flywheel-logo.png",
    "description":"Configure target domain for CNAME record.",
-   "variableDescription":"site is the primary domain for a Flywheel managed site",
+   "variableDescription":"site is the primary domain for a Flywheel managed site, verification is the domain ownership verification code",
    "syncBlock":false,
    "syncPubKeyDomain":"domainconnect.getflywheel.com",
    "syncRedirectDomain":"getflywheel.com,staging.getflywheel.com,flywheel.localhost",
    "hostRequired": true,
    "records":[
       {
+         "groupId":"cname",
          "type":"CNAME",
          "host":"@",
          "pointsTo":"%site%",
          "ttl":3600
+      },
+      {
+         "groupId":"verify",
+         "type":"TXT",
+         "host":"flywheel-domain-verification",
+         "data":"%verification%",
+         "ttl":3600,
+         "txtConflictMatchingMode": "All"
       }
    ]
 }


### PR DESCRIPTION
- Added `groupId` to specify the groups from the template to apply
- Added `verify` group to verify domain ownership by adding a TXT Record.