### PR TITLE
Add delegated.to site template

### DIFF
--- a/delegated.to.site.json
+++ b/delegated.to.site.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "delegated.to",
+  "providerName": "Mission Control",
+  "serviceId": "site",
+  "serviceName": "Mission Control Site",
+  "version": 1,
+  "logoUrl": "https://delegated.to/logo.png",
+  "description": "Point your domain to your Mission Control site with automatic SSL via Caddy.",
+  "variableDescription": "`IP` is the public IP address of the Mission Control VPS server hosting the site.",
+  "syncPubKeyDomain": "delegated.to",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "%IP%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## New Provider Template: delegated.to

**Provider:** Mission Control (delegated.to)
**Service:** Site — points a custom domain to a Mission Control VPS

### Template details

- **providerId:** `delegated.to`
- **serviceId:** `site`
- Sets `@` and `www` A records to the VPS IP (`%IP%` variable)
- TTL: 3600
- SSL handled automatically by Caddy on the VPS

### Use case

When a user builds a website with Mission Control's AI web builder (Ada), they connect their custom domain via Domain Connect. This template automates the DNS setup — pointing `@` and `www` to the VPS IP — so the domain resolves to their site with zero manual DNS editing.

The `%IP%` variable is provided programmatically by our platform at the time of connection.