### PR TITLE
Create nextcommerce template

### DIFF
--- a/nextcommerce.com.email.json
+++ b/nextcommerce.com.email.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "nextcommerce.com",
+  "providerName": "NextCommerce",
+  "serviceId": "email",
+  "serviceName": "Connect Email Sending Domain",
+  "version": 1,
+  "logoUrl": "https://nextcommerce-public-assets.s3.us-east-1.amazonaws.com/final-logo-dark-stroked-md.png",
+  "description": "Configures your domain for sending email via NextCommerce (powered by Amazon SES). Adds DKIM signing records required for email deliverability.",
+  "variableDescription": "dkim1, dkim2, dkim3 are the three DKIM tokens issued by Amazon SES for your domain. These are provided automatically by NextCommerce.",
+  "syncPubKeyDomain": "29next.store",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/nextcommerce.com.subdomain.json
+++ b/nextcommerce.com.subdomain.json
@@ -1,0 +1,20 @@
+{
+    "providerId": "nextcommerce.com",
+    "providerName": "NextCommerce",
+    "serviceId": "website",
+    "serviceName": "Connect Store Domain",
+    "version": 1,
+    "logoUrl": "https://nextcommerce-public-assets.s3.us-east-1.amazonaws.com/final-logo-dark-stroked-md.png",
+    "description": "Connects your domain to your NextCommerce store at nextcommerce.com.",
+    "variableDescription": "cname is the DNS CNAME target for NextCommerce infrastructure. verification is the domain ownership verification token issued by NextCommerce.",
+    "syncPubKeyDomain": "29next.store",
+    "records": [
+     {
+        "type":"CNAME",
+        "host":"@",
+        "pointsTo":"%cname%",
+        "ttl":3600
+     }
+  ]
+}
+

--- a/nextcommerce.com.website.json
+++ b/nextcommerce.com.website.json
@@ -1,0 +1,32 @@
+{
+    "providerId": "nextcommerce.com",
+    "providerName": "NextCommerce",
+    "serviceId": "website",
+    "serviceName": "Connect Store Domain",
+    "version": 1,
+    "logoUrl": "https://nextcommerce-public-assets.s3.us-east-1.amazonaws.com/final-logo-dark-stroked-md.png",
+    "description": "Connects your domain to your NextCommerce store at nextcommerce.com.",
+    "variableDescription": "cname is the DNS CNAME target for NextCommerce infrastructure. verification is the domain ownership verification token issued by NextCommerce.",
+    "syncPubKeyDomain": "29next.store",
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip%",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "%cname%",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "29next-verification",
+            "data": "%verification%",
+            "ttl": 3600
+        }
+    ]
+}
+


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test nextcommerce.com/website example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKMc1mkC%2F%2B2UUW%2FaMBDHv0pkqU8jIQkURqRJo3Rbt6moUtuHtkLI2AbcJnZmO4QM8d13DqQkrJP6tk2qEimxfXe%2B3%2Fnv2yDDkjTGhqFog1IlV5wy9ZWiCAm2NkQmCVOEefCDWs%2FrY5yAPRqDxWhvAauaqRUnrHTO2UxzU5vdu4ykEIwY59pIxZxzmWAuwGjFlOZSoChooVgu5K2KwXhpTKqjdrueiZtms5gTF2vNjPZ0x8u0y7A2buDhBP%2BUAufaptuec4Fj10ZzKVZPrjZKPjHqJtRLxQI2pUwTxVNTblxlpp1CZsqhZWaOkbthndTRZe7YOMcV8iwJVhzPYnbeCE4E4DtcO2YJ1ONrZzQeXn5yDFYLZpy5PNqBi7kCJJURkynmOVAePucE22hVlH2GMhdQuyVPm0YGUK2pzhh1ZkUjvE1TF4JcZbPvrNifQYTCgeXxSjqwUIxIRTWKHjbIFKk9vCFML6U28PvRqkFyYfSNhOEJT09gxhg4tk7P97etZ6eS9OCY5%2FmRa1mbV3qf1CFPmoGo0G592TsCOoSfbFsIhMKmB8YJyKEqBFtjuBKV5vc7GwafFloomaVTXvmkWOFE26tTeT803CeV%2F8MuAIx5akdB2Pd8eAI7VVbAzgKCZ%2B0q3zqOXR%2Bejc6DsNNFloAvBIBNNXyxlQmKQDCshZIsNnyKc3yYomSK0zQuAFjDKoRqHupu%2F4qRYoNhdEixVrsWmlJiebm95X44p4z2fLdHwrnbZZi5s6BL3d6pTwb9MBj0B6TWNv7UVl5uHM3CM7jvwnBs%2B8IwznGh0fYFnexJQGVek6ZR2v8PCM8ItSf%2FO9XrNP9vYU5acHneJPgmwb8oQWivGq8YnWJrGvphz%2FW7rv%2F%2Bxh9EwSm8Xm%2FQDzr%2BO9%2BPfN%2BCQLQd8wa6b73voovPP9aj5WNw9iQDVnwq2p0vj21f9a%2F0%2FaUw%2BJs%2BTS7Wd7cXw%2Fu7D2j7C6z8IZh0CQAA)
[Test nextcommerce.com/email example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOIc1mkC%2F%2B1VW0%2FbMBT%2BK5alSZtI0ly6jkbaQ0VhYhNoGuwJoegkPi2GxM5spyVD%2FPfZaTrCLvRhT0NUqpycy%2BfzHX8%2BuaMGq7oEgzS9o7WSK85QHTOaUoG3ppBVharAwD5Q76f%2FFCobT09txEEfYb0a1YoX2CVjBbx8sPUJB1IILAw5dF5yhoJxsSRzaV%2BFDV6h0lwKmkYeLeVSflWlTboyptbpaDSsx6%2BbvOSFD1qj0YFOgkb7CNr4UQAVfJcC1toVPVpwAaXv0HwG6sbXRskbZH7Fglos7aYMdaF4bbqNXYULvmwUatLKRhHW1UYWUhHdl9tRIysOZMifvK7lGhUykrdk1pVAzg7P3gRkxpgm80%2FHJ0TzpXAICguprFHht4a7FAe%2FgWVYctsGyHnJTRu4poDikJc4f1Qnu%2BFV5BG3xJslIaCQmCv3V4ibHY3lKjThWje%2FVtZtOuAYkPMr1Nih9OfMCDTGOg0voCxblz%2Bk7KrTrSg%2BN%2FknbPtTTGk8dScVaCOVU0VPlqYXd9S0dSeD09nJoXVdSW3s66uOzKsg2xRyg62TmuTC6HM58LulP12NupekMVYjySQM770n8eMd%2BPE%2F4ic78JOd%2BJf3HrUuzB46dmnluW0r3oK9qNub2G9t0C4eXSrZ1Bnf5tSgoNLuQm%2BzLx6lX27zLzYAbhvXYmfoHjLHobfGW2s8tCZba7Kx2tqtuO2JZ07kYOwNoqlRDXq0akrDM1jDg4kVGdR12Vqq2not1u%2FiEJuR8bOeQXuDnjYDA49Cnu6wRzNWuK5wN6EgGo%2BnDMBP3kaRP2ZF5E%2Bn7975OZuM2SKPF3E0GYy8v43EPw29x4eDdkYJw8HNslm5hlbT%2Bz%2BIacA33s03fk58k918k%2F%2BM76VnL%2BKLqF9E%2FaxEbYe%2FhhWyDFxoHMYTPxz74f55OE2jSRrtB2%2BjffvbC8M0DB0Ni7YhfGe%2FEMNvA70%2BOsrFaH%2Fy4bhuPzazj1%2Buz09GYTXdiz63S3FiRu18Xuf6bHbw9T29%2FwEsuN1gqAoAAA%3D%3D)
[Test nextcommerce.com/website example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABUd1mkC%2F91T7W7aMBR9lchSf5WEAC2FSJPWtZNGt6Gq7VZpFUKOfQGriZ3aN0CGePddB7JCt73A%2FhCufe7xOfdjwxDyIuMILNmwwpqlkmBHkiVMwxqFyXOwAiL6w1q%2F78c8JzwbE%2BJqj6BbB3apBNTJK0idwoPTfcqV0RoEBvdoLATXJudKE2gJ1imjWdJpsczMzTebEXiBWLik3T5UEhZlmikRcucAXeR6UelC4A7DTsRz%2FtNovnJebnumNM9CzxZKbp9Dh9Y8gwxzGRV6To9KcMKqAuuHG2UuqExpA1krC9DswkOngau1cwzeVijyTrhVPM3g%2BohcaLIfKBfgglyP74Or8eXXjwFyOwcMZubNC0rPLFmypcDSQhRQedRMCe7ZGpa9QrPSVLuFKo5BSFY91JUgg7Q6ovcyXaXFbZl%2Bhmrfg4R1h95PVLsjxMI4vIOXUlmghpIWaDELwljpWPK0YVgVdUO9kT2cwvd%2BSozS6B4MhSe18RM6RKSO9vpxvJ1sW4zaBNNXtgk1o5EBa04D2UzcnhaBPi02t6YspqrJKbjlufOD22Q%2FHaVPmvynHQHFtZ7mINpbRvphXpaaazI%2FdfTlvvKN77zMUE35ir8eSTHlRZFV5MLRLVH%2BWZPdW414yZHvo6OHD2rTYlMpvB%2Fld0jOunFP9HthH2QcnonBIBx05HkIM3Ge9ruDftrpHyzlv5b272t5XFigbdKouN%2B6y2zFK8e220mLivz%2FuaIpcHwJcso9tBt3%2B2F8FsaDh3iYdC6SeBj1OvGwc34ax0kceyPEtrO5oRk5nA52IfTd46cbPB3FAqv27dq%2BpF%2B%2B97gt1%2BNeIR9vRh%2FGP%2Fh9pkbP79j2F2fZQUdtBQAA)