### PR TITLE
add Figuro, Figuro Engage

### DIFF
--- a/figuro.la.custom-domain.json
+++ b/figuro.la.custom-domain.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "figuro.la",
+    "providerName": "Figuro",
+    "serviceId": "custom-domain",
+    "serviceName": "Figuro Engage",
+    "description": "Configure a custom subdomain for your Figuro Engage microsite",
+    "variableDescription": "CNAME target for agent microsite",
+    "syncPubKeyDomain": "figuro.la",
+    "syncRedirectDomain": "engage.figuro.la",
+    "hostRequired": true,
+    "version": 1,
+    "logoUrl": "https://engage.figuro.la/images/figuroLogo.webp",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "custom.figuro.la",
+            "ttl": "3600"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for Figuro Engage, enabling custom subdomain configuration for Figuro Engage microsites. Creates a CNAME record pointing to `custom.figuro.la`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value — N/A (no variables in record values)
- [x] no bare variable is used as the full `host` label — N/A (no variables in host)
- [x] no variable is used in the `host` field to create a subdomain — uses `hostRequired` and protocol `host` parameter instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — N/A (single CNAME, no user-modifiable records)

## Online Editor test results

**Editor test link(s):**
[Test figuro.la/custom-domain agent.com/figuroform](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALvw32kC%2F92TbW%2BbMBDHvwry24XEJClNkCYtW9OuWht1Hds0VREy%2BEJdAaa2SUSjfPedYXlgnfoB9gpxD7%2B7%2B995SwzkZcYMkGBLSiXXgoO65iQgK5FWSvYzRnoHx4LlGEguGxfaNai1SKCJTyptZO5ymTNRHH2dFGdepCwF9HLQiRKlEbJA7ydZNOXAYU7LcXQVtyhnJZVTy0o5HYaTi0RJLYylrZkSLM7goktdzG7njmEqBdNQMK0wnURdF8ldFX%2BB%2BqLtuzu3dd8DFwoScwiApn7%2FNO5RanMPzxUGohRGVYA9gdJNH16PZDKV31WGyY%2FGlDoYDP6GDESO%2F3rQGm4wvr%2BBuEQ21paKaxI8bImpS9gP9qcs%2Fn6wG5KiMDqUh0V0%2BjPG1h75lJLdctcjL7KA6Ahe4j720zUa9ROZH%2FktCQW0tlTJqozEPq9kiuXaHs%2Be8HCCWO4ZD6cQ24FIC6kg0vhlBhe%2FVy2vMiMitmFHE08iVpZZjQ1r9CLstRJFe2WdTjkz7A05rBo9EvHENi%2FsBQ%2F9hMc%2B99145PvumFHqspF37oIH3jT24uFqcvoYXr2St17Dv6QErVEowexuZtmG1ZrsdsseyvpfD4hHodkaeMRswpAOfZeOXe8sHNLAo8HorH8%2BHk3o9B2lAR4sTgPatLNu8XJOb4ZcjS9XP%2BIspCVPvla3357ozefyZfFrHk7DKy%2BPfz75s8lz%2BDG8Tt%2BT3W%2BvgGlC7gQAAA%3D%3D)