### PR TITLE
Add domain verification configuration for S4E platform

### DIFF
--- a/s4e.io.domain-verification.json
+++ b/s4e.io.domain-verification.json
@@ -1,0 +1,20 @@
+{
+    "providerId": "s4e.io",
+    "providerName": "S4E",
+    "serviceId": "domain-verification",
+    "serviceName": "Domain Verification",
+    "version": 1,
+    "logoUrl": "https://static.s4e.io/web/public/img/logo/circle/white/s4e.svg",
+    "description": "Verifies domain ownership to continue scanning assets for security analysis and vulnerability detection on the S4E platform.",
+    "variableDescription": "A unique verification text is provided by S4E and should be added as a TXT record in the domain's DNS settings to complete ownership verification.",
+    "syncPubKeyDomain": "s4e.io",
+    "syncRedirectDomain": "s4e.io,app.s4e.io",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "@",
+            "data": "s4e-site-verification=%verify_text%",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Added the domain verification template for S4E to include a unique verification text for each domain. This addition ensures that each domain receives a distinct verification code during the setup process.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
domain: example.com
host: @
verify_text: 2390fdacda61c067f81dd8e4dababf9c
```

```
"testData": {
  "s4e-test": {
    "variables": {
      "domain": "example.com",
      "host": "@",
      "verify_text": "2390fdacda61c067f81dd8e4dababf9c"
    },
    "results": [
      {
        "type": "TXT",
        "name": "@",
        "ttl": 3600,
        "data": "\"s4e-site-verification=2390fdacda61c067f81dd8e4dababf9c\""
      }
    ]
  }
}
```
