### PR TITLE
Add Axene Mailer email sending template (mail.axene.io)

### DIFF
--- a/mail.axene.io.email.json
+++ b/mail.axene.io.email.json
@@ -3,14 +3,12 @@
     "providerName": "Axene Mailer",
     "serviceId": "email",
     "serviceName": "Axene Mailer - Transactional and Marketing Email",
-    "sharedServiceName": false,
+    "version": 1,
     "logoUrl": "https://mail.axene.io/email-assets/logo.png",
     "description": "Configure DNS records for transactional and marketing email sending via Axene Mailer. Adds DKIM signing, SPF authorization, DMARC reporting, and bounce-handling records.",
-    "variableDescription": "These values are generated automatically by Axene Mailer for your domain.",
-    "syncBlock": false,
-    "hostRequired": false,
-    "version": 1,
+    "variableDescription": "%verification_token%: domain ownership token; %dkim_selector%: DKIM key selector; %dkim_public_key%: RSA public key for DKIM signing",
     "syncPubKeyDomain": "mail.axene.io",
+    "syncRedirectDomain": "mail.axene.io",
     "records": [
         {
             "groupId": "axene-verification",

--- a/mail.axene.io.email.json
+++ b/mail.axene.io.email.json
@@ -1,0 +1,55 @@
+{
+    "providerId": "mail.axene.io",
+    "providerName": "Axene Mailer",
+    "serviceId": "email",
+    "serviceName": "Axene Mailer - Transactional and Marketing Email",
+    "sharedServiceName": false,
+    "logoUrl": "https://mail.axene.io/email-assets/logo.png",
+    "description": "Configure DNS records for transactional and marketing email sending via Axene Mailer. Adds DKIM signing, SPF authorization, DMARC reporting, and bounce-handling records.",
+    "variableDescription": "These values are generated automatically by Axene Mailer for your domain.",
+    "syncBlock": false,
+    "hostRequired": false,
+    "version": 1,
+    "syncPubKeyDomain": "mail.axene.io",
+    "records": [
+        {
+            "groupId": "axene-verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "axene-verify=%verification_token%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "axene-verify=",
+            "ttl": 300
+        },
+        {
+            "groupId": "axene-dkim",
+            "type": "TXT",
+            "host": "%dkim_selector%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%dkim_public_key%",
+            "txtConflictMatchingMode": "All",
+            "ttl": 300
+        },
+        {
+            "groupId": "axene-spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:mail.axene.io"
+        },
+        {
+            "groupId": "axene-dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc@mail.axene.io",
+            "txtConflictMatchingMode": "All",
+            "essential": "OnApply",
+            "ttl": 300
+        },
+        {
+            "groupId": "axene-returnpath",
+            "type": "CNAME",
+            "host": "axene-bounce",
+            "pointsTo": "bounces.mail.axene.io",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **Axene Mailer** (`mail.axene.io`), a transactional and marketing email platform for African businesses. This template configures all DNS records needed to send authenticated email from a customer's custom domain via Axene Mailer infrastructure: domain ownership verification, DKIM signing, SPF authorization, DMARC reporting, and bounce/Return-Path handling.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — `mail.axene.io.email.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://mail.axene.io/email-assets/logo.png`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `mail.axene.io`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — `warnPhishing` is absent from the template
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `mail.axene.io`
- [x] no TXT record contains SPF content — SPF uses `SPFM` type with `spfRules: "include:mail.axene.io"`
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — verification uses `Prefix` + `txtConflictMatchingPrefix: "axene-verify="`, DKIM and DMARC use `All`
- [x] no variable is used as a bare full record value — verification token is embedded as `axene-verify=%verification_token%`; DKIM key is embedded in `v=DKIM1; k=rsa; p=%dkim_public_key%`
- [x] no bare variable is used as the full `host` label — DKIM selector is embedded as `%dkim_selector%._domainkey` with fixed `._domainkey` suffix
- [x] no variable is used in the `host` field to create a subdomain — not applicable, subdomain handling is via the standard `host` protocol parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record so users can tighten their DMARC policy independently without triggering a template conflict

## Online Editor test results

**Editor test link(s):** [Test apex: mail.axene.io/email example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF5H3mkC%2F%2B1Wa2%2FqOBD9K1akfirQBChNUyE1hd4VquiDcqWVqioyyQRcgp21HR636v3tOw7QQKG3V9rVqiv1W%2BJzPJ4zMz7Js6VhkiZUg%2BU9W6kUUxaB7ESWZ00oSyp0DhwqTFilV%2FCaTpBs%2BQYhXSSBRFSBnLIQ8p1gthZrezaQMulLyhUNNROcJoTyCCE5Bs34kFyuAkxBKsQtzylZiRiK7zLBQCOtU%2BUdHW0leJQfWqZKgVZHhlxJ%2BRBjRKBCyVKdx7FagsdsmEkg7et7IiEUMlIkFpLonXwmr%2FnksYkCHpm3KaNkU0yF%2BBEGaV91ukSxIUdOidzffiM00yMh2Q9qgpZIu%2Bv3WnhmKqTOOeaQgch4COURPicm%2BCqlilFPJaODBNpbCg6wKCxmYR400GIM%2FMAjkcAUOREzjiUbsZTkwBk5iMZsEihIINRCIjHPcgwLsl5bc9JskLAwQAhZvXufLBdyrqnPpjzT2wUPb7PBFSza%2BdF7BsZQehAxlKTfJa30Wt7DszWUIkvzCcoJ5U2lSNWL1MxR%2F88%2BvoyE0vhybjpMNd3es2juq5IJMddmAlCX7lIdjlBLV0Qm6q2EmM33U1bYmyMMV%2BM81mz7pbSbvCnqO0m%2FaUolWHYPK12omTZNwZ0zMm5KRc9I2txp0y%2F1%2BEnyQYIqjYv8cFy721VFuJclgJ2xGA%2BTLAJvu3d7ReOdCd9RHazBQqG5EI7RxgWHMyIz2jRnaOHl3PO3w%2FKRXMDbzzWjxiVuuJ%2BmyeKDIkjQmeQp1aMi69a1370s8l4Sl%2FfU2KBgXKu%2BQGS5pio7aa4PfHwpWT9QWlBM%2BSPqX98FmFP0XqiEYlIch095kgFb81Mq6UQZf17vfNja%2Brje%2B2CZ593JNwgdhE61ZvCt4cshk3nVrtZf0WLIDN7tdC46T%2F71xXD812jM%2Fjid2Rf%2B3eU3379p%2BXeub%2FDW8AqfL%2F0qdQa1sB4dQyM%2BGbqjU2Y%2FWaYMaBxCQmAMhGLJsc5aZlCyJlmiWUBntFiKwoCa1mHVFKKYAnrD1kTx5Rflvcu%2F0lo0ooTDF5oCMtN5N6pF1AmdcnR8EpfrENHyqR2flhsNcEPXiQdu7G587%2FZ%2BDPd97ooGbs6hn8zoQlkvZvr2iXit%2Fm%2FawD%2Fuxv%2BjLOebNUAvcsheFyI%2FaWF0Dftza%2Fo3HPATtG7trJs61565OdSFZ670fuSXn6J3jyX03C%2FD%2BTKcL8P5Mpz%2FxHDwr0vRKUQBNTS8mY2yXS879b5T846PvXq14tZc96RxaNuebZv0Qemlwmf8s9r8p7KeejV%2B3PNhorPvN4N2eFg%2Fmc%2Bgfe9n2ehwGk%2Fmd6pDG1dR41A0rZe%2FAWjn8bf%2BDwAA) [Test subdomain: mail.axene.io/email mail.example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAENJ3mkC%2F%2B1WXW%2FiOBT9K1akPg2hCQlfqZAmhXaX7UI7lJVGqqrISQx4CHbWdqBM1f3tex2gIUC3Wu1LV%2Bpb4nN8fc%2B91yd5NhRZpAlWxPCejVTwJY2J6MeGZywwTar4iTBSpdyovIJDvACy4WsEDYBEBKCSiCWNSL6T6K3F2okNyERjgZnEkaKc4QRhFgMk5kRRNkVX2wBLIiTghmdXjIRP%2BR8igUAzpVLpnZ%2BXEjzPDzWxlETJc02upmwKMWIiI0FTlccxupxN6DQTBPWG90iQiItYogkXSB3ls3jNJ4%2BNJGGxfltSjPbFVJEfQ5DeTX%2BAJJ0y4FTQ%2Fd01wpmacUF%2FYh20gnoDf9SFM1MuVM7Rh4Q8YxExZ%2FCc6ODblKpaPRYUhwnplRScQVHohEZ50EDxOWFnHoo5pMgQXzEo2YymKAcu0Fk8p4tAkoREigsg5lnOyRrt1nacNAsTGgUAAWt076PNQs7V9dmXp3u7ZtFdFt6QdS8%2F%2BsTAaMqIxBQkqTdJW72G9%2FBsTAXP0nyCcoK5rxSoap3qORp%2FH8PLjEsFL191h7HC5T3rzqkq6RBPSk8A6FIDrKIZaBnwWEe9E2RCn05TttjBEZqrYB4dy3qpHCevi%2FpG0gdNqQab7kGlCzXLji64fYHmHSHxBUo7R236Rz1%2BkryToEwnRX4wroNyVQEeZQmBzhiURUkWE6%2Fcu5Oi4c5Eb6gOdmChUF8IW2tjnJELJDLc0Wco7uXcr4fD8p5cArefKYq1S9wyP02T9TtFEERlgqVYzYqsu0N%2FcFXkvSFu7qm2QU6ZkmMOyGZNVo%2FS3B34%2BFIxfoK0oJjyR9C%2FuwvkCYP3kmrEF8VxW%2BvLEw3obk%2BKBV5I7dG73Q%2Bl7Y%2B7%2FQ%2BbAI%2B5eR7cAI3iMLJrjsZLQ5hDWkHNqrmvaDFsGh%2F0%2B5f9H%2F7wcjr%2Fczanv7RX1qX%2F7era92%2B7%2FreWr%2FHu9Aaer%2FwatkMncuM6aUya09asTa0fhi4HGAgXJNBGgqH0UG8lMlIxFlmiaIBXuFiKowDrFkL1JKCQAnhEabLY5suyLdkpH9jKLXpSgTmMdB2pHgLLwQ5ux02zHpHQdMOmY7Yadce0JrbTiFy77sbtvU%2Ffye%2FiqS9fuZf7Y%2BknK7yWxosexlNaXpuw5wrVssBja%2FjPnfn%2F1OewFGBTNjppUOgvXHhgw%2Fr40jYGedzsf%2B2SH6SVOwfeF7zz1v1p33rrgfD3zPXDdPOxAgb96UyfzvTpTJ%2FO9LGcCf7jJF6SOMCaCne3YVquabtj2%2FUsx3Ob1XrNbrfaXyzLsywtgUi1UfkM%2F2r7f2lGctNrXjvE%2BS1pjYZdi8%2Fd7q9y1f3%2BxW3crW6TZFVfh7X%2B7%2F3bkHeMl78Bg%2B6EG1gQAAA%3D)