### PR TITLE
[SmugMug] remove usage of %fqdn% template var; add subdomain template

### DIFF
--- a/smugmug.com.custom-domain.json
+++ b/smugmug.com.custom-domain.json
@@ -1,21 +1,23 @@
-{  
-   "providerId":"smugmug.com",
-   "providerName":"SmugMug",
-   "serviceId":"custom-domain",
-   "serviceName":"SmugMug Custom Domain",
-   "version": 2,
-   "logoUrl":"https://www.domainconnect.org/wp-content/uploads/2016/02/smugmug-300x80.png",
-   "description":"Enables a domain to work with SmugMug",
-   "records":[
-      {  
+{
+   "providerId": "smugmug.com",
+   "providerName": "SmugMug",
+   "serviceId": "custom-domain",
+   "serviceName": "SmugMug Custom Domain",
+   "version": 3,
+   "logoUrl": "https://cdn.smugmug.com/img/domain-connect/smugmug-logo.png",
+   "description": "Enables a domain to work with SmugMug",
+   "syncRedirectDomain": "smugmug.com, smugmug.net",
+   "records": [
+      {
          "type": "REDIR301",
-         "target": "www.%fqdn%"
+         "target": "www.%domain%",
+         "host": "%domain%."
       },
-      {  
-         "type":"CNAME",
-         "host":"www",
-         "pointsTo":"domains.smugmug.com",
-         "ttl":600
+      {
+         "type": "CNAME",
+         "host": "www.%domain%.",
+         "pointsTo": "domains.smugmug.com",
+         "ttl": 600
       }
    ]
 }

--- a/smugmug.com.custom-subdomain.json
+++ b/smugmug.com.custom-subdomain.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "smugmug.com",
+  "providerName": "SmugMug",
+  "serviceId": "custom-subdomain",
+  "serviceName": "SmugMug Custom Domain",
+  "version": 1,
+  "logoUrl": "https://cdn.smugmug.com/img/domain-connect/smugmug-logo.png",
+  "description": "Enables a domain to work with SmugMug",
+  "syncRedirectDomain": "smugmug.com, smugmug.net",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "domains.smugmug.com",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
GoDaddy does not support the `%fqdn%` builtin variable, which serves as a shortcut to [host.]domain

https://github.com/Domain-Connect/spec/blob/master/Domain%20Connect%20Spec%20Draft.adoc#692-variable-values

Instead, use "www.%domain%" as the redirect target for the domain template.  Additionally use an absolute value for the CNAME host, effectively ignoring any host provided when applying the template. (see note on absolute trailing dot here: https://github.com/Domain-Connect/spec/blob/master/Domain%20Connect%20Spec%20Draft.adoc#53-template-record)

The `host` field for the "REDIR301", may not do anything, as its unclear from the docs whether it is considered for a REDIR301 context (though other templates use it), but it specifies an absolute host as well, effectively hard coding the redirect to be from %domain% > www.%domain%.  In the event that host is ignored here, it's not a big deal because we dont pass a host when applying so the end result will be the same.  It's more for correctness of the template.

Additionally, a second, subdomain specific template was created.  This template will only be applied to subdomains (ie. photos.mysite.org).  There is no redirect associated with it.

Other changes:
- Updated `logoUrl` to SmugMug hosted
- Added `syncRedirectDomain` entries