### PR TITLE
Add HiveStatus domain verification template

### DIFF
--- a/hivestatus.cloud.domain-verification.json
+++ b/hivestatus.cloud.domain-verification.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "hivestatus.cloud",
+  "providerName": "HiveStatus",
+  "serviceId": "domain-verification",
+  "serviceName": "Domain Verification",
+  "version": 1,
+  "logoUrl": "https://static.cdn.hivestatus.cloud/v1/assets/logo.svg",
+  "description": "Enables a domain to work with HiveStatus",
+  "variableDescription": "Unique verification code provided for purpose of verification",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.hivestatus.cloud",
+  "syncRedirectDomain": "hivestatus.cloud",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "@",
+      "data": "hivestatus-verification=%verifytxt%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "hivestatus-verification="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a TXT record template for domain ownership verification.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test hivestatus.cloud/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADVp2WkC%2F91UYU%2FbMBD9K5ElPq1NnZJlLNKkwboBA6aOFYSEqsixndaQ2sF20mZV%2F%2FvOaSkNKto%2B71Ni37vne%2FfOXiLLZ0VOLEfxEhVaVYJxfc5QjKai4sYSWxqf5qpkqLON%2FyAzwKMzQPxqEBAzXFeC8iaVqRkRsltxLTJBiRVKviA2yYMG4922MZBi3F8cdFCuJupG564UawsT93quHEF9yqT%2FurpeFfSIMdyansvzTTUBOsYN1aJoyGP0VZI058Yj3rpAzypvrvSjNxd26rXUVEQLBx60CG6keCq5t6vLo4pxb9MY5mVKe0WpC2W4pzLvdQdqSU9yRR9RnJHc8PXOsEwveL3ux7Z5VEnJqfX3uOByrjkTGuLbrD24qTL2mj%2BVAGTbAyFJaWZQfL9EE63KojHsVZ22LpxFo7vRhgYWn107iSWts1oWfzpoVrVd2ANHYsG6wwhj%2BF3YL0pmuaD2ilg6FXJyBW0DqqHmmVigvZBN7O3z0Gq86qDfSvLkRda4s%2BkgJPIFgeHmPlWztpBGeSKahLZ4SC%2BIJjPj7sMz0X2LafxMdQ9c4w3ZPqJtO1zQzQly9YqJVJonBr4gSUMXrC7BmVmZW5GQOXnZYjQhRZHXIM9AFGjAtZY5cn2Z%2FsGc5vyWKwmjTqRwA5BFh2kY9Wk34Ie4G5I07aZ9WGYRiz7ikKUBCXYegLceiL8%2FAjsmcLiu0gribvhxPie1QavVuAMO%2Fv8qYToMqThLiMP1cT%2Fq4rAb4FE%2FiIOjOHzvY3wUBfgdxjHGThEUsda%2BhBnanR50etkfnU6qWx4%2BPtxdHkc%2FSVo%2FnJ8M9YeBHpyfaHz2zSye8PdhGsKV%2BQO8EnY08gUAAA%3D%3D)
[Test hivestatus.cloud/domain-verification example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFVp2WkC%2F%2BVUYU%2FbMBD9K5ElPtG0SdulEGnSYJ20sRUQA4aEqsixr61FYgfbSdtV%2Fe87p6UlqIgfsE%2BJfe%2Be7907e0Us5EVGLZB4RQqtKsFB%2F%2BAkJjNRgbHUlqbNMlVy0trFL2mOePIdEb9rBMYM6EowqFO5yqmQfgVaTASjVii5R2yThzXGu29iMMW4vzhskUxN1Z3OXCnWFibudFw5grUZl%2B231XWqsEONAWs6Lq9tqinScTBMi6Imj8k3SdMMjEe9TYGeVd5c6SdvLuzMa6ipqBYOPGwQ3EnxXIL3WpfHFAdv2xjuTZT2ilIXyoCnJt7bDiwlO88UeyLxhGYGNjvXZfoTlpt%2B7JrHlJTAbPuACy7nBrjQGN9lHcDNlLE38FwikO8OxCSluSHx44pMtSqL2rA3ddpl4Sy6fbjd0uDii2sntbRxVsPiz0f1amkX9siRWLSuFwUB%2Fi7sVyUnmWB2RC2bCTkdYduQ6lrDRCzIQcg29v55ZD1et8hfJSHZyxq3th3ERFhQHG5oM5XvhZgyxUWtPRF1SlM%2BEhRU09y4G%2FFC9djgGr%2BQPdZs4y3dIapdS1zQzQpxNYupVBoSg1%2BUpbETVpfoTl5mViR0TvdbnCW0KLIlSjQYRRp0rmGQ3Fyoja4PLKoraHiTcOaECjcG0OtDGrHIH4SM%2B%2F2U9v006vX93oBHfMDYCYXo1TPw3jPx8VPQsALw2korqLvpZ9mcLg1Zr8ctdPL%2FUIpTYmgFPKEO2Q26kR%2F0%2FTC47YZxeBqHg%2FYgDHqfTo6DIA4CpwnL2Khf4Sy9niLyK5vn3eNgdnF18zy6qKKTyyJ4GBqqT%2B%2FP%2FpyLdHZ3VZ5dD4%2B1muL1%2BQcIJtpk%2FgUAAA%3D%3D)