### PR TITLE
Add gethoneybun.com hosting template

### DIFF
--- a/gethoneybun.com.hosting.json
+++ b/gethoneybun.com.hosting.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "gethoneybun.com",
+  "providerName": "HoneyBun",
+  "serviceId": "hosting",
+  "serviceName": "HoneyBun Website Hosting",
+  "version": 1,
+  "logoUrl": "https://app.gethoneybun.com/logo.png",
+  "description": "Connect your domain to your HoneyBun-powered website. This will point your domain to your website's server.",
+  "variableDescription": "IP is the IP address of your website server.",
+  "syncPubKeyDomain": "gethoneybun.com",
+  "syncRedirectDomain": "gethoneybun.com",
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%DOMAIN%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a Domain Connect template for **HoneyBun** (`gethoneybun.com`), a platform that provides turnkey websites for photo booth rental operators.

## Template Details

- **Provider ID:** `gethoneybun.com`
- **Service ID:** `hosting`
- **Records:**
  - `A` record for `@` → `%IP%` (server IP)
  - `CNAME` record for `www` → `%DOMAIN%`

## Use Case

HoneyBun provisions WordPress websites for small business clients. Domain Connect enables 1-click DNS configuration so clients can connect their domains without manually editing DNS records.

## Checklist

- [x] Template follows the Domain Connect specification
- [x] `providerId` matches the domain we control
- [x] Template includes `warnPhishing: true`
- [x] Records are minimal and specific to hosting needs