### PR TITLE
Add sendcanary.com/lockdown template for non-sending domain protection

### DIFF
--- a/sendcanary.com.lockdown.json
+++ b/sendcanary.com.lockdown.json
@@ -1,0 +1,32 @@
+{
+    "providerId": "sendcanary.com",
+    "providerName": "SendCanary",
+    "serviceId": "lockdown",
+    "serviceName": "Non-Sending Domain Lockdown",
+    "version": 1,
+    "logoUrl": "https://sendcanary.com/logo.png",
+    "description": "Lock down a domain that does not send email. Sets DMARC to reject and SPF to deny all senders, preventing anyone from spoofing your domain.",
+    "variableDescription": "ruaAddress: Email address to receive DMARC aggregate reports (e.g. you@company.com)",
+    "syncPubKeyDomain": "sendcanary.com",
+    "syncRedirectDomain": "sendcanary.com,app.sendcanary.com",
+    "warnPhishing": false,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=reject; rua=mailto:%ruaAddress%",
+            "ttl": 3600,
+            "essential": "OnApply",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1"
+        },
+        {
+            "type": "TXT",
+            "host": "@",
+            "data": "v=spf1 -all",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=spf1"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for SendCanary non-sending domain lockdown. Provisions two records in a single apply to fully protect domains that do not send email:

1. **DMARC TXT** at `_dmarc.<domain>` -- `p=reject` policy with user-provided `%ruaAddress%` for aggregate report delivery
2. **SPF TXT** at `@` -- `v=spf1 -all` to deny all senders

This template uses TXT (not SPFM) for the SPF record because the intent is to replace any existing SPF with a deny-all policy. SPFM merge behavior would preserve existing `include:` mechanisms, which is incorrect for a lockdown. The `-all` mechanism is also not valid in SPFM `spfRules`. This matches the pattern used by other templates in the registry (e.g. `about.me/website_and_email`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
- [x] Validated with `dc-template-linter` -- zero errors, zero warnings (INFO-only notes)
- [x] Validated with `dc-template-linter -cloudflare` -- zero errors, zero warnings

# Checklist of common problems

- [x] `syncPubKeyDomain` is set -- published at `1._domainconnect.sendcanary.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` -- `warnPhishing` is `false`
- [x] `syncRedirectDomain` is set -- `sendcanary.com,app.sendcanary.com`
- [x] SPF record uses TXT (not SPFM) because SPFM cannot express a deny-all policy (`-all` is not a valid spfRule, and merge behavior would preserve unwanted includes)
- [x] `txtConflictMatchingMode` is set on both TXT records: DMARC prefix `v=DMARC1`, SPF prefix `v=spf1`
- [x] no variable is used as a bare full record value -- `%ruaAddress%` is embedded within `v=DMARC1; p=reject; rua=mailto:%ruaAddress%`; SPF record is fully static
- [x] no bare variable is used as the full `host` label -- hosts are static: `_dmarc`, `@`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC TXT record

## Online Editor test results

**Editor test link(s):**
[Test sendcanary.com/lockdown example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKJZ3WkC%2F%2B1U70%2FbMBD9VyxLSJtI2yQFSoOQYGVoiJV1%2FJAmIVRdk2tqSG3Ldluyqv%2F7zm2hdBRp0z5Mk%2FYpju%2Fe%2Bd17Z0%2B5w6EuwCFPplwbNRYZmrOMJ9yizFKQYMpqqoY8eI5ewJCy%2BRXFW%2FM4xSyasUhxDixU%2BpCpiVxtLxEXSlY8SsicnaghCMk%2Br3LHaKxQkidRQCVydWMKwgyc0zap1dbZ1HxCVcuccBna1Ajt5ljuCzJfkQF95me4AThao2VSOeYLMaRAUWVX6Cw7aR9ftphTzOA9po4Bxa86p34nQ1kyKIo5iOgFTBsco3S%2BA5Clksj6Rg2Z1Ur1%2FWapRmZ5btX3BEZAr8CTNY5mBMdZZtDahH30TBgsfhcsUhRjXNKCPDeYkz20r5Uhuu%2Bwmlf9OUekgyYSXo%2F3XutSpp1R7xzLhbabLPQ5l5gJOsS9kRWA1tVXwAkY2RkIO6AmedKHwmLAqYoymeXJ7ZS7UnuLr79dU%2FZAWUc%2F3WwIJvUWgQP6Hx%2FOm4oOmD5ciH3ASItDL4FTydZKly0COUf%2B1%2FfCMOC040UHPxBf5LHWhZ859%2BhaSvYLkbo2uNRTa6vMs%2BgY7IvHzSnL2IoNnwWb6R%2B9ZG51P2IVmoV1Zn%2FMwdfls7tZwL%2FTNHVXkt7R4U8O4SPQJcWlF0t6tMqNGumueMrXYGBo%2FUV%2BQt6uQe%2BesLfcr1dyzxO9C0dr6URK5FIZ7Fr6ghsZasyZEVk%2FHBVOdIHG4nkrS7vgnaEeLEWp5s9jIRfPwG%2BOxWtiaw50s9R3LPzLEzWaUdrfjyrQa%2B5WduK4UYEw2q309uMGNpoh7vd6Lx6yzc%2FcG0%2FZSvVN0zh7NUTLZn9liP5uC8fFBEpLHdwFNET%2FPfu3PKN7bGGMWRd8WhzGe5VwpxLVr%2BMoCaMkjqvRTrNeb26HYRKGvge0btHclO73y5vN96KH0rVb9fPGfe9Mbe980p3HWnHZON2buHb84aLRb05E5%2Bv2Tat9yGc%2FAIaCpq87CAAA)
[Test sendcanary.com/lockdown example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM5Y3WkC%2F%2B1UYU%2FbMBD9K5YlpE2kIW1KC0FIlLJNiJUhYBodQtU1uaaB1LZsp6Wg%2Fvedm0IpFGnSPkyT9imx7975vbtnP3KLI5WDRR49cqXlOEtQHyc84gZFEoMAPfVjOeLec%2FQURpTNLyjenscpZlCPsxjnwFzGd4mciOX2AnEqRcWhMpGyIzmCTLCvy9wxapNJwaOqRyVS%2BV3nhBlaq0y0tbXKZssl%2BEqkhEvQxDpTdo7lriBzFRnQZ36GHYKlfzRMSMtcIYYUyH12gdawo07rvM2sZBpvMbYMKH5x9tntJCimDPJ8DiJ6HlMaxyisUwBiKgWygZYjZpSUA7c5lYVenOs7TaAz6Od4tMJRF9BKEo3GROyTY8KgXJYsYszGuKAFaaoxpfHQvpKa6H5AP%2FXdOQfUB0UkXD8%2Bul5PRXxW9E9wWvZ23QhdzjkmGR1i38nyQCn%2FDXACWpwNMzMkkTwaQG7Q41RF6sTw6PqR26lyI768uqTsoTSWFr1kBDp2IwILtB7vz0VV95jaL5u9x6gX%2B64FVkYby75sEMhamn%2FYCAKP045rOjhDfBMtpXLnOXtv21IM8iy2HbCxo9aRiWNxpnGQ3a9PWcSWbPjMW0%2F%2F4CVzowZVViEvrDL7Yw6uLp%2FdzDz%2BQG7qLVt6Q4c%2FTQjvgS4pLmaxoGeKPi1SLQvVy54gCjSMjLvLT%2BDrFfTNE%2Fx6jqflsunzXDeLgxUEUctSITX2DH3BFprkWV2QAUZFbrMekDmet5K4B24%2BpMRQlGq%2BNocoH4PSHH6p4vcM8pbcyix6SeyEZ%2B4NCpo7uwGGuxXEJK7Ua4Nqpd%2BoYaVZDcNgO2zWg7D54klb%2F%2BC986it9H%2BdNWdvHLXQ%2FErsO5766zpa%2BQSmhmTceOSp%2F%2FP7d%2BdH99vAGJMeuMxaUGtUgnqlGl7Wgmi7GW0HfmOnXgsbm0EQBYGTgcaW%2Bh7p3r%2B88fyu27zsnh82voTHVym07nd%2B7nTbx4ebm43d9u2Pk2LQr3c%2Fxw8T7Hb2%2BewX3C%2FkD1kIAAA%3D)