### PR TITLE
Add Resend click tracking domain template

### DIFF
--- a/resend.com.click-tracking.json
+++ b/resend.com.click-tracking.json
@@ -6,13 +6,14 @@
 	"version": 1,
 	"syncPubKeyDomain": "resend.com",
 	"syncRedirectDomain": "resend.com",
+	"hostRequired": true, 
 	"description": "Configure a custom domain for click and open tracking.",
 	"logoUrl": "https://cdn.resend.com/brand/resend-wordmark-black.svg",
 	"records": [
 		{
 			"type": "CNAME",
-			"host": "%trackingSubdomain%",
-			"pointsTo": "%cnameTarget%",
+			"host": "@",
+			"pointsTo": "%cnameTarget%.resend-dns.com",
 			"ttl": 3600
 		}
 	]

--- a/resend.com.click-tracking.json
+++ b/resend.com.click-tracking.json
@@ -1,0 +1,19 @@
+{
+	"providerId": "resend.com",
+	"providerName": "Resend",
+	"serviceId": "click-tracking",
+	"serviceName": "Click Tracking",
+	"version": 1,
+	"syncPubKeyDomain": "resend.com",
+	"syncRedirectDomain": "resend.com",
+	"description": "Configure a custom domain for click and open tracking.",
+	"logoUrl": "https://cdn.resend.com/brand/resend-wordmark-black.svg",
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "%trackingSubdomain%",
+			"pointsTo": "%cnameTarget%",
+			"ttl": 3600
+		}
+	]
+}

--- a/resend.com.click-tracking.json
+++ b/resend.com.click-tracking.json
@@ -13,7 +13,7 @@
 		{
 			"type": "CNAME",
 			"host": "@",
-			"pointsTo": "%cnameTarget%.resend-dns.com",
+			"pointsTo": "%clickTrackingCnameTarget%.resend-dns.com",
 			"ttl": 3600
 		}
 	]


### PR DESCRIPTION
# Description
<!-- short description of the template(s) and/or reason for update -->

We are introducing the capability of users to choose their own custom
click tracking domain at Resend.

This setup is separate from the domain configurations for sending
and/or receiving emails (whose templates are already available).

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) 
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [X] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, no TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR
description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — N/A, single CNAME is the core record

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test resend.com/click-tracking example.com/tracking](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIAK1WkC%2F91UW2vbMBT%2BK0bQp8aOb0mpYbCS7WG9UUI2AiUYRVJTLbbkSrKzLPi%2F70iNF7dpC3vdk%2B1z%2Bc75vnOOd8iwsiqwYSjboUrJhlOmvlGUIcU0EzQgskSDv55bXEIkmjof2DVTDSfMJZCCk7VvFCZrLlYH5z5nYt3e7OBumNJcCpRFELoV5K5eXrHtF1liLl7Xt%2F4po1wxYt6OeJTaTNlTDSHQjFE1GyDKNFG8Mq4KmkjxwFe1Yh72SK2NLD3qoLwHqTzXvYcF9WTFhNfRCAC6kCv5XRUA8WhMpbPhkFARHKoPlwryhs8GfyMVLbFa%2B8sCIALdWK7QN5g1yu53yGwrp8ftxc3XfePw%2BdmqLLkweibh88T106k1EaDhDKsVMyf7wj4Vek%2FdGOgtGYdhu2gH6LcULD%2FUW4AMnWDsF4Zhs55iYOwNbKVkXeW8y6uwwqW2i9Eh3L%2BAWHQY9wcQsL3XuY0ruFhHyLbJV0Iqlmt4YgND6WZW1oXhOd7gg4mSHFdVsQVWGryAc6yieF6yHhmKDQaLq%2FiBZgOUU2I5crvD8UOcnMfj1KfLUeSn56PEXyaU%2BilNzlgckSQ9I71zOD6UDw%2FiWHGmIddwbJfrotjgrUZtuxiA%2Bv85RdgTjRtGc2zD4zAe%2B2Hqh2ezKMnSEbQdRGEyHoWnYZiFoWXDtHnmu3Pvbi%2FrCkwA0v%2BJNVhxvCyYC3h%2FF%2Fer%2BK%2FXYS%2BjtfdsN%2FHNe341pqAHG7ycykfjg1NurdQF%2FPAcQdfNEV%2BI6Z8QYlUc%2F6juYnkV0yhJr%2BcNnw%2Fns8n88mbMR6eby6ebZv1zGF2X%2BhNq%2FwCbrU0a%2FgUAAA%3D%3D)