### PR TITLE
Add breachme.ai domain verification template

### DIFF
--- a/breachme.ai.domain-verification.json
+++ b/breachme.ai.domain-verification.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "breachme.ai",
+    "providerName": "BreachMe",
+    "serviceId": "domain-verification",
+    "serviceName": "Domain Verification",
+    "version": 1,
+    "logoUrl": "https://breachme.ai/logo.svg",
+    "description": "Verify domain ownership for BreachMe breach monitoring service",
+    "variableDescription": "%verification%: unique domain verification token provided by BreachMe",
+    "syncBlock": false,
+    "syncPubKeyDomain": "breachme.ai",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_breachme",
+            "data": "%verification%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "None"
+        }
+    ]
+}

--- a/breachme.ai.domain-verification.json
+++ b/breachme.ai.domain-verification.json
@@ -2,20 +2,19 @@
     "providerId": "breachme.ai",
     "providerName": "BreachMe",
     "serviceId": "domain-verification",
-    "serviceName": "Domain Verification",
+    "serviceName": "BreachMe Domain Verification",
+    "syncPubKeyDomain": "domainconnect.breachme.ai",
+    "syncBlock": false,
     "version": 1,
     "logoUrl": "https://breachme.ai/logo.svg",
-    "description": "Verify domain ownership for BreachMe breach monitoring service",
-    "variableDescription": "%verification%: unique domain verification token provided by BreachMe",
-    "syncBlock": false,
-    "syncPubKeyDomain": "breachme.ai",
+    "description": "Use this DNS record to verify your domain ownership with BreachMe.",
+    "hostRequired": false,
     "records": [
         {
             "type": "TXT",
             "host": "_breachme",
-            "data": "%verification%",
-            "ttl": 3600,
-            "txtConflictMatchingMode": "None"
+            "data": "breachme-verify=%verification%",
+            "ttl": 3600
         }
     ]
 }


### PR DESCRIPTION
# Description

Adds a Domain Connect template for [BreachMe](https://breachme.ai) breach monitoring service. The template creates a TXT record at `_breachme` with a `breachme-verify=` prefixed verification token, allowing BreachMe to verify domain ownership.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `breachme.ai.domain-verification.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `domainconnect.breachme.ai`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — not applicable, template does not use `redirect_uri`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — not applicable
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — not needed; `_breachme` is a dedicated label, no conflict risk with other records
- [x] no variable is used as a bare full record value — data uses fixed prefix `breachme-verify=%verification%`
- [x] no bare variable is used as the full `host` label — host is fixed as `_breachme`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not required — no records the end user needs to modify independently

## Online Editor test results

**Editor test link(s):**

[Test breachme.ai/domain-verification example.com/@ (apex)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABLj4WkC%2F%2BVTTY%2FaMBD9K5GlPZGAySdE2kO3e2jVdgtbtloJocjYA1hN4tR2YLOI%2F16bLJ%2BqtL33FMfz5s2bN%2BMt0lBUOdGA0i2qpFhzBvIzQymaSyB0VUCXcOQeQw%2BkMFB0tw9%2BAxNRINecwj6HiYLw0luD5AtOieaiPCGuUp37Pdj5eQVuSjqq51%2BgaeNHVirKEqjuXuqy8Ltc0F8oXZBcgYtMcWWp0r6LcrEUTzI3HCutK5X2emfZPRvtqvXS0DBQVPJqryFFTwocveLKuX%2F44UigQjJHC2ffVuM0opZOq8kRm9KUW%2FHK2XC9cg69dQ3lSij9CL9rLoEdxbVkCqXTLdJNZf2YPE%2Fe0OYnO%2BizmogmZ3NoXW1ub87dvTE4rU2DQYzxbrZz0asoITuVmblv9hkmeCFm1tClojhVNKelFHWV8QO%2BIpIUyu7DIXN6kTo75E6RPV8M29wxiuNkHoeMETyP%2FcE8GPhhQJNh0vdpHC6QVcmXpZCQKfMlupbGBy1r409R55pnZENOV4xmpKryxjSlTNSUuPaubBfrH7x7V9uZmy7KGLUucLvZUejHmEYDj%2FYj6oX9AfMGLAIPJ0FAyCKIsB%2BdPZO%2FvKD338lpIqAUlJoTu7kf8g1pFNrtZq6Zzv%2Fau1k0RdbAMmJhPvZjD4deP5ngxChOI9wN8RBjv4NxirHtBZRundiafTvfNET9%2B2JIxySgj9H3kUhG%2FZD3xqwTJBI6r%2BHzZByNP376GvvR8hbt%2FgCt0dGHIwUAAA%3D%3D)

[Test breachme.ai/domain-verification example.com/sub (subdomain host)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABDk4WkC%2F%2BVTXW%2BbMBT9K8hSnwrUJBQSpD60SqdVU6umTadqVYSMfQFrgJltkrIo%2F30Gmo9Wm%2FoD9mTZ95x7zz33eoM0lHVBNKBog2opVpyBvGEoQokEQvMSXMKRvQ%2FdkdJA0VUfvAUTUSBXnELPYaIkvHJWIHnKKdFcVAfEB6o168HW9w%2FgtqL3TfIN2iG%2Bz0pFVQHV7ntdHfyqEPQnilJSKLCRKa66VJFno0Jk4kkWJkeuda2is7Mj9lkXddUqM2kYKCp53WuI0JMCS%2BdcWbO7R0sCFZJZWlh9W63VikZagyZLrCtTLue1teY6t3a9uSZlLpR%2BgF8Nl8D24oZkCkUvG6TbuvNj8bx4Q5tLvNPXaSKaHM1hcLW9ODl298TgtDYNjgOMt8utjX6LCuJDmaX9Zp%2FJBK%2FEzBpcKspDRdUk5pJJ0dQx31FqIkmpupXYkV%2FesZc7%2BkvPX%2FauH6ZonhnFQZgEPmMEJ8FokownI39Mw2nojWjgp6jTyrNKSIiVOYlupHFDy8a4VDaF5jFZk8MTozGp66I1rSkTNSU%2BOlgN67V30B06%2B4eLn%2Bo78tVGMaOdGbzbcT88Pw8mE%2BoASVLHcDxnytKJE46J7we%2BefXSow%2Fzl7%2F0%2BY95NxtQCirNSbfGl8WatAptt0vbzOk%2Ft8CsnSIrYDHpkCM8ChzsO164wGHkexH23SmeBmF4inGEcdcOKD2YsTHbd7x36Dn7ml7eP9BwcfNjVl6P514xn93OM3WdPX6RZDJ%2FvXrSt%2FnppfQv0PYPrvCHKDcFAAA%3D)
