### PR TITLE
Add spaceship.com template for urlredirect service

### DIFF
--- a/spaceship.com.urlredirect.json
+++ b/spaceship.com.urlredirect.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "spaceship.com",
+  "providerName": "Spaceship",
+  "serviceId": "urlredirect",
+  "serviceName": "UrlRedirect",
+  "version": 1,
+  "logoUrl": "https://spaceship-cdn.com/static/spaceship/favicon/spaceship-icon.svg",
+  "description": "Enables UrlRedirect service for 3rd party domain",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.spaceship.com",
+  "variableDescription": "%ip% is a target IP address",
+  "records": [
+    {
+      "groupId": "root",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 300
+    },
+    {
+      "groupId": "wildcard",
+      "type": "A",
+      "host": "*",
+      "pointsTo": "%ip%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

We would like to ease the process of adding DNS records required for setting custom domain or subdomain with spaceship.com services.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
> editor does not work correctly with wildcard `*`
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
```
ip: 127.0.0.1
```

