### PR TITLE
Add streamnode.io website template

### DIFF
--- a/streamnode.io.website.json
+++ b/streamnode.io.website.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "streamnode.io",
+  "providerName": "Streamnode",
+  "serviceId": "website",
+  "serviceName": "Streamnode Websites",
+  "version": 1,
+  "logoUrl": "https://streamnode.io/assets/www/images/logos/logo.svg",
+  "description": "Connect your domain to Streamnode",
+  "variableDescription": "%cname%: Streamnode edge CNAME target; %apex-cname%: apex CNAME/ALIAS target; %ipv4%: Streamnode apex IPv4 address",
+  "syncPubKeyDomain": "domainconnect.streamnode.io",
+  "syncRedirectDomain": "streamnode.io",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "subdomain",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 600
+    },
+    {
+      "type": "A",
+      "groupId": "apex",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "apex-cname",
+      "host": "@",
+      "pointsTo": "%apex-cname%",
+      "ttl": 600
+    }
+  ]
+}

--- a/streamnode.io.website.json
+++ b/streamnode.io.website.json
@@ -8,7 +8,7 @@
   "description": "Connect your domain to Streamnode",
   "variableDescription": "%cname%: Streamnode edge CNAME target; %apex-cname%: apex CNAME/ALIAS target; %ipv4%: Streamnode apex IPv4 address",
   "syncPubKeyDomain": "domainconnect.streamnode.io",
-  "syncRedirectDomain": "streamnode.io",
+  "syncRedirectDomain": "streamnode.io, app.streamnode.io",
   "hostRequired": true,
   "records": [
     {


### PR DESCRIPTION
# Description

Adds a new `streamnode.io.website.json` Domain Connect template for Streamnode custom domains, supporting subdomain CNAME and apex A/CNAME flows via `groupId` selection. The template uses signed synchronous flow (`syncPubKeyDomain` + `syncRedirectDomain`) and includes `logoUrl`/`variableDescription` metadata for provider review.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test streamnode.io/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOc%2B4WkC%2F91UYW%2BbMBD9K8hSP5UEEkjaMk1alq5atK2q2k6rVEXIwZfUG2BqG2ga5b%2FvDEmApf0D%2B0LI3XuPu3tnb4iGJIupBhJsSCZFwRnIGSMBUVoCTVLBoM8FsQ%2FJa5ogmNwd0phTIAseQcUrYaG4bkWPCNavGqIQU4BUXKQkGNgkFivxU8aIfdI6U4HjdGpwqFKglVOWpcMTugLlGEb97KtihXIMVCR5pitJMhVpCpG21iKXFhMJ5amlhdUpvaCS00UMlx3mSZRi1SdBC2sBW4E1vZ78%2BGJpKlegP1gnNIOX3h5r%2FtQAZ%2FJ9NrlrYDwr%2FK5YhZ3dFL5FGZOgzCzUOo1u8sU3WF9WtWIdddFR3Uf%2FX0sM4RYYl5g8UDogGz%2BUHfGehNK38JwjER3TMgeboIaQTJHgcUP0OjOOVa0gfCVFntU7kS%2FqinYiGPpkVkPwVKt70QwOg1qjk2PX3doHwUlHzIzgfZ1qZG%2FLHNfV2PC%2BYMuqtux8a5NXkULYDGBu7%2BaONHiheD6gH4mkkcYN3H8%2B5BWlNRlkZ1TSRJkTtdd57AjN90qPldR8p3WkU3dkoo2BMU%2F%2FmJyZj0mZ91b7VQRb4qtUSAgV%2FlKdS9jbnOSx5iEtaRNiUYhLEq9xAgqzKHG8ArX2rnFGNe0uWlVUM1SbhCwy7XNjznK0jDxv5PXo2Fv2fDq66F14kdc7x6C%2FGDPfo17rfnnz8nn7gunYgWcIUs2puT8mcUnXimy3cxvd%2FI%2FaQbMVLYCF1CCH7nDcc%2F3eYHw%2FuAhG42Do9Yeee%2BYPT103cF3TAyhdN7jBrWjvA1lmxeLqdLrkuZ9cveYTX5fPI5moh%2Bnd58Gzq2%2FOv347T67PHn7PPpLtX%2FRbRNoqBgAA)
[Test streamnode.io/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACA%2F4WkC%2F9VU7W7aMBR9lchSfy2EkIYAmSYNlU6r1lVd22lbEUImvqRukziznVCGePddJwWSlT7A%2FvDhe87xvefY3hANaZ5QDSTckFyKkjOQF4yERGkJNM0EA4cLYu%2BLVzRFMLndl7GmQJY8goq3goXiurH6imD9qCEKMSVIxUVGwp5NEhGL7zJB7IPWuQq73VYPXaoUaNVdrVZdntIYVNcw6k9HlTHKMVCR5LmuJMmZyDKItLUWhbSYSCnPLC2sVusllZwuEpi0mCdRhl2fhA2sBSwG6%2Bxq%2FPXc0lTGoN9bJzSH584Oa%2F7UgO748mJ8e4DxvPTbYhX24rr0LcqYBGW8UOssui4WX2A9qXrFPuqmo3oO599IDOEGGJdY3FNaIBs3yl%2FxHoTSN%2FC7QCImpmUBNkENIZki4XRD9Do3iVWjIDyWosjrM1Es6o5eRHDpozkagmda3YmDcbioNSYZuO7W3guOW2LGgrd1KsuOy7zu6xDD24KNqJqys61N%2FogM5gcDZvaL70iDZ4r3A5xIpG3pavM5rwj1KEjLqaSpMldpJzBtKcx2ElPUmL2INAXqGXChEVnCsydTM46YUm%2FkOb1g6LhOzyw3Zj%2FGw%2FF4nAkJc4XfVBcSdpGnRaL5nK7oYYlFczwwyRrdUFhFxWkrvXqbygBGNcWfzW4OttpkziLjAzfxeIM%2BDYLTZWfhL6OOPwSvM2SnUYd6S9%2Bno37QX%2FiNF%2Bbo83P8iWkEgncIMs2peT%2FGyYquFdluZzam%2BZ%2BPgBkrWgKbU4PzXC%2FouH6nF9z1RmF%2FEHqu4w1Gbn%2F0znVD1zUTgNL1aBtMv5k7%2BTUcXKbPT%2BJxMjjzi8DNWHS%2BUHc%2F74drevXZd8Xg0%2BT0%2FnH57Sb%2BQLZ%2FAQbJ6L4eBgAA)
[Test streamnode.io/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFQ%2F4WkC%2F91U207bQBD9FWslnuI4TmJC7KpSI6gEpVAK9CYURWvvYLbYXrO7dkij%2FHtn7VzsJvxAX3KZOefszJnZXRINaZ5QDSRYklyKkjOQF4wERGkJNM0EA4cLYm%2BT1zRFMLnbpjGnQJY8goo3h1Bx3YjuEawfNUQhpgSpuMhI0LdJImLxTSaIfdI6V0Gv16qhR5UCrXrz%2BbzHUxqD6hlG%2FemoMkY5BiqSPNeVJDkVWQaRthaikBYTKeWZpYXVKr2kktMwgbMW8yjKsOqjoIG1gMVgnV5Prj5amsoY9DvriObw2t1gzZ8a0Jt8vpjc7WA8L722WIW9uCk9izImQRkv1CKLborwEhZnVa1YR110VPfh%2FDsSQ7gFxiUmt5QWyMaD8j3ek1D6Fl4KJOLEtCzAJqghJFMkeFgSvcjNxKpWEB5LUeT1ThRhXdFaBEMfzGoInml1L3bGYVBrnOTIdVf2VnDSEjMWvK1TWXZYZr%2Bu3RjeFmyMqik7Xdnkj8hgtjNgaq99Rxq8Urwf4EQi3UnjBm6On%2FGK0qwA6TmVNFXmSm2EHlpK043UQ6U1XYvtC9U%2FMNwYYcKzZ5MzDplU3x84%2FdHYcZ2%2BCTcEDvGwXR5nQsJM4TfVhYTNCqRFovmMzukuxKIZLlCyQHcUZlFxfz3qo9amMKppewmrY3eG22TGIuMMN4Mbh2449JnXHZ9Eg6438gZdf%2BiNuuGj54fHJycw9I8bb8%2FBh%2Bnw49MaFd4vyDSn5m2ZJHO6UGS1mto46f%2BoHZy9oiWwGTXIgTsYdV2v2x%2Fd9%2F3geBz0B447HA3HXsd1A9c1PYDSdYNL3IrmPhDvZRxD9ukXhcHknH7Vx%2BedzvPvq%2FiLD7649Nn99xBfuMfXzk%2F1nqz%2BAuE1NepGBgAA)