### PR TITLE
[SmugMug] fix redirect target

### DIFF
--- a/smugmug.com.custom-domain.json
+++ b/smugmug.com.custom-domain.json
@@ -3,14 +3,14 @@
    "providerName": "SmugMug",
    "serviceId": "custom-domain",
    "serviceName": "SmugMug Custom Domain",
-   "version": 3,
+   "version": 4,
    "logoUrl": "https://cdn.smugmug.com/img/domain-connect/smugmug-logo.png",
    "description": "Enables a domain to work with SmugMug",
    "syncRedirectDomain": "smugmug.com, smugmug.net",
    "records": [
       {
          "type": "REDIR301",
-         "target": "www.%domain%",
+         "target": "https://www.%domain%",
          "host": "%domain%."
       },
       {


### PR DESCRIPTION
target needs to be a url, not just a domain.  SmugMug provides certs, so hard-coding https is fine.

https://github.com/Domain-Connect/Templates/pull/552#discussion_r1735312593