### PR TITLE
Template for pass.qrtick.com

### DIFF
--- a/qrtick.member-portal.json
+++ b/qrtick.member-portal.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "qrtick",
+  "serviceId": "member-portal",
+  "providerName": "QRTick Member Access",
+  "serviceName": "Digital Membership Portal",
+  "syncBlock": false,
+  "variableOptionId": "default",
+  "syncRedirectDomain": "pass.qrtick.com",
+  "syncPubKeyDomain": "pass.qrtick.com",
+  "logoUrl": "https://pass.qrtick.com/logo.png",
+  "description": "Connect your custom domain to your digital membership portal.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/qrtick.member-portal.json
+++ b/qrtick.member-portal.json
@@ -7,7 +7,6 @@
   "variableOptionId": "default",
   "syncRedirectDomain": "pass.qrtick.com",
   "syncPubKeyDomain": "pass.qrtick.com",
-  "logoUrl": "https://pass.qrtick.com/logo.png",
   "description": "Connect your custom domain to your digital membership portal.",
   "records": [
     {


### PR DESCRIPTION
### Type of change
* [x] New template

### How Has This Been Tested?
* [x] Template functionality checked using Online Editor.
* [x] Template file name follows the pattern <providerId>.<serviceId>.json.

### Checklist of common problems
* [x] `syncPubKeyDomain` is set — mandatory for security.
* [x] `warnPhishing` is not set — exclusive with syncPubKeyDomain.
* [x] `syncRedirectDomain` is set — for synchronous flow base URL.

### Online Editor test results
**Editor test link(s):**
* qrtick.member-portal: https://editor.domainconnect.org/template/qrtick/member-portal
