### PR TITLE
Update vercel website template to add apex CNAME record

### DIFF
--- a/vercel.com.website.json
+++ b/vercel.com.website.json
@@ -7,6 +7,7 @@
   "description": "Enables a domain to work with Vercel",
   "syncPubKeyDomain": "domainconnect.vercel.com",
   "syncRedirectDomain": "vercel.com",
+  "hostRequired": true,
   "records": [
     {
       "type": "TXT",

--- a/vercel.com.website.json
+++ b/vercel.com.website.json
@@ -3,7 +3,7 @@
   "providerName": "Vercel",
   "serviceId": "website",
   "serviceName": "Vercel Websites",
-  "version": 3,
+  "version": 4,
   "description": "Enables a domain to work with Vercel",
   "syncPubKeyDomain": "domainconnect.vercel.com",
   "syncRedirectDomain": "vercel.com",
@@ -34,6 +34,13 @@
       "groupId": "apex",
       "host": "@",
       "pointsTo": "%ip%",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "apex-cname",
+      "host": "@",
+      "pointsTo": "%apex-cname%",
       "ttl": 600
     }
   ]


### PR DESCRIPTION
# Description

Vercel needs to be able to set CNAMEs for apex domains on providers that support CNAME flattening so that we can determine the correct IP dynamically for the domain instead of hardcoding it during DNS setup.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test vercel.com/website example.com/elliot](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE5U1WkC%2F%2B1V72vbMBD9V4ygn2oHx0nTxFBY6cp%2BlJZSQtetBKPIl1arY2mWHDcL%2Bd93luM4bmI2ygYr5JNt3bt370l38oJomMqIaiD%2BgshEzHgIyaeQ%2BGQGCYOoxcSU2OvIFZ0iktyaGK4rSGacgUnIYKw4Eq1Xa2DrSxFWGEdqxUVM%2FK5NQlAs4VKbb3Ie03EEyqJWKKaUx5YWViaSJyvj%2BtGqys5jdp2OL2D%2B3sAws8AzEcfAdKsmPkffQMgTjKzxNcSjUPoGfqQIQSc6ScEmiBZJqIh%2FvyB6LnMnw7shgh8SkUrjmEp4dpCITzijxkFBhaFgVmoNqaZ5PeYUEouE%2BcnBVvYBorWOiN9z3aXdWFWl402m15TeTdFQ%2F%2Bzq9PJ8t4KqaEWZs0jBY62GIg%2BwGNuggfp0azsrxncveLj8Y31mZ03dZroKU6MdLW3yU8QQVMc%2FslfNhWnwTHFcYKNt8sUo4kKXCgJusnY2R%2BPRbe7ohnosLWlCpyqfzlLEfU3FqJRxX%2BoYrYT8RRHbNMiNs2yKNfCtEF4NUpdZ8OOSeVkNrRPGqnTGjYm1gt%2Fg8ej4QywSCBQ%2BqU4TKId5mkaaBzSj1VLIAiplNMeTVhhF2peDXlQr56m1PuamsTIbUvWSTYKQ5QfHTU%2F2vXav3x84YR9cp9vudpwBPcI31j4%2BctvHEHp046LdvoJ3X7UvWxCUglhzGuXTFWV0rshy6y55jTHvP3dW3gIrb0XalrWdjfMGjb1BRyMbb9L9iO1HbD9i%2F2zE8l8tnUEY0BzsuV7PcbuOezxsD3zX9Ttuqz8Y9Lq9Q%2Fxw3dwDtl3hcoF%2Fz83%2FJumd3fU%2FQvp9cHjmPd5eTDowOf387cNDp%2FP1aagEj6Q8F5nLnrLLE7L8BU53U%2B5JDAAA)