### PR TITLE
Add Pagesmith.ai website hosting template

### DIFF
--- a/pagesmith.app.cname-setup.json
+++ b/pagesmith.app.cname-setup.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "pagesmith.app",
+  "providerName": "Pagesmith.ai",
+  "serviceId": "cname-setup",
+  "serviceName": "Pagesmith.ai Website Hosting",
+  "version": 1,
+  "logoUrl": "https://pagesmith.ai/favicon.png",
+  "description": "Connect your domain to your Pagesmith.ai website",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%host%",
+      "pointsTo": "%pointsTo%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Pagesmith.ai is an AI-powered website builder that deploys sites to custom domains. This template allows users to automatically configure CNAME and A records for connecting their domain to Pagesmith hosting via the Domain Connect protocol.

# Description

New Domain Connect template for Pagesmith.ai website hosting. Sets up:
- A CNAME record pointing the user's chosen host to `sites.pagesmith.app`
- An A record pointing the apex domain (@) to the redirect server IP

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

## Checklist

- [x] My template follows the [style guidelines](https://github.com/Domain-Connect/Templates/blob/master/README.md)
- [x] I have performed a self-review of my template
- [x] My template validates against the schema