### PR TITLE
Add ATLOS Mail template (atlos.email)

### DIFF
--- a/atlos.email.mail.json
+++ b/atlos.email.mail.json
@@ -4,11 +4,10 @@
   "serviceId": "mail",
   "serviceName": "ATLOS Mail — Email Service",
   "version": 1,
-  "logoUrl": "https://app.atlos.email/logo-icon.svg",
+  "logoUrl": "https://app.atlos.email/logo-wordmark.svg",
   "description": "Configure DNS records for ATLOS Mail email service. Creates MX, SPF, DMARC, and auto-discovery records.",
   "variableDescription": "The domain to configure for ATLOS Mail",
   "syncBlock": false,
-  "shared": true,
   "syncPubKeyDomain": "domainconnect.atlos.email",
   "syncRedirectDomain": "app.atlos.email",
   "records": [
@@ -20,16 +19,17 @@
       "ttl": 3600
     },
     {
-      "type": "TXT",
+      "type": "SPFM",
       "host": "@",
-      "data": "v=spf1 a mx include:mx1.atlos.email ~all",
-      "ttl": 3600
+      "spfRules": "include:mx1.atlos.email"
     },
     {
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@%domain%; fo=1",
-      "ttl": 3600
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
     },
     {
       "type": "CNAME",

--- a/atlos.email.mail.json
+++ b/atlos.email.mail.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "atlos.email",
+  "providerName": "ATLOS Mail",
+  "serviceId": "mail",
+  "serviceName": "ATLOS Mail — Email Service",
+  "version": 1,
+  "logoUrl": "https://app.atlos.email/logo-icon.svg",
+  "description": "Configure DNS records for ATLOS Mail email service. Creates MX, SPF, DMARC, and auto-discovery records.",
+  "variableDescription": "The domain to configure for ATLOS Mail",
+  "syncBlock": false,
+  "shared": true,
+  "syncPubKeyDomain": "domainconnect.atlos.email",
+  "syncRedirectDomain": "app.atlos.email",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.atlos.email",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "v=spf1 a mx include:mx1.atlos.email ~all",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@%domain%; fo=1",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig",
+      "pointsTo": "app.atlos.email",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "autodiscover",
+      "pointsTo": "app.atlos.email",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **ATLOS Mail** — a business email hosting platform. This template allows customers with domains on Cloudflare to auto-configure all required DNS records (MX, SPF, DMARC, autoconfig, autodiscover) for email service with a single authorization.

**Provider:** atlos.email
**Service:** mail
**Template:** `atlos.email.mail.json`

### Records created:
- **MX** — `mx1.atlos.email` (priority 10)
- **SPFM** — `include:mx1.atlos.email` (SPF merge)
- **TXT (DMARC)** — `v=DMARC1; p=quarantine; ...` (with txtConflictMatchingMode)
- **CNAME (autoconfig)** — `app.atlos.email`
- **CNAME (autodiscover)** — `app.atlos.email`

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `domainconnect.atlos.email`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — using `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — DMARC uses txtConflictMatchingMode with Prefix mode

## Online Editor test results

**Editor test link(s):**
[Test atlos.email/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMw61mkC%2F%2B1WXW%2FaMBT9K5alPS2kCV%2BjqZDKoJumNawqbOvUVcjYBrwmcWY7FFZ1v33XQCApbJr21El94mLfe3zu11HuseFxGhHDcXCPUyXngnH1juEAExNJ7fKYiAg726s%2BicEVd4bnHwYoXN9pruaC8lVUXDra80Zfs6rn19GZ9UODtRf4z7nSQiY48B0cyan8qCKImxmT6uDoiKSpW6BzZD0qd1KxmKhbV8%2BngMC4pkqkZoWCuzKZiGmmOOr1B0hxCs4aTaRCBS4rMLSh6qKu4lAHjcIrBw0u3jioF3Yuuw4iCUMkM7LChKYSmC5zQNcyJ0qQccR7pfeHM46YBPwEGYnolk2ZgS3UMqGvI0lvcTAhkebrk4ts%2FJ4veysAQFsjAUrCqXHLjbHul5wJoGS2AY8KBm4bxji4vsdmmdquhFdwPpPagH1qWyxFYvRQ2i4ufPdx%2F4VUwiyhQ56DjYH21Jqe9%2BBs4aBkYRlQp5PLLOLwKAb2UcZ48Bi4ED%2B8Gu7CR7a11LaVGAL%2F5%2B1VM%2FwTlLa%2FZ0SRxIiEnyCVkbYFMjJYRZy%2BWNfqxQmUuu3jAlUwF8bORSSoCYmhM5FMQ8ns2xeKT8QCH3TZ3O04FEl3%2B53wbEfbjsm62eV67vfjUAUPgOUj9%2FdwNw8O%2FiETPtp1%2FMbZTBCE8gWBfeculfHuJbCmSmbpSOT%2BKZQ41lYT8sjrUuhNHnuNrU1yQ2fj3KQJLH%2FRCWqbm%2FFie0jUlG%2FOgbmYJlLxkYZfYmBhcGBUBksRZ5ERI3JHdkeMjqAO0RIS1XALEI9GO1mLz%2BluivbHujAd5QkfMWqzF1bT2KvJK0bGjUpj7HuVOvVYZdyqjiu1%2BvFxs9Zq1hukXpDIA%2Bp5QCF3pedacxhnYhWvE92RpcYPe3uxn8y8Dfvlo99sFvpJom2CkN%2FTTemfV70wj4e2%2Femkm%2B%2F1JuGSSGyS%2FsNGP%2FFMCgr1P%2BRy44C8PQvFs1A8C8WzUPxRKOzXDJlzNiLWrepVmxWvXvFaQ98PqrWg0XSPW16z0XrpeYHnWfJcm3Vm9%2FAlU%2FyGwc1woAa15l2107o9vuh%2BiSf9s7f9D1989rk3pqw1myz4%2BafF%2B28t2cYPvwBza9P3lQ0AAA%3D%3D)
[Test atlos.email/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL411mkC%2F%2B1WXU%2FiQBT9K5NJfLLUFgjaGhIR3cTs4iJg1sQ1ZJgOMNp2ujNTBAn72%2FcO5aNFduPDPmjiE2V675lz77n3pHOsWZSERDPsz3EixYQHTF4F2MdEh0LZLCI8xNbm1TWJIBQ3et%2B%2Bd1Ere6eYnHDKlllR4ehVNPqZlh23ii5NHOpmURA%2FYVJxEWPftXAoRuJWhpA31jpR%2FtERSRI7R%2BfIRJSehQwiIp9sNRkBQsAUlTzRSxTcFPGQj1LJ0MV1F0lGIVihoZAox2UJhlZUbdSUDPqgUOvOQt32FwtdtBqdpoVIHCCSalEKuKICmM7WgLZhTiQng5BdFO7vjRkKBODHSAtEN2yKDEyjZjE9DwV9wv6QhIplJ%2B108JXNLpYAgJYhAUrMqLaLwpjwDgs4UNKbhJ2GQdiKMfbv51jPEqNK6w7Ox0JpeD4zEgsea9UTRsWpa%2B%2Fqz4XkegYKORbWGuSp1BxnYW3goGWtIqBKhp00ZHApBvZhGjB%2FFziX37vrbdP7RlpqZCWawP9JfSmGe4qS%2Bq%2BUSBJrHrNTJFNSN0Ba%2BMuMs4OsVwen0Oq6i3NU4XGqzVyEnOoW0XTM41FLBObutmRDPsV7Q1bvthzypJvXjdbllrYZk0zsYj9f67Gvg3vA1iP3driHhYVfRMz6W8UfrNUEQSqbEth3ZlMRbW9agYykSJM%2BX%2Bck0OZIGV9YZ98X0h%2FW%2BfcZgLmZj2IhWV%2FBL9Ew8NjXMoWhjtJQ8z55JtujgPahjnAGRBW8BZid0Ywz81iRWw3C68nMCVwc0n5ADXlubMlzacWpVKulgAwHpWrNrZQGlHolr1Ym1Ds%2BcTzvOOdyewxwj8kVu8eUYjCVxBhXI3wmM4UXr8Z7b02TOmyKi%2F6yI%2Bg3CTd1Qpnvu7Jsce3dAt%2B4vbnx2rfA76vu9bquKt%2Fu%2Fk71%2F9jWD1DS2oE%2BWlEPFnjYp6N8Osqno3w6yv9xFPjgUWTCgj4xoWWnXCs51ZJz0nNd3yn75bLtVmtexT10HN9xTAFM6ay6OXwb5b%2BKcPyj0n651dybTa8m5LzSJLG6OWzcPDYeWW3YqYXSeYnazvTRu6rjxR%2Be6jtYpw0AAA%3D%3D)
