### PR TITLE
Add Meteorack hosting Domain Connect templates

### DIFF
--- a/meteorack.app.hosting-apex-v1.json
+++ b/meteorack.app.hosting-apex-v1.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "meteorack.app",
+  "providerName": "Meteorack",
+  "serviceId": "hosting-apex-v1",
+  "serviceName": "Connect apex domain",
+  "syncPubKeyDomain": "meteorack.app",
+  "syncRedirectDomain": "app.meteorack.com",
+  "version": 1,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%APEX_IPV4%",
+      "ttl": "300"
+    },
+    {
+      "type": "AAAA",
+      "host": "@",
+      "pointsTo": "%APEX_IPV6%",
+      "ttl": "300"
+    },
+    {
+      "type": "CNAME",
+      "host": "%VERIFY_HOST%",
+      "pointsTo": "%VERIFY_TARGET%",
+      "ttl": "300"
+    }
+  ]
+}

--- a/meteorack.app.hosting-subdomain-v1.json
+++ b/meteorack.app.hosting-subdomain-v1.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "meteorack.app",
+  "providerName": "Meteorack",
+  "serviceId": "hosting-subdomain-v1",
+  "serviceName": "Connect subdomain",
+  "syncPubKeyDomain": "meteorack.app",
+  "syncRedirectDomain": "app.meteorack.com",
+  "hostRequired": true,
+  "version": 1,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%TARGET_CNAME%",
+      "ttl": "300"
+    },
+    {
+      "type": "CNAME",
+      "host": "%VERIFY_HOST%",
+      "pointsTo": "%VERIFY_TARGET%",
+      "ttl": "300"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add two new Meteorack hosting templates for Google-hosted tenant domains:

- `meteorack.app.hosting-apex-v1.json`
- `meteorack.app.hosting-subdomain-v1.json`

These templates are used by Meteorack to connect apex/root domains and subdomains to tenant sites hosted on the Meteorack Google tenant edge.

Notes:
- `syncPubKeyDomain` is set and live at `_dcpubkeyv1.meteorack.app`
- `syncRedirectDomain` is set to `app.meteorack.com`
- no SPF/TXT records are created by these templates
- bare variable values are intentionally used in `A`, `AAAA`, and `CNAME` targets because the target values are runtime infrastructure values provided by Meteorack during the sync flow
- `%VERIFY_HOST%` is intentionally used in `host` only for the Google-managed verification record; it is not used to emulate the Domain Connect `host` parameter for the customer-facing domain label

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- [Test meteorack.app/hosting-apex-v1 example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGRGs2kC%2F%2B1Va2%2BbMBT9K5WlfBow80hIkSYtyuiWre2iLErXVhFy8E2KBphhJy2N8t93vYSQPrZ9mzapCAnjc67xufdcsyYKsiJlCkiwJkUpVgmHcsBJQDJQIEoWf7NYURBjD56zDMnkrIYRklCukhh%2Bht0IqZJ8YbIC7syV3aC7uL7Ic4jVkcaPuMhYkmtOlcfD5ewTVO%2B2U0%2B%2Frykj4EmJ0XsSQlZDjEWGxBWUMhGI2gZBsii5JMH1mqiq0BvoIUVvEodvtSyR5EqOBb62esPwazQYTrwWAkqlOOdSSjZGE4zXn%2BM7v4zvn%2FfOwmaB1iQcDU4uow%2Bfv4xbjxbbQePe6H04frTgdGOQe5FD1OibGoTXWYE7hkWFXT5238LRohTLIkpqfsFKlkld%2BDry%2BkHotI69Jnq8z46ecD3Ltm3LsanV6R6iHY06HUoD%2B5jaAQ263rwdBJpyIFaTIhZnYMY3LE0hX8ABY6tZc7CWybyy6l3loIjWnixyUUIk8cnUssTMqnIJBsmWqUoidsuaKR5HaJK0wlRJRHHRh1bIt7bUpeRMMZ3hB9J2ece0GyTisc5Won1O7bbruD41bZtT05v7vjnjvGu2u443Y75%2FPGv7B13zbEv9vm%2BauoGUkKuE6fr30ltWSbJ5asqnSp4pw38gp%2B6RnZ7HNtmre8Yb%2F6y6qYEN92K8F%2BP9dePhqSrZCnjENM2hTsekrmk7Y8cNqIe35VKfet4rrBj%2BWlAISLUVusaT9vCMJYOL5WR8f8Em%2FX57cHl%2BBSfh6%2FvZyF7NK1Wdws3VMMzk948hbdM3ZPMDrBcSiFwIAAA%3D)
- [Test meteorack.app/hosting-subdomain-v1 example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGRGs2kC%2F%2B1UbWvbMBD%2BK0OQT7WN47h5g8FCm25lfdk8sxFCMIp9ScVsyZXkOG7If98pifPSZrCPYwwMRnfPc9xzz0kroiHLU6qB9Fckl2LBEpC3CemTDDQISeOfDs1zYu2TDzRDMLmv05hSIBcshg3tSSjN%2BNxWxTQRGWXcXjQPkB35SnAOsX63BxlExeMvxfQzVNfb0NsWDCSAhEnk7kGYcg7AWGQINE0E8FwgEnvSsgCLLEAqJpDRtAgWEDJRpD9eEV3lm5YeBvfDHRWPH4xiwbhWocBjIxwEH4dhtEE1MKd1iuGW65K19bsaje%2FD4PZmFH16%2FBY2XtXbpbZlXxWcrC3yIjhEhzYnFklqwbCkaBkcScVgWZZ4mEtR5BGrKTmVNFPG2Zo8PmFPavp4w8fjsUwTRtOXlXPqA8KOhBlUROMM7PiJpinwOTi7YicaDQ4tYLPKqVvgoInRyuZcSIgU%2FqkuJNSOZUWqWURLegglcYQtpBWORmEWi751kG93bUpeRMMZ3hB9J2ece0GyTisc5Won1O7bbruD41bZtT05v7vjnjvGu2u443Y75%2FPGv7B13zbEv9vm%2BauoGUkKuE6fr30ltWSbJ5asqnSp4pw38gp%2B6RnZ7HNtmre8Yb%2F6y6qYEN92K8F%2BP9dePhqSrZCnjENM2hTsekrmk7Y8cNqIe35VKfet4rrBj%2BWlAISLUVusaT9vCMJYOL5WR8f8Em%2FX57cHl%2BBSfh6%2FvZyF7NK1Wdws3VMMzk948hbdM3ZPMDrBcSiFwIAAA%3D)
