### PR TITLE
Add Valiant AI email sending template

### DIFF
--- a/valiant.biz.email.json
+++ b/valiant.biz.email.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "valiant.biz",
+  "providerName": "Valiant AI",
+  "serviceId": "email",
+  "serviceName": "Valiant Email Sending",
+  "version": 1,
+  "logoUrl": "https://app.valiant.biz/valiant-logo.png",
+  "description": "Configure DNS records for email sending via Valiant AI platform (DKIM, SPF, MX)",
+  "syncPubKeyDomain": "valiant.biz",
+  "syncRedirectDomain": "valiant.biz",
+  "warnPhishing": true,
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey.%host%",
+      "data": "p=%domainKey%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "%host%",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mx",
+      "type": "MX",
+      "host": "%host%",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "ttl": 3600,
+      "priority": 10
+    }
+  ],
+  "variableDescription": "domainKey: DKIM public key from Resend"
+}

--- a/valiant.biz.email.json
+++ b/valiant.biz.email.json
@@ -8,26 +8,26 @@
   "description": "Configure DNS records for email sending via Valiant AI platform (DKIM, SPF, MX)",
   "syncPubKeyDomain": "valiant.biz",
   "syncRedirectDomain": "valiant.biz",
-  "warnPhishing": true,
+  "hostRequired": true,
   "records": [
     {
       "groupId": "dkim",
       "type": "TXT",
-      "host": "resend._domainkey.%host%",
+      "host": "resend._domainkey",
       "data": "p=%domainKey%",
       "ttl": 3600
     },
     {
       "groupId": "spf",
       "type": "SPFM",
-      "host": "%host%",
+      "host": "@",
       "spfRules": "include:amazonses.com",
       "ttl": 3600
     },
     {
       "groupId": "mx",
       "type": "MX",
-      "host": "%host%",
+      "host": "@",
       "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
       "ttl": 3600,
       "priority": 10


### PR DESCRIPTION
# Description

Add Domain Connect template for Valiant AI email sending service. Configures DKIM (TXT), SPF (SPFM), and MX records for client sending domains via Resend/Amazon SES.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `valiant.biz`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — removed in latest commit
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `valiant.biz`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — using `SPFM` record type for SPF
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, no DMARC records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) — DKIM uses `p=%domainKey%` prefix
- [x] no bare variable is used as the full `host` label — DKIM host is `resend._domainkey` (fixed prefix)
- [x] no variable is used in the `host` field to create a subdomain — using `host` parameter via `hostRequired: true`
- [x] `%host%` does not appear explicitly in any `host` attribute — using `@` and built-in host parameter
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A, all records are required for email sending

## Online Editor test results

[Test valiant.biz/email example.com/send](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHM72GkC%2F%2B1UbU%2FbMBD%2BK5alSZuWhLRNSxsJaYWyUkEr%2BsKLQKhyErdYJLGxnUJA3W%2FfOW0pHeXDtC9M4lMc391z95yfu2esaSJioin2n7GQfMYiKjsR9vGMxIyk2gnYE7ZeTD2SgCs%2BXxhRswM2ReWMhbSIoglh8fruD%2FdDY0VDmkYsnYLXjErFeIr9koVjPuVnMgbvW62F8nd2iBDOqyp2lmfbeDqiAIioCiUTugDBBzydsGkmKWr1hkjSkMtIoQmXqCgLqUViNGMErRkgwx%2BcEvS1ddzpWmh4%2BtNC3ctvhkaehqdZcEzzFgeI9E1fjMOARgyS6XdcbrnSA3qfgQ90SMuMWnhZG%2Favn%2FFU8kwUzYvuWAIBOhemaaPL0TIafiQ1xTvjqMhxR3NDnmgCJrH3ZXELVX4x4RqaWKm57tx6Da7EZI0NFLtr8B%2BGiJgMsphCSZilYZxF1CcJeeKposoJefI%2BcPK4xu1ebqIKzlKtRhx%2BJ5RGAQnvbJVo4WTKpkRpu%2BS8m8WIjnHJdA76cOc3IBciGQli2tp49RfyPjLvh0QWxCxE0CM0kTxBg6J1eG5hyEPH69YDYrR6MvpIYA7osoYlgyLOWlAds1WMIJIkyszLKvp6I%2FxmFX%2B9AHhJAyWay26nPek23fbB8L497ASVVv9wv9k%2Faza9dq%2FZOthn%2FeP9af9AU8C4garZNOWSjhV8iQZxrzSUZLFmY%2FJA1ldROIahiXMgqcAK2UBfG3JKFwP5Rk7OkuuLpv6myo1HG0eh6Q0z0gjcUs2rlst2rdpwbW%2FXC%2Bx6vR7a1QZ1K%2BVavVL3dl8tly17Z9tu2XwdquCgGTGboxk%2FkFzhuRHoNtqbJGd7IPoS2ip39IvE8YcmVozaVl7%2FOGkfhOmNBcP2Kd9P%2Bf6n8oW1r8iMRmNiXMtuuWa7nu02RuWKXy35papTLXueV%2Fnuur7rGj6gxUULnmHrv973%2BLTRzStn5cHjVb1%2BpG6nF0fqIuvt3ovRlVs6USzoTfXVyflV3q7v4flvzX426tUJAAA%3D)
