### PR TITLE
Add Pending property page template

### DIFF
--- a/pending.property-page.json
+++ b/pending.property-page.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "pending",
+  "providerName": "Pending",
+  "serviceId": "property-page",
+  "serviceName": "Property Page Hosting",
+  "version": 2,
+  "logoUrl": "https://trypending.com/logo.png",
+  "description": "Enables custom domain hosting for property pages.",
+  "variableDescription": "",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "d1234567890.cloudfront.net",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "d1234567890.cloudfront.net",
+      "ttl": 3600
+    }
+  ],
+  "syncRedirectDomain": "app.trypending.com"
+}

--- a/pending.property-page.json
+++ b/pending.property-page.json
@@ -11,13 +11,13 @@
     {
       "type": "CNAME",
       "host": "www",
-      "pointsTo": "d1234567890.cloudfront.net",
+      "pointsTo": "d269thkyr6dwzy.cloudfront.net",
       "ttl": 3600
     },
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "d1234567890.cloudfront.net",
+      "pointsTo": "d269thkyr6dwzy.cloudfront.net",
       "ttl": 3600
     }
   ],


### PR DESCRIPTION
   This PR adds a Domain Connect template for Pending's property page hosting service.
   
   The template configures:
   - CNAME records for www and @ (apex) domains
   - Points to CloudFront distribution for property page hosting
   - Supports custom domain setup for property listings
   
   Provider: pending
   Service: property-page