### PR TITLE
Add u301.com template

### DIFF
--- a/u301.com.bender.json
+++ b/u301.com.bender.json
@@ -1,0 +1,19 @@
+{
+    "providerId": "u301.com",
+    "providerName": "U301 URL Shortener",
+    "serviceId": "bender",
+    "serviceName": "Bender",
+    "version": 1,
+    "syncPubKeyDomain": "u301.com",
+    "syncRedirectDomain": "u301.com",
+    "logoUrl": "https://kit.u301.com/u301-logo-v2.svg",
+    "description": "Configure domain CNAME record for U301 URL Shortener.",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%cname%",
+            "ttl": 3600
+        }
+    ]
+}

--- a/u301.com.bender.json
+++ b/u301.com.bender.json
@@ -8,11 +8,12 @@
     "syncRedirectDomain": "u301.com",
     "logoUrl": "https://kit.u301.com/u301-logo-v2.svg",
     "description": "Configure domain CNAME record for U301 URL Shortener.",
+    "hostRequired": true,
     "records": [
         {
             "type": "CNAME",
             "host": "@",
-            "pointsTo": "%cname%",
+            "pointsTo": "%cname%.bender.u301.com",
             "ttl": 3600
         }
     ]

--- a/u301.com.ip.json
+++ b/u301.com.ip.json
@@ -1,0 +1,25 @@
+{
+    "providerId": "u301.com",
+    "providerName": "U301 URL Shortener",
+    "serviceId": "ip",
+    "serviceName": "ip",
+    "version": 1,
+    "syncPubKeyDomain": "u301.com",
+    "syncRedirectDomain": "u301.com",
+    "logoUrl": "https://kit.u301.com/u301-logo-v2.svg",
+    "description": "Configure domain A record for U301 URL Shortener.",
+    "records": [
+        {
+           "type":"A",
+           "host":"@",
+           "pointsTo":"%ip%",
+           "ttl":3600
+        },
+        {
+           "type":"A",
+           "host":"@",
+           "pointsTo":"%fallbackip%",
+           "ttl":3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description
Many users are unfamiliar with DNS configuration. By integrating Cloudflare via Domain Connect, our users can set up DNS with just one click, allowing them to use their own domain names for short URL services.


## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
<-- to make review process easier please provide example set of variable values for this template -->

example for `u301.com.bender.json`
```
cname: dulce118
```
example for `u301.com.ip.json`
```
ip: 47.254.3.252
fallbackip: 152.53.36.77
```

