### PR TITLE
Add informaten.com.a template and update our logo path

### DIFF
--- a/informaten.com.a
+++ b/informaten.com.a
@@ -1,0 +1,20 @@
+{
+  "providerId": "informaten.com",
+  "providerName": "Informaten",
+  "serviceId": "a",
+  "serviceName": "Connect your Domain with Informaten.com",
+  "version": 2,
+  "syncPubKeyDomain": "informaten.com",
+  "logoUrl": "https://informaten.com/assets/logo_dark.png",
+  "description": "Enables a domain to work with Informaten Servers",
+  "variableDescription": "ip is the IPv4 address of the server",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "essential": "Always",
+      "ttl": 3600
+    }
+  ]
+}

--- a/informaten.com.gameserver_generic.json
+++ b/informaten.com.gameserver_generic.json
@@ -3,9 +3,9 @@
   "providerName": "Informaten",
   "serviceId": "gameserver_generic",
   "serviceName": "Gameserver on Informaten.com",
-  "version": 1,
+  "version": 2,
   "syncPubKeyDomain": "informaten.com",
-  "logoUrl": "https://informaten.com/assets/logo_dark.png",
+  "logoUrl": "https://informaten.com/logo_dark.png",
   "description": "Connect a domain to a gameserver running on informaten.com",
   "variableDescription": "servicesubdomain is the host of the A record. In the most cases, this is equal to %service% but there are some cases, there the need a different host. The other variables for SRV and ttl should be self-explanatory.",
   "records": [

--- a/informaten.com.hosting.json
+++ b/informaten.com.hosting.json
@@ -3,9 +3,9 @@
   "providerName": "Informaten",
   "serviceId": "hosting",
   "serviceName": "Webhosting on Informaten.com",
-  "version": 1,
+  "version": 2,
   "syncPubKeyDomain": "informaten.com",
-  "logoUrl": "https://informaten.com/assets/logo_dark.png",
+  "logoUrl": "https://informaten.com/logo_dark.png",
   "description": "Enables a domain to work with Informaten webhosting",
   "variableDescription": "ip and ip6 are the v4/v6 address of the webspace server, domain is the domain this template is applied to and hostname is the hostname of the webspace server",
   "records": [

--- a/informaten.com.hosting_email.json
+++ b/informaten.com.hosting_email.json
@@ -3,9 +3,9 @@
   "providerName": "Informaten",
   "serviceId": "hosting_email",
   "serviceName": "Webhosting on Informaten.com",
-  "version": 1,
+  "version": 2,
   "syncPubKeyDomain": "informaten.com",
-  "logoUrl": "https://informaten.com/assets/logo_dark.png",
+  "logoUrl": "https://informaten.com/logo_dark.png",
   "description": "Enables a domain to work with Informaten webhosting",
   "variableDescription": "ip and ip6 are the v4/v6 address of the webspace server, domain is the domain this template is applied to and hostname is the hostname of the webspace server",
   "records": [

--- a/informaten.com.hosting_web.json
+++ b/informaten.com.hosting_web.json
@@ -3,9 +3,9 @@
   "providerName": "Informaten",
   "serviceId": "hosting_web",
   "serviceName": "Webhosting on Informaten.com",
-  "version": 2,
+  "version": 3,
   "syncPubKeyDomain": "informaten.com",
-  "logoUrl": "https://informaten.com/assets/logo_dark.png",
+  "logoUrl": "https://informaten.com/logo_dark.png",
   "description": "Enables a domain to work with Informaten webhosting",
   "variableDescription": "ip is the IPv4 address of the webserver and ip6 is the IPv6 address of the webserver",
   "records": [


### PR DESCRIPTION
# Description

- Add informaten.com.a template which simply creates an A record
- update the URL of our Logo in all our templates

## Type of change

- [x] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
```
ip: 1.2.3.4
```
