### PR TITLE
Add streamnode.io website template

### DIFF
--- a/streamnode.io.website.json
+++ b/streamnode.io.website.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "streamnode.io",
+  "providerName": "Streamnode",
+  "serviceId": "website",
+  "serviceName": "Streamnode Websites",
+  "version": 1,
+  "logoUrl": "https://streamnode.io/assets/www/images/logos/logo.svg",
+  "description": "Connect your domain to Streamnode",
+  "variableDescription": "%cname%: Streamnode edge CNAME target; %apex-cname%: apex CNAME/ALIAS target; %ipv4%: Streamnode apex IPv4 address",
+  "syncPubKeyDomain": "domainconnect.streamnode.io",
+  "syncRedirectDomain": "streamnode.io",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "subdomain",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 600
+    },
+    {
+      "type": "A",
+      "groupId": "apex",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "apex-cname",
+      "host": "@",
+      "pointsTo": "%apex-cname%",
+      "ttl": 600
+    }
+  ]
+}

--- a/streamnode.io.website.json
+++ b/streamnode.io.website.json
@@ -8,7 +8,7 @@
   "description": "Connect your domain to Streamnode",
   "variableDescription": "%cname%: Streamnode edge CNAME target; %apex-cname%: apex CNAME/ALIAS target; %ipv4%: Streamnode apex IPv4 address",
   "syncPubKeyDomain": "domainconnect.streamnode.io",
-  "syncRedirectDomain": "streamnode.io",
+  "syncRedirectDomain": "streamnode.io, app.streamnode.io",
   "hostRequired": true,
   "records": [
     {


### PR DESCRIPTION
# Description

Adds a new `streamnode.io.website.json` Domain Connect template for Streamnode custom domains, supporting subdomain CNAME and apex A/CNAME flows via `groupId` selection. The template uses signed synchronous flow (`syncPubKeyDomain` + `syncRedirectDomain`) and includes `logoUrl`/`variableDescription` metadata for provider review.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test streamnode.io/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN4R4WkC%2F91UXW%2BbMBT9K8hSnwaBJDTNmCYtarsp2vqhNlsfqggZfEe9gc1sA2VR%2FvtsSAI07R%2FYCyH3nnu4555rb5CCLE%2BxAhRsUC54SQmIJUEBkkoAzhgnMKIc2YfkNc40GN0f0jonQZQ0hqaugkhS1YseFVgPLURqTAlCUs5QMLZRyhP%2BXaQa%2B6RULgPXHfTgYilBSbeqKpdmOAHpmor2OZJloukIyFjQXDWU6JwzBrGyal4Ii%2FAMU2Ypbg1aL7GgOErhYlB5EjPd9UnQw1pAErDOrxdXl5bCIgH1wTrBOTw7e6z50wLcxbfl4r6D0bz0h2QNdnlb%2BhYmRIA0s5A1i2%2BL6CvUF02vuo%2B26bjVMXppiSm4A0KFTh5KXoKeuFR38KfQKG2PEgXYSBdwQSQKHjdI1bmxp%2BlbwxPBi7xdgCJqP78j0aFPZg84ZUqueDclHVRK2zbzvK19IFwMyIzet3ma%2BbxOc9xXN%2FO3CXu%2B9GnXWxv95QzCbgBrezdkXQbPWB8GGMU866j1uu0%2FH9KmpDcZXZ1jgTNpjs%2Be53FAtN4zPTZU6x3XEU%2BryEQ7A1PKfpucmY9Jmfee%2FCaiJdGEcQGh1L9YFQL2NmdFqmiIK9yFSBziPE9rPQGps5rieAVa7p1wghUeblXTVDdUG4UkNvKpMQei6dSfT2dO%2FBNmjh95Eyc6nRBnDPMpPiPemHhR7zJ59aZ5%2FTYZ2KEPDDBFsbksFmmFa4m227Wt3fyP5GizJS6BhNggJ95k5ni%2BM56txrPA94OxP%2FLm3tnk%2FTvPCzzPaACpWoEbvRX9fUD%2BhK0u%2Bd0PdXUtqs83v%2F6cuhdVyqro9IZBWa7q2Rf%2F%2BXz%2BkE%2BXH9H2HxEuT3YXBgAA)
[Test streamnode.io/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA0S4WkC%2F91U7W7aMBR9lchSf5FAoCmITJOGaDVVa1EH3aqtQtElvkutJXFqOwGKePfZCR9JoS%2BwP%2FnwPff43nOuvSEKkywGhcTfkEzwglEUt5T4RCqBkKScYptxYh%2BCE0g0mMwOYR2TKAoWYpm3xIVkqrZ6kmA9VRCpMQUKyXhK%2FK5NYh7xHyLW2BelMul3Oo0aOiAlKtlZLpcdlkCEsmMyqmdbFpGmoyhDwTJVUpIxT1MMlbXmubAoT4ClluJWo%2FQCBINFjNeNzIsw1VVf%2BDWshTRCazwZ3d9YCkSE6pN1ARmunD3W%2FFSAzujudjQ7wlhWeE2yEnv7UHgWUCpQGi3kOg0f8sU3XF%2BXteo6qqLDqo%2F2e0tMwhQpEzp4SHkPeuFSTfE11yhtjxI52kQncEEl8Z83RK0zY09Zt4ZHgudZNQD5otp%2BR6KXvpg54CxV8pEfVdKLSmnb%2Bq67tQ%2BEowaZ6fdjnlKf8zSndR01%2F5iw5kuddr61yRtPMTgKMLd3Ius0XIE%2BDNgOeXKk1uO23z5gZUq9Ap2egYBEmvOzJ3puMM33VM8l13xHdkpUfejlmoUxS%2F%2BamFHIhMx3LescWPfIopQLDKR%2Bg8oF7n1P8lixAJZwXKJhAFkWr7UkUkc14%2BlMVFvtlKCgoDlm5bZHlW0S0NDIwYxbV15%2FCH%2FowFkMceF4QMEZDsOeg5S6FLrQw7Bbu13OXj3nr5eGP%2FoEYaoYmNtjFC9hLcl2O7e1vf9RO9p7CQXSAAyy5%2Fb6jus53f5jt%2B97V77bbXuX7tDrtlzXd13TA0pVNbjRU1GfBwLfw1%2FR6ySctKZsMCtE63I6GD%2B10tHKg%2Fvfs8FX92558%2FYzZuPwM9n%2BA10rLq8oBgAA)
[Test streamnode.io/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACIS4WkC%2F91Ua2%2FaMBT9K5GlfmrIgwKFTJOG2q3q1lYdpVpXhJCJ71JvSZzZToAi%2FvuuEx5JH39gX0DxPef43nNsr4mGJIupBhKsSSZFwRnIS0YCorQEmqSCgcMFsffFG5ogmNzty1hTIAseQslbwFxxXVt9RbB%2BVBCFmAKk4iIlgW%2BTWETiXsaIfdI6U4HrNnpwqVKglbtYLFye0AiUaxjVr6OKCOUYqFDyTJeS5EykKYTaWolcWkwklKeWFlaj9YJKTucxnDeYR2GKXR8FNawFLALr7GZ4%2FdnSVEagP1hHNINla4c1HxXAHV5dDu8OMJ4VnaZYib28LToWZUyCMl6oVRre5vNvsDove8U%2BqqbDag7nZSSGMALGJRb3lJegJ6H0CP7miMJ4tMzBJkgQkikSTNZErzITT9k3wiMp8qw6APm82n4rgkufzDkQPNVqLA4u4aLWGFvP8zb2XnDYEDPzvq9T%2BvO2zOu%2BDp6%2FL1jLpS473djkWaQwOxgwtbcmIw2WFC8DOKFIDtJ43Hbbz3hJqYZBYkYlTZS5OTuJSUNjuhOZlCrTrUxdopoDF2qxxTz9Y2rGFVPyB23H7%2FUdz%2FHNcm3%2Bt3g4Io9SIWGm8J%2FqXMIu9iSPNZ%2FRBT0ssXBGsyxeoSMKq6g4aSRYbbM1gVFN8aPez8Fcm8xYaLzgJqTBr25IGWUtn0G%2F1Qm73daAgdfqePTE6%2FpscMoGtUflzRfn7VelEQteHEg1p%2BbRGMYLulJks5namOp%2FMAZmrWgBbEYNsu21ey2v0%2FJ7Y78XdLpBu%2B30%2Br7XPjn2vMDzzAygdDXcGk9BPX%2FyXfxcPvx%2BhNH1t2c9vnrsnfoX4svX0XL54N7qkzgdRsftcXZ%2Bf9H%2FSDb%2FAFDMPB0XBgAA)
[Test streamnode.io/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK8S4WkC%2F9VU7W7aMBR9lchSfy3kqynQTJPG2m6r2nWsH6s2hJCJL9RaEqe2E8oQ777rpEDS0gfYH0h8zzm%2B95zYK6IhzROqgUQrkktRcgbynJGIKC2Bpplg4HBB7G3xiqYIJjfbMtYUyJLHUPEWMFVcN1ZfEaz7GqIQU4JUXGQk8m2SiLm4kwliH7TOVeS6rR5cqhRo5S4WC5endA7KNYz611HlHOUYqFjyXFeS5ERkGcTaWopCWkyklGeWFlar9ZJKTqcJnLaYB3GGXR9EDawFbA7WydXg25mlqZyDfm8d0ByeOhuseakB7uDyfHCzg%2FG8DNtiFfZ8WIYWZUyCMl6oZRYPi%2BkFLE%2BrXrGPuum4nsN5GYkhXAPjEotbykvQg1D6Gh4LRGE8WhZgEyQIyRSJRiuil7mJp%2Bob4XMpirz%2BAIppvf2zCC59NN%2BB4JlWt2LnEi5qjbF1PW9tbwUHLTEz79s6lT%2F7ZV73tfP8bcFGLk3Z8domf0UGk50BY%2FvZZKTBE8XDAE4s0rZ0tfmEV4R6FKTlVNJUmXOzERi1FMYbiRFqjJ9FmgL1DLjQiCzh2R9TM46Ykn8cOH6373iOb5Ybs%2B%2Fj4Xh8ngkJE4X%2FVBcSNpGnRaL5hC7obonFE5rnyRLdUFhFxVErvXqbygBGNcXHZjc7W20yYbHxgZt44IhSNutD58jrHXfCmd%2Fr0IABPs2gyw5pzwvCxnWy967Zf580AsEDA5nm1FwWg2RBl4qs12Mb0%2FzPR8CMFS2BTajBBV7Q7Xhhx%2B%2Fe%2Bt0o7EXhoRP0fS8M3nle5HlmAlC6Hm2F6TdzJycX%2FWSY51dnP57Cu0v1uQiG0y%2Bf8vtr7Z79nH1dXrrBr9%2FfC%2FeuGHwg639%2B2FGZCwYAAA%3D%3D)