### PR TITLE
Add ReviewGuard (y12.ai) review page CNAME template

### DIFF
--- a/y12.ai.reviewguard.json
+++ b/y12.ai.reviewguard.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "y12.ai",
+    "providerName": "ReviewGuard",
+    "serviceId": "reviewguard",
+    "serviceName": "Review Page",
+    "version": 1,
+    "logoUrl": "https://reviewguard.us/assets/logo.svg",
+    "description": "Add a CNAME record to connect your custom domain to your ReviewGuard review page.",
+    "variableDescription": "host: The subdomain to point to ReviewGuard (e.g. reviews, feedback)",
+    "syncPubKeyDomain": "domainconnect.y12.ai",
+    "syncRedirectDomain": "reviewguard.us",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "%host%",
+            "pointsTo": "reviews-proxy.y12.ai",
+            "ttl": 3600
+        }
+    ]
+}

--- a/y12.ai.reviewguard.json
+++ b/y12.ai.reviewguard.json
@@ -6,14 +6,13 @@
     "version": 1,
     "logoUrl": "https://reviewguard.us/assets/logo.svg",
     "description": "Add a CNAME record to connect your custom domain to your ReviewGuard review page.",
-    "variableDescription": "host: The subdomain to point to ReviewGuard (e.g. reviews, feedback)",
     "syncPubKeyDomain": "domainconnect.y12.ai",
     "syncRedirectDomain": "reviewguard.us",
     "hostRequired": true,
     "records": [
         {
             "type": "CNAME",
-            "host": "%host%",
+            "host": "@",
             "pointsTo": "reviews-proxy.y12.ai",
             "ttl": 3600
         }


### PR DESCRIPTION
# Description

New template for ReviewGuard (y12.ai) — a review management platform for businesses. This template adds a single CNAME record so customers can use a custom domain (e.g. `reviews.mybusiness.com`) for their branded review page, pointing to `reviews-proxy.y12.ai`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] digital signatures are used and `syncPubKeyDomain` specified — set to `domainconnect.y12.ai`, public key published as TXT record at `_dcpubkeyv1.domainconnect.y12.ai`
- [x] `syncRedirectDomain` is specified when intended to use `redirect_uri` parameter in the synchronous flow — set to `reviewguard.us`
- [x] no TXT record with SPF content — N/A (only CNAME record)
- [x] `txtConflictMatchingMode` is set on TXT records which shall be unique — N/A (no TXT records)
- [x] variables are set to the smallest scope needed — no custom variables used, only a static CNAME target
- [x] no variables as a host name to apply template on subdomain instead of standard `host` parameter — uses `@` with `hostRequired: true`
- [x] no explicit usage of `%host%` variable in `host` attribute — uses `@`
- [x] `essential` setting is used on records — N/A (single CNAME, user can remove domain from ReviewGuard dashboard)

## Online Editor test results

**Editor test link(s):**

[Test y12.ai/reviewguard](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC6rr2kC%2F91Ua2%2BbMBT9K8hfBwTyaoo0adEeUTutaqO2mlJFyLFvUk8EU9uQsoj%2FvmvIi7Wdtq%2F7ZON77%2FE9x%2BeyJQbWWUINkGhLMiULwUFdcBKRMuz6VBD3cHpF15hFplAI2ExyqjgGNahCMKgrVB1ZtSOtKueargBjBSgtZEqi0CWJXMk7lWDOozGZjjqdExw%2F1x2qNRjdsXm%2BLlZYzkEzJTJTQ5Ax5w51Pl6Nv312FDCpuGOkw2SaAjNOKXPlsFwbuXa4XVOR2mh9esLEae50MuzPt82XKbvOF1%2Bh%2FFTX4DVN8Q7WP6hjM6fABd5sDrltBpj1KLWZwlOOaaiUUTm4pOlVk%2BhhS0yZWZVqErt0%2FPxg1ZciNfpWHlC1hw%2FyXB47MAbF6w2DoJpXLvkpU4iP0HN31%2FhbXb14t5WSeRaLfXVGFV1r6449zsPvQPM9UitCbDdilUoFscaVmlzBnvs6T4yI6YYejziLaZYlJTavMYpoL3VJGzO1G%2BbU0L9QxyUxZ5aHsF5lNOR8wc881mcjrx%2Fypbfosp7XPwuXbBAGS35%2BfuL99kS8bfpXFQU0cGoEtR4fJxtaalJVcxfV%2Fb8Zoi80LYDH1FZ0g%2B7QC3peGNwGg6g7iIKuH4aj%2FrD3LgiiILBMQJuG67be6%2F3GrgVVgi4SaHnxXzxt%2FVzZsbP2enXsXorvt%2FH9ttx%2FehccxsrqmOB%2FASVoWDRk8Px0Isjy6WYm1WDxOJnd%2FViEl%2F1yej%2FppZeziXkePQ2%2BfIf7ITsf5Bf65j2pfgFe5mqEswUAAA%3D%3D)