### PR TITLE
Add Buckt CDN templates (buckt.dev)

### DIFF
--- a/buckt.dev.acm-validation.json
+++ b/buckt.dev.acm-validation.json
@@ -15,7 +15,7 @@
 		{
 			"type": "CNAME",
 			"host": "%certValidationName%",
-			"pointsTo": "%certValidationValue%",
+			"pointsTo": "%certValidationValue%.acm-validations.aws.",
 			"ttl": 3600
 		}
 	]

--- a/buckt.dev.acm-validation.json
+++ b/buckt.dev.acm-validation.json
@@ -1,0 +1,22 @@
+{
+	"providerId": "buckt.dev",
+	"providerName": "Buckt",
+	"serviceId": "acm-validation",
+	"serviceName": "Buckt SSL Certificate Validation",
+	"version": 1,
+	"logoUrl": "https://cdn.buckt.dev/logo.png",
+	"description": "Configures DNS records for AWS ACM certificate validation for Buckt CDN.",
+	"variableDescription": "Certificate validation CNAME record for SSL provisioning.",
+	"syncPubKeyDomain": "buckt.dev",
+	"syncRedirectDomain": "buckt.dev",
+	"shared": false,
+	"multiInstance": true,
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "%certValidationName%",
+			"pointsTo": "%certValidationValue%",
+			"ttl": 3600
+		}
+	]
+}

--- a/buckt.dev.cdn-cname.json
+++ b/buckt.dev.cdn-cname.json
@@ -1,0 +1,23 @@
+{
+	"providerId": "buckt.dev",
+	"providerName": "Buckt",
+	"serviceId": "cdn-cname",
+	"serviceName": "Buckt CDN Domain",
+	"version": 1,
+	"logoUrl": "https://cdn.buckt.dev/logo.png",
+	"description": "Points your domain to Buckt's CDN distribution.",
+	"variableDescription": "CNAME record pointing to your Buckt CDN distribution.",
+	"syncPubKeyDomain": "buckt.dev",
+	"syncRedirectDomain": "buckt.dev",
+	"shared": false,
+	"hostRequired": true,
+	"multiInstance": false,
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "@",
+			"pointsTo": "%pointsTo%",
+			"ttl": 3600
+		}
+	]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

> [!NOTE]
>  `acm-validation` uses `%certValidationName%` as a bare host variable because AWS ACM generates fully dynamic validation hostnames (e.g. `_abc123.example.com`) that cannot be predicted with a fixed prefix.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

- `acm-validation → subdomain`: [Editor link](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPpy1mkC%2F%2BVTYW%2FaMBD9K5GlfhpJk5DSNNI%2B0FBp1Tq6FbpJrVB0cS5gLbEj21Ao4r%2FPTkuBUm0%2FYJ8S%2B%2B6d7713tyYa66YCjSRZk0aKBStQXhckIfmc%2FtZegQvSeQsMoTaJ5NKGzLVCuWAU23SgtbuAihWgmeC74D7EGY1unBSlZiWj5k3n5z5ggVLZvyTokEpMxb2sDHCmdaOS01NacO%2BtpVMb9xo%2BNbACFZWsaYskJBW8ZNO5ROUMhiNHIhWyUE4ppNP%2FNXL66TeH7jWw67hNeekyHQw92w9IBnmFg8MHPkanw%2F63q9fn2lKWaiub5cT41FZUK06%2Fz%2FOvuBqIGhh%2Fp7IN32HBTBX9ccIMJBqxS6gUdkg9rzS75koDp0ZjLefm8pUxSR7XRK8aq33bm4HPhNLmeGIF2ClvDTqxHgvGtRqL4wzzN8cT79Bh5cGTsqS0NjZ1e76%2FmWw65FlwzHY9TIw%2FWya4BDNq6FFR75oxtprDVIp5k7EtpAEJtbITuQU%2FHqAnW%2FhjizfHY0o2mHXLMA8gonFxnNSyepfl2Sk7eMlQYlMuJGbKfEGbydoq3cqfwRPsrgqaQdNUK6OAMlFT%2FdgF%2FrIQ7161gwwajgP77fzTgg7JCmp1Y3YlMYjDoBfFbnxR5G5EsXRzCAr3AgJE2oPy%2FDzcW%2B6jrf%2Freh%2F4h0oh1wzswvarJ1gpstlMOsbL%2F5m%2FGTkFCywysJmhH%2FZcP3L9eBycJWE36cbeWRBFof%2FJ9xPftzxQ6RcV1mbu9ieOpLFfzu4HTROP7y79iobP6UN5u4xmt%2BrH8uzhZpaPxsvzsud%2FufpMNn8AMURb8dcFAAA%3D)
- `acm-validation → apex`: [Editor link](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABlz1mkC%2F%2BVTXW%2BbMBT9K8hSnxYoAZY2SHtIkz5UaaO19ENLFaEb21BrYDPb0GZR%2Fvts2pSkqbYfsCeM7z3X55x77xppWlYFaIriNaqkaBih8oKgGC1r%2FFN7hDao9x6YQWkS0ZkNmWtFZcMwbdMBl24DBSOgmeBdcBfiJMmlM6ZSs4xh86ZzvwtoqFT2FPd7qBC5uJOFAT5pXan4%2BBgT7r1TOrZxr%2BK5gRGqsGRVWyRGY8EzlteSKmcySxxJsZBEOZmQzughcUbjKwfvEOgYtymvLMeTmWf5gGSwLOhk%2F4HP0ePZ6Or87bm2lJXa2mY1MZ7bimrF8fd6OaWriSiB8Q8u2%2FANJcxU0Z8nPIGkxuwMCkV7qKwLzS640sCx8VjL2ly%2BKUbx4xrpVWW9b7kZ%2BJNQ2vweWQM6522DjmyPBeNa3YrDDHOq6ZG332HlwbOyorQ2bQoHvr9ZbHrot%2BA07TgsTH%2B2SugLmFGjHhZlR8accinqKmXb%2FAoklMqO4xb5uAddbLGPyJ4PxdhIGmbBsg8RPiWHSa2eD1mena%2B9Z4wYlnMhaarMF7SZqa3HrfEpPEN3RXAKVVWsjHZloqb6of%2F8dRV2uRkgaNi%2F%2FEjln8b3UEqwNYzZRQwiMowIzdzTMKNuFOKBO6SDgRvAAHAYZRE5Ge6s9MGu%2F3Wpu65RpSjXDOyOjopnWCm02Sx6poP%2FpXAzZAoaSlKwaYEfDFw%2Fcv3T2%2F7XOIhif%2BiF0dDvn3zx%2Fdj3rQiq9KsFazNpuzOGzh6uQ32p9PTlx01w%2FutufsvvVZI0ZD69mfu8mmbJPHzhgzPIv6HNH0X3I6DDBQAA)
- `cdn-cname → subdomain`: [Editor link](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK9I1mkC%2F91TbW%2FaMBD%2BK5Glah9GQhJeCpEmjcE0VdVoh5i2CaHI2Ae4S%2BzUduhSxH%2FfOYy3df0D%2B5Tcy%2FPc3eO7LbGQFxm1QJItKbTaCA76hpOELEr20wYcNqRxDIxpjonkgwuh24DeCAZ1OuPSZ9LFj%2F7zbG84GnsjlVMhMWED2gglSRI1SKZW6qvOMHFtbWGSZhOpgmP1posHhVwhjINhWhS2hpJ7JaQ1XqVK7fGa2bPKq6u9MXU9LozVYlE6QODKUi3oIoPRBc9wPPj80dPAlOZe4UiFXDmqmvnU%2Fd9sppLsvlzcQvVnrkvNXHgCXCCx%2FXfCmmpA6ZY0M9Aga2XsBB5LUTutLtGXl5kVN9JYKhkcM%2FetGpLMtsRWBRxmIHsSNN%2B7N6vlmSo0rw7%2FV%2Bi3FrVudcNwN981yLOSkJ4I5yjyoVf4RXE1IGAqPzHj26Cx0qosUnGAFFTT3LgNOoBnF%2Bj5AT6r8fPz5maER3Gr3ekGLFMlX2olbSDBEtedWEmlITX4pbbUcKFLSp%2FoycVZSosiq3AYg1EkfqmO3C%2FkfgZOLUXjlepnOjVIypkbTrg9j6JrHtPo2od%2Bm%2FqIjPxef8F9tuz22zxqA2vHZxfz4pReu5kLfcEYwDWk7ioG2ROtDNnt5g3U%2Br8bCpfB0A3wlLrMOIy7ftj2w940ipO4lURR0O%2F0seG3YZiEoRsBjN2PucUNOd8N8uOB3uVad%2BG7%2FdTaPE%2Ba0e11Ph0%2BhNUX%2Fq0X9e6LWHVGjx0YD96R3W8nmkaX%2FAQAAA%3D%3D)
