### PR TITLE
Add Ruhanix Creations Publish Template

### DIFF
--- a/builder.ruhanixcreations.in.publish.json
+++ b/builder.ruhanixcreations.in.publish.json
@@ -1,7 +1,7 @@
 {
-  "providerId": "ruhanix.websitebuilder",
+  "providerId": "builder.ruhanixcreations.in",
   "providerName": "Ruhanix",
-  "serviceId": "publish",
+  "serviceId": "publish"
   "serviceName": "Ruhanix Website Builder",
   "version": 1,
   "logoUrl": "https://ruhanixcreations.in/logo.png",

--- a/ruhanixcreations.in.website.json
+++ b/ruhanixcreations.in.website.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "ruhanix.websitebuilder",
+  "providerName": "Ruhanix",
+  "serviceId": "publish",
+  "serviceName": "Ruhanix Website Builder",
+  "version": 1,
+  "logoUrl": "https://ruhanixcreations.in/logo.png",
+  "description": "Connect your domain to Ruhanix Website Builder",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "103.50.162.186",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "ruhanixcreations.in",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This PR adds a new Domain Connect template for **Ruhanix Website Builder**.

The template is intended to connect a customer domain to the Ruhanix builder using only the minimum required DNS records for website publishing:
- apex/root `A` record
- `www` `CNAME` record

Template file:
- `ruhanixcreations.in.website.json`

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- Pending - will be added after Online Editor validation and apply test are completed.