### PR TITLE
Add Storehaus (storehaus.ai) custom domain template

### DIFF
--- a/storehaus.ai.domain.json
+++ b/storehaus.ai.domain.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "storehaus.ai",
+  "providerName": "Storehaus",
+  "serviceId": "domain",
+  "serviceName": "Custom Domain",
+  "version": 1,
+  "logoUrl": "https://storehaus.ai/logo.svg",
+  "description": "Connect your domain to your Storehaus store",
+  "variableDescription": "verifyCode is the domain verification token from Vercel",
+  "syncPubKeyDomain": "storehaus.ai",
+  "syncRedirectDomain": "storehaus.ai",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_vercel",
+      "data": "vc-domain-verify=%domain%,%verifyCode%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## New Template: storehaus.ai.domain.json

**Provider:** Storehaus (https://storehaus.ai)
**Service:** Custom Domain

### Description
Storehaus is an all-in-one commerce platform for DTC brands. This template allows customers to connect their custom domains to their Storehaus stores via Vercel hosting.

### Records
- **A record**: `@` → `76.76.21.21` (Vercel)
- **TXT record**: `_vercel` → `vc-domain-verify={domain},{verifyCode}` (Vercel domain verification)

### Security
- `syncPubKeyDomain`: `storehaus.ai`
- Public key published at: `_dck1._domainconnect.storehaus.ai` TXT record
- `syncBlock`: false (synchronous flow only)

### Testing
Template validated against the Domain Connect schema.