### PR TITLE
Adding SMTPKit.com Template

### DIFF
--- a/smtpkit.com.domain-auth.json
+++ b/smtpkit.com.domain-auth.json
@@ -18,10 +18,10 @@
         "ttl": 3600
       },
       {
-        "groupId": "spf",
-        "type": "TXT",
+        "groupId": "spfm",
+        "type": "SPFM",
+        "spfRules": "v=spf1 a mx include:smtpkit.com  include:*.smtpkit.com -all",
         "host": "@",
-        "data": "%spf_value%",
         "ttl": 3600
       },
       {

--- a/smtpkit.com.domain-auth.json
+++ b/smtpkit.com.domain-auth.json
@@ -20,7 +20,7 @@
       {
         "groupId": "spfm",
         "type": "SPFM",
-        "spfRules": "v=spf1 a mx include:smtpkit.com  include:*.smtpkit.com -all",
+        "spfRules": "v=spf1 a mx include:smtpkit.com include:smtp.smtpkit.com -all",
         "host": "@",
         "ttl": 3600
       },

--- a/smtpkit.com.domain-auth.json
+++ b/smtpkit.com.domain-auth.json
@@ -18,9 +18,8 @@
         "ttl": 3600
       },
       {
-        "groupId": "spfm",
         "type": "SPFM",
-        "spfRules": "v=spf1 a mx include:smtpkit.com include:smtp.smtpkit.com -all",
+        "spfRules": "%spfm_value%",
         "host": "@",
         "ttl": 3600
       },

--- a/smtpkit.com.domain-auth.json
+++ b/smtpkit.com.domain-auth.json
@@ -1,0 +1,44 @@
+{
+    "providerId": "smtpkit.com",
+    "providerName": "SMTPKit",
+    "serviceId": "domain-auth",
+    "serviceName": "SMTPKit Domain Authentication",
+    "version": 1,
+    "syncPubKeyDomain": "smtpkit.com",
+    "syncRedirectDomain": "sync.smtpkit.com",
+    "logoUrl": "https://smtpkit.com/assets/media/logo/android-icon-192x192.png",
+    "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by SMTPKit on behalf of the user",
+    "variableDescription": "The variable %smtpkit_code% represents a combination of prefix string and a MD5 hash. %spf_value% is the SPF value. %dkim_selector% and %dkim_selector2% is the DKIM selector for placing the DKIM public key. This needs to be a variable because the selector is dynamically generated. %dkim_public_key% is the DKIM public key. %dmarc_value% is dmarc value.",
+    "records": [
+      {
+        "groupId": "smtpkit_code",
+        "type": "TXT",
+        "host": "@",
+        "data": "%smtpkit_code%",
+        "ttl": 3600
+      },
+      {
+        "groupId": "spf",
+        "type": "TXT",
+        "host": "@",
+        "data": "%spf_value%",
+        "ttl": 3600
+      },
+      {
+        "groupId": "dkim_raw",
+        "type": "TXT",
+        "host": "%dkim_selector%._domainkey",
+        "data": "%dkim_public_key%",
+        "ttl": 3600
+      },
+      {
+        "groupId": "dmarc",
+        "type": "TXT",
+        "host": "_dmarc",
+        "data": "%dmarc_value%",
+        "ttl": 3600,
+        "txtConflictMatchingMode": "All",
+        "essential": "OnApply"
+      }
+    ]
+  }

--- a/smtpkit.com.domain-auth.json
+++ b/smtpkit.com.domain-auth.json
@@ -8,7 +8,7 @@
     "syncRedirectDomain": "sync.smtpkit.com",
     "logoUrl": "https://smtpkit.com/assets/media/logo/android-icon-192x192.png",
     "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by SMTPKit on behalf of the user",
-    "variableDescription": "The variable %smtpkit_code% represents a combination of prefix string and a MD5 hash. %spf_value% is the SPF value. %dkim_selector% and %dkim_selector2% is the DKIM selector for placing the DKIM public key. This needs to be a variable because the selector is dynamically generated. %dkim_public_key% is the DKIM public key. %dmarc_value% is dmarc value.",
+    "variableDescription": "The variable %smtpkit_code% represents a combination of prefix string and a MD5 hash.  %dkim_selector% and %dkim_selector2% is the DKIM selector for placing the DKIM public key. This needs to be a variable because the selector is dynamically generated. %dkim_public_key% is the DKIM public key. %dmarc_value% is dmarc value.",
     "records": [
       {
         "groupId": "smtpkit_code",

--- a/smtpkit.com.domain-auth.json
+++ b/smtpkit.com.domain-auth.json
@@ -1,43 +1,44 @@
 {
-    "providerId": "smtpkit.com",
-    "providerName": "SMTPKit",
-    "serviceId": "domain-auth",
-    "serviceName": "SMTPKit Domain Authentication",
-    "version": 1,
-    "syncPubKeyDomain": "smtpkit.com",
-    "syncRedirectDomain": "sync.smtpkit.com",
-    "logoUrl": "https://smtpkit.com/assets/media/logo/android-icon-192x192.png",
-    "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by SMTPKit on behalf of the user",
-    "variableDescription": "The variable %smtpkit_code% represents a combination of prefix string and a MD5 hash.  %dkim_selector% and %dkim_selector2% is the DKIM selector for placing the DKIM public key. This needs to be a variable because the selector is dynamically generated. %dkim_public_key% is the DKIM public key. %dmarc_value% is dmarc value.",
-    "records": [
-      {
-        "groupId": "smtpkit_code",
-        "type": "TXT",
-        "host": "@",
-        "data": "%smtpkit_code%",
-        "ttl": 3600
-      },
-      {
-        "type": "SPFM",
-        "spfRules": "%spfm_value%",
-        "host": "@",
-        "ttl": 3600
-      },
-      {
-        "groupId": "dkim_raw",
-        "type": "TXT",
-        "host": "%dkim_selector%._domainkey",
-        "data": "%dkim_public_key%",
-        "ttl": 3600
-      },
-      {
-        "groupId": "dmarc",
-        "type": "TXT",
-        "host": "_dmarc",
-        "data": "%dmarc_value%",
-        "ttl": 3600,
-        "txtConflictMatchingMode": "All",
-        "essential": "OnApply"
-      }
-    ]
-  }
+  "providerId": "smtpkit.com",
+  "providerName": "SMTPKit",
+  "serviceId": "domain-auth",
+  "serviceName": "SMTPKit Domain Authentication",
+  "version": 1,
+  "syncPubKeyDomain": "smtpkit.com",
+  "syncRedirectDomain": "sync.smtpkit.com",
+  "logoUrl": "https://smtpkit.com/assets/media/logo/android-icon-192x192.png",
+  "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by SMTPKit on behalf of the user",
+  "variableDescription": "The variable %smtpkit_code% represents a combination of prefix string and a MD5 hash.  %dkim_selector% and %dkim_selector2% is the DKIM selector for placing the DKIM public key. This needs to be a variable because the selector is dynamically generated. %dkim_public_key% is the DKIM public key. %dmarc_value% is dmarc value.",
+  "records": [
+    {
+      "groupId": "smtpkit_code",
+      "type": "TXT",
+      "host": "@",
+      "data": "%smtpkit_code%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "spfRules": "include:smtpkit.com",
+      "host": "@",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim_raw",
+      "type": "TXT",
+      "host": "%dkim_selector%._domainkey",
+      "data": "%dkim_public_key%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarc_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
Add smtpkit.com template

# Description

Aiming to enhance our domain validation services, the SMTPKit team is submitting this template to streamline integration with Domain Connect. This addition ensures a smoother and more standardized implementation, improving compatibility with the platform’s services.

We appreciate your review and are available for any necessary adjustments.

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [ ] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
<-- to make review process easier please provide example set of variable values for this template -->

<-- Example: -->

```
smtpkit_code: smtpkit-code:4e22f31e3032e7e7d86df7cabc1b8e24
dkim_selector: mail
dkim_public_key: v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7vJ/Dgoaedp367Fc2xSwzq0liCrVTmLtGGa31D9V0NGu2usNFI+7sGyQQuSjfAsZvFJEdIHIDjA352hKFNuSwRL/517Q114x//alUCwvOx9n//b12N1Y0KGEpBvIDLWGgd1kpcN80Cowx0RLCxOB6KnUxsD0PBNknE5Uxjv9B1QIDAQAB
dmarc_value: v=DMARC1; p=quarantine; pct=100
```

<-- Or provide the whole `testData` object from the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) after testing and using "Add as test" button -->
```
 "testData": {
    "Test data": {
      "variables": {
        "domain": "2jdev.com",
        "smtpkit_code": "smtpkit-code:4e22f31e3032e7e7d86df7cabc1b8e24",
        "dkim_selector": "mail",
        "dkim_public_key": "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7vJ/Dgoaedp367Fc2xSwzq0liCrVTmLtGGa31D9V0NGu2usNFI+7sGyQQuSjfAsZvFJEdIHIDjA352hKFNuSwRL/517Q114x//alUCwvOx9n//b12N1Y0KGEpBvIDLWGgd1kpcN80Cowx0RLCxOB6KnUxsD0PBNknE5Uxjv9B1QIDAQAB",
        "dmarc_value": "v=DMARC1; p=quarantine; pct=100"
      },
      "results": [
        {
          "type": "TXT",
          "name": "@",
          "ttl": 3600,
          "data": "\"smtpkit-code:4e22f31e3032e7e7d86df7cabc1b8e24\""
        },
        {
          "type": "TXT",
          "name": "@",
          "ttl": 6000,
          "data": "\"v=spf1 include:smtpkit.com ~all\""
        },
        {
          "type": "TXT",
          "name": "mail._domainkey",
          "ttl": 3600,
          "data": "\"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7vJ/Dgoaedp367Fc2xSwzq0liCrVTmLtGGa31D9V0NGu2usNFI+7sGyQQuSjfAsZvFJEdIHIDjA352hKFNuSwRL/517Q114x//alUCwvOx9n//b12N1Y0KGEpBvIDLWGgd1kpcN80Cowx0RLCxOB6KnUxsD0PBNknE5Uxjv9B1QIDAQAB\""
        },
        {
          "type": "TXT",
          "name": "_dmarc",
          "ttl": 3600,
          "data": "\"v=DMARC1; p=quarantine; pct=100\""
        }
      ]
    }
  }
```
