### PR TITLE
Add domchekr.com.domaincheck.json template

### DIFF
--- a/domchekr.com.domaincheck.json
+++ b/domchekr.com.domaincheck.json
@@ -10,6 +10,7 @@
   "syncBlock": false,
   "syncPubKeyDomain": "dc.domchekr.com",
   "syncRedirectDomain": "dc.domchekr.com",
+  "multiInstance": true,
   "records": [
     {
       "groupId": "verification",

--- a/domchekr.com.domaincheck.json
+++ b/domchekr.com.domaincheck.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "domchekr.com",
+  "providerName": "DomChekr",
+  "serviceId": "domaincheck",
+  "serviceName": "Domain Check",
+  "version": 1,
+  "logoUrl": "https://www.domchekr.com/logo.png",
+  "description": "Enables a domain to be verified with DomChekr",
+  "variableDescription": "Unique verification code provided for purpose of verification",
+  "syncBlock": false,
+  "syncPubKeyDomain": "dc.domchekr.com",
+  "syncRedirectDomain": "dc.domchekr.com",
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "@",
+      "data": "domchekr-verification=%verifytxt%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Add a template verification for domchekr.com. This template will be used with several DNS Providers including Cloudflare for domains verification.