### PR TITLE
Add template for Zibray Mail email hosting

### DIFF
--- a/zibray.com.email.json
+++ b/zibray.com.email.json
@@ -1,0 +1,48 @@
+{
+  "providerId": "zibray.com",
+  "providerName": "Zibray Mail",
+  "serviceId": "email",
+  "serviceName": "Email Hosting",
+  "version": 1,
+  "logoUrl": "https://zibray.com/logo.svg",
+  "description": "Configure your domain for email hosting with Zibray Mail. Sets up MX records, SPF, DKIM, and DMARC in one step.",
+  "variableDescription": "%dkimSelector%: DKIM selector (default); %dkimValue%: DKIM public key TXT record value (the full v=DKIM1; k=rsa; p=... string)",
+  "syncPubKeyDomain": "zibray.com",
+  "syncRedirectDomain": "zibray.com",
+  "warnPhishing": false,
+  "records": [
+    {
+      "groupId": "mx",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mail.zibray.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "ttl": 3600,
+      "spfRules": "include:zibray.com"
+    },
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "%dkimValue%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@zibray.com",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ],
+  "syncBlock": false,
+  "hostRequired": false
+}


### PR DESCRIPTION
# Description

Add Domain Connect template for Zibray Mail (zibray.com) email hosting service. Sets up MX, SPF, DKIM, and DMARC records in one step.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description. Note: `%dkimValue%` is bare because DKIM public keys must be the complete TXT record value (`v=DKIM1; k=rsa; p=...`), prefixing is not possible.
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

[https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPbW12kC%2F%2B1WbW%2FaSBD%2BK6uVKrWqIXbMkcYRUhxIrijnlLxcyzWK0GKvYY%2B119ldQ5yI%2B%2B03a0zAJf10J7WV8oll3meeZwaesKZJxomm2HvCmRRzFlHZj7CHH9lYkqIZigRbz5oLkoAl%2FlrqUEAYB6Wics5CWnrRpCar7E%2BNFH0USrN0Ato5lYqJFHuOhbmYiD8lB6up1pny9vY2mfeMsqnmxieiKpQs06Uf7oo0ZpNcUlSIXKJIQIYUxUKisgI0XeVCC6anaKvcJrqmWqE8Q8EQSRoKGSkLXQ%2FOLNQ77wcWImmEeoF%2F1UUQT6QUKU2zpqmZSEbGnPZqdbyJZiy5ppyGWsg3XhkEqeo7ehvRmORcvztCpeFnwnO6tsryMWchmtEC3QxvqmLQ3Jigt3pKUZxzjuYdY%2BwcoVlHKnKEsk6z2YSiJHT3zgy6SMNBPj6nRa%2BcwbfIGf0VjRiE1y9bLIhMB1OmpgYbLyZcUQtXo8He7ROeSJFnJbrJA9jrIjOYBkN4mzHD%2B9hQRLBUqxthzMygv%2BEPE5LpAhC3IYIGuN22bS%2Bt7egqizfhAZKgnuDZyzKWVzmnUB5macjziHpb6epRzdw3YWHSm6h18JqjFYsAEEM3osnaZAUb%2Fm7hUUJk%2BJ0co7WyCgh4GnY5Bsn7nEiSAk%2FpEZI56Zi5aeGVHse1%2BW31rh%2B0IT9QRwdEhwa1QEQm70DSmJUI7ZpUuk1%2BvLxbkeOEi3D2jLup%2Bore58CXqBIuLfwIizDaUAI8ozWV6AOBA0KrOqum4VVOZ8TW9hl0mihzZNaetzXXu7XvLTbvbWCMrNqjtaoExMh3tyPo90%2F6f%2FsXJ5PZ%2FXTGfj9c2Cf%2B5emZ73%2Fq%2BpcffKPvTs7hferjO%2BiNTVIh6UjBJ9FwULCnZQ6TSCAfGxHYjmdRFI5IlvECRqFMNd4tbMf2OqSrc3e8gXt3FbagrG%2FFKArNfJhhVDweu2774KARH7oHjZZLnAYJHbsR2yR23AMSjt1o6yzvHuyXbvIGHKoUBd4Rc3V9viCFwktD6RqBd5uZd2DxHLS7cugfwnm9t5%2B0m4pIL%2B76fyTTr9D%2B%2F36NfnSfdxZcl9ctfN3C1y38kVto%2FkuQOY1GxJjt2%2Fvtht1q2Ic3Tttr7Xuu3fzN%2FuC47fe27dm2KZ4qver%2BCX6Dt399cde%2FPmw9OF8G%2FK%2BP9gX%2Fo72gEzJ8TIKzM3X%2BWbHiU294ebrvFl9aHbz8F9MQ%2FDjCDAAA

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHTY12kC%2F%2B1WbW%2FaOhT%2BK5alSZtuSANltKRCGpRuQ122vt0KraoiExvwMHFqO9C0Yr%2F9HodQktJ92pdeqZ9Kfd6f5zkHHrFh80QQw7D%2FiBMlF5wyNaDYxw98pEjmRnKOnSfLdzIHT%2Fwzt6GAcAFGzdSCRyyPYvPKW%2BF%2FYl%2FRV6kNjydgXTCluYyxX3ewkBP5rxLgNTUm0f7e3rbynjW6emFjKNOR4onJ4%2FCxjMd8kiqGMpkqRCVUiNFYKpR3gKbrWmjJzRSV2nXRJTMapQkKhkixSCqqHXR59tlB%2FdNB4CASU9QPuhfHCPLJmCFtWOLananiZCRYv9LHOzrj80smWGSkeufnSZAu%2FkfvKRuTVJgPRyh3vCYiZRuvJB0JHqEZy9DV8KpoBi2sC3pvpgyNUyHQomOd60do1lGaHKGk47ouNKVgug8W6CyOztLRKcv6OQbPmbP2C0Y5pDcveyyJis%2BmXE8tN%2F6YCM0cXECD%2FZtHPFEyTXJ25%2Ffgb7LEchoM4bOFGT5%2FshKRPDb6Slo3C%2FQz%2FXCpuMmAcQ8yGKB7v%2BV5K6ecXSfjbXqgJKgWeIpyrOdFKhi0h3kciZQyv1SumtXivk0LSG%2BzVslzw7WKgBArN2LIxmVNG%2F5j43ROVPSHGuHGWCQEPq266pbJu5QoEoNO2RFSKelY3Iz084hPFfxKs5t7Y8UP0jEBMZFlLZDU1j1TbMxzhnZdCtu2Pl7drsXREzKaPfFuu75gdynohRaPKwc%2FwCKEW0lAJN1Iid0TOCCs6LMYujgCOUIh38QkMO1c20Ozib6phN9u4m%2FWCWyZEkH2vdinjSknxr7vbkkwGPQGv7rfe5PZ3XTGv7SXXq97fvK52%2F1x3D0%2F7Fr78eQUPp908S3MyCexVCzU8JcYOCzYNyoFROZQj4cEtuTpiUYhSRKRASTaduPfwJaU1yJen70ChoL53a0osVpdkJBGFiZuxTVmh1FEm15tRGmz1mwRVhvVaatGvXGj4XkHDe%2BjV7rQu7f7pfNc5YlpzUCGxB7hrliSTOOVVXhFzy%2FOtOjAKtbR7hKi30SI6oiveKhCVqUL4D6f86%2F09X%2FBYX2sdmf%2Fu4v1Gga%2BdeACvW3p25a%2Bbelr3lL7m4QsGA2JdW14jVbNa9a89lW95TcP%2FY8Nt%2B216%2Fv7%2F3ie79kWDNNmjcAjfIeXv73x5AfpXY8OWnKYHSzPLw%2Fb3%2Fqz5kHUiCZ7y97w%2FudDQw%2F1df3rSX%2FZwav%2FANGrfjkKDQAA](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFvd12kC%2F%2B1WbW%2FaSBD%2BK6uVKrWqIYbQGBwhxZCkx0U0KcnluIsia7EXvGXxOrtrEieiv72zxgS7pJ%2FupLZSPrHM%2B8zzzMAT1nSRcKIpdp9wIsWShVQOQuziRzaRJKsHYoGtZ80nsgBL%2FG%2BuQ0PCOCgVlUsW0NyLLiqywv7ESNEfQmkWz0C7pFIxEWO3YWEuZuIvycEq0jpR7t7eNvOeUdbV0viEVAWSJTr3w30RT9kslRRlIpUoFJAhRlMhUV4Bita50D3TESqVW0eXVCuUJmg4RpIGQobKQpcXpxY6PhsMLUTiEB0PvVEfQTwRU6Q0TeqmZiIZmXB6XKnjTThni0vKaaCFfOPmQZAqvqO3IZ2SlOt3hyg3vCY8pRurJJ1wFqA5zdDV%2BKooBi2NCXqrI4qmKedo2TXGjUM070pFDlHSrdfrUJSE7t6ZQWdxcJFOzmh2nM%2Fge%2BSMfkRDBuH1yxb3RMYXEVORwcadEq6ohYvRYPfmCc%2BkSJMc3cUD2OssMZgOx%2FA2Y4b3kaGIYLFWV8KYmUF%2Fxx8mJNMZIG5DBA1w7x%2FY9soqR1fJdBseIBlWEzx7WcZylHIK5WEWBzwNqVtKV41q5r4NC5PeRq2CV%2FfXLAJADN2IJhuTNWz4h4WHCyKDH%2BTwN8oiIOBp2NUwSN6lRJIYeEoPkUxJ18xNCzf3OKrMr9S7ftCG%2FEAdPSQ6MKgNRWjyXkg6ZTlCuyaFbpsfr27X5OhxEcyfcTdVj%2BhdCnwJC%2BHKwo%2BwCP6WEuAZbqhEHwgcEFrUWTQNr3w6PtvYJ9DpQpkjs%2FG8qbjebnxvsHmXgTGyYo82qhwQI9%2FdjuFg0Bt88T71ZvO7aM4%2Bdu7tnvf55NTzzvve57Zn9P3ZGbxPPHwLvbFZLCT1FXwSDQcFu1qmMIkF5GM%2Bge14FoWBT5KEZzAKZapxb2A7yusQr8%2Fd0Rbu3VUoQVndCj8MzHyYYVTLdj60Dyadmt0OPtRadNqqtTuOUwuc%2FXC%2FczB1Gq126SzvHuyXbvIWHKoUBd4Rc3U9fk8yhVeG0hUC7zaz7MLiNdDuyqGvhPNqb79oNwWRXtz1%2F0im36H9%2F%2F0a%2Few%2Bby24Lq9b%2BLqFr1v4M7fQ%2FJcgSxr6xJg17eZBzW7V7M5Vw3Htjtty6s2W07b339u2a9umeKr0uvsn%2BA0u%2F%2Fri6%2BuIJ822WEaRN344dzqPgrf%2BPn10%2Bq1s9HF23vnnnI%2Fnf86bvVkXr74B5jfrwsIMAAA%3D)

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO%2Fd12kC%2F%2B1WXW%2FaSBT9K6ORKrVa4xhKSXCEVAhpgiJnyVeVbRShwXOBWWyPMzOG0Ij97b1jTMAhfepLVspTyNzvc8698EQNxGnEDFD%2FiaZKzgQH1ePUpz%2FFULGFG8qYOs%2BWcxajJ%2F2R20jARIRGDWomQsijIC69Ff7H9pWcSm1EMkbrDJQWMqF%2B1aGRHMsbFaHXxJhU%2B3t7m8p71ujqmY3hoEMlUpPH0SOZjMQ4U0AWMlOES6yQkJFUJO%2BATFa1yFyYCdlq1yVXYDTJUhLcEgWhVFw75Kr%2FzSHds17gEJZw0g3al0cE88kEiDaQurZnpgQbRtAt9fGBT0V8BRGERqoPfp6E6OJ%2F8pHDiGWR%2BXRIcsfvLMpg7ZVmw0iEZAoLcn17XTRDZtaFfDQTIKMsisisZZ2rh2TaUpodkrTlui42pXC6TxboRRL2s%2BEZLLo5Bi%2BZs%2FZL4ALTm9c95kwl%2FYnQE8uNP2KRBocW0FD%2F7omOlczSnN34Ef3NIrWcBrf42cKMn79aiUiRGH0trZsF%2BoV%2BhFTCLJBxDzMYpPtzw%2FOWznZ2nY426ZGSoFzgOcqxnpdZBNgeFUkYZRz8rXLlrBb3TVpEepO1TJ47WKkICbFyY4atXVa00d82zmOmwt%2FUGKyNRULk06qrapl8yJhiCeoUDonKWMviZqSfR3wt4bc1u3k0VvwoHRMwE1rWAslt3b6CkcgZ2nUpbJv6dHm%2FEkcnkuH0mXfb9SU8ZKgXXjwuHfoTF2GwkQRG8rWU4JHhAYGiz2Lo4gjkCA3EOibFaWNtD806%2Bq4Ufr%2BOv1slsGW2CLLvxT6tTTkx9n13S4Jer9P7t33eGU8fJlNx0px7nfbF8bd2%2B%2B%2Bj9sVB29qPxmf4%2BbhN73FGMU6kgoHGv8zgYaG%2BURkiEmM9MWC4Jc9PPBywNI0WCIm23fh3uCXba5Gszl4BQ8H87lZssVpekAEPLUzCiqvWrB8wj7PKcAi8Uq%2FW6xXW3G9WRsB5o%2FalwZoNb%2BtC797u185zmSfQGlCGzB7hdjRnC02XVuElPb8606yFq1glu0tI%2FmNRVB7xDQ9VyGrrArgv5%2Fwjff1fcFgdq93Z%2F%2BxivYWB7x28QO9b%2Br6l71v6lrfU%2FiZhM%2BADZl1rXq1R8eoVr3ld3ferNb%2F6xf3cbGIHf3me79kWDGizQuAJv8O3v73pQy2dx52TCTtN%2Fpn0TfMiiedDOPMOZPf85AZufgTcO5%2BFN%2Fun0xZd%2FgJgFU8JCg0AAA%3D%3D