### PR TITLE
create resend.com template

### DIFF
--- a/resend.com.mail.json
+++ b/resend.com.mail.json
@@ -17,15 +17,15 @@
 			"priority": 10
 		},
 		{
-			"type": "TXT",
+			"type": "SPFM",
 			"host": "send",
 			"ttl": 3600,
-			"data": "v=spf1 include:amazonses.com ~all"
+			"spfRules": "include:amazonses.com"
 		},
 		{
 			"type": "TXT",
 			"host": "send",
-			"ttl": 0,
+			"ttl": 3600,
 			"data": "p=%domainKey%"
 		}
 	]

--- a/resend.com.mail.json
+++ b/resend.com.mail.json
@@ -1,0 +1,32 @@
+{
+	"providerId": "resend.com",
+	"providerName": "Resend",
+	"serviceId": "mail",
+	"serviceName": "Mail",
+	"version": 1,
+	"syncPubKeyDomain": "resend.com",
+	"syncRedirectDomain": "resend.com",
+	"description": "Enable email signing and specify authorized senders.",
+	"logoUrl": "https://resend.com/static/brand/resend-wordmark-black.svg",
+	"records": [
+		{
+			"type": "MX",
+			"host": "send",
+			"pointsTo": "feedback-smtp.%region%.amazonses.com",
+			"ttl": 3600,
+			"priority": 10
+		},
+		{
+			"type": "TXT",
+			"host": "send",
+			"ttl": 3600,
+			"data": "v=spf1 include:amazonses.com ~all"
+		},
+		{
+			"type": "TXT",
+			"host": "send",
+			"ttl": 0,
+			"data": "p=%domainKey%"
+		}
+	]
+}


### PR DESCRIPTION
# Description

Creation of the Domain Connect template for resend.com to enable email signing and specify authorized senders.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [ ] Template functionality checked using [Online Editor](https://pdnsadmin.revproxy.short-lived.de/dc/free/templateedit)
- [ ] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
region: us-east-1
publicKey: RANDOM-VALUE
```
