### PR TITLE
Changed the groupId for the second SPFM group

### DIFF
--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -77,7 +77,7 @@
     {
       "groupId":"mailfrom",
       "type":"SPFM",
-      "host":"%mailfrom_host%",
+      "host":"nwl",
       "spfRules":"include:amazonses.com",
       "ttl":300
     },

--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -76,11 +76,10 @@
     },
     {
       "groupId":"spfmailfrom",
-      "type":"TXT",
-      "host":"nwl",
-      "data": "v=spf1 include:amazonses.com ~all",
-      "ttl": 300,
-      "txtConflictMatchingMode": "All"
+      "type":"SPFM",
+      "host":"%mailfrom_host%",
+      "spfRules":"include:amazonses.com",
+      "ttl":300
     },
     {
       "groupId":"mailfrom",

--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -6,7 +6,7 @@
   "syncPubKeyDomain": "themarketer.com",
   "syncRedirectDomain": "app.themarketer.com",
   "variableDescription": "",
-  "version": 1,
+  "version": 2,
   "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by theMarketer.com on behalf of the user",
   "logoUrl": "https://app.themarketer.com/_nuxt/img/logo.cad7c7f.svg",
   "records": [

--- a/themarketer.com.domain-validation.json
+++ b/themarketer.com.domain-validation.json
@@ -6,7 +6,7 @@
   "syncPubKeyDomain": "themarketer.com",
   "syncRedirectDomain": "app.themarketer.com",
   "variableDescription": "",
-  "version": 2,
+  "version": 3,
   "description": "Places TXT record for domain verification and DKIM records to authenticate email sent by theMarketer.com on behalf of the user",
   "logoUrl": "https://app.themarketer.com/_nuxt/img/logo.cad7c7f.svg",
   "records": [
@@ -75,11 +75,12 @@
       "ttl": 300
     },
     {
-      "groupId":"mailfrom",
-      "type":"SPFM",
+      "groupId":"spfmailfrom",
+      "type":"TXT",
       "host":"nwl",
-      "spfRules":"include:amazonses.com",
-      "ttl":300
+      "data": "v=spf1 include:amazonses.com ~all",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
     },
     {
       "groupId":"mailfrom",


### PR DESCRIPTION
# Description

Changed the groupId for the second SPFM group

## Type of change

Please mark options that are relevant.

- [ ] New template
- [X] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Schema validated using JSON Schema [template.schema](./template.schema)
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
<-- to make review process easier please provide example set of variable values for this template -->

<-- Example: -->

```
var1: aaa
var2: foo.com
```

<-- Or provide the whole `testData` object from the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) after testing and using "Add as test" button -->
```
"testData": {
    "testset": {
      "variables": {
        "domain": "example.com",
        "host": "foo",
        "example": "bar"
      },
      "results": [
        {
          "type": "TXT",
          "name": "foo",
          "ttl": 86400,
          "data": "\"bar\""
        }
      ]
    }
  }
```
