### PR TITLE
Update CNAME target for mcp-use custom domains

### DIFF
--- a/mcp-use.com.custom-domain.json
+++ b/mcp-use.com.custom-domain.json
@@ -20,7 +20,7 @@
       "type": "CNAME",
       "groupId": "subdomain",
       "host": "%subdomain%",
-      "pointsTo": "gateway.mcp-use.run",
+      "pointsTo": "deploy.mcp-use.com",
       "ttl": 600
     },
     {


### PR DESCRIPTION
Updates the CNAME record target from `gateway.mcp-use.run` to `deploy.mcp-use.com` to reflect our current gateway infrastructure.