### PR TITLE
Changed SPF host for "mailfrom" group to "nwl" instead of %mailfrom_host% variable

### DIFF
--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -77,7 +77,7 @@
     {
       "groupId":"mailfrom",
       "type":"SPFM",
-      "host":"%mailfrom_host%",
+      "host":"nwl",
       "spfRules":"include:amazonses.com",
       "ttl":300
     },

--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -6,7 +6,7 @@
   "syncPubKeyDomain": "themarketer.com",
   "syncRedirectDomain": "app.themarketer.com",
   "variableDescription": "",
-  "version": 1,
+  "version": 2,
   "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by theMarketer.com on behalf of the user",
   "logoUrl": "https://app.themarketer.com/_nuxt/img/logo.cad7c7f.svg",
   "records": [


### PR DESCRIPTION
# Description

Changed SPF host for "mailfrom" group to "nwl" instead of %mailfrom_host% variable because Cloudflare does not recognize the %mailfrom_host% variable for SPFM records and does not add the desired SPFM record to the list of records.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [X] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
<-- to make review process easier please provide example set of variable values for this template -->

<-- Example: -->

```
var1: aaa
var2: foo.com
```

<-- Or provide the whole `testData` object from the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) after testing and using "Add as test" button -->
```
"testData": {
    "testset": {
      "variables": {
        "domain": "example.com",
        "host": "foo",
        "example": "bar"
      },
      "results": [
        {
          "type": "TXT",
          "name": "foo",
          "ttl": 86400,
          "data": "\"bar\""
        }
      ]
    }
  }
```
