### PR TITLE
add teachify.com template

### DIFF
--- a/teachify.com.website-arecord.json
+++ b/teachify.com.website-arecord.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "Teachify.com",
+  "providerName": "Teachify",
+  "serviceId": "website-arecord",
+  "serviceName": "Teachify Site",
+  "version": 1,
+  "syncPubKeyDomain": "domainconnect.teachify.com",
+  "logoUrl": "https://teachify.com/favicon.png",
+  "description": "Enables a domain to work with Teachify",
+  "variableDescription": "IP is the IP address for the site",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    }
+  ]
+}

--- a/teachify.com.website-cname.json
+++ b/teachify.com.website-cname.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "Teachify.com",
+  "providerName": "Teachify",
+  "serviceId": "website-cname",
+  "serviceName": "Teachify Site",
+  "version": 1,
+  "syncPubKeyDomain": "domainconnect.teachify.com",
+  "logoUrl": "https://teachify.com/favicon.png",
+  "description": "Enables a domain to work with Teachify",
+  "variableDescription": "Subdomain is the subdomain for the domain name and Prefix is the identifier for the Teachify account",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%subdomain%",
+      "pointsTo": "%prefix%.cname.myteachify.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/teachify.com.website-cname.json
+++ b/teachify.com.website-cname.json
@@ -8,10 +8,11 @@
   "logoUrl": "https://teachify.com/favicon.png",
   "description": "Enables a domain to work with Teachify",
   "variableDescription": "Subdomain is the subdomain for the domain name and Prefix is the identifier for the Teachify account",
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",
-      "host": "%subdomain%",
+      "host": "@",
       "pointsTo": "%prefix%.cname.myteachify.com",
       "ttl": 3600
     }


### PR DESCRIPTION
# Description

We would like to ease the process of adding DNS records required for setting custom domain or subdomain with teachify.com services.

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Schema validated using JSON Schema [template.schema](./template.schema)
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
prefix: user2025
subdomain: blog
```

```
ip: 34.96.87.87
```
