### PR TITLE
Add SendCanary SPF sender authorization template

### DIFF
--- a/sendcanary.com.spf.json
+++ b/sendcanary.com.spf.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "sendcanary.com",
+  "providerName": "SendCanary",
+  "serviceId": "spf",
+  "serviceName": "SPF Sender Authorization",
+  "version": 1,
+  "logoUrl": "https://sendcanary.com/logo.png",
+  "description": "Add an authorized email sender to your SPF record. SendCanary detects which services send email on your behalf and helps you authorize them with one click.",
+  "variableDescription": "include: SPF include mechanism to add (e.g. amazonses.com, _spf.google.com)",
+  "syncPubKeyDomain": "sendcanary.com",
+  "syncRedirectDomain": "sendcanary.com,app.sendcanary.com",
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:%include%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New SPF sender authorization template for SendCanary. Uses a single `SPFM` record to merge an `include:` mechanism into the domain's existing SPF record. This enables one-click SPF fixes when SendCanary detects an authorized email sender (e.g. Amazon SES, Google Workspace) that is not yet in the domain's SPF record.

The template uses one variable (`include`) which is the SPF include mechanism to add (e.g. `amazonses.com`, `_spf.google.com`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
- [x] Validated with `dc-template-linter` -- zero errors, zero warnings
- [x] Validated with `dc-template-linter -cloudflare` -- zero errors, zero warnings

# Checklist of common problems

- [x] `syncPubKeyDomain` is set -- published at `1.sendcanary.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` -- `warnPhishing` is not present
- [x] `syncRedirectDomain` is set -- `sendcanary.com,app.sendcanary.com`
- [x] no TXT record contains SPF content -- uses `SPFM` record type for SPF merge
- [x] `txtConflictMatchingMode` is set on TXT records -- N/A, no TXT records in this template
- [x] no variable is used as a bare full record value -- `include:%include%` is embedded in `spfRules` with static `include:` prefix
- [x] no bare variable is used as the full `host` label -- host is fixed `@`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on appropriate records -- N/A, SPFM records do not support `essential`

## Online Editor test results

**sendcanary.com.spf.json:**
- [Test sendcanary.com/spf example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGUP4GkC%2F91Tf2vbMBD9KkJQ2JjjOLbTH4bCwtptpayErmMbJRhFusTaZMuT5KRuyD77TomzpLT7AvvLZ927u3fv7lbUQVkr5oBmK1obvZACzJWgGbVQCc4qZtqQ65IGf703rEQ0%2FYz%2Bdxs%2F%2BiyYheSwDaxn%2B5cdePye%2BAAwZNS4Qhv5yJzUFQIXYKy3skFAlZ7rL0ZhQOFcbbN%2B%2FymLvgeEdTXHOAGWG1lvsmR0JARhFWFdchAESiYVsduiTpNWN4Z4Hga4NiIk%2BwaIAAfcWbIsJC9IR91ugrs8utommELB1AxLCVKAqq1%2F3VclroCSLKUrMAAIV5L%2FDH2PzEg2VXDxhLOsuGoEZBtW3Q8pgReskrb0nBl29QrCeUhYyR51ZcF6GQKSo8jhXOu5Av%2Fw2gveVnzcTK%2BhvdBIuXpphB5zC0KiBO4fqIDVdfgscKuZpdn9irq27kb6CT2Ftg7%2F3vrs9ey2UWAPWjvqjCN0O4eDTY6jaD1ZBxS7gXyfdoID3RGCB4Y7CV3prgBac6ObOpc7fM0MK63f213k%2FZPQyS72nnq7Y%2FIMhVzkvNIGcotf5hqDGGcaCGjZKCdztmT7J8FzFEi1SN2iF7PtFbn7docsq%2B3Ge0EEcwzNxTkqM9hNODuoTn4zpQ6lCWguuG9J%2Bkvi%2FGR6dszTHoiTWS9NzpLeaRLz3kykacxBsNNZdHCYL5%2Ft89PcKwoW4U4yf3EjtWStpev1JEB1%2F7%2BucAUsW4DImYfFUXzci9LeYHgXx1k8yOJhmGL9NH0TRVnkCTiwbtvrCnfkcDvoKJFuPLq5OfnaN99PP15Or4AnrfzwaxwVj2mSpMnw%2BsflQ2Gn0Tld%2FwHmI4S9ZQUAAA%3D%3D)
- [Test sendcanary.com/spf example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHgP4GkC%2F91T227bMAz9FUFAgQ1LXDu3IgYKLFsxYOguWduh7YogYCQm1ipbniQnTYvs20clzpKg3Q%2FsyabIQx4ekk%2FcY15q8MjTJ15aM1cS7UfJU%2B6wkAIKsMtImJw3%2Fnq%2FQE7R%2FJL879d%2B8jm0cyVwAyynu5dt8PADCwC0bFD5zFj1CF6ZggLnaF34S5MG12ZmvltNgMz70qXHx4csjkNAVBYzwkl0wqpynSXlAykZFAzq5CgZ5qA0c5ui3rClqSwLPCwKY2XEdg0wiR6Fd2yRKZGxmrpbg%2Bs8ptgkmGAGekqlJMtQly687qoyn2HOFspnBEAmtBL3UegRrIKJxrMDzqoQupKYrlnVBstRZFAolwfOQF29wmgWMcjh0RQOXZChwcYkcjQzZqYxPLwOgi8LMawm57g8M0S5eGmEIeYCpSIJ%2FD%2BiGlCW0TPgRjPH07sn7pdlPdLP5MmM82S9DdnL6UWl0e21dlT%2FHJHbexpsuxfHq9GqwakbHO%2FSjmigW0L4ALSTWJeuC7hqQsbMmqocqy2kBAu5C6u7Bd8doEdb%2BN0aT2bN51kgMVKzwlgcO%2FqCryzFeFthg%2BeV9moMC9g9STEmmfSSGnDkpWw7Xa5urohosdn7DWsJHsiYn5JCyXbS6V599hu03peowcdShL5UuChIRO%2FkpNNvTvtxt9npJrI5ge60eQJ96HWSOEn6Yu9AXz7f5yd6oCw6QngF4fgGegFLx1erUYNU%2Fk9bo2VwMEc5hhDZilu9ZtxpJt2rVittJWmnE7Xb3XYreRPHaRyHDtD5TbtPtC37e8L7i8uh6MTXX88G%2Bqf%2B9qn1cNmW9%2Bdn06zTKsW7H9e3j78G%2Fd7tzXBwyld%2FAEotOel1BQAA)
