### PR TITLE
Lightfunnels domain-connect template

### DIFF
--- a/lightfunnels.com.website.json
+++ b/lightfunnels.com.website.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "lightfunnels.com",
+  "providerName": "LightFunnels",
+  "serviceId": "website",
+  "serviceName": "LightFunnels",
+  "version": 1,
+  "logoUrl": "https://www.lightfunnels.com/images/lightfunnels-logo.svg",
+  "description": "Enables a domain to work with LightFunnels",
+  "variableDescription": "v1 is the subdomain prefix",
+  "records": [
+      {
+        "type": "CNAME",
+        "host": "www",
+        "pointsTo": "shop.mylightfunnels.com",
+        "ttl": 3600
+      },
+      {
+        "type": "CNAME",
+        "host": "%v1%",
+        "pointsTo": "shop.mylightfunnels.com",
+        "ttl": 3600
+      }
+    ]
+}


### PR DESCRIPTION
# Description

This pull request adds a Domain Connect template for LightFunnels, enabling users to easily connect their custom domain to their LightFunnels shop. The template includes CNAME records for the www subdomain and custom subdomains, simplifying the domain configuration process for LightFunnels users

## Type of change

Please mark options that are relevant.

- [X] New template

# How Has This Been Tested?

Please mark the following checks done
- [X] Schema validated using JSON Schema [template.schema](./template.schema)
- [X] Template functionality checked using [Online Editor](https://pdnsadmin.revproxy.short-lived.de/dc/free/templateedit)
- [ ] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
v1: aaa
```
