### PR TITLE
add vaultcord.com

### DIFF
--- a/vaultcord.com.vaultcord-custom-domains.json
+++ b/vaultcord.com.vaultcord-custom-domains.json
@@ -1,0 +1,24 @@
+{
+  "providerId":"vaultcord.com",
+  "providerName":"VaultCord",
+  "serviceName":"VaultCord",
+  "serviceId":"vaultcord-custom-domains",
+  "logoUrl":"https://cdn.vaultcord.com/logo.png",
+  "version": 1,
+  "description":"Enables a domain to work with VaultCord",
+  "syncPubKeyDomain": "vaultcord.com",
+  "records":[
+    {
+      "type": "CNAME",
+      "host": "%cnamehost%",
+      "pointsTo": "%domain%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_vercel",
+      "data": "%verifytxt%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/vaultcord.com.vaultcord-custom-domains.json
+++ b/vaultcord.com.vaultcord-custom-domains.json
@@ -11,7 +11,7 @@
     {
       "type": "CNAME",
       "host": "%cnamehost%",
-      "pointsTo": "%domain%",
+      "pointsTo": "customers.vaultcord.com",
       "ttl": 3600
     },
     {


### PR DESCRIPTION
We would like to allow our customers to use DomainConnect to seamlessly setup their custom domains for our service's vanity pages.

https://docs.vaultcord.com/guides/verify-page#custom-domains

We plan to implement with the DNS provider Cloudflare

Thank you for your time, I appreciate it.