### PR TITLE
Add Better Stack status page template

### DIFF
--- a/betterstack.com.status-page.json
+++ b/betterstack.com.status-page.json
@@ -1,0 +1,19 @@
+{
+    "providerId": "betterstack.com",
+    "providerName": "Better Stack",
+    "serviceId": "status-page",
+    "serviceName": "Status page",
+    "version": 1,
+    "logoUrl": "https://betterstack.com/static/images/better-stack-logo.png",
+    "description": "Configures a sub-domain for use as a Better Stack status page",
+    "syncPubKeyDomain": "betterstack.com",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "statuspage.betteruptime.com",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

H! At Better Stack, we're implementing Domain Connect so that users can easily add CNAME records for status pages on their own domains. This PR adds a template to allow that.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

The template doesn't use any variables.
