### PR TITLE
Add theMarketer.com template

### DIFF
--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -23,7 +23,6 @@
       "type":"SPFM",
       "host":"@",
       "spfRules":"include:amazonses.com",
-      "txtConflictMatchingMode": "All",
       "ttl":300
     },
     {
@@ -80,7 +79,6 @@
       "type":"SPFM",
       "host":"%mailfrom_host%",
       "spfRules":"include:amazonses.com",
-      "txtConflictMatchingMode": "All",
       "ttl":300
     },
     {
@@ -89,7 +87,7 @@
       "host":"%mailfrom_mx_host%",
       "priority":10,
       "pointsTo":"%mailfrom_mx_value%",
-      "ttl":3600
+      "ttl":300
     }
   ]
 }

--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -22,7 +22,7 @@
       "groupId":"spf",
       "type":"SPFM",
       "host":"@",
-      "spfRules":"include:amazonses.com ~all",
+      "spfRules":"include:amazonses.com",
       "txtConflictMatchingMode": "All",
       "ttl":300
     },
@@ -79,7 +79,7 @@
       "groupId":"mailfrom",
       "type":"SPFM",
       "host":"%mailfrom_host%",
-      "spfRules":"include:amazonses.com ~all",
+      "spfRules":"include:amazonses.com",
       "txtConflictMatchingMode": "All",
       "ttl":300
     },

--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -1,0 +1,95 @@
+{
+  "providerId": "themarketer.com",
+  "providerName": "theMarketer",
+  "serviceId": "domain-validation",
+  "serviceName": "theMarketer Domain Validation",
+  "syncPubKeyDomain": "themarketer.com",
+  "syncRedirectDomain": "app.themarketer.com",
+  "variableDescription": "",
+  "version": 1,
+  "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by theMarketer.com on behalf of the user",
+  "logoUrl": "https://app.themarketer.com/_nuxt/img/logo.cad7c7f.svg",
+  "records": [
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; adkim=r; aspf=r; pct=0;",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All",
+    },
+    {
+      "groupId":"spf",
+      "type":"SPFM",
+      "host":"@",
+      "spfRules":"include:amazonses.com ~all",
+      "txtConflictMatchingMode": "All",
+      "ttl":300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_selector%._domainkey",
+      "pointsTo": "%dkim_value%",
+      "ttl": 300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_selector2%._domainkey",
+      "pointsTo": "%dkim_value2%",
+      "ttl": 300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_selector3%._domainkey",
+      "pointsTo": "%dkim_value3%",
+      "ttl": 300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_selector4%._domainkey",
+      "pointsTo": "%dkim_value4%",
+      "ttl": 300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_selector5%._domainkey",
+      "pointsTo": "%dkim_value5%",
+      "ttl": 300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_selector6%._domainkey",
+      "pointsTo": "%dkim_value6%",
+      "ttl": 300
+    },
+    {
+      "groupId": "redirect",
+      "type": "CNAME",
+      "host": "%redirect_host%",
+      "pointsTo": "%redirect_value%",
+      "ttl": 300
+    },
+    {
+      "groupId":"mailfrom",
+      "type":"SPFM",
+      "host":"%mailfrom_host%",
+      "spfRules":"include:amazonses.com ~all",
+      "txtConflictMatchingMode": "All",
+      "ttl":300
+    },
+    {
+      "groupId":"mailfrom",
+      "type":"MX",
+      "host":"%mailfrom_mx_host%",
+      "priority":10,
+      "pointsTo":"%mailfrom_mx_value%",
+      "ttl":3600
+    }
+  ]
+}

--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -16,7 +16,7 @@
       "host": "_dmarc",
       "data": "v=DMARC1; p=none; adkim=r; aspf=r; pct=0;",
       "ttl": 300,
-      "txtConflictMatchingMode": "All",
+      "txtConflictMatchingMode": "All"
     },
     {
       "groupId":"spf",


### PR DESCRIPTION
# Description

We would like to ease the process of adding DNS records required by theMarketer for domain validation through Cloudflare.

## Type of change

Please mark options that are relevant.

- [ X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ X] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [ X] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
<-- to make review process easier please provide example set of variable values for this template -->

"testData": {
    "themarketer": {
      "variables": {
        "domain": "extradom3.ro",
        "dkim_selector": "7kv3xhoa75mvuwh5pta4ipcfu257qgml",
        "dkim_value": "7kv3xhoa75mvuwh5pta4ipcfu257qgml.dkim.amazonses.com",
        "dkim_selector2": "x57xjpdcsnh25lyceerscwkol2jhnkhy",
        "dkim_value2": "x57xjpdcsnh25lyceerscwkol2jhnkhy.dkim.amazonses.com",
        "dkim_selector3": "fhh4kg2s5b24rglraxhayapmchnbbgs7",
        "dkim_value3": "fhh4kg2s5b24rglraxhayapmchnbbgs7.dkim.amazonses.com",
        "dkim_selector4": "ddxs44yogrxpljmfrzgtyda3txhvhajr",
        "dkim_value4": "ddxs44yogrxpljmfrzgtyda3txhvhajr.dkim.amazonses.com",
        "dkim_selector5": "gz5amewwf3zmmzhjh2l7rgnis3mtqjz4",
        "dkim_value5": "gz5amewwf3zmmzhjh2l7rgnis3mtqjz4.dkim.amazonses.com",
        "dkim_selector6": "xdu3yyzbs6yelq3dmq5tjahkm3rog7zz",
        "dkim_value6": "xdu3yyzbs6yelq3dmq5tjahkm3rog7zz.dkim.amazonses.com",
        "redirect_host": "mktr.extradom3.ro",
        "redirect_value": "api2.mktr2.com",
        "mailfrom_host": "nwl.extradom3.ro",
        "mailfrom_mx_host": "nwl.extradom3.ro",
        "mailfrom_mx_value": "feedback-smtp.eu-central-1.amazonses.com"
      },
      "results": [
        {
          "type": "TXT",
          "name": "_dmarc",
          "ttl": 300,
          "data": "\"v=DMARC1; p=none; adkim=r; aspf=r; pct=0;\""
        },
        {
          "type": "TXT",
          "name": "@",
          "ttl": 6000,
          "data": "\"v=spf1 include:amazonses.com ~all\""
        },
        {
          "type": "CNAME",
          "name": "7kv3xhoa75mvuwh5pta4ipcfu257qgml._domainkey",
          "ttl": 300,
          "data": "7kv3xhoa75mvuwh5pta4ipcfu257qgml.dkim.amazonses.com"
        },
        {
          "type": "CNAME",
          "name": "x57xjpdcsnh25lyceerscwkol2jhnkhy._domainkey",
          "ttl": 300,
          "data": "x57xjpdcsnh25lyceerscwkol2jhnkhy.dkim.amazonses.com"
        },
        {
          "type": "CNAME",
          "name": "fhh4kg2s5b24rglraxhayapmchnbbgs7._domainkey",
          "ttl": 300,
          "data": "fhh4kg2s5b24rglraxhayapmchnbbgs7.dkim.amazonses.com"
        },
        {
          "type": "CNAME",
          "name": "ddxs44yogrxpljmfrzgtyda3txhvhajr._domainkey",
          "ttl": 300,
          "data": "ddxs44yogrxpljmfrzgtyda3txhvhajr.dkim.amazonses.com"
        },
        {
          "type": "CNAME",
          "name": "gz5amewwf3zmmzhjh2l7rgnis3mtqjz4._domainkey",
          "ttl": 300,
          "data": "gz5amewwf3zmmzhjh2l7rgnis3mtqjz4.dkim.amazonses.com"
        },
        {
          "type": "CNAME",
          "name": "xdu3yyzbs6yelq3dmq5tjahkm3rog7zz._domainkey",
          "ttl": 300,
          "data": "xdu3yyzbs6yelq3dmq5tjahkm3rog7zz.dkim.amazonses.com"
        },
        {
          "type": "CNAME",
          "name": "mktr.extradom3.ro",
          "ttl": 300,
          "data": "api2.mktr2.com"
        },
        {
          "type": "TXT",
          "name": "nwl.extradom3.ro",
          "ttl": 6000,
          "data": "\"v=spf1 include:amazonses.com ~all\""
        },
        {
          "type": "MX",
          "name": "nwl.extradom3.ro",
          "ttl": 300,
          "data": "10 feedback-smtp.eu-central-1.amazonses.com"
        }
      ]
    }
  }
