### PR TITLE
AuthlyX

### DIFF
--- a/authly.cc.api.json
+++ b/authly.cc.api.json
@@ -4,7 +4,7 @@
   "serviceId": "api",
   "serviceName": "AuthlyX API",
   "version": 1,
-  "logoUrl": "https://authly.cc/logo-round.svg",
+  "logoUrl": "https://cdn.authly.cc/logos/logo-round.svg",
   "description": "Connect a custom domain to the AuthlyX API by creating the required CNAME record.",
   "syncPubKeyDomain": "domainconnect.authly.cc",
   "hostRequired": true,

--- a/authly.cc.api.json
+++ b/authly.cc.api.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "authly.cc",
+  "providerName": "AuthlyX",
+  "serviceId": "api",
+  "serviceName": "AuthlyX API",
+  "version": 1,
+  "logoUrl": "https://authly.cc/logo-round.svg",
+  "description": "Connect a custom domain to the AuthlyX API by creating the required CNAME record.",
+  "syncPubKeyDomain": "domainconnect.authly.cc",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.authly.cc",
+      "ttl": 3600,
+      "essential": true
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for AuthlyX custom API domains. Adds a single CNAME record so users can point `{host}.{domain}` to `cname.authly.cc` via Cloudflare’s “Authorize DNS records” flow.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://cdn.authly.cc/logos/logo-round.svg`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
  - Not used
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
  - Not applicable (no TXT records)
- [x] no variable is used as a bare full record value unless necessary
  - Not applicable (no record values are variables)
- [x] no bare variable is used as the full `host` label
  - Not applicable (no variables in `host`)
- [x] no variable is used in the `host` field to create a subdomain (uses `host` parameter + `hostRequired=true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template

## Online Editor test results

**Editor test link(s):**
- [Test authly.cc/api example.com/api](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABFf1WkC%2F91Sf2%2FaMBD9KpH%2FXRLSEAJEmjRUNomuv1YxqVuFImNfwVtip%2FaFFhDffXZSCqjbF9g%2Fic53997du7clCGVVUASSbUml1Upw0BNOMkJrXBbrkDHivyWuaWkLyahJ3duEAb0SDNqGShxeTiu90e3E5lagjVCSZGc%2BKdRCfdeFrVkiVibrdBiX4Rtpx%2BVN8w20qiUPzWphITgYpkWFDQw5V1ICQ496rDaoSo%2BrkgrpofJwCd4Ruzdfe0wDRSEXTU7DUy00cO%2F8enT12YZMaR66BdaS3dbzr7AeN2CWpkVlLVl4LMxSGbx7RSIZ6hp80kIZkj1sCa4rJ0PD8Vpuw09OUiUkmqmyIZNWrBNYRCdMN40iG4AxIFFQ93QjR1VVrMlutvPJRknID2wz%2F3VQWwcv1J4VQqbKA217oIWVs8rFvqWimpbGXX%2Ff%2FHDSPdu3PzT9jlcspNKQG%2FunWGvYL17WBYqcPtPDE2c5dQPbMY3NWpT3osjWKu10nCL9tyROEZ%2FknLl5hTMdT9LeWZJCEPMoDhIYsGDA42GQ0ITTAY%2Fm3cHjkYHfOfu9gU%2FE%2Bqv2u5lvlfsvFrHXNXQFPKeuNI7iNIiSIOpPz4ZZkmZxL4wGvW43%2BhBFWWNGBIPtalvrhGMPkA19xnt21x9v0v7L9NdPev3jUSaXlxcXPK2erqgpvgyxOxn%2Fjr99JLs%2Ftym4InoEAAA%3D)

Tested in the Online Editor with:
- Domain: `example.com`
- Host: `api`

Note: `hostRequired=true`, so an apex-only test is not applicable.
