### PR TITLE
feat: add new variable to Resend template

### DIFF
--- a/resend.com.mail.json
+++ b/resend.com.mail.json
@@ -3,7 +3,7 @@
 	"providerName": "Resend",
 	"serviceId": "mail",
 	"serviceName": "Mail",
-	"version": 2,
+	"version": 3,
 	"syncPubKeyDomain": "resend.com",
 	"syncRedirectDomain": "resend.com",
 	"description": "Enable email signing and specify authorized senders.",

--- a/resend.com.mail.json
+++ b/resend.com.mail.json
@@ -11,14 +11,14 @@
 	"records": [
 		{
 			"type": "MX",
-			"host": "send",
+			"host": "%spfDomain%",
 			"pointsTo": "feedback-smtp.%region%.amazonses.com",
 			"ttl": 3600,
 			"priority": 10
 		},
 		{
 			"type": "SPFM",
-			"host": "send",
+			"host": "%spfDomain%",
 			"ttl": 3600,
 			"spfRules": "include:amazonses.com"
 		},


### PR DESCRIPTION
# Description
We are introducing the capability of users to choose their own custom return-path address at Resend.

With that, we'll need to make the host field for these records a variable to match this new behavior (previously fixed as `send`).

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
```
spfDomain: bounces
region: us-east-1
domainKey: RANDOM-VALUE
```