### PR TITLE
Customer.io: Add MX params

### DIFF
--- a/customer.io.email.json
+++ b/customer.io.email.json
@@ -4,25 +4,25 @@
   "serviceId": "email",
   "serviceName": "Customer.io Email",
   "hostRequired": true,
-  "version": 2,
+  "version": 3,
   "syncBlock": false,
   "syncPubKeyDomain": "customer.io",
   "syncRedirectDomain": "customer.io",
    "logoUrl": "https://cdp-prod-us-cio-hydra-assets-us.customer.io/assets/images/logos/logo-forest.e11e5daf4d9ed5cc6860.svg",
   "description": "Enables domain to send emails on Customer.io",
-  "variableDescription": "dkim_selector refers to the prefix on the DKIM; dkim_key refers to the public key for the DKIM record",
+  "variableDescription": "dkim_selector refers to the prefix on the DKIM; dkim_key refers to the public key for the DKIM record; mx1 and mx2 refer to the values for the MX records.",
   "records": [
     {
       "type": "MX",
       "host": "@",
-      "pointsTo": "mxa.mailgun.org",
+      "pointsTo": "%mx1%",
       "priority": 10,
       "ttl": 3600
     },
     {
       "type": "MX",
       "host": "@",
-      "pointsTo": "mxb.mailgun.org",
+      "pointsTo": "%mx2%",
       "priority": 10,
       "ttl": 3600
     },


### PR DESCRIPTION
# Description

Value is not static for all customers so we'll introduce `mx1` and`mx2` params. 

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
```
 "testData": {
    "cio-test": {
      "variables": {
        "domain": "example.com",
        "host": "cio123",
        "mx1": "mxa.dc.mailgun.org",
        "mx2": "mxb.dc.mailgun.org",
        "dkim_selector": "mx",
        "dkim_key": "someFunKeyGoesHere"
      },
      "results": [
        {
          "type": "MX",
          "name": "cio123",
          "ttl": 3600,
          "data": "10 mxa.dc.mailgun.org"
        },
        {
          "type": "MX",
          "name": "cio123",
          "ttl": 3600,
          "data": "10 mxb.dc.mailgun.org"
        },
        {
          "type": "TXT",
          "name": "cio123",
          "ttl": 6000,
          "data": "\"v=spf1 include:mailgun.org ~all\""
        },
        {
          "type": "TXT",
          "name": "mx._domainkey.cio123",
          "ttl": 3600,
          "data": "\"k=rsa; p=someFunKeyGoesHere\""
        }
      ]
    }
  }
}
```
