### PR TITLE
Add redirect.pizza

### DIFF
--- a/redirect.pizza.apex-www.json
+++ b/redirect.pizza.apex-www.json
@@ -2,7 +2,7 @@
   "providerId": "redirect.pizza",
   "providerName": "redirect.pizza",
   "serviceId": "apex-www",
-  "serviceName": "redirect.pizza apex-www",
+  "serviceName": "redirect.pizza",
   "version": 1,
   "syncPubKeyDomain": "domainconnect.redirect.pizza",
   "logoUrl": "https://redirect.pizza/favicons/apple-touch-icon.png",

--- a/redirect.pizza.apex.json
+++ b/redirect.pizza.apex.json
@@ -2,7 +2,7 @@
   "providerId": "redirect.pizza",
   "providerName": "redirect.pizza",
   "serviceId": "apex",
-  "serviceName": "redirect.pizza apex",
+  "serviceName": "redirect.pizza",
   "version": 1,
   "syncPubKeyDomain": "domainconnect.redirect.pizza",
   "logoUrl": "https://redirect.pizza/favicons/apple-touch-icon.png",

--- a/redirect.pizza.subdomain.json
+++ b/redirect.pizza.subdomain.json
@@ -2,7 +2,7 @@
   "providerId": "redirect.pizza",
   "providerName": "redirect.pizza",
   "serviceId": "subdomain",
-  "serviceName": "redirect.pizza subdomain",
+  "serviceName": "redirect.pizza",
   "version": 1,
   "syncPubKeyDomain": "domainconnect.redirect.pizza",
   "logoUrl": "https://redirect.pizza/favicons/apple-touch-icon.png",


### PR DESCRIPTION
# Description

This adds 3 templates for the SaaS solution [redirect.pizza](https://redirect.pizza). redirect.pizza provides a full-domain redirect service. Redirects can be configured on the apex and/or any subdomain. This PR includes 3 templates, one for the apex (i.e. non-www to www redirect for instance), one for subdomain (i.e. test.example.com for instance), and 1 "common" case: the apex & www combined, so that the user can apply the template in 1 click for both cases.

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Schema validated using JSON Schema [template.schema](./template.schema)
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [ ] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values
```
ipv4: 89.106.200.1
ipv6: 2a12:5240::1
cname: edge.redirect.pizza
```

Typically, these variables are always the same, but users may set-up a Dedicated IP in their account, which will change these values. See https://redirect.pizza/support/dns-type & https://redirect.pizza/support/dedicated-ip

Open for suggestions for the serviceId names.