### PR TITLE
Add Domain Connect template for Tribefii

### DIFF
--- a/services/tribefii/tribefii.site-setup.json
+++ b/services/tribefii/tribefii.site-setup.json
@@ -5,8 +5,8 @@
   "serviceName": "Tribefii Site Setup",
   "version": 2,
   "logoUrl": "https://app.tribefii.com/Images/tribefii250x250.png",
-  "description": "Connect your custom domain to your Tribefii microsite.",
-   "warnPhishing": true,
+  "description": "Connect your custom domain or subdomain to your Tribefii microsite. This setup includes both A and CNAME records.",
+  "warnPhishing": true,
   "records": [
     {
       "type": "A",
@@ -19,12 +19,36 @@
       "host": "%cnamehost%",
       "pointsTo": "app.tribefii.com",
       "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "@",
-      "data": "tribefii-verification=%verification%",
-      "ttl": 3600
     }
-  ]
+  ],
+  "variables": {
+    "cnamehost": {
+      "prompt": "Enter the subdomain prefix you want to connect (e.g., 'www', 'events')",
+      "description": "Used to create a CNAME record for the subdomain like events.yourdomain.com",
+      "mask": "^(?!@)[a-zA-Z0-9-]+$",
+      "required": true
+    }
+  },
+  "testData": {
+    "test1": {
+      "variables": {
+        "domain": "example.com",
+        "cnamehost": "douglas"
+      },
+      "results": [
+        {
+          "type": "A",
+          "name": "@",
+          "ttl": 3600,
+          "data": "52.163.103.108"
+        },
+        {
+          "type": "CNAME",
+          "name": "douglas",
+          "ttl": 3600,
+          "data": "app.tribefii.com"
+        }
+      ]
+    }
+  }
 }

--- a/services/tribefii/tribefii.site-setup.json
+++ b/services/tribefii/tribefii.site-setup.json
@@ -20,13 +20,5 @@
       "pointsTo": "app.tribefii.com",
       "ttl": 3600
     }
-  ],
-  "variables": {
-    "cnamehost": {
-      "prompt": "Enter the subdomain prefix you want to connect (e.g., 'www', 'events')",
-      "description": "Used to create a CNAME record for the subdomain like events.yourdomain.com",
-      "mask": "^(?!@)[a-zA-Z0-9-]+$",
-      "required": true
-    }
-  }
+  ]
 }

--- a/services/tribefii/tribefii.site-setup.json
+++ b/services/tribefii/tribefii.site-setup.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "tribefii",
+  "providerName": "Tribefii",
+  "serviceId": "site-setup",
+  "serviceName": "Tribefii Site Setup",
+  "version": 2,
+  "logoUrl": "https://app.tribefii.com/Images/tribefii250x250.png",
+  "description": "Connect your custom domain to your Tribefii microsite.",
+   "warnPhishing": true,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "52.163.103.108",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%cnamehost%",
+      "pointsTo": "app.tribefii.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "tribefii-verification=%verification%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/services/tribefii/tribefii.site-setup.json
+++ b/services/tribefii/tribefii.site-setup.json
@@ -28,27 +28,5 @@
       "mask": "^(?!@)[a-zA-Z0-9-]+$",
       "required": true
     }
-  },
-  "testData": {
-    "test1": {
-      "variables": {
-        "domain": "example.com",
-        "cnamehost": "douglas"
-      },
-      "results": [
-        {
-          "type": "A",
-          "name": "@",
-          "ttl": 3600,
-          "data": "52.163.103.108"
-        },
-        {
-          "type": "CNAME",
-          "name": "douglas",
-          "ttl": 3600,
-          "data": "app.tribefii.com"
-        }
-      ]
-    }
   }
 }


### PR DESCRIPTION
### Description
This PR adds a new Domain Connect template for Tribefii, allowing users to auto-configure their root domain or subdomain for use with Tribefii microsites.

---

### Type of change

- [x] New template  
- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  

---

### How Has This Been Tested?

- [x] Schema validated using JSON Schema template.schema  
- [x] Template functionality checked using Online Editor  
- [x] Template is checked using template linter  
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`  

---

### Example variable values

```json
"testData": {
  "test1": {
    "variables": {
      "domain": "example.com",
      "cnamehost": "douglas"
    },
    "results": [
      {
        "type": "A",
        "name": "@",
        "ttl": 3600,
        "data": "52.163.103.108"
      },
      {
        "type": "CNAME",
        "name": "douglas",
        "ttl": 3600,
        "data": "app.tribefii.com"
      }
    ]
  }
}
```
