### PR TITLE
Add HolyDocs custom domain template

### DIFF
--- a/holydocs.com.custom-domain.json
+++ b/holydocs.com.custom-domain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "holydocs.com",
+  "providerName": "HolyDocs",
+  "serviceId": "custom-domain",
+  "serviceName": "HolyDocs Custom Domain",
+  "version": 1,
+  "description": "Automatically configures the DNS CNAME required to connect a documentation subdomain to HolyDocs.",
+  "logoUrl": "https://holydocs.com/favicon.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.holydocs.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "proxy.holydocs.com",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for HolyDocs custom documentation domains.

The template creates the required CNAME from the user-supplied docs subdomain to `proxy.holydocs.com` so HolyDocs customers can connect a custom docs hostname.

Notes:
- `providerId`: `holydocs.com`
- `serviceId`: `custom-domain`
- `syncPubKeyDomain`: `domainconnect.holydocs.com`
- `hostRequired`: `true`
- target CNAME value: `proxy.holydocs.com`

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMAM3GkC%2F91Ta4%2FTMBD8K5G%2FkrR5tVwjIdG7HnBCV6G7QwKqKtraTmoRx8F2WkLV%2F866D1p6CL4jRbLsHY9ndicbYrlsKrCcZBvSaLUSjOs7RjKyVFXHFDU9qiTxf9WmIBFL3mF1glWsGK5XgvLdJdoaq2TAlARRn2oXl7ybHcybHGErro1QNckinzBuqBaN3e3JuEUgWEGhqjqPqroQZau58eySe5Ppo3czHd%2Ffepp%2Fa4XmzLPKgWpOrQceym8lry04Ms%2B0i70uBzpK6eHrlSrVR105z9Y2Juv3z733C0ALqu6ZVekcdTW9rhT9SrICKsP3Jx%2FaxXveHfxkZP%2FOQUjvopNLZezDQS%2FJrG6RQ3OqNDMkm22I7RrXrJ2xAxy3r90MlKiteVK4xXF87y6ZrUUTSRhu51uf%2FFA1z0%2B8c%2F%2BgytmEpulabLHkZ5p2uncTLbVqm1wc7zWgQRoXkCPD7BnF%2FMgx25M4BaKslea5wRUsDu1oVraVFTms4XTEaI6EVYeCDVaR5nkj6n2IDhoZWPhXH3ySM%2Bp0C5fNqAhHg3gAQbxYDIO0gCIYxcCCBK7ChMEogUF0FvQ%2F%2FQR%2Fi%2FrvLeTGYPAEuFSNqzV0hmy3cx%2Fb%2BV8aw%2FEbWHGWg4PGYTwMwjSI4qc4yvAL014ah8NB%2BiIMszB0Trixe6cbTMp5Rsj6bpzI8lP0Oe2%2FKVsZx30mrxcPXKZT9Ti9mr79cn%2BbyJdLO0pfke1PRGfWmcIEAAA%3D

`hostRequired=true`, so the included editor test covers the required non-empty `host` case (`docs.happyuptime.com`).
