### PR TITLE
fix: resend host domain key

### DIFF
--- a/resend.com.mail.json
+++ b/resend.com.mail.json
@@ -3,7 +3,7 @@
 	"providerName": "Resend",
 	"serviceId": "mail",
 	"serviceName": "Mail",
-	"version": 1,
+	"version": 2,
 	"syncPubKeyDomain": "resend.com",
 	"syncRedirectDomain": "resend.com",
 	"description": "Enable email signing and specify authorized senders.",

--- a/resend.com.mail.json
+++ b/resend.com.mail.json
@@ -24,7 +24,7 @@
 		},
 		{
 			"type": "TXT",
-			"host": "send",
+			"host": "resend._domainkey",
 			"ttl": 3600,
 			"data": "p=%domainKey%"
 		}


### PR DESCRIPTION
# Description

Fix an issue where the domain key was using the wrong host value. 

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [ ] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
region: us-east-1
publicKey: RANDOM-VALUE
```
