### PR TITLE
Add Happy Uptime status page template

### DIFF
--- a/happyuptime.com.status-page.json
+++ b/happyuptime.com.status-page.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "happyuptime.com",
+    "providerName": "Happy Uptime",
+    "serviceId": "status-page",
+    "serviceName": "Status Page",
+    "version": 1,
+    "logoUrl": "https://happyuptime.com/happyuptime-logo.svg",
+    "description": "Configures a sub-domain for use as a Happy Uptime status page",
+    "syncPubKeyDomain": "domainconnect.happyuptime.com",
+    "syncRedirectDomain": "happyuptime.com,www.happyuptime.com",
+    "hostRequired": true,
+    "syncBlock": false,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "status-proxy.happyuptime.com",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a new Happy Uptime Domain Connect template for status-page custom domains.

The template configures a single CNAME for a customer-provided subdomain:
- `providerId`: `happyuptime.com`
- `serviceId`: `status-page`
- `syncPubKeyDomain`: `domainconnect.happyuptime.com`
- `hostRequired`: `true`
- target record: `CNAME @ -> status-proxy.happyuptime.com`

Notes:
- This template is subdomain-only; apex testing is not required because `hostRequired=true`.
- There are no TXT records, no template variables, and no end-user-modifiable records that require `essential: "OnApply"`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
- [Test happyuptime.com/status-page example.com/status](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJkW3WkC%2F%2BVTTW%2FaQBD9K9ZeaxN%2FQailSoW0StoqBCWkPSBkLd7BbGPvurtrjIv4793FmLgkOfTck7Xz5r2ZeZ7ZIQV5kWEFKNqhQvANJSC%2BEBShNS6KuiwUzaGX8BzZJ3iCc52ObkyC9XjI0KgEsaEJHLhSYVVKp8BpBznSHg6YNW2wDQhJOUORZ6OMp%2FxRZKa2UoWMLi7Oeui%2BHZPdk5tUixCQiaA6bITQFWcrmpYCpIUtWS4dwnNMmbXiwiolWNjEu81bTbtW227Nkmm5%2FAb1pwNRSzYKCWcMEtV76Yyh3AOhQsMn0lmaXVXVK9Q1l%2BoefpWaq51TooRGbpzx5AlFK5xJHdHCXBCJovkOqbowPl5NRrefjwL6%2BdH8IE6ZkjPe%2BQOCb%2BtXqiqlbQ4Grrtf7G30mzOIn0ss7OPAWge2WO9Ht9mTuH6ngpdFTFtWgQXOpdmklj%2F%2FS2DRKsxbCVOdpowLiKX%2B6piA1oW8zBSNcYWfQySJ9ShZrZuVGtVCL%2F1gzZqdeiRY4X8wxEYxScwI1Cyyf%2BkPfeJeOsHQI06Y9ANnSYKVA4MwgdV7CJc47FzGG4fz9mmcGwpSAlMUmyMYZRWuJdrvF7Y2978YVC%2BIxBsgMTbJvusPHDd0vGDmDSKvH%2Flez%2B8PvTB857qR65ppQKpm7p3epO4OoZl%2FK0c%2Fy%2B3FtZp6il4%2F3PF6mAVPufpewdi%2FYdVo%2FHXt%2FbibhB%2FQ%2Fg%2Fu1sahCQUAAA%3D%3D)
