### PR TITLE
Add 10 DomainBridge templates

### DIFF
--- a/domainbridge.io.a-record.json
+++ b/domainbridge.io.a-record.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "a-record",
+  "serviceName": "A Record",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Single A record pointing the root domain to an IPv4 address.",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "ip is IPv4 address to point the domain to",
+  "sharedProviderName": true,
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%ip%"
+    }
+  ]
+}

--- a/domainbridge.io.aaaa-record.json
+++ b/domainbridge.io.aaaa-record.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "aaaa-record",
+  "serviceName": "AAAA Record",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Single AAAA record pointing the root domain to an IPv6 address.",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "ipv6 is IPv6 address to point the domain to",
+  "sharedProviderName": true,
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "AAAA",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%ipv6%"
+    }
+  ]
+}

--- a/domainbridge.io.dkim-txt.json
+++ b/domainbridge.io.dkim-txt.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "dkim-txt",
+  "serviceName": "DKIM Record (TXT)",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Sets a DKIM TXT record at selector._domainkey for providers that publish the key directly",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "dkimHost is DKIM selector (e.g. s1, google), dkimValue is DKIM TXT record value (the full key string)",
+  "sharedProviderName": true,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "%dkimHost%._domainkey",
+      "ttl": 14400,
+      "data": "%dkimValue%"
+    }
+  ]
+}

--- a/domainbridge.io.dkim.json
+++ b/domainbridge.io.dkim.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "dkim",
+  "serviceName": "DKIM Record (CNAME)",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Sets up a DKIM record via CNAME for email authentication",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "dkimSelector is DKIM selector (e.g. s1, google), dkimTarget is DKIM CNAME target hostname",
+  "sharedProviderName": true,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkimSelector%._domainkey",
+      "ttl": 14400,
+      "pointsTo": "%dkimTarget%"
+    }
+  ]
+}

--- a/domainbridge.io.dmarc.json
+++ b/domainbridge.io.dmarc.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "dmarc",
+  "serviceName": "DMARC Record",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "DMARC policy record for email authentication reporting and enforcement.",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "dmarcPolicy is DMARC policy: none, quarantine, or reject, dmarcRua is Email address for DMARC aggregate reports",
+  "sharedProviderName": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "ttl": 3600,
+      "data": "v=DMARC1; p=%dmarcPolicy%; rua=mailto:%dmarcRua%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}

--- a/domainbridge.io.mx.json
+++ b/domainbridge.io.mx.json
@@ -1,0 +1,55 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "mx",
+  "serviceName": "MX Records",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Mail exchange records for email delivery. Supports primary and secondary MX.",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "mx1 is Primary mail server hostname (priority 10), mx2 is Secondary mail server hostname (priority 20), mx3 is Tertiary mail server hostname (priority 30), mx4 is Fourth mail server hostname (priority 40), mx5 is Fifth mail server hostname (priority 50)",
+  "sharedProviderName": true,
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%mx1%",
+      "priority": 10,
+      "groupId": "mx-primary"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%mx2%",
+      "priority": 20,
+      "groupId": "mx-secondary"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%mx3%",
+      "priority": 30,
+      "groupId": "mx-tertiary"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%mx4%",
+      "priority": 40,
+      "groupId": "mx-quaternary"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%mx5%",
+      "priority": 50,
+      "groupId": "mx-quinary"
+    }
+  ]
+}

--- a/domainbridge.io.spf.json
+++ b/domainbridge.io.spf.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "spf",
+  "serviceName": "SPF Record",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Sender Policy Framework TXT record to authorize mail senders.",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "spfDomain is SPF include domain (e.g. _spf.google.com)",
+  "sharedProviderName": true,
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:%spfDomain%"
+    }
+  ]
+}

--- a/domainbridge.io.subdomain.json
+++ b/domainbridge.io.subdomain.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "subdomain",
+  "serviceName": "Subdomain CNAME Pointing",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Points a subdomain to a target via CNAME record",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "subdomain is Subdomain to point (e.g. app, blog), target is Target hostname",
+  "sharedProviderName": true,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%subdomain%",
+      "ttl": 3600,
+      "pointsTo": "%target%"
+    }
+  ]
+}

--- a/domainbridge.io.verify.json
+++ b/domainbridge.io.verify.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "verify",
+  "serviceName": "Domain Verification (TXT)",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Verifies domain ownership by adding a TXT record",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "verification is Unique verification token",
+  "sharedProviderName": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "ttl": 3600,
+      "data": "domainbridge-verify=%verification%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "domainbridge-verify="
+    }
+  ]
+}

--- a/domainbridge.io.website.json
+++ b/domainbridge.io.website.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "domainbridge.io",
+  "providerName": "DomainBridge",
+  "serviceId": "website",
+  "serviceName": "Website Hosting (A + CNAME www)",
+  "version": 1,
+  "logoUrl": "https://domainbridge.io/logo.svg",
+  "description": "Points root domain via A record and www via CNAME for website hosting",
+  "syncPubKeyDomain": "domainbridge.io",
+  "syncRedirectDomain": "domainbridge.io, api.domainbridge.io, app.domainbridge.io",
+  "variableDescription": "primaryIp is Primary IPv4 address, fallbackIp is Fallback IPv4 address, cnameTarget is Target hostname for www CNAME",
+  "sharedProviderName": true,
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%primaryIp%",
+      "groupId": "web-a"
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "ttl": 3600,
+      "pointsTo": "%fallbackIp%",
+      "groupId": "web-a-fallback"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "ttl": 3600,
+      "pointsTo": "%cnameTarget%",
+      "groupId": "web-www"
+    }
+  ]
+}


### PR DESCRIPTION
## New Domain Connect Templates

**Provider:** DomainBridge (domainbridge.io)

- `domainbridge.io.verify.json`
- `domainbridge.io.dkim.json`
- `domainbridge.io.spf.json`
- `domainbridge.io.subdomain.json`
- `domainbridge.io.mx.json`
- `domainbridge.io.website.json`
- `domainbridge.io.dmarc.json`
- `domainbridge.io.a-record.json`
- `domainbridge.io.aaaa-record.json`
- `domainbridge.io.dkim-txt.json`

We are building a new tool to help software providers make it easier for their customers to modify DNS records for domains being connected to their app. 