### PR TITLE
Add KeyAuth.com

### DIFF
--- a/keyauth.com.panel-custom-domains.json
+++ b/keyauth.com.panel-custom-domains.json
@@ -1,0 +1,24 @@
+{
+    "providerId": "keyauth.com",
+    "providerName": "KeyAuth",
+    "serviceId": "panel-custom-domains",
+    "serviceName": "KeyAuth",
+    "version": 1,
+    "logoUrl": "https://cdn.keyauth.cc/v2/assets/media/logos/logo-1-dark.png",
+    "description": "Enables a domain to work with KeyAuth customer panel",
+    "syncPubKeyDomain": "keyauth.cc",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "%cnamehost%",
+            "pointsTo": "panel.keyauth.com",
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_cf-custom-hostname",
+            "ttl": 3600,
+            "data": "%verifytxt%"
+        }
+    ]
+}


### PR DESCRIPTION
We would like to allow our customers to use DomainConnect to seamlessly setup their custom domains for our service's self user-management portal.

Example: https://panel02.nelsoncybersecurity.com

I confirm it's intentional that `syncPubKeyDomain` and `logoUrl` don't match exactly to `providerId`. Cloudflare's custom hostnames for SaaS product doesn't appear to allow multiple different use-cases, it only allows 1 use-case per domain which has already been used.

Thank you for your time, I appreciate it.

![image](https://github.com/user-attachments/assets/0d737c62-a003-46e3-845b-6b6aebfdc58b)

