### PR TITLE
Merge for IMH Care domain connect support

### DIFF
--- a/imh.care.whitelabel.json
+++ b/imh.care.whitelabel.json
@@ -13,43 +13,43 @@
        "type": "CNAME",
        "host": "%host1%",
        "pointsTo": "%record1%",
-       "ttl": 60
+       "ttl": 300
      },
      {
       "type": "CNAME",
       "host": "%host2%",
       "pointsTo": "%record2%",
-      "ttl": 60
+      "ttl": 300
     },
     {
       "type": "CNAME",
       "host": "%sendgridhost1%",
       "pointsTo": "%sendgridrecord1%",
-      "ttl": 60
+      "ttl": 300
     },
     {
       "type": "CNAME",
       "host": "%sendgridhost2%",
       "pointsTo": "%sendgridrecord2%",
-      "ttl": 60
+      "ttl": 300
     },
     {
       "type": "CNAME",
       "host": "%sendgridhost3%",
       "pointsTo": "%sendgridrecord3%",
-      "ttl": 60
+      "ttl": 300
     },
      {
        "type": "A",
        "host": "%host3%",
        "pointsTo": "%record3%",
-       "ttl": 60
+       "ttl": 300
      },
      {
        "type": "A",
        "host": "%host4%",
        "pointsTo": "%record4%",
-       "ttl": 60
+       "ttl": 300
      }
    ]
  }


### PR DESCRIPTION
# Description

Adding a new Domain Connect template for IMH Care's white label service. This template sets up CNAME and A records to support subdomains and email authentication.

## Type of change

[x] New template

# How Has This Been Tested?

- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)

# Example variable values
<-- Example: -->
```
host1: jupitor
record1: dev.imh.care.
host2: patient
record2: dev-pat.imh.care.
sendgridhost1: s1._domainkey
sendgridrecord1: s1.domainkey.u123456.wl.sendgrid.net.
sendgridhost2: s2._domainkey
sendgridrecord2: s2.domainkey.u123456.wl.sendgrid.net.
sendgridhost3: email
sendgridrecord3: u123456.wl.sendgrid.net.
host3: jupitor
record3: 192.0.2.1
host4: patient
record4: 192.0.2.2
```