### PR TITLE
poststack.dev: Update syncPubKeyDomain to poststack.dev

### DIFF
--- a/poststack.dev.email.json
+++ b/poststack.dev.email.json
@@ -1,51 +1,51 @@
 {
-  "providerId": "poststack.dev",
-  "providerName": "PostStack",
-  "serviceId": "email",
-  "serviceName": "PostStack Email",
-  "version": 2,
-  "logoUrl": "https://poststack.dev/logo.svg",
-  "description": "Configure DNS records for PostStack email sending and receiving (SPF, DKIM, DMARC, Return-Path, MX)",
-  "variableDescription": "DKIM public key for your domain",
-  "syncPubKeyDomain": "domainconnect.poststack.dev",
-  "syncRedirectDomain": "poststack.dev",
-  "shared": false,
-  "multiInstance": false,
-  "syncBlock": false,
-  "records": [
-    {
-      "type": "SPFM",
-      "host": "@",
-      "spfRules": "include:poststack.dev",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "poststack._domainkey",
-      "data": "v=DKIM1; k=rsa; h=sha256; p=%dkim_record%",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "_dmarc",
-      "data": "v=DMARC1; p=none; rua=mailto:dmarc@poststack.dev",
-      "ttl": 3600,
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=DMARC1",
-      "essential": "OnApply"
-    },
-    {
-      "type": "CNAME",
-      "host": "bounce",
-      "pointsTo": "bounce.poststack.dev",
-      "ttl": 3600
-    },
-    {
-      "type": "MX",
-      "host": "@",
-      "pointsTo": "poststack.dev",
-      "priority": 10,
-      "ttl": 3600
-    }
-  ]
+	"providerId": "poststack.dev",
+	"providerName": "PostStack",
+	"serviceId": "email",
+	"serviceName": "PostStack Email",
+	"version": 2,
+	"logoUrl": "https://poststack.dev/logo.svg",
+	"description": "Configure DNS records for PostStack email sending and receiving (SPF, DKIM, DMARC, Return-Path, MX)",
+	"variableDescription": "DKIM public key for your domain",
+	"syncPubKeyDomain": "poststack.dev",
+	"syncRedirectDomain": "poststack.dev",
+	"shared": false,
+	"multiInstance": false,
+	"syncBlock": false,
+	"records": [
+		{
+			"type": "SPFM",
+			"host": "@",
+			"spfRules": "include:poststack.dev",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "poststack._domainkey",
+			"data": "v=DKIM1; k=rsa; h=sha256; p=%dkim_record%",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "_dmarc",
+			"data": "v=DMARC1; p=none; rua=mailto:dmarc@poststack.dev",
+			"ttl": 3600,
+			"txtConflictMatchingMode": "Prefix",
+			"txtConflictMatchingPrefix": "v=DMARC1",
+			"essential": "OnApply"
+		},
+		{
+			"type": "CNAME",
+			"host": "bounce",
+			"pointsTo": "bounce.poststack.dev",
+			"ttl": 3600
+		},
+		{
+			"type": "MX",
+			"host": "@",
+			"pointsTo": "poststack.dev",
+			"priority": 10,
+			"ttl": 3600
+		}
+	]
 }


### PR DESCRIPTION
Change `syncPubKeyDomain` from `domainconnect.poststack.dev` to `poststack.dev`. The public key is served from the main domain at `https://poststack.dev/_dnsconnect/keys/{keyId}`, eliminating the need for a separate subdomain.