### PR TITLE
Add imagine.bo custom-domain template

### DIFF
--- a/imagine.bo.custom-domain.json
+++ b/imagine.bo.custom-domain.json
@@ -10,7 +10,7 @@
   "syncPubKeyDomain": "app.imagine.bo",
   "syncRedirectDomain": "app.imagine.bo",
   "warnPhishing": true,
-  "hostRequired": false,
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",

--- a/imagine.bo.custom-domain.json
+++ b/imagine.bo.custom-domain.json
@@ -9,7 +9,6 @@
   "syncBlock": false,
   "syncPubKeyDomain": "app.imagine.bo",
   "syncRedirectDomain": "app.imagine.bo",
-  "warnPhishing": true,
   "hostRequired": true,
   "records": [
     {

--- a/imagine.bo.custom-domain.json
+++ b/imagine.bo.custom-domain.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "imagine.bo",
+  "serviceId": "custom-domain",
+  "providerName": "imagine.bo",
+  "serviceName": "Custom Domain",
+  "version": 1,
+  "logoUrl": "https://app.imagine.bo/logo.png",
+  "description": "Connect your domain to your Imagine.bo project",
+  "syncBlock": false,
+  "syncPubKeyDomain": "app.imagine.bo",
+  "syncRedirectDomain": "app.imagine.bo",
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "domain.imagine.bo",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "domain.imagine.bo",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description
Imagine.bo is a platform where clients deploy AI-powered projects. This template adds a CNAME record for www pointing to domain.imagine.bo, our reverse proxy infrastructure. We support Cloudflare-hosted domains only. Requests are digitally signed using RSA SHA-256.

## Type of change
- [x] New template

# How Has This Been Tested?
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `imagine.bo.custom-domain.json`
- [x] resource URL `https://app.imagine.bo/logo.png` is served by a webserver

# Checklist of common problems
- [x] `syncPubKeyDomain` is set to `app.imagine.bo`
- [x] `warnPhishing` is set alongside `syncPubKeyDomain` — using warnPhishing
- [x] `syncRedirectDomain` is set to `app.imagine.bo`
- [x] no TXT records — N/A
- [x] `txtConflictMatchingMode` — N/A, no TXT records
- [x] no variables used — all record values are static
- [x] no bare variable in `host` label — N/A, no variables
- [x] no variable in `host` field — N/A, no variables
- [x] `%host%` not used — N/A
- [x] `essential` — N/A, no records the end user needs to modify

## Online Editor test results
**Editor test link(s):** [Test imagine.bo/custom-domain domain.imagine.bo/52.201.69.110](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAIu3mkC%2F%2B1Ua2%2BbMBT9K5G%2FDoiBPJEmLX1oraZWbZVtraIIGXxDvIHNbENEo%2Fz3mgB9rdHUr9U%2BId97z%2FG5x%2FeyRRqyPCUaULBFuRQloyDPKQoQy0jCODiRQBZSIEsWwz4RF0qLzKYiI4ybXIe6JBkcwLWp4z2yd9IhS5CKCY4C10KpSMR3mZqqtda5Cvp9kufOE1m%2FLnBynhgcBRVLlus9Fh0LziHWvUoUsteo6mnRHM8f8T0j85cpq0VVPD5KRfwbBSuSKmgiV0X0DapWW4Be3t6iboAyaUgOV22I5FdrptbMKA20LAz7Wih9A38KA6VdzLAISRUKFlukq3zvzuXs4hQ15eb4pbZWMK7VXJhj09jLy7Q2fvkjjHfWIZbNZvMenuXOQveCQ%2Fikb2m1mAPg9qKh53jYdUZTx3WxCSdSFHnIOoqcSJKpesg6ssUbbMuObvGKr9bFEi4khMp8iS4kdFZmRapZSIzzjyEah%2BZl0sq0oUzW8P1tM29m8rVuSjT5l00WCmlc98LqfXCjibea%2BCt7DB62B1Ps2tORT20SgR9N8WQaRaNna%2FK%2B5TrgLigFXDNS78ss3ZBKod0bQ9D2aIbA%2BUB9Li0zUf8f9AM9qNl7RUqgIakxHvZGNh7Y7mDuegEeBz52hgNvPJx8wjjANY0GpZuGt%2BbP8PyfgH6uZHl3e9ufk68Jn%2Fevi%2FEPMTsrI0i9S1aditndiX90xi%2Fm99ef0e4Bylf08gEHAAA%3D)