### PR TITLE
Create vercel.com template

### DIFF
--- a/vercel.com.website.json
+++ b/vercel.com.website.json
@@ -9,18 +9,21 @@
   "records": [
     {
       "type": "TXT",
+      "groupId": "verification",
       "host": "_vercel",
       "data": "vc-domain-verify=%verification%",
       "ttl": 3600
     },
     {
       "type":"CNAME",
+      "groupId": "subdomain",
       "host": "%subdomain%",
       "pointsTo": "cname.vercel-dns.com",
       "ttl":3600
     },
     {
       "type": "A",
+      "groupId": "apex",
       "host": "@",
       "pointsTo": "76.76.21.21",
       "ttl": 3600

--- a/vercel.com.website.json
+++ b/vercel.com.website.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "vercel.com",
+  "providerName": "Vercel",
+  "serviceId": "website",
+  "serviceName": "Vercel Websites",
+  "version": 1,
+  "logoUrl": "https://vercel.com/favicon.ico",
+  "description": "Enables a domain to work with Vercel",
+  "variableDescription": "Required variables: \n- verification_token: Domain verification token\n- subdomain: The subdomain to configure",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_vercel",
+      "data": "vc-domain-verify=%verification_token%",
+      "ttl": 300,
+      "essential": "OnApply"
+    },
+    {
+      "type":"CNAME",
+      "host": "%subdomain%",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl":3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 3600
+    }
+  ]
+}

--- a/vercel.com.website.json
+++ b/vercel.com.website.json
@@ -4,16 +4,14 @@
   "serviceId": "website",
   "serviceName": "Vercel Websites",
   "version": 1,
-  "logoUrl": "https://vercel.com/favicon.ico",
   "description": "Enables a domain to work with Vercel",
-  "variableDescription": "Required variables: \n- verification_token: Domain verification token\n- subdomain: The subdomain to configure",
+  "syncPubKeyDomain": "domainconnect.vercel.com",
   "records": [
     {
       "type": "TXT",
       "host": "_vercel",
-      "data": "vc-domain-verify=%verification_token%",
-      "ttl": 300,
-      "essential": "OnApply"
+      "data": "vc-domain-verify=%verification%",
+      "ttl": 3600
     },
     {
       "type":"CNAME",


### PR DESCRIPTION
# Description

Hey, we're setting up domain connect to make it easier for our users to add domains

When a user is configuring a domain on Vercel, there's 3 fields they need to set:

1. TXT Verification - The user may need to do this to prove ownership of their domain, optional
2. CNAME Record - Only used if the user is adding a subdomain
3. A Record - Only used if the user is adding an apex domain

Here's an example of the types of states the domain config can be in:
![image](https://github.com/user-attachments/assets/e5380d0d-bcfb-4fec-8c40-27f2d7e4aa1d)

I'm also working on getting us setup as a DNS Provider with Domain Connect support as well

Thanks for taking a look at the PR, let me know any fixes that need to be made

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Schema validated using JSON Schema [template.schema](./template.schema)
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
verification: cloudflare.com,99d313170ac2cfc82c10
subdomain: www
```
