### PR TITLE
Added Domain Connect template for Beagle Security staging environment for domain ownership verification

### DIFF
--- a/beaglesecurity-staging.domainVerification.json
+++ b/beaglesecurity-staging.domainVerification.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "beaglesecurity-staging",
+  "providerName": "Beagle Security (Staging)",
+  "serviceId": "domainVerification",
+  "serviceName": "Domain Ownership Verification (Staging)",
+  "version": 1,
+  "logoUrl": "https://stage.beaglesecure.com/assets/logo.svg",
+  "description": "Development and staging environment: Automates adding a TXT record to verify domain ownership.",
+  "variableDescription": "%txt%: the domain ownership verification token to be added as a TXT record",
+  "syncPubKeyDomain": "stage.beaglesecure.com",
+  "syncRedirectDomain": "stage.beaglesecure.com",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "ttl": 3600,
+      "data": "%txt%"
+    }
+  ]
+}

--- a/beaglesecurity-staging.domainVerification.json
+++ b/beaglesecurity-staging.domainVerification.json
@@ -4,7 +4,7 @@
   "serviceId": "domainVerification",
   "serviceName": "Domain Ownership Verification (Staging)",
   "version": 1,
-  "logoUrl": "https://stage.beaglesecure.com/assets/logo.svg",
+  "logoUrl": "https://cdn.beaglesecurity.com/assets/brand/svg/beagle-blue.svg",
   "description": "Development and staging environment: Automates adding a TXT record to verify domain ownership.",
   "variableDescription": "%txt%: the domain ownership verification token to be added as a TXT record",
   "syncPubKeyDomain": "stage.beaglesecure.com",

--- a/beaglesecurity-staging.domainverification.json
+++ b/beaglesecurity-staging.domainverification.json
@@ -1,7 +1,7 @@
 {
   "providerId": "beaglesecurity-staging",
   "providerName": "Beagle Security (Staging)",
-  "serviceId": "domainVerification",
+  "serviceId": "domainverification",
   "serviceName": "Domain Ownership Verification (Staging)",
   "version": 1,
   "logoUrl": "https://cdn.beaglesecurity.com/assets/brand/svg/beagle-blue.svg",

--- a/beaglesecurity-staging.domainverification.json
+++ b/beaglesecurity-staging.domainverification.json
@@ -10,7 +10,6 @@
   "syncPubKeyDomain": "stage.beaglesecure.com",
   "syncRedirectDomain": "stage.beaglesecure.com",
   "syncBlock": false,
-  "warnPhishing": true,
   "records": [
     {
       "type": "TXT",

--- a/beaglesecurity-staging.domainverification.json
+++ b/beaglesecurity-staging.domainverification.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://cdn.beaglesecurity.com/assets/brand/svg/beagle-blue.svg",
   "description": "Development and staging environment: Automates adding a TXT record to verify domain ownership.",
   "variableDescription": "%txt%: the domain ownership verification token to be added as a TXT record",
-  "syncPubKeyDomain": "stage.beaglesecure.com",
+  "syncPubKeyDomain": "_domainconnect.stage.beaglesecure.com",
   "syncRedirectDomain": "stage.beaglesecure.com",
   "syncBlock": false,
   "records": [


### PR DESCRIPTION
# Description

Added a Domain Connect template for Beagle Security staging environment to automate adding TXT records for domain ownership verification in the staging domain beaglesecure.com. This template supports secure DNS automation and eases domain verification during development and testing.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

<-- Example: -->

```
txt: "example-verification-token-12345"
```