### PR TITLE
Add clerk.com template

### DIFF
--- a/clerk.com.app.json
+++ b/clerk.com.app.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "clerk.com",
+  "providerName": "Clerk",
+  "serviceId": "app",
+  "serviceName": "Clerk Application",
+  "version": 1,
+  "description": "Enables a domain to work with Clerk",
+  "syncPubKeyDomain": "domainconnect.dashboard.clerk.com",
+  "syncRedirectDomain": "dashboard.clerk.com",
+  "records": [
+    {
+      "type":"CNAME",
+      "groupId": "auth",
+      "host": "clerk",
+      "pointsTo": "frontend-api.clerk.services",
+      "ttl":3600
+    },
+    {
+      "type":"CNAME",
+      "groupId": "auth",
+      "host": "accounts",
+      "pointsTo": "accounts.clerk.services",
+      "ttl":3600
+    },
+    {
+      "type":"CNAME",
+      "groupId": "mail",
+      "host": "clk._domainkey",
+      "pointsTo": "dkim1.%mailtoken%.clerk.services",
+      "ttl":3600
+    },
+    {
+      "type":"CNAME",
+      "groupId": "mail",
+      "host": "clk2._domainkey",
+      "pointsTo": "dkim2.%mailtoken%.clerk.services",
+      "ttl":3600
+    },
+    {
+      "type":"CNAME",
+      "groupId": "mail",
+      "host": "clkmail",
+      "pointsTo": "mail.%mailtoken%.clerk.services",
+      "ttl":3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

 

[Clerk](clerk.com) customers have to add 5 CNAME records so as to be able to deploy their Clerk application to production[1]. This templates enables us to automate this process.

[1] https://clerk.com/docs/deployments/overview#dns-records

## Type of change


- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
<-- to make review process easier please provide example set of variable values for this template -->

<-- Example: -->

```
mailtoken: acb1kxavm8s3
```