### PR TITLE
bongo.bot.email: add syncBlock: false

### DIFF
--- a/bongo.bot.email.json
+++ b/bongo.bot.email.json
@@ -4,6 +4,7 @@
 	"serviceId": "email",
 	"serviceName": "Email Sending & Receiving",
 	"version": 1,
+	"syncBlock": false,
 	"syncPubKeyDomain": "bongo.bot",
 	"syncRedirectDomain": "bongo.bot",
 	"description": "Configure DNS records for sending and receiving email through BongoBot.",


### PR DESCRIPTION
Adds `"syncBlock": false` to the `bongo.bot.email` template.

## Why

Cloudflare's Domain Connect implementation requires `syncBlock` to be explicitly set to `false` (synchronous flow only) for templates to be onboarded to Cloudflare-hosted DNS zones. Without this field, the BongoBot email template cannot be offered through Cloudflare's Domain Connect UI.

Reference: https://developers.cloudflare.com/dns/reference/domain-connect/

## Change

Single-field addition — no record or signing changes:

```diff
 "version": 1,
+"syncBlock": false,
 "syncPubKeyDomain": "bongo.bot",
```