### PR TITLE
Add cordesk.cc email template

### DIFF
--- a/cordesk.cc.email.json
+++ b/cordesk.cc.email.json
@@ -1,0 +1,35 @@
+{
+  "providerId": "cordesk.cc",
+  "providerName": "Cordesk",
+  "serviceId": "email",
+  "serviceName": "Mail",
+  "version": 1,
+  "syncPubKeyDomain": "dc.cordesk.cc",
+  "syncRedirectDomain": "cordesk.cc",
+  "logoUrl": "https://cordesk.cc/logo.svg",
+  "description": "Enables a domain to send and recieve emails with Cordesk",
+  "variableDescription": "%dkim_public_key% is the DKIM public key",
+  "records": [
+    {
+      "pointsTo": "mail.cordesk.cc",
+      "type": "MX",
+      "host": "@",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "spfRules": "include:spf.cordesk.cc",
+      "type": "SPFM",
+      "host": "@",
+      "essential": "Always"
+    },
+    {
+      "type": "TXT",
+      "host": "cordesk._domainkey",
+      "data": "%dkim_public_key%",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}
+


### PR DESCRIPTION
# Description

Adds template for cordesk.cc to send and/or receive email

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
dkim_public_key: v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAttqR4+k7N9Mo3bZ7tHnH6DILQDTxsanyJHLouKj0hdjGs3P/ApQONoC0fjSNBdOIrx6O+C6A3wb0plv4W59ejlYGBOF9VevA3f/WTvtTmHJ/2JMgYXYgIy+UZwgZELISbvQ0gLmThQ1yhmVlfTDk5jBIf5V+ZS4++ziLO0jDfEeQIUVdNhT0ttOiSFWfgMMycL7aPRqsHyFTbBft9RDURUcD9bzrdMAaI0j7cTZXyFU8NWx7oCFlaD7p+xYoeBmAWtdN7JWUod8CLXQ2dVV1mRXyAA/8+1Sc9F8pjZ2n35LtVfJ4Y3sojIzjdifAN8HeiccbeEwFQ/T4pJmHRAl0UwIDAQAB
```