### PR TITLE
Add rstream.io.tunnels template

### DIFF
--- a/rstream.io.tunnels.json
+++ b/rstream.io.tunnels.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "rstream.io",
+  "providerName": "rstream",
+  "serviceId": "tunnels",
+  "serviceName": "rstream tunnels",
+  "version": 1,
+  "logoUrl": "https://rstream.io/images/brand/rstream-logo-square-light.svg",
+  "description": "Route your custom domain through your rstream tunnel.",
+  "variableDescription": "%cluster%: CNAME target pointing at the rstream edge; %verifytoken%: hex token used to prove ownership of the hostname.",
+  "syncPubKeyDomain": "rstream.io",
+  "syncRedirectDomain": "rstream.io",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cluster%.",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_rstream-verify",
+      "data": "rstream-verify=%verifytoken%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "rstream-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for rstream tunnels.

The template provisions two DNS records to route a custom subdomain to a customer's rstream cluster:
- `CNAME` on the chosen host, pointing to the customer's rstream cluster edge (`%cluster%`).
- `TXT` at `_rstream-verify` carrying the ownership token (`rstream-verify=%verifytoken%`) that the rstream backend reads to confirm the domain belongs to the user before activating it.

Synchronous flow, RSA-SHA256 signed. Public key published as TXT at `_dck1.rstream.io`. `syncRedirectDomain` is set because the service uses `redirect_uri` to send the user back to the rstream dashboard after apply.

This template covers subdomains only. `hostRequired: true` signals to providers that the template is not intended to be applied without a host parameter. The technical reason is that the rstream cluster edge is currently exposed only as a CNAME target, and a CNAME record at the apex is not portable across DNS providers. Apex customers are guided through a manual ALIAS/ANAME flow in the rstream dashboard instead. Apex may become a separate template in the future once a stable anchor IP (A/AAAA) or an APEXCNAME-compatible target is available.

## Type of change

- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using the Online Editor
- [x] File name follows `<providerId>.<serviceId>.json` (`rstream.io.tunnels.json`)
- [x] `logoUrl` resource is served (`https://rstream.io/images/brand/rstream-logo-square-light.svg`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`rstream.io`)
- [x] `warnPhishing` is not set
- [x] `syncRedirectDomain` is set (`rstream.io`)
- [x] No TXT record carries SPF content
- [x] `txtConflictMatchingMode: Prefix` is set on the TXT record with `txtConflictMatchingPrefix: "rstream-verify="` so re-applies replace the previous token
- [x] No variable is used as a bare full record value — TXT data is prefixed with `rstream-verify=`
- [x] No bare variable is used as a full `host` label — `host` is `@` or `_rstream-verify`
- [x] No variable in `host` is used to target a subdomain — handled via the protocol `host` parameter (`hostRequired: true`)
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is intentionally not set — both records are service-managed and must not be edited manually

## Online Editor test results

**Editor test link(s):**
[Test rstream.io/tunnels example.com/api](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALml32kC%2F%2B1U227bMAz9FUNAnxYnvjVpPAxY2m7DLi2KLgW6FYEhW7QtzLZcSc5lQf59VC510nTY6wbsyRbJQ%2FHwiFwSDWVdUA0kXJJaiilnID8yEhKptARadrkgnSfPNS2h9aFDgZzyBNYI3VQVFKq1HkZbrX8KUnFRkdDtkEJk4k4WGJdrXauw12tv7vGSZqB6saQV29ltg7DVY0Ml2AXPct1V0wyzMlCJ5LVeZya3otFgLUQjraRRWpQWEyXllaVzKZos37gOa%2Bua2qjkNC7g8iDbSVJgEpAnoXVxPbp6Z2kqM9BWLXileZVZVGNieMoHLIPX1gkS5elCix9QITKHubX%2BtxoFDH8t01ewxKzChuS8tkS6zpILpStsnqlHLarkpok%2Fw%2BJyXf9zaYz%2FFhiXkOjfR5wXIvlBwpQWCjrE5L%2BFxwZBKJyWDdoQLyRTJHxYEr2ojXBrpmQTjse35iEYvmos9ltiqtQaFfQdZ9V5Qo%2Fvxy022om36YhRi2raVrq1vzno2F5e%2FJvrC1GlBU%2F0FdVJjk2%2FEsxcdCMh5XPyYsjWd3QPWU1WHfJTVBC1xCdY1a6DMKc4GNBNRNmyoDXHQ4bvp474DlJTSUtl5mcHfjhAT3bwhzUej9vGGUvS3ZNqsp6MHX3jZoGX9j16FqeeG7OBHw9jBwKIWRz0h%2F1TIIYFzyohIVL4pbqRsFO0bArNIzqjrYklEa3rYoGkFXrximO1q83UbrhuVdovs3sgS8QSQ52bBeAHLgQJZXbqeL4d9B3fPoMBxWPqDYaJ24c42Fsmx2vm5W1y0HxQCnDiqFkYo2JGF4qsjh7dlsKzR9c9oPTsQfyx038d6UkHX99%2F%2Bf5Z%2BXDaFZ0Ci6iJ9ByvbzuB7Z6O3SA8dULf7w684NQdvHKc0HEMAVB6w36JU78%2F7%2BTboJ9Pb%2BIP0%2BDu%2Fj5wZ%2F70cTTzXKfx388Lzryz0dfxd2f45dN5gqvvF2cqKkb2BwAA)