### PR TITLE
Allows Ryzeo to send email on behalf of the provided domain store

### DIFF
--- a/ryzeo.com.email-auth.json
+++ b/ryzeo.com.email-auth.json
@@ -8,6 +8,7 @@
   "version": 1,
   "description": "Enable Ryzeo to send emails on behalf of the provided domain",
   "variableDescription": "Values required: SPF rule string, DKIM selector + key, DMARC policy, and CNAME records",
+  "syncPubKeyDomain": "domainconnect.ryzeo.com",
   "warnPhishing": true,
   "records": [
     {

--- a/ryzeo.com.email-auth.json
+++ b/ryzeo.com.email-auth.json
@@ -1,0 +1,45 @@
+{
+  "providerId": "ryzeo.com",
+  "providerName": "Ryzeo",
+  "serviceId": "email-auth",
+  "serviceName": "Email Auth Setup",
+  "logoUrl": "https://ryzeo.com/wp-content/uploads/2021/11/ryzeo-logo-white-svg-1-1.svg",
+  "syncRedirectDomain": "app1.ryzeo.com,ryzeo.com",
+  "version": 1,
+  "description": "Enable Ryzeo to send emails on behalf of the provided domain",
+  "variableDescription": "Values required: SPF rule string, DKIM selector + key, DMARC policy, and CNAME records",
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "%spf_value%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim_selector%",
+      "pointsTo": "%dkim_value%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarc_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "CNAME",
+      "host": "%delivery_host%",
+      "pointsTo": "%delivery_value%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim_key_host%",
+      "pointsTo": "%dkim_key_value%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/ryzeo.com.email-auth.json
+++ b/ryzeo.com.email-auth.json
@@ -9,7 +9,6 @@
   "description": "Enable Ryzeo to send emails on behalf of the provided domain",
   "variableDescription": "Values required: SPF rule string, DKIM selector + key, DMARC policy, and CNAME records",
   "syncPubKeyDomain": "domainconnect.ryzeo.com",
-  "warnPhishing": true,
   "records": [
     {
       "type": "SPFM",


### PR DESCRIPTION
# Description

Added a new template for **Ryzeo email authentication (SPF, DKIM, DMARC setup)**.  
This template allows users to configure all required DNS records for `ryzeo.com` with a single click.

## Type of change

Please mark options that are relevant.

- [x] New template  
- [ ] Bug fix (non-breaking change which fixes an issue in the template)  
- [ ] New feature (non-breaking change which adds functionality to the template)  
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)  

# How Has This Been Tested?

Please mark the following checks done:

- [x] Schema validated using JSON Schema [template.schema](./template.schema)  
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)  
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)  
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`  

# Example variable values

Below is the `testData` object generated after testing in the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit):

```json
"testData": {
  "Ryzeo": {
    "variables": {
      "domain": "example.com",
      "spf_value": "include:_spf.smtp.com",
      "dkim_selector": "smtpmail._domainkey",
      "dkim_value": "smtpcustomer._domainkey.smtpsend.com",
      "dmarc_value": "v=DMARC1; p=none; rua=mailto:email@example.com; ruf=mailto:email@example.com; fo=0:1:s;",
      "delivery_host": "delivery",
      "delivery_value": "delivery.ryzeo.com",
      "dkim_key_host": "nc2048._domainkey.example.com",
      "dkim_key_value": "nc2048._domainkey.ryzeo.com"
    },
    "results": [
      {
        "type": "TXT",
        "name": "@",
        "ttl": 6000,
        "data": "\"v=spf1 include:_spf.smtp.com ~all\""
      },
      {
        "type": "CNAME",
        "name": "smtpmail._domainkey",
        "ttl": 3600,
        "data": "smtpcustomer._domainkey.smtpsend.com"
      },
      {
        "type": "TXT",
        "name": "_dmarc",
        "ttl": 3600,
        "data": "\"v=DMARC1; p=none; rua=mailto:email@example.com; ruf=mailto:email@example.com; fo=0:1:s;\""
      },
      {
        "type": "CNAME",
        "name": "delivery",
        "ttl": 3600,
        "data": "delivery.ryzeo.com"
      },
      {
        "type": "CNAME",
        "name": "nc2048._domainkey.example.com",
        "ttl": 3600,
        "data": "nc2048._domainkey.ryzeo.com"
      }
    ]
  }
}
