### PR TITLE
Add Stytch custom sender email template

### DIFF
--- a/stytch.com.email.json
+++ b/stytch.com.email.json
@@ -1,0 +1,49 @@
+{
+    "providerId": "stytch.com",
+    "providerName": "Stytch",
+    "serviceId": "email",
+    "serviceName": "Stytch Custom Sender Domain",
+    "version": 1,
+    "logoUrl": "https://stytch.com/favicon.ico",
+    "description": "Configure DNS records for Stytch custom sender domain",
+    "variableDescription": "%domain%: Your custom domain (e.g., example.com); %verification%: Stytch verification DNS value; %pm_id%: Domain-specific email identifier; %sg_em_id%: Domain-specific email identifier; %pm_rsa_key%: RSA public key for domain authentication",
+    "syncPubKeyDomain": "stytch.com",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "@",
+            "data": "stytch_verification_dns=%verification%",
+            "ttl": 600
+        },
+        {
+            "type": "TXT",
+            "host": "%pm_id%._domainkey",
+            "data": "%pm_rsa_key%",
+            "ttl": 600
+        },
+        {
+            "type": "CNAME",
+            "host": "pm-bounces",
+            "pointsTo": "pm.mtasv.net",
+            "ttl": 600
+        },
+        {
+            "type": "CNAME",
+            "host": "%sg_em_id%",
+            "pointsTo": "u17391058.wl059.sendgrid.net",
+            "ttl": 600
+        },
+        {
+            "type": "CNAME",
+            "host": "st._domainkey",
+            "pointsTo": "st.domainkey.u17391058.wl059.sendgrid.net",
+            "ttl": 600
+        },
+        {
+            "type": "CNAME",
+            "host": "st2._domainkey",
+            "pointsTo": "st2.domainkey.u17391058.wl059.sendgrid.net",
+            "ttl": 600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a template for [Stytch custom sender emails](https://stytch.com/docs/guides/custom-domains/overview#login-emails).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

```
  "testData": {
    "stytch_email": {
      "variables": {
        "domain": "example.com",
        "verification": "some_verification_id",
        "pm_id": "20250820194120pm",
        "pm_rsa_key": "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCzjoM9bRqrk69vLOz4D4Fbuxu6W1Rnk+dn3D8iElpZYcKm2bBR1Zu5FxVz+w/akzgKMfIDZi/IL62cbteHQIG16kJ790wVhTQgksy5+c5A2u6if7w/rQsfpVbs+73/mn+HxAyeRvmcCix9kzzebEkVYgokbL6rQtSV+w77g7KrswIDAQAC",
        "sg_em_id": "em1121"
      },
      "results": [
        {
          "type": "TXT",
          "name": "@",
          "ttl": 600,
          "data": "\"stytch_verification_dns=some_verification_id\""
        },
        {
          "type": "TXT",
          "name": "20250820194120pm._domainkey",
          "ttl": 600,
          "data": "\"k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCzjoM9bRqrk69vLOz4D4Fbuxu6W1Rnk+dn3D8iElpZYcKm2bBR1Zu5FxVz+w/akzgKMfIDZi/IL62cbteHQIG16kJ790wVhTQgksy5+c5A2u6if7w/rQsfpVbs+73/mn+HxAyeRvmcCix9kzzebEkVYgokbL6rQtSV+w77g7KrswIDAQAC\""
        },
        {
          "type": "CNAME",
          "name": "pm-bounces",
          "ttl": 600,
          "data": "pm.mtasv.net"
        },
        {
          "type": "CNAME",
          "name": "em1121",
          "ttl": 600,
          "data": "u17391058.wl059.sendgrid.net"
        },
        {
          "type": "CNAME",
          "name": "st._domainkey",
          "ttl": 600,
          "data": "st.domainkey.u17391058.wl059.sendgrid.net"
        },
        {
          "type": "CNAME",
          "name": "st2._domainkey",
          "ttl": 600,
          "data": "st2.domainkey.u17391058.wl059.sendgrid.net"
        }
      ]
    }
  }
```
