### PR TITLE
Create tinkerhost.net.th-sslverify.json

### DIFF
--- a/tinkerhost.net.th-sslverify.json
+++ b/tinkerhost.net.th-sslverify.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "tinkerhost.net",
+  "providerName": "TinkerHost",
+  "serviceId": "th-sslverify",
+  "serviceName": "TinkerHost Hosting",
+  "version": 1,
+  "syncPubKeyDomain": "domainconnect.tinkerhost.net",
+  "syncRedirectDomain": "app.tinkerhost.net",
+  "logoUrl": "https://app.tinkerhost.net/assets/image/th.svg",
+  "description": "Verifies a domain name for SSL Certificates via the ACME protocol",
+  "variableDescription": "id is a unique identifier for a certificate order",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%id%.acme.sslmgmt.tinkerhost.net",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adding template for SSL verification for TinkerHost's SSL v2 (ACME)

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
id: 9221740362670
id: 9701740362602
id: 2147483647
```

```
"testData": {
    "demo1": {
      "variables": {
        "domain": "tinkerhost.net",
        "host": "formboost.xyz",
        "id": "2147483647"
      },
      "results": [
        {
          "type": "CNAME",
          "name": "_acme-challenge.formboost.xyz",
          "ttl": 3600,
          "data": "2147483647.acme.sslmgmt.tinkerhost.net"
        }
      ]
    }
  }
```
