### PR TITLE
Add Tortus website hosting template

### DIFF
--- a/tortus.io.connect-site.json
+++ b/tortus.io.connect-site.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "tortus.io",
+  "providerName": "Tortus",
+  "serviceId": "connect-site",
+  "serviceName": "Tortus Website",
+  "version": 1,
+  "logoUrl": "https://tortus.io/logo.png",
+  "description": "Connect your domain to your Tortus-powered website with automatic SSL.",
+  "variableDescription": "CNAME record pointing to Tortus hosting",
+  "syncPubKeyDomain": "tortus.io",
+  "syncBlock": false,
+  "sharedProviderName": false,
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%host%",
+      "pointsTo": "sites.tortus.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Service Provider: Tortus (tortus.io)

Tortus is a real estate technology platform providing white-label websites for brokerages and agents. This template adds a CNAME record pointing to our hosting infrastructure (sites.tortus.com) with automatic SSL provisioned via Cloudflare for SaaS.

- **Provider ID:** tortus.io
- **Service ID:** connect-site
- **Record:** CNAME → sites.tortus.com
- **Website:** https://tortus.io