### PR TITLE
update syncRedirectDomain to be FQDN

### DIFF
--- a/smugmug.com.custom-domain.json
+++ b/smugmug.com.custom-domain.json
@@ -3,10 +3,10 @@
    "providerName": "SmugMug",
    "serviceId": "custom-domain",
    "serviceName": "SmugMug Custom Domain",
-   "version": 4,
+   "version": 5,
    "logoUrl": "https://cdn.smugmug.com/img/domain-connect/smugmug-logo.png",
    "description": "Enables a domain to work with SmugMug",
-   "syncRedirectDomain": "smugmug.com, smugmug.net",
+   "syncRedirectDomain": "www.smugmug.com",
    "records": [
       {
          "type": "REDIR301",

--- a/smugmug.com.custom-subdomain.json
+++ b/smugmug.com.custom-subdomain.json
@@ -3,10 +3,10 @@
   "providerName": "SmugMug",
   "serviceId": "custom-subdomain",
   "serviceName": "SmugMug Custom Domain",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://cdn.smugmug.com/img/domain-connect/smugmug-logo.png",
   "description": "Enables a domain to work with SmugMug",
-  "syncRedirectDomain": "smugmug.com, smugmug.net",
+  "syncRedirectDomain": "www.smugmug.com",
   "hostRequired": true,
   "records": [
     {


### PR DESCRIPTION
This needs to be a fully qualified domain, not a root domain, according to GoDaddy.  The spec is ambiguous here.