### PR TITLE
Add JustEmails email hosting template

### DIFF
--- a/justemails.app.email.json
+++ b/justemails.app.email.json
@@ -1,62 +1,58 @@
 {
-  "providerId": "justemails.app",
-  "serviceId": "email",
-  "name": "JustEmails Email Hosting",
-  "description": "Configure DNS records for JustEmails custom domain email hosting. Sets up MX, SPF, DKIM, DMARC, MTA-STS, and domain verification.",
-  "variableDescription": "IP: mail server hostname, DKIM_KEY: DKIM public key, RANDOMTEXT: verification token",
-  "syncPubKeyDomain": "justemails.app",
-  "version": 1,
-  "logoUrl": "https://justemails.app/icon.svg",
-  "syncRedirectDomain": "justemails.app",
-  "warnPhishing": true,
-  "hostRequired": false,
-  "records": [
-    {
-      "type": "MX",
-      "host": "@",
-      "pointsTo": "%IP%",
-      "priority": 10,
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "@",
-      "data": "v=spf1 a:%IP% ~all",
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=spf1",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "dkim._domainkey",
-      "data": "v=DKIM1; k=rsa; p=%DKIM_KEY%",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "_dmarc",
-      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@justemails.app",
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=DMARC1",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "@",
-      "data": "justemails-verify=%RANDOMTEXT%",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "_mta-sts",
-      "data": "v=STSv1; id=1",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "mta-sts",
-      "pointsTo": "mta-sts.justemails.app",
-      "ttl": 3600
-    }
-  ]
+	"providerId": "justemails.app",
+	"providerName": "JustEmails",
+	"serviceId": "email",
+	"serviceName": "Email Hosting",
+	"version": 1,
+	"syncPubKeyDomain": "justemails.app",
+	"syncRedirectDomain": "justemails.app",
+	"description": "Configure DNS records for JustEmails custom domain email hosting. Sets up MX, SPF, DKIM, DMARC, MTA-STS, and domain verification.",
+	"logoUrl": "https://justemails.app/icon.svg",
+	"records": [
+		{
+			"type": "MX",
+			"host": "@",
+			"pointsTo": "mail1.justemails.app",
+			"priority": 10,
+			"ttl": 3600
+		},
+		{
+			"type": "SPFM",
+			"host": "@",
+			"spfRules": "a:mail1.justemails.app",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "dkim._domainkey",
+			"data": "v=DKIM1; k=rsa; p=%dkimKey%",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "_dmarc",
+			"data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@justemails.app",
+			"txtConflictMatchingMode": "Prefix",
+			"txtConflictMatchingPrefix": "v=DMARC1",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "@",
+			"data": "justemails-verify=%verificationToken%",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "_mta-sts",
+			"data": "v=STSv1; id=1",
+			"ttl": 3600
+		},
+		{
+			"type": "CNAME",
+			"host": "mta-sts",
+			"pointsTo": "mta-sts.justemails.app",
+			"ttl": 3600
+		}
+	]
 }

--- a/justemails.app.email.json
+++ b/justemails.app.email.json
@@ -1,0 +1,62 @@
+{
+  "providerId": "justemails.app",
+  "serviceId": "email",
+  "name": "JustEmails Email Hosting",
+  "description": "Configure DNS records for JustEmails custom domain email hosting. Sets up MX, SPF, DKIM, DMARC, MTA-STS, and domain verification.",
+  "variableDescription": "IP: mail server hostname, DKIM_KEY: DKIM public key, RANDOMTEXT: verification token",
+  "syncPubKeyDomain": "justemails.app",
+  "version": 1,
+  "logoUrl": "https://justemails.app/icon.svg",
+  "syncRedirectDomain": "justemails.app",
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "v=spf1 a:%IP% ~all",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=spf1",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "dkim._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%DKIM_KEY%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@justemails.app",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "justemails-verify=%RANDOMTEXT%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_mta-sts",
+      "data": "v=STSv1; id=1",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "mta-sts",
+      "pointsTo": "mta-sts.justemails.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **JustEmails** (https://justemails.app), a multi-domain email hosting platform that provides custom domain email hosting with full IMAP/SMTP/POP3 support.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
[Test justemails.app/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADU222kC%2F%2B1XbU%2FqMBT%2BK00TPzmwkxfNDInEd80IEbzXxJClbgV72dbZdug03t9%2BTwc4EFRucj%2FoDV%2Bg6znn6XNe%2Bix7xppFSUg1w84zTqQY8YDJswA7%2BFeqwEZ5qMo0SbD1am3RCLzxOdiPcjvYFJMj7rM8MA8q9ibuuSs6FUrzeADWEZOKixg7Nnhmsd9Oby9YdijALV52uvG5ZAGXzNfvewVM%2BZInOkfGByLu80EqGTpsdRBEChko1BcSFeSRD0sRoSDHRDkauhvTLKMO0wqlCXKvLdRpH1vo8OLMhV%2B3eXlgIbfbLHW6HQvROJgCQF68z31qKJSBUSgG4kqGwOZO60Q5W1vzpLe4D45qZGoyYYidm2ess8SUzb2GfUMH1vumCYLHWnUFPBoIu7ykTVxIrjOoLLGw1nB0pU7Ii%2FWKCYm486gq6V%2BmIYOTMXXewV2G1L3uFkDBkEdlb1yGIctMN6imYBg1TNXsPTRsSEX3UNLYML7Q7o1VcL0gotKfgzPltw3QfUoljaFXbA%2FJlDYMYS2cPGJ%2FMYVHbUYi5L52qfbvoMWuCMyBbcn6%2FHG5y8RWHLwK6f2Cb0GjlA9H1tiYHZKuGLJ4tUJEmpaUVrOlgPEbQSV40HiP1kGr6R4VIAXG7CiNNz9qeu%2FFwk8iZl4xpD3gMb2J7JGCjrCyL6LiLFgNpEgTj0%2F9E2hXpIzWTCNv5kJ709gbbNaTMTGPmikNU2VvV4xhoYBTF20eqrU6Nnz5IBaSeQr%2BqQYZwI6WKbNwlIaae%2FSBFluB70HGYQbpKbAC3Js7GI9lbKavn92Tt1fRC3yTODcaWfVJvVbd3S3dkhopVf0qrCq3tdJtnQR2hdDazg6ZkdzlgrxMdIvKM6UY3AxqpKcZPtBM4ZeFyVrMatQAMbDRchlAv2kYzuf4hbP6C0Gama7vkt0%2FlMVvke%2BHijp39b9NB1fX86%2BWx%2FSlMslkIZHPXyhfI6OeBW%2BltdKvlX6t9GulXyv9%2F6z08NWg6IgFHjVu22S7XiLVkr3dJXWH1JyqXSZkt27XNglxiKFgJm2c5DN8S8x%2BReDNi3b2VMserw5%2BHg13jlunPyrHaXzSvtttVlz%2FhLVaQpy7m%2B37s2EDv%2FwBKpUu72URAAA%3D)
[Test justemails.app/email example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFM222kC%2F%2B1XbU%2FbMBD%2BK5YlPpGUpC0ZBFWio2wDlIrRTkNDKDKJ25omcbCdQofYb985bUhfwkD7BFKlqk1958f33J2fUx6xonEaEUWx%2B4hTwScspOIkxC6%2BzSTYCItkjaQpNp6tXRKDNz4F%2B3FuB5ukYsICmm%2FMN5Vrc%2FfcFX3jUrFkCNYJFZLxBLs2eE6T4Dy7OaPTDge3pOp07XNBQyZooF72CqkMBEtVjoyPeDJgw0xQ1On2EOzkIpRowAUqg0cBPPIYhTkmytHQaBZmDfWokihLkXdpoN75FwN1zk48%2BPbaF0cG8vpts9fvGYgkYQEAvNiABUSHUIOIIj7kP0QE0YyUSqW7s7Mc9A4LwFFOdE7mEWL36hGraarT5l3Cug4Hng91EThLlOxz%2BKsh7FpFmRgXTE0hs5aBlYKjG45lPRnPmEDEW0aV6eAiiyicjIn7Am4VUv%2ByXwKFYxbX%2FFkaxnSqq0EUAcOkpbNmH6BxS0hygNLWlvaFcm%2B9BdcPYyKCJTidflsD3WVEkARqRQ%2BQyEhLB6y4m%2B84XKfwoHRLRCxQHlHBCErs8VAfeC7ogD1Uu8xt5cFvCfqwjLcMw8ybY9raWmySPh%2FT5G2JiBUxpZKLqYD2m0AmWNh6Kayjbts7LkFKjMVWmi3%2Bq%2BjXTwb%2BzRPql016DXEUN5E%2BENARWgt4XJ6lKPwYeCh4lvqs2JNCyWKp9abYfbW0%2FbrYfzUD0MfM2qVYgu6y6w1tWEtk4aL0n%2Baug3XcbJhwQX0Jv0SBHGBXiYwaOM4ixXxyT8qlMPCBeTQFmhKsALdyF5OZnM2pzevw2pVZvZV%2BGGj%2BTMulfdMgVrDnmI61T80moXWTDOieWbeDGxLYNt0NnQX1rdbmKv1dLgKVksJFIVqJ2tE9mUr8tNZoleQmLZAHG1ULA%2FpDomiZ6jsntyJTtVWyq1q10HAfieZMNdfZ%2Fa90fhjiy4zXxXdJHT5URQuVXq3pCzPgPRIqhtGcUjWj16fR%2B6F2bcBI24yIzYjYjIjNiNiMiM2IqBgR8J4iyYSGPtGudavumFbTtOt9y3HhY9u13U%2FOfnNv27Jcy9IkAG1G9BHeXhbfW%2FD2Pmvs9s5P75wk%2Fdk927bsTvx59It537uDW%2Bdr8y7rU%2B%2FbSXs%2FHLbw019QCqaK3xEAAA%3D%3D)