### PR TITLE
WEGIC, 2 templates

### DIFF
--- a/wegic.ai.website-apex.json
+++ b/wegic.ai.website-apex.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "wegic.ai",
+  "providerName": "WEGIC",
+  "serviceId": "website-apex",
+  "serviceName": "WEGIC Websites",
+  "version": 1,
+  "logoUrl": "https://cdn.wegic.ai/assets/logo.png",
+  "description": "Enables a root domain to work with WEGIC",
+  "variableDescription": "%apex_ip%: apex A record target IP; %target%: canonical hostname for the www alias",
+  "syncPubKeyDomain": "domainconnect.wegic.ai",
+  "syncRedirectDomain": "wegic.ai",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "website",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%apex_ip%",
+      "ttl": 600
+    },
+    {
+      "groupId": "website",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%target%",
+      "ttl": 600
+    }
+  ]
+}

--- a/wegic.ai.website-subdomain.json
+++ b/wegic.ai.website-subdomain.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "wegic.ai",
+  "providerName": "WEGIC",
+  "serviceId": "website-subdomain",
+  "serviceName": "WEGIC Websites",
+  "version": 1,
+  "logoUrl": "https://cdn.wegic.ai/assets/logo.png",
+  "description": "Enables a subdomain to work with WEGIC",
+  "variableDescription": "%target%: canonical hostname for the subdomain CNAME target; the target host label is supplied via the Domain Connect host parameter",
+  "syncPubKeyDomain": "domainconnect.wegic.ai",
+  "syncRedirectDomain": "wegic.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "website",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add two new Domain Connect templates for WEGIC Websites:

- `wegic.ai.website-apex.json` for apex domains
- `wegic.ai.website-subdomain.json` for subdomains

The templates use `syncPubKeyDomain`, include `groupId`, set `ttl` to `600`, and follow the repository rule of using the standard Domain Connect `host` parameter for subdomain application rather than `%host%` in record hosts.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Comments:
- `txtConflictMatchingMode`: N/A, these templates do not create TXT records.
- `essential`: N/A, these templates only create service-managed A/CNAME records.

## Online Editor test results

**Editor test link(s):**
- [Test wegic.ai/website-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANi53WkC%2F%2B1T72vbMBD9V4Sgn2Ynjptf9RgsNKGEkVFKS%2BlKMIp8SURtyZWUuFnI%2F75T7NRuPvTr9mHgkEP37unePd2eWsjylFmg0Z7mWm1FAnqa0IgWsBK8xQT13s9%2Fsgxx9HFyM73GYwN6KzhU6IURFnyWw1udahaQxxJiML0FbYSSNOp4NFUr9aBThK2tzU3UbvNEtk63t5kxYE3boVq5XGFxAoZrkdsjAZ1ItkjBEEa0UpYkKmNCEqtIofQLKYRdk1O%2FW6aFA48%2FEFy4lmORX0TERWRENHClE2KZXoEl09uv5KKMEcKZVFJwlpK1MlaiPrJUmtg1kKIoCEsFcwLNTvLbzeIH7MbHhvCesjOupARuW43pOuwdJAKvte%2FoRt5ddAevGwTgpJcsNeDRskdDo%2Bc9XWm1yZsuYJHd5W7yo6oew%2B%2FOSCWkNfeqKduBLY6%2FHwQH71Oy65%2Bj2aQmRL1nlNWUmozzg0d%2FKwlx3fDcq2aBJfDG8PlBi6usJsbo2EUsjvj3RrAwZ5plxr3VE8XzB475ieSZuvhIc0ZR6Xang34Lv7CDn8uU7bsEd8bWHjkRYiWVhtjgP7MbjfOweoNGZJvUipgVrD5KeMzyPN2hZoNZJESTGobIciucIQmzDMNmI%2FXwPBon3GkVzo5ObxnwMOn73f5g6HevlsxfLDs9P%2BFwuQzxB4N%2BY1fPd%2FiTZa3HDrhs0grmtnGUFmxn6ME9irMHUAkoH0Al4Wxk%2F5yKuYcP778Pf98HXDTDtpDEzMHCIOz7QdfvdO%2BDy6jXiXphaxheDYLhlyCIgsAJAGNLcXvcw%2BYGUniZ7ZJdNtncTMRinT31sqfLh95M3M4exw8w7Rd3r7%2FW2ZiFQ%2F6NHv4Ae40U7e0GAAA%3D)
- [Test wegic.ai/website-apex example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOC93WkC%2F%2B1TUW%2FaMBD%2BK5alPi2EQFNSMk0aaqFDaG3HivpQoehwTPAW4sw2pAzx33cmoQQe%2BtyHSZGS%2BL77fN99d1tq%2BDJPwXAabmmu5FrEXA1jGtKCJ4K5IKjzdn4PS8TR5%2F7d8AaPNVdrwXiFnmlheANy%2FnoM1RPIcwnRGF5zpYXMaNhyaCoTOVEpwhbG5DpsNlmcuYfbm6A1N7ppUW6eJZgcc82UyM2egPYzmKVcEyBKSkNiuQSRESNJIdVvUgizIId616CEBd%2BeEFzYkiORX4TEfpEeUZxJFRMDKuGGDB8%2Fk4vyGyEMMpkJBilZSG0y1EfmUhGz4KQoCgKpACtQbzL2uJqN%2BOZ2XxDeU1bGZJZxZtxady12zGOB15o3dC1uLxrzPysEYKfnkGru0LJGTcOXLU2UXOV1FzDJbHLb%2BV6Vj59frZFSZEY%2FybpsCzbY%2Fo7n7Zx3yW7ue9%2F7R0LUe0ZZdanOON059K%2FMeHQseOpUvcAU%2Fgo4ftxlcnkknqHZ%2BLevJBL7nLdiMDkHBUtt5%2FVA83LCMz0QvZRM04rqjKbSb0%2BDjotPu4WPjZQybIBZg49eWTEiyaTikcY3mJXCvhi1QkOWq9SICAo4HsUsgjxPN6hdYxQJ0ayaMVm5HZXcGAzgX72WYx8dGsXMShbWmUvfj9l1O2jEc2ANP7icN4AF1w0frrpBl135s26rtrbn6%2FzO3p46wHH3MiPALmcvLWCj6c7OyNk8VDpwHtxTLWft%2B5Bypg4O5H9fPp4vuIga1jyOwELbXrvT8PxGy3%2Fy%2FNDrhp7vdoPWZaf9yfNCz7MiuDalwC3uaX1D6f2Pwa%2FR07diIu%2FY6Grcehwlqv8qO5OHYPBwqybD8c%2FrYDEYDWbJF7r7BzTTIUAVBwAA)
- [Test wegic.ai/website-subdomain example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABS63WkC%2F91TXWvbMBT9K0LQp9mJ47hu8Risa7JSxkoIGYWWEGT5OhFxJFdSnKYh%2F31Xdj7cvOx9EHB07znnfu%2BohVVZMAs02dFSq0pkoB8zmtANzAXvMEG9k%2F2JrRBHn4cPj%2FdoNqArweGATo2w4Jt1mqkVE%2FLsb7PIc4Mz6K5AG6EkTXoeLdRc%2FdEFwhbWlibpdnkmO8cUuswYsKbrUJ1SzpGcgeFalLYWoEPJ0gIMYeQUn1hFNkovyUbYBTmmXDEtHHTwiX5lmZ6DvUoIZ1JJwVlBFspYiZmTXGliF9BSvn%2B6%2Bz0kDedr7Wv%2B1xxSsBQKIgwSyrIQkJFKsBo1ONCVlMAP6JJpDGJBu35tJR%2Bt01%2BwbZCYWRORN4xOayQOO4ZMaLSf0C2%2FEx%2FD2xoBOB6r1%2BBRxCqdGZq87uhcq3XZnhxy7LZ0g6rLO0jg87tbACWkNRPV6pXDWxxYHAT76d6jH0rC7Bxh6h1yRwq8M9wx6HC1OsumOEx81XnMRM05pYLkui%2FGLeVR5vWTzvQo9NooTQ9SFzJNss7I3TDPHXQpi7lUGmYGv8yuNRz7tFoXVszYhp1NGZ8xnOYWKzToRUHs4UW%2FZLPnh8IyZhm%2BLsKem%2BbRWcZdfcIN4ZbnIb9Jcz%2Fux8yP8ptrn4Vxz%2B%2F3gl4YRUGexnnrEC8P9F%2BX%2BLnngNckrWDu3O6KDdsaut9PPZzZf1cUroBhFWQz5qBhEMZ%2BEPm9aBL0k%2BsQf504uO0H4ZcgSILAVQLGNlXucEPau0EHo5vNaLP8GD1U70ouJ%2BO320HK9M%2FxC3QnL3Guh10e%2FQij63L5je7%2FAn7yrupaBQAA)