### PR TITLE
add tiide.app

### DIFF
--- a/tiide.app.cluster.json
+++ b/tiide.app.cluster.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "tiide.app",
+  "providerName": "Tiide",
+  "serviceId": "cluster",
+  "serviceName": "Connect your domain to Tiide",
+  "version": 1,
+  "description": "Automatically configures DNS records so your domain points to your Tiide site.",
+  "logoUrl": "https://tiide.app/img/logo-blue.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "tiide.app",
+  "syncRedirectDomain": "tiide.app",
+  "variableDescription": "Connects %domain% to your Tiide site",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600,
+      "groupId": "tiide"
+    }
+  ]
+}


### PR DESCRIPTION
  # Description                                                                                                                          
                                                                                                                                         
  New Domain Connect template for Tiide (https://tiide.app), a hosting platform for customer sites. The template lets customers connect a domain to their Tiide site by setting a single CNAME record that points their chosen hostname at the Tiide cluster handling their site. Cloudflare for SaaS on Tiide's side handles ownership and SSL verification automatically over HTTP once the CNAME propagates, so no customer-side TXT records are required.                

## Type of change

  Please mark options that are relevant.

  - [x] New template
  - [ ] Bug fix (non-breaking change which fixes an issue in the template)
  - [ ] New feature (non-breaking change which adds functionality to the template)                                                       
  - [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)
                                                                                                                                         
# How Has This Been Tested?                               
                                                                                                                                         
  Please mark the following checks done                     
  - [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
  - [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — `tiide.app.cluster.json`                                
  - [x] resource URL provided with `logoUrl` is actually served by a webserver                                                           
                                                                                                                                         
# Checklist of common problems                                                                                                         
                                                            
  Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.                                       
  See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.
                                                                                                                                         
  - [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
  - [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together                                    
  - [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow                                    
  - [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead *(no TXT records in this template)*     
  - [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) *(no TXT records in this template)*                                                                                                             
  - [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service foo=%foo%"`; if bare, justify in the PR description                                                                                                    
  - [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description *(host is the literal `@`; subdomain is supplied via the protocol's `host` parameter with `hostRequired: true`)*
  - [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead              
  - [x] `%host%` does not appear explicitly in any `host` attribute                                                                      
  - [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)  
  *(N/A — the only record is the CNAME that wires the domain to Tiide; removing it breaks the service, so `essential` is not  appropriate)*

## Online Editor test results

[Test tiide.app/cluster example.com/tag](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOoj32kC%2F91UXW%2BbMBT9K8hSnhYIoUmIkCYta7e16pZVXbpOqyLk4BtqFTC1DR2N%2BO%2B7JqE0a%2FbxvKdwv%2B85PjcboiHNE6qBBBuSS1FyBvKMkYBojp8OzXPSfwrMaYqJZGFC6FYgSx5Bkx4lhdIgO%2B8u91hkGUTaqkQhLSZSyjNLC6ttUYJUXGQkGPYJAxVJnuvGJrNCY7bmEU2SyopEtuZxIUFZJ%2FMvloRISKYsJfYa54JnWpn%2BjbcZYimuwcFRiYjFlUyw9a3WuQoGgyeIA57GAxO3V0kBjipjg6PKoreJiO5IsKaJgq3nolidQ3XSzPuFJRO%2BBMZxOX0woaSS01UCJ3tAdwwpq7dF0TuwPxbfCqUv4b7A9si3lgUutKOBBDcboqu84Xs%2B%2B%2FRul47mG%2FN6DSsLgWZPUxmD7qFXa6TiaOK6fRJLUeTdo5N6WffJo8gg7AYs8X1aTPCDomjAiUTaTdLUkNa0CnlbklNJU2W01Rbf7FUv2%2FKbph7N7YLGoSpmu0NnJyzldEya9XicCQmhwl%2BqURctJWmRaB7SB9q5WBRiVVIhGoVR7P2Srmyr1i0IRjVF4%2FcL7LEXssgA5Ia%2Fqe8zCsy3xyvPs0cjf21P19HQHh8NYeWvpmt3Onp2Ty8O7fBF7TEMSkGmOTVCniUPtFKkrpd9ZPv%2FQ4V6ULQEFlKT6bnexHZH9nC8cMe4ZjDyHM%2FzXd9%2F5bqB6xoAoPQW56b5bqTXWO3tNZ5WZH8k45%2FlbqRem2M06jp4jN07OM%2BaOfuM%2F%2FV98CxrQ2aC%2FxbIicGH%2BZSg8%2FkdkOtv1%2BNZMZmw6vZjOTs%2F%2FVxcSe%2Felev3i6%2BXp8d0%2Fjj%2FcKzPvvOLu9ek%2FgmFofs7AwYAAA%3D%3D)
[Test tiide.app/cluster example.com/other](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF0k32kC%2F91U7W7aMBR9lcgSv0ZCgJK2kSatK9PUVUMbpdOmCiHj3KYWJk7tG9oU8e67DkkpLd0D7Bfx%2FT7nnsuaISxzxRFYvGa50SuZgLlIWMxQ0mfA85y1nx0jvqRANnEuMlswKymgCheqsAhmZ61jz3WWgUCv1IXxEr3kMvNQe02JFRgrdcbibpslYIWROVZvdlYgRaMUXKnSEzq7lWlhwHrD0ZVnQGiTWM%2FqvcK5lhlaV7%2ByVk08KxECaqV0qq%2BNotJ3iLmNO51niB25TDvO789VAYFdpQ5HmYnPSosFi2%2B5srC1%2FCjml1AOq36vWHLuMSSShsODAStuJJ8rGO4BrRmyXmuLonVgfkq%2B0xbHcF9QeeIbTUED1TSw%2BGbNsMwrvkdn37%2FU4fT85LZXsTLR9GwhNylgi6yIREU%2FCsM2S40u8t3S2Wa6abMnncFs12BK%2B2kwwSMn0UAg9HLXSeNdtf6q2Ew2STk3fGmdupr0m738aVPgpq5Ahu2QzlRYP%2BwGtbZssCPTTSjTTBuYWfrlSNJoWFkWCuWMP%2FCdKREzylIlAbLkpdJvGcu2gm1wJBw5Pd%2BdYI%2FBWSIcROk4jKLwtNcH7kd8MPePev1T%2FyTs9vwIxICf3opI9OYvburNsR2%2Bqlcsg7WQoeROzmfqgZeWbTbTNjH%2BXwIjUVi%2BgmTGXWwv7EV%2BeOR3B5NwEPdP4v5x0O8OBv3jD2EYh6GDABa3QNfVd6XA6tUcYWVplEa3m7xLx791jzxtVO8Uv3FX6TR28CrrVVBO8KJYsM95vaD3R6L73Dg6Ff1tECcOH8VzRsaX18C6V5dP40U0uv96vIjUohTfBtfnOTxNeukY8dd9Mvzz8%2Bj35QVcPHxkm79AXNKGDAYAAA%3D%3D)
