### PR TITLE
Octara.xyz template

### DIFF
--- a/octara.xyz.verification.json
+++ b/octara.xyz.verification.json
@@ -5,8 +5,8 @@
   "serviceName": "Octara Domain Verification",
   "version": 1,
   "logoUrl": "https://octara.xyz/favicon.svg",
-  "description": "Cette template permet de v\u00e9rifier la propri\u00e9t\u00e9 de votre domaine pour Octara.",
-  "variableDescription": "%txt%: Le jeton de v\u00e9rification TXT fourni par Octara.",
+  "description": "Cette template permet de vérifier la propriété de votre domaine pour Octara.",
+  "variableDescription": "verificationToken: Le jeton de vérification fourni par Octara.",
   "syncPubKeyDomain": "octara.xyz",
   "syncRedirectDomain": "octara.xyz",
   "records": [
@@ -14,7 +14,7 @@
       "type": "TXT",
       "host": "@",
       "ttl": "3600",
-      "data": "%txt%",
+      "data": "octara-verification=%verificationToken%",
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "octara-verification="
     }

--- a/octara.xyz.verification.json
+++ b/octara.xyz.verification.json
@@ -1,0 +1,22 @@
+{
+    "providerId": "octara.xyz",
+    "providerName": "Octara",
+    "serviceId": "verification",
+    "serviceName": "Octara Domain Verification",
+    "version": 1,
+    "logoUrl": "https://octara.xyz/favicon.svg",
+    "description": "Cette template permet de vérifier la propriété de votre domaine pour Octara.",
+    "variableDescription": "%txt%: Le jeton de vérification TXT fourni par Octara.",
+    "syncPubKeyDomain": "octara.xyz",
+    "syncRedirectDomain": "localhost",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "@",
+            "ttl": "3600",
+            "data": "%txt%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=octara-verification="
+        }
+    ]
+}

--- a/octara.xyz.verification.json
+++ b/octara.xyz.verification.json
@@ -1,22 +1,22 @@
 {
-    "providerId": "octara.xyz",
-    "providerName": "Octara",
-    "serviceId": "verification",
-    "serviceName": "Octara Domain Verification",
-    "version": 1,
-    "logoUrl": "https://octara.xyz/favicon.svg",
-    "description": "Cette template permet de vérifier la propriété de votre domaine pour Octara.",
-    "variableDescription": "%txt%: Le jeton de vérification TXT fourni par Octara.",
-    "syncPubKeyDomain": "octara.xyz",
-    "syncRedirectDomain": "localhost",
-    "records": [
-        {
-            "type": "TXT",
-            "host": "@",
-            "ttl": "3600",
-            "data": "%txt%",
-            "txtConflictMatchingMode": "Prefix",
-            "txtConflictMatchingPrefix": "v=octara-verification="
-        }
-    ]
+  "providerId": "octara.xyz",
+  "providerName": "Octara",
+  "serviceId": "verification",
+  "serviceName": "Octara Domain Verification",
+  "version": 1,
+  "logoUrl": "https://octara.xyz/favicon.svg",
+  "description": "Cette template permet de v\u00e9rifier la propri\u00e9t\u00e9 de votre domaine pour Octara.",
+  "variableDescription": "%txt%: Le jeton de v\u00e9rification TXT fourni par Octara.",
+  "syncPubKeyDomain": "octara.xyz",
+  "syncRedirectDomain": "octara.xyz",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "ttl": "3600",
+      "data": "%txt%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=octara-verification="
+    }
+  ]
 }

--- a/octara.xyz.verification.json
+++ b/octara.xyz.verification.json
@@ -16,7 +16,7 @@
       "ttl": "3600",
       "data": "%txt%",
       "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=octara-verification="
+      "txtConflictMatchingPrefix": "octara-verification="
     }
   ]
 }


### PR DESCRIPTION
# Description
This PR adds a new template for Octara (octara.xyz). This template allows users to verify their domain ownership for the Octara platform by adding a specific TXT record.

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [X] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [X] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [X] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [X] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [X] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [X] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [X] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [X] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [X] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [X] `%host%` does not appear explicitly in any `host` attribute
- [X] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results
Editor test link(s):
[Test octara.xyz/verification octara.xyz/search](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIZo22kC%2F%2BVU226bQBD9ldVKeQo4GFM7RqrU5vIQ5dqWNqlSCw0wmE2ARbsL8UX%2B9%2B6aOL7Eivrep1125sycMxfmVGFR5aCQ%2BnNaCd6wBMVFQn3KYwUCOpPpjFpvlhsotCe9Xdr0u0TRsBiXgAYFS1kMivFybdpCkDNeACvJr21XjZTm5nctmvMx%2FylyDcmUqqR%2FdLQmcpSCDsnLjmzGGpagjAWrlkF8eopKIVnJIRWKAhVJkDR%2FasfBocmIguRAtJhKsPZVtcfSjyuBJFky1HheC9Ky7hiKIBhEOZ5t5dyUHPBnLH1yheQJFS93Mrc%2BJNVRS0Yq2Iwtp2V8V0eXOG3Ls1t8Y%2F%2BOCRMYq%2F0e2sJFIqn%2FOKdqWpmCBw%2BBNmRcKv3xRV%2BVMkXt9R3HlA4UvAWxN2V8Pngn6sCgJ%2BqUl2nOYnUNKs5YOb7miUl0JzBlk%2F0ur7b9iehitLDojJcYrvmPNLe9El%2BVSAQRZ%2Fp7LHhdhWwF0hWFQpohXsEfN%2FGjVYDHVYSR9b57a9A20%2BD8RxAGt5fnN2HX7VFDm41LLjCU%2BgRVC10IJWq0aFHnioXwAuunJA6hqvKpVim1VSfZ7VLZ7sibtg%2B68w%2F0XlttOm3RMIlNUZhZ0OPUcfte2rW9qOfZnhMnduSmkY3QjzyIB94Ak41df%2F8X%2BGDbd9uDUmKpGJiZ%2B5q%2FwFTSxWJk6Vb9t%2BL1xEloMAnBOLuaju14dtcNnKHvOb7rdgbe8ae%2Bc%2Bg4%2FnJJFUrVVmOuJ25z1ujV8%2FD02%2BH9U3cYn8yis6i6eBYAD7%2BLyVUvO8lOqqy%2BbAb1%2FcNM6j37C2DUtXzmBQAA)
[Test octara.xyz/verification octara.xyz/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHRo22kC%2F%2BVT207bQBD9ldVKPNVOHNslxVIlUIAKUe4uakUja7MeJ1tsr7U7DglR%2Fr27MSEORKjvfdrLzJk5Zy4LilBUOUOg0YJWSk5FCuospRGVHJlindn8mTqvlktWGE96tbKZfw1qKjisAFNQIhOcoZDlxrSFIMeyYKIk99uuBqntLeo5NJdj%2BUPlBjJBrHTU7W6IdDNmQsqyo6djA0tBcyWqVZCIDgARyFoOqUAVgCQFMv1dex4c2IygSM6IEVMp0fxic6z8JCog6YqhwctakYZ1x1JkSrBRDsdbOduSY%2FkIZUS%2BA%2FkDKMs3mRsfkpmopSAVa8fW85Jf16NzmDfleVt8a7%2BFVCjguNvDWKRKNY0eFhTnlS14%2FDM2honUaB6H5opoixrse54tHUP2GsRty%2Fi6907UnkXPcCDLLBccLxjyiSjHFzK1ia4VZGK22%2BXFtjsRXQ6XDn2WJSQb%2FkPDbafElpKxknWViLW%2FKSYrtJ3fNfKhDR2usQ8GPHTe92zjv80vPrmLk%2Fjq%2FOQy6fkBtWTFuJQKEm1OhrUy8lHV4NCizlEk7IltvlKesKrK50abNlaT5G1vymYzDj9uxz8we%2Bmtba1Dk5TbUgi7kT0GPDgIP7usz7gbwn7qsgB8N8v6POwHI%2FBHYWu536%2F9B%2Bvd6gdoDSUKZufrKH9ic02Xy6FjevOfSTbTpdkU0oRZP9%2Fz910vdHt%2B7B1EoRd5YScIev6X8JNnHnYNETQ2hViY6WrPFS1us3tvPOD1Kf8mjx5Huuv1qhSDX4Obyc3g7PbkjvdH6J16UppN%2BgtPbpKmyAUAAA%3D%3D)