### PR TITLE
Add gethoneybun.com hosting template

### DIFF
--- a/gethoneybun.com.hosting.json
+++ b/gethoneybun.com.hosting.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "gethoneybun.com",
+  "providerName": "HoneyBun",
+  "serviceId": "hosting",
+  "serviceName": "HoneyBun Website Hosting",
+  "version": 1,
+  "logoUrl": "https://app.gethoneybun.com/logo.png",
+  "description": "Connect your domain to your HoneyBun-powered website. This will point your domain to your website's server.",
+  "variableDescription": "IP is the IP address of your website server.",
+  "syncPubKeyDomain": "gethoneybun.com",
+  "syncRedirectDomain": "gethoneybun.com",
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%DOMAIN%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **HoneyBun** (`gethoneybun.com`), a managed website hosting service for photo booth rental operators. This template enables 1-click DNS configuration for clients connecting their custom domains to their HoneyBun-powered websites.

**Records configured:**
- A record: `@` → `%IP%` (client's server IP)
- CNAME record: `www` → `%DOMAIN%` (root domain alias)

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] digital signatures are used and `syncPubKeyDomain` specified (yes, `warnPhishing` is an option, but some providers reject such templates by policy, so signing shall be a default)
- [x] `syncRedirectDomain` is specified when intended to use `redirect_uri` parameter in the synchronous flow
- [x] no TXT record with SPF content (i.e. `"v=spf1 ..."`) instead of using SPFM record type on APEX
- [x] `txtConflictMatchingMode` is set on TXT records which shall be unique on a label (like DMARC)
- [x] variables are set to the smallest scope needed (i.e. limit possibility to be misused to set any arbitrary record and conflict with other template). Too broad scope example: @ TXT "%verification%". Better usage: @ TXT "foo-verification=%verification%".
- [x] no variables as a host name to apply template on subdomain instead of standard `host` parameter
- [x] no explicit usage of `%host%` variable in `host` attribute
- [x] `essential` setting is used on records, which the user shall be able to change or remove manually later without dropping the whole template (like DMARC)

## Online Editor test results

**Editor test link(s):**
[Test gethoneybun.com/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJwfsGkC%2F%2B1TXW%2FaQBD8K9ZJVR9iHBsIBEuVSkOloDYpihylSoSsw7eGa82de3fGcRD%2FvXuYz5T2OQ99Yr23s%2BzM7C6JgXmeUQMkXJJcyQVnoIaMhGQKZiYFVJNCeImcE3f3fEvnWE6u7eunQuCLBrXgCaxxM6kNF9N99lW58wATzQ0417vCBSjNpSBh4JJMTuW9ymwjY3Idnp%2FTPPdeDXNuq7x8DWagE8Vzs25ArqQQkBinkoVymJxTLhwj68%2FtBI1clqCAOWU9iedEM66dkmeZk0suTqM3xe%2B1Y3mB8uzgVHE6yWBwNMNw5GA7MwMHI8qYAq0dmR61OWgiK5EMoskXqAbrfzypvS26A8YVkvtHWUmVGCGZmRU2NKoAd23IHfwqEIv%2BpDTTmMQ%2BUjFNwqclMVVuDeqTuhbDj9Ztq4SOJH6%2BG47eYcYYtKXV8f2VuwNd3fZvPu%2BBZVm%2Bgg6%2B3fSHt8fw8colLzh4vJ9ijEZuacEzxZ2EDaVNZ4ymShZ5zLf1OVV0ru3ebpFPR9DxFvtEbDwc2ajptzzfC4KWF9hkPd0fSJyPT4VUEGv8paZQsFVzXmSGxxSF3qVYEuOOZhXS0fiK3Y5FFfUBWFEZNRTDwykOhHFJzBJLiNtDol3%2FMuiknUav12s22q2UNeikmzT8i5R12xQuIW0fXOVfjvb0ae5Fxd0EYTi1F9fPSlppsjrh74ZD7e%2BGxbFPb4%2FF2MU1%2BW%2FFm7ACb03TBbCYmrXozU7DbzUCPwpaYTsI25de0PP9ZvPM90PftxxAm5rcEq%2Fx8A5J84FV3eQx6o%2Bi9D4qHi%2Fg%2B3NOg1n2Epmzl4vsrrx%2B%2FDro9X8sfn4gq99fThX44wYAAA%3D%3D)