### PR TITLE
add moodiycloud.com template

### DIFF
--- a/moodiycloud.com.lms-apex-cname.json
+++ b/moodiycloud.com.lms-apex-cname.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "moodiycloud.com",
+  "providerName": "MooDIYCloud.com",
+  "serviceId": "lms-apex-cname",
+  "serviceName": "MooDIYCloud Hosting",
+  "version": 1,
+  "logoUrl":"https://moodiycloud.com/logo-bg-wh.svg",
+  "description": "Enables custom domain to point to MooDIYCloud.com via APEXCNAME for LMS hosting.",
+  "syncPubKeyDomain": "domainconnect.moodiycloud.com",
+  "syncRedirectDomain": "moodiycloud.com",
+  "hostRequired": false,
+  "variableDescription": "prefix completes the fully qualified domain name that the record will point to.",
+  "records":[
+    {
+      "type": "APEXCNAME",
+      "host": "@",
+      "pointsTo":"%prefix%.moodiycloud.com",
+      "essential": "Always",
+      "ttl":600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "essential": "Always",
+      "ttl": 600
+    }
+  ]
+}

--- a/moodiycloud.com.lms-apex-cname.json
+++ b/moodiycloud.com.lms-apex-cname.json
@@ -7,7 +7,6 @@
   "logoUrl":"https://moodiycloud.com/logo-bg-wh.svg",
   "description": "Enables custom domain to point to MooDIYCloud.com via APEXCNAME for LMS hosting.",
   "syncPubKeyDomain": "domainconnect.moodiycloud.com",
-  "syncRedirectDomain": "moodiycloud.com",
   "hostRequired": false,
   "variableDescription": "prefix completes the fully qualified domain name that the record will point to.",
   "records":[
@@ -15,14 +14,12 @@
       "type": "APEXCNAME",
       "host": "@",
       "pointsTo":"%prefix%.moodiycloud.com",
-      "essential": "Always",
       "ttl":600
     },
     {
       "type": "CNAME",
       "host": "www",
       "pointsTo": "@",
-      "essential": "Always",
       "ttl": 600
     }
   ]

--- a/moodiycloud.com.lms-domain-cloudflare-cname.json
+++ b/moodiycloud.com.lms-domain-cloudflare-cname.json
@@ -1,14 +1,13 @@
 {
   "providerId": "moodiycloud.com",
   "providerName": "MooDIYCloud.com",
-  "serviceId": "lms-subdomain-cname",
+  "serviceId": "lms-domain-cloudflare-cname",
   "serviceName": "MooDIYCloud Hosting",
   "version": 1,
   "logoUrl":"https://moodiycloud.com/logo-bg-wh.svg",
-  "description": "Enables custom subdomain to point to MooDIYCloud.com via CNAME for LMS hosting.",
+  "description": "Enables custom domains/subdomain to point to MooDIYCloud.com via CNAME for LMS hosting.",
   "syncPubKeyDomain": "domainconnect.moodiycloud.com",
   "variableDescription": "prefix completes the fully qualified domain name that the record will point to.",
-  "hostRequired": true,
   "records":[
     {
       "type": "CNAME",

--- a/moodiycloud.com.lms-subdomain-cname.json
+++ b/moodiycloud.com.lms-subdomain-cname.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "moodiycloud.com",
+  "providerName": "MooDIYCloud.com",
+  "serviceId": "lms-subdomain-cname",
+  "serviceName": "MooDIYCloud Hosting",
+  "version": 1,
+  "logoUrl":"https://moodiycloud.com/logo-bg-wh.svg",
+  "description": "Enables custom subdomain to point to MooDIYCloud.com via CNAME for LMS hosting.",
+  "syncPubKeyDomain": "domainconnect.moodiycloud.com",
+  "syncRedirectDomain": "moodiycloud.com",
+  "hostRequired": true,
+  "variableDescription": "prefix completes the fully qualified domain name that the record will point to.",
+  "records":[
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo":"%prefix%.moodiycloud.com",
+      "essential": "Always",
+      "ttl":600
+    }
+  ]
+}

--- a/moodiycloud.com.lms-subdomain-cname.json
+++ b/moodiycloud.com.lms-subdomain-cname.json
@@ -7,15 +7,12 @@
   "logoUrl":"https://moodiycloud.com/logo-bg-wh.svg",
   "description": "Enables custom subdomain to point to MooDIYCloud.com via CNAME for LMS hosting.",
   "syncPubKeyDomain": "domainconnect.moodiycloud.com",
-  "syncRedirectDomain": "moodiycloud.com",
-  "hostRequired": true,
   "variableDescription": "prefix completes the fully qualified domain name that the record will point to.",
   "records":[
     {
       "type": "CNAME",
       "host": "@",
       "pointsTo":"%prefix%.moodiycloud.com",
-      "essential": "Always",
       "ttl":600
     }
   ]


### PR DESCRIPTION
# Description

We would like to ease the process of adding DNS records required for setting custom domain or subdomain with MooDIYCloud.com services.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
```
prefix: mkts1w1
```