### PR TITLE
Add Kismet Travel AI Proxy Domain Connect Template

### DIFF
--- a/kismet.travel.ai-proxy.json
+++ b/kismet.travel.ai-proxy.json
@@ -15,13 +15,13 @@
       "type": "CNAME",
       "host": "ai",
       "pointsTo": "edge.kismet.travel",
-      "ttl": 3600
+      "ttl": 300
     },
     {
       "groupId": "ai-proxy",
       "type": "TXT",
       "host": "_kismet",
-      "ttl": 3600,
+      "ttl": 300,
       "data": "kismet-verify-%token%"
     }
   ]


### PR DESCRIPTION
# Description

Add a Domain Connect template for Kismet Travel that configures **both**:
1) AI subdomain routing via **CNAME** (`ai → edge.kismet.travel`), and  
2) Domain ownership verification via **TXT** at a scoped label (`_kismet → "kismet-verify-%token%"`).

This enables one-click onboarding for hotels: traffic routes immediately to Kismet Edge while ownership is verified without cluttering apex TXT records.

---

## Type of change

- [x] New template  
- [ ] Bug fix (non-breaking change which fixes an issue in the template)  
- [ ] New feature (non-breaking change which adds functionality to the template)  
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

---

## How Has This Been Tested?

- [x] Schema validated using `template.schema`  
- [x] Verified in Online Editor (CNAME + TXT)  
- [x] Checked with template linter  
- [x] Template file name follows `<providerId>.<serviceId>.json`

---

## Template filename

`kismet.travel.ai-proxy.json` (version **2**)

---

## Example variable values

```txt
%token% = mg1b21ti-awm0adefcyf  (example)
Creates:
  - CNAME  ai        -> edge.kismet.travel   (TTL 300)
  - TXT    _kismet   -> "kismet-verify-%token%"  (TTL 300)
