### PR TITLE
Add sendcanary.com/revert-lockdown template

### DIFF
--- a/sendcanary.com.revert-lockdown.json
+++ b/sendcanary.com.revert-lockdown.json
@@ -1,0 +1,32 @@
+{
+    "providerId": "sendcanary.com",
+    "providerName": "SendCanary",
+    "serviceId": "revert-lockdown",
+    "serviceName": "Revert Domain Lockdown",
+    "version": 1,
+    "logoUrl": "https://sendcanary.com/logo.png",
+    "description": "Reverts a previously applied domain lockdown by replacing strict DMARC reject policy with monitoring-only and permissive SPF. Use when a locked-down domain needs to start sending email.",
+    "variableDescription": "ruaAddress: Email address to receive DMARC aggregate reports (same as original lockdown)",
+    "syncPubKeyDomain": "sendcanary.com",
+    "syncRedirectDomain": "sendcanary.com,app.sendcanary.com",
+    "warnPhishing": false,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:%ruaAddress%",
+            "ttl": 3600,
+            "essential": "OnApply",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1"
+        },
+        {
+            "type": "TXT",
+            "host": "@",
+            "data": "v=spf1 ~all",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=spf1"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for SendCanary lockdown revert. Companion to `sendcanary.com/lockdown` (PR #984). Replaces strict lockdown records with permissive ones so a previously locked-down domain can start sending email:

1. **DMARC TXT** at `_dmarc.<domain>` -- `p=none` policy (monitoring only) with user-provided `%ruaAddress%` for aggregate report delivery
2. **SPF TXT** at `@` -- `v=spf1 ~all` (soft fail, permissive)

Used via a one-click revert link in the lockdown confirmation email. Same TXT-for-SPF rationale as the lockdown template: SPFM merge behavior would preserve the `-all` mechanism from the lockdown, defeating the revert.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
- [x] Validated with `dc-template-linter` -- zero errors, zero warnings (INFO-only notes)
- [x] Validated with `dc-template-linter -cloudflare` -- zero errors, zero warnings

# Checklist of common problems

- [x] `syncPubKeyDomain` is set -- published at `1._domainconnect.sendcanary.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` -- `warnPhishing` is `false`
- [x] `syncRedirectDomain` is set -- `sendcanary.com,app.sendcanary.com`
- [x] SPF record uses TXT (not SPFM) because SPFM merge would preserve the lockdown `-all` mechanism instead of replacing it with `~all`
- [x] `txtConflictMatchingMode` is set on both TXT records: DMARC prefix `v=DMARC1`, SPF prefix `v=spf1`
- [x] no variable is used as a bare full record value -- `%ruaAddress%` is embedded within `v=DMARC1; p=none; rua=mailto:%ruaAddress%`; SPF record is fully static
- [x] no bare variable is used as the full `host` label -- hosts are static: `_dmarc`, `@`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC TXT record

## Online Editor test results

**Editor test link(s):**
[Test sendcanary.com/revert-lockdown example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABtd3WkC%2F%2B1U728TORD9VyxLSJzIJrtNCGFRJXLtnXSCQFUKOlRV0cSe7Bq89sp2ki5V%2BNsZ50fT0BwC8eWQ%2BBBl7XnjeW%2Fe2Dc8YFVrCMjzG147O1cS3T%2BS59yjkQIMuKYtbMVbt9FXUBGav6H4ySpOMY9urgSuEh3O0YVEW%2FFR2oXZRTeJ56s4O7UVKMNe7mC07ZU1PM9aXNvCvnWa4GUItc87nX0%2BnQho16agPIleOFWHVe7meM%2BA1cRE2ZnXDYO61golk%2BuiW25s0jCHpF8oUzAfnBJEbDQ8P6HtD0iL2molGrZQoWSVNSpYR9DEmniokaxGVynv1RzZm7O%2F2%2BytR7Yo0VD5WARlsqqzqWsQpWfBUimgFkRJsTBSULdjB8ApmGg83VPkZjCU0qH3OfsrQhmsl%2FEkhwJj9TVrKAqHBdkZZdnYhoeeus7AMyJeKAP6Vvwf0ZnGiLPZ5AU2azsO%2BR4x5ygVVQr%2FgWpRf9v3EhfgzFmpfEkaeT4F7bFF0yGsk57nlzc8NHUciIt%2FLwhdWh9oMZYVOBFdhQC0nh%2BvlGXPWH1srMFnjNpxHLsQbP5g15oHlBICDUy3n6YtTjtogoI4Qa%2FNkOyPYxquw4k1U7I0jCCISGxkZeRw5nCqrg9DNrEdF75sHSb%2F%2FC5vX08z9hm03mf20xziuXx5tWzxT9SP8a6hV1R86w9eA91r3DixoUdfhbOzeqy2%2BBocVD7e%2FW3m5V7q1Tb3ksfvXbtXwOjC8z04kVKFsQ7Hnv4hzBwJC25GxlczHdQYaChut6QYx4vZkAZPUTrz66Ew6yfjh4biPq29%2Fo%2BliHpVfKq6jwfdCfRkAt0%2BJD2cYkKrbjJIxaQXf4P0yZ2X7%2FC7%2BO23b9f6QyO5vDdJG8XfM0n%2FCyVDvYDGk5CrFg3Ub%2F9%2BXf%2FofnuYoxxDhB2lR%2F0k7SVZ9%2BIoy7N%2BnmXtNE276dGjNM3TNEpBH9Yab%2Bje373x%2FEm%2F7E9K0dOP5J%2BjTqVHg8HTD6%2Bun77vDF%2B%2FWywefxSDJntZno7c%2B2O%2B%2FAJ%2BEfG%2FhggAAA%3D%3D)
[Test sendcanary.com/revert-lockdown example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACpd3WkC%2F%2B1U224TMRD9FcsSEohssrkQmq0qEbXcBIGqFFRUVdHEnmxMd%2B2V7U26VOHbGefSNG2KkHhBiKeVd2Y858w5nmvuMS8y8MiTa15YM1US7VvJE%2B5QSwEabFUXJue1m%2BgHyCmbf6L44SJOMYd2qgQuCi1O0fooM%2BJSmpneRFeFJ4s4OzI5KM3eb9Lot1NG86RZ45lJzWebUfrE%2B8IljcY2nkZIqBc6pTqJTlhV%2BEXt6nrHgBWERJnSZRWDosgUSiaXTdfY2KhiFom%2FUDplzlslCNigf3JIv78hHQqTKVGxmfITlhutvLGUGhkdLtWSFWhz5ZyaIvt0%2FKrOPjtkswlqah%2BaoIwWfVZ9NaJ0zBtqBTSCQCk0Rgpm9TABsApGGR5tMbIl9KW06FzCXoZUBstjuMmiwNB9iRrS1GJKcgZaJozhsaOpM3CMgKdKQ3ZD%2FklQptLiuBy9w2opxy7dQ84JSkWd%2FANZNZpv%2FV7hDKw%2Bnig3IY48GUPmsEbuEMZKx5Pza%2B6rIhji9OyUsifGeToMZQ5WBFXBA52nBwtmzX1WHGijcZ%2FROA7CFLxJHm1G84hKvCfDtLtxXOP0B7VXEBz0UfdJ%2FmBTf%2BUPjR6TpH4AXgRgAyMDhmOLY3W1O2UV22Dh89pu8C9u43bFuMl%2BQJZtI%2FtjDOFePr%2BY1%2Fh3msdwM9ALar7WB6%2BA3jWulFjBc%2BWIDqk1ZTFU65ICLOQuPP918flW9cW6%2FHxRT8fN0Be5QYsXWxUETaXaWBw6%2BoIvLdHztiT58zLzaghkjZtfUgzD86yIiaMo3XnXGnq5OJbWqC9Z%2FI497kPbUmIoRaCtwtIadYTANnajXq%2FbiTrYjKO9Xq8Vjfa6INrPcdTq4K0duHtD%2FnoLbomwy5%2Fze7ZaEb%2FD%2BAFj%2FS10%2BtkMKkdsLmrkr%2F9a%2Fhta0rt3MEU5hJDZilvdKO5EzfZpq5k0u0mrW99rPut12k%2FjOInjwAadX9K8pn1wexPwxuD7x8NX6NLq8uXbXtoYw1m%2FYwYne68vs%2Bf506v29Nub8qjz9UvuDvj8J4fvuO%2BkCAAA)