### PR TITLE
Add Ablazgo domain verification template

### DIFF
--- a/ablazgo.com.domain-verification.json
+++ b/ablazgo.com.domain-verification.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "ablazgo.com",
+  "providerName": "Ablazgo",
+  "serviceId": "domain-verification",
+  "serviceName": "Ablazgo Domain Verification",
+  "version": 1,
+  "logoUrl": "https://portal.ablazgo.com/ablazgo-logo-ag17-710.png",
+  "description": "Verify domain ownership for your Ablazgo store",
+  "variableDescription": "The verification token for your domain",
+  "syncPubKeyDomain": "ablazgo.com",
+  "syncBlock": false,
+  "syncRedirectDomain": "portal.ablazgo.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_ablazgo",
+      "data": "ablazgo-site-verification=%token%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/ablazgo.com.domain-verification.json
+++ b/ablazgo.com.domain-verification.json
@@ -4,7 +4,7 @@
   "serviceId": "domain-verification",
   "serviceName": "Ablazgo Domain Verification",
   "version": 1,
-  "logoUrl": "https://portal.ablazgo.com/ablazgo-logo-ag17-710.png",
+  "logoUrl": "https://portal.ablazgo.com/ablazgo-logo.png",
   "description": "Verify domain ownership for your Ablazgo store",
   "variableDescription": "The verification token for your domain",
   "syncPubKeyDomain": "ablazgo.com",


### PR DESCRIPTION
# Description

Ablazgo ([ablazgo.com](https://ablazgo.com)) is a multi-tenant e-commerce platform for collectibles stores. This template adds a single TXT record for domain ownership verification.

- **Provider ID:** `ablazgo.com`
- **Service ID:** `domain-verification`
- **Record:** TXT `_ablazgo.{domain}` → `ablazgo-site-verification={token}`
- **syncPubKeyDomain:** `ablazgo.com`
- **syncRedirectDomain:** `portal.ablazgo.com`

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — N/A, our TXT record uses a unique prefix `ablazgo-site-verification=`
- [x] no variable is used as a bare full record value — we use `ablazgo-site-verification=%token%` (prefixed)
- [x] no bare variable is used as the full `host` label — host is fixed as `_ablazgo`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — N/A, verification TXT records are managed by the platform

## Online Editor test results

**Editor test link(s):**
[ablazgo.com.domain-verification with domain apex](https://domainconnect.paulonet.eu/dc/free/templateedit?templateId=ablazgo.com.domain-verification)