### PR TITLE
add Everinbox domain authentication templates

### DIFF
--- a/everinbox.domain-auth-tracking.json
+++ b/everinbox.domain-auth-tracking.json
@@ -1,0 +1,60 @@
+{
+  "providerId": "everinbox",
+  "providerName": "Everinbox", 
+  "serviceId": "domain-auth-tracking",
+  "serviceName": "Domain Authentication with Tracking",
+  "version": 1,
+  "logoUrl": "https://everinbox.com.br/everinbox-logo-dark.svg",
+  "description": "Configures domain authentication, DKIM, DMARC and link tracking records for complete email delivery service",
+  "variableDescription": "MAIL_SUBDOMAIN is the mail routing subdomain, MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy, URL_TRACKING_SUBDOMAIN is the URL tracking subdomain, URL_TRACKING_TARGET is the URL tracking target, CLICK_TRACKING_SUBDOMAIN is the click tracking subdomain, CLICK_TRACKING_TARGET is the click tracking target",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.everinbox.com.br",
+  "syncRedirectDomain": "everinbox.com.br", 
+  "warnPhishing": false,
+  "records": [
+    {
+      "groupId": "mail_routing",
+      "type": "CNAME",
+      "host": "%MAIL_SUBDOMAIN%",
+      "pointsTo": "%MAIL_TARGET%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%DKIM_SELECTOR1%._domainkey",
+      "pointsTo": "%DKIM_TARGET1%", 
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%DKIM_SELECTOR2%._domainkey",
+      "pointsTo": "%DKIM_TARGET2%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%DMARC_POLICY%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "tracking",
+      "type": "CNAME",
+      "host": "%URL_TRACKING_SUBDOMAIN%",
+      "pointsTo": "%URL_TRACKING_TARGET%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "tracking",
+      "type": "CNAME", 
+      "host": "%CLICK_TRACKING_SUBDOMAIN%",
+      "pointsTo": "%CLICK_TRACKING_TARGET%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/everinbox.domain-auth.json
+++ b/everinbox.domain-auth.json
@@ -1,0 +1,46 @@
+{
+  "providerId": "everinbox",
+  "providerName": "Everinbox",
+  "serviceId": "domain-auth",
+  "serviceName": "Domain Authentication",
+  "version": 1,
+  "logoUrl": "https://everinbox.com.br/everinbox-logo-dark.svg",
+  "description": "Configures domain authentication records for email delivery service including DKIM, DMARC and mail routing",
+  "variableDescription": "MAIL_SUBDOMAIN is the mail routing subdomain (e.g., 'em5027'), MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy configuration",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.everinbox.com.br",
+  "syncRedirectDomain": "everinbox.com.br",
+  "warnPhishing": false,
+  "records": [
+    {
+      "groupId": "mail_routing",
+      "type": "CNAME",
+      "host": "%MAIL_SUBDOMAIN%",
+      "pointsTo": "%MAIL_TARGET%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME", 
+      "host": "%DKIM_SELECTOR1%._domainkey",
+      "pointsTo": "%DKIM_TARGET1%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%DKIM_SELECTOR2%._domainkey", 
+      "pointsTo": "%DKIM_TARGET2%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%DMARC_POLICY%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adding Domain Connect templates for Everinbox email service provider to enable automated DNS configuration for email authentication including DKIM, DMARC, and tracking capabilities.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

**everinbox.domain-auth.json:**
```
MAIL_SUBDOMAIN: em5027
MAIL_TARGET: u44981471.wl222.sendgrid.net
DKIM_SELECTOR1: s1
DKIM_TARGET1: s1.domainkey.u44981471.wl222.sendgrid.net
DKIM_SELECTOR2: s2
DKIM_TARGET2: s2.domainkey.u44981471.wl222.sendgrid.net
DMARC_POLICY: v=DMARC1; p=none;
```

**everinbox.domain-auth-tracking.json:**
```
MAIL_SUBDOMAIN: em7052
MAIL_TARGET: u44981471.wl222.sendgrid.net
DKIM_SELECTOR1: s1
DKIM_TARGET1: s1.domainkey.u44981471.wl222.sendgrid.net
DKIM_SELECTOR2: s2
DKIM_TARGET2: s2.domainkey.u44981471.wl222.sendgrid.net
DMARC_POLICY: v=DMARC1; p=none;
URL_TRACKING_SUBDOMAIN: url165
URL_TRACKING_TARGET: sendgrid.net
CLICK_TRACKING_SUBDOMAIN: 44981471
CLICK_TRACKING_TARGET: sendgrid.net
```