### PR TITLE
Create informaten.com.gameserver_generic.json

### DIFF
--- a/informaten.com.gameserver_generic.json
+++ b/informaten.com.gameserver_generic.json
@@ -7,11 +7,11 @@
   "syncPubKeyDomain": "informaten.com",
   "logoUrl": "https://informaten.com/assets/logo_dark.png",
   "description": "Connect a domain to a gameserver running on informaten.com",
-  "variableDescription": "host and ip are used to create an A record for the service which is required as the target for the SRV record, The other variables for SRV and ttl should be self-explanatory.",
+  "variableDescription": "randomnumber is a positive int to allow multiple services, The other variables for SRV and ttl should be self-explanatory.",
   "records": [
     {
       "type": "A",
-      "host": "%host%",
+      "host": "%service%-%randomnumber%",
       "pointsTo": "%ip%",
       "essential": "Always",
      "ttl": "%ttl%"
@@ -23,7 +23,7 @@
       "priority": "%priority%",
       "weight": "%weight%",
       "port": "%port%",
-      "target": "%host%.%fqdn%.",
+      "target": "@",
       "essential": "Always",
       "ttl": "%ttl%"
     }

--- a/informaten.com.gameserver_generic.json
+++ b/informaten.com.gameserver_generic.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "informaten.com",
+  "providerName": "Informaten",
+  "serviceId": "gameserver_generic",
+  "serviceName": "Gameserver on Informaten.com",
+  "version": 1,
+  "syncPubKeyDomain": "informaten.com",
+  "logoUrl": "https://informaten.com/assets/logo_dark.png",
+  "description": "Connect a domain to a gameserver running on informaten.com",
+  "variableDescription": "host and ip are used to create an A record for the service which is required as the target for the SRV record, The other variables for SRV and ttl should be self-explanatory.",
+  "records": [
+    {
+      "type": "A",
+      "host": "%host%",
+      "pointsTo": "%ip%",
+      "essential": "Always",
+     "ttl": "%ttl%"
+    }, {
+      "type": "SRV",
+      "name": "@",
+      "service": "%service%",
+      "protocol": "%protocol%",
+      "priority": "%priority%",
+      "weight": "%weight%",
+      "port": "%port%",
+      "target": "%host%.%fqdn%.",
+      "essential": "Always",
+      "ttl": "%ttl%"
+    }
+  ]
+}

--- a/informaten.com.gameserver_generic.json
+++ b/informaten.com.gameserver_generic.json
@@ -7,11 +7,11 @@
   "syncPubKeyDomain": "informaten.com",
   "logoUrl": "https://informaten.com/assets/logo_dark.png",
   "description": "Connect a domain to a gameserver running on informaten.com",
-  "variableDescription": "randomnumber is a positive int to allow multiple services, The other variables for SRV and ttl should be self-explanatory.",
+  "variableDescription": "servicesubdomain is the host of the A record. In the most cases, this is equal to %service% but there are some cases, there the need a different host. The other variables for SRV and ttl should be self-explanatory.",
   "records": [
     {
       "type": "A",
-      "host": "%service%-%randomnumber%",
+      "host": "%servicesubdomain%",
       "pointsTo": "%ip%",
       "essential": "Always",
      "ttl": "%ttl%"
@@ -23,7 +23,7 @@
       "priority": "%priority%",
       "weight": "%weight%",
       "port": "%port%",
-      "target": "@",
+      "target": "%servicesubdomain%.%fqdn%.",
       "essential": "Always",
       "ttl": "%ttl%"
     }


### PR DESCRIPTION
# Description

The new template should simplify the connection of custom domains to our gameservers (Minecraft, FimeM etc.) .

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)

RESOLVED:
I was not able to test the template in the online editor because it doesn't support variables for numeric fields like ttl or the SRV parameters.


- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)

The linter shows a warning for the SRV protocol variable saying that the value is invalid. But according to the example in this repository (README) and the spec, this sould be no problem-

- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`


# Example variable values
```
servicesubdomain: mc
protocol: tcp
service: minecraft
```

