### PR TITLE
Add KeyAuth.cc

### DIFF
--- a/keyauth.cc.api-custom-domains.json
+++ b/keyauth.cc.api-custom-domains.json
@@ -1,0 +1,24 @@
+{
+    "providerId": "keyauth.cc",
+    "providerName": "KeyAuth",
+    "serviceId": "api-custom-domains",
+    "serviceName": "KeyAuth",
+    "version": 1,
+    "logoUrl": "https://cdn.keyauth.cc/v2/assets/media/logos/logo-1-dark.png",
+    "description": "Enables a domain to work with KeyAuth API",
+    "syncPubKeyDomain": "keyauth.cc",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "%cnamehost%",
+            "pointsTo": "api-worker.keyauth.win",
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_cf-custom-hostname",
+            "ttl": 3600,
+            "data": "%verifytxt%"
+        }
+    ]
+}


### PR DESCRIPTION
We would like to allow our customers to use DomainConnect to seamlessly setup their custom domains for our service's API.

https://keyauthdocs.apidog.io/doc-446443

Thank you for your time, I appreciate it.

![image](https://github.com/user-attachments/assets/7f3ae75b-2d59-48e6-9c61-c610b52b2134)