### PR TITLE
Create sidemail.io.domain-auth.json

### DIFF
--- a/sidemail.io.domain-auth.json
+++ b/sidemail.io.domain-auth.json
@@ -1,0 +1,25 @@
+{
+	"providerId": "sidemail.io",
+	"providerName": "Sidemail.io",
+	"serviceId": "domain-auth",
+	"serviceName": "Sidemail.io Domain Authentication",
+	"description": "This template sets up the necessary DNS records for Sidemail.io domain authentication, including DKIM and sending domain configurations.",
+	"version": 1,
+	"logoUrl": "https://sidemail.io/assets/logo.png",
+	"syncPubKeyDomain": "sidemail.io",
+	"syncRedirectDomain": "sidemail.io, api.sidemail.io",
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "%DKIM_HOSTNAME%",
+			"pointsTo": "%DKIM_HOSTNAME_POINTS_TO%",
+			"ttl": 1800
+		},
+		{
+			"type": "CNAME",
+			"host": "%SENDING_DOMAIN%",
+			"pointsTo": "%SENDING_DOMAIN_POINTS_TO%",
+			"ttl": 1800
+		}
+	]
+}


### PR DESCRIPTION
# Description

Initial creation of the Domain Connect template for Sidemail.io to provide simpler DNS configuration for our users for email sending.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://pdnsadmin.revproxy.short-lived.de/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
