### PR TITLE
Add flowapt.com.email template

### DIFF
--- a/flowapt.com.email.json
+++ b/flowapt.com.email.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "flowapt.com",
+  "providerName": "Flowapt",
+  "serviceId": "email",
+  "serviceName": "Flowapt Email",
+  "version": 1,
+  "logoUrl": "https://app.flowiq.live/original_logo.png",
+  "description": "Configure DNS so this domain can send authenticated email through Flowapt. Adds a DKIM TXT record at resend._domainkey, plus a bounce-handling MX and SPF on a 'send' subdomain. Does not change the apex MX or apex SPF: existing inbound email to the root domain is unaffected.",
+  "variableDescription": "domainKey: RSA public key material for DKIM signing, provided by Flowapt. The template prepends the 'p=' prefix so the variable itself carries key bytes only.",
+  "syncPubKeyDomain": "flowapt.com",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%domainKey%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "outbound",
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.eu-west-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "outbound",
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template: `flowapt.com.email.json` — enables customers of Flowapt to one-click-configure DNS on their domain for outbound email through Flowapt's infrastructure (SES-backed via Resend).

The template writes three records:
- `TXT` at `resend._domainkey` — DKIM public key (variable `%domainKey%`)
- `MX` at `send` — `feedback-smtp.eu-west-1.amazonses.com` priority 10 (SES bounce handler)
- `SPFM` at `send` — `include:amazonses.com`

It does **not** modify the apex MX, apex SPF, or apex DKIM — existing inbound email on the root domain is untouched. All records are scoped to the `send` subdomain (bounce infrastructure) and a specific DKIM selector.

Signing: RSA-SHA256 with Flowapt's private key. Public key published at `_dckey.flowapt.com` TXT (verifiable via `dig _dckey.flowapt.com TXT +short`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **mandatory** — set to `flowapt.com`; public key published at TXT `_dckey.flowapt.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — `warnPhishing` is absent
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — template does not use `redirect_uri`, so field is correctly omitted
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label — set to `"All"` on the DKIM TXT at `resend._domainkey`
- [x] no variable is used as a bare full record value — DKIM TXT uses `"p=%domainKey%"` with the fixed `p=` prefix
- [x] no bare variable is used as the full `host` label — both variable-free hosts (`resend._domainkey`, `send`) and no host-level variables are used
- [x] no variable is used in the `host` field to create a subdomain — fixed hosts only; Domain Connect `host` parameter is used for targeting apex/subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — none of our records are user-modifiable (DKIM/MX/SPF are integral to the service); field intentionally omitted

## Online Editor test results

**Editor test link(s):**

- [Test flowapt.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABGG42kC%2F%2B1V227bOBD9FYJAkYfainyJkwjIgxwnaTZ1ENfubrBBYFDSSGZDk6xI%2BdIg%2FfYdSr5uspeHfSgWfTKtuZ0zc4Z8phamWjALNHimOlcznkB%2BndCApkLNmbZerKa0tjHdsim60svKiAYD%2BYzHUIbAlHGx%2FbbvSy5W1hnkhitJg0aNCpWpz7lAr4m12gSHh0xrz5XmXz3BZ3Cocp5xycTYuXpaZpghARPnXNsyCz1XMuVZkQPp3Q6JUcROuCGJwnKSxEwSAzIhrLATkJbHyDUhJVJ0zFWRTcgKoUfCJDGEkd7NdZ%2BM7kckh1jlGGvx5LJ44yrtEyxrRIvCOUeqkDHUJ0wmgsuM9O8JHsnw7pIoifYDF3hATBFVsR7pKTBEKktiDMoAYQBhGhYuVOXVEcMDAgturMvJpauyga3KkFxhihVNJFxIlqYQIzvPNZnlnEUCenutqrxvYBmQT8OQ6CISPCbIhkyxLRghSIoISv6GZxJrI89q9AmJlttOjRDAWjroARpJmhLWgT47cF9SvqiGAWQNhnBrQKQ4lDzn2ANXOFpaPCkplg62Wcr4rogQYa%2BE%2BkqH1UQMDR6eaYbT06XwkifujHapneBwcvhnoozFP68G5%2FTDLEOTPnu3acg7F25RiK2O7%2BNxYZ2ssDu2z2w8wUb0VeKSh0LQl9pucVXYcjpbAP37bX1X3e2P4tKakXKEAJKIxU91M7Xag6I%2BB2PrDY9N2TclDZjNynEUv13iovg74P6pOCqn%2F6q80emnQgD2jXIZiyKB4M%2FltgUeX2oUTTDeNvuxttKO2%2FIFw7nDKmxVB08lqDEv%2FdcT2cDDBJrlbGrcPbNO9bCX63Gd7IG6c5nuL1Jtxubs%2FeurtB%2F6V%2BfDr1fD66jVG1x0w8HnMGxf3Ya98y4f3HSzQS8Jk5OPEU86qDc7uhiO3voNB2GXOv4ofpXD2C0Bs3i30MDmBdTotBCWj9mcbT8l8RgvLbHEdhm0IiTU5p4UZXUR%2Fq0U%2F3MWe3oeJ7FrPHeSacRpE%2BJjqLPTo6jebp%2B06qzFOvWjRpT6rTRlpyenOzf%2BG4%2FBW3f%2BVgdgjLtomSi3Zc6Whr440e4ux6ojK3WumvBvF2OH1%2F6O%2FEAs9wa%2FT3N2htvYIG%2FuIfnOhPjBRvdYw%2FX%2FKemfkv4fSRrfEMNmkIyZc2v6zU7db9cbJ6NGK2i2g1bLax%2BfNo%2F9974f%2BL5Dj3OryD7j67D7LtBvd3D4fv5r98vkeHFUtE2W6qu7Dvi%2FfdAff%2Bla1v7S%2Fv3pchLaD%2F4ZffkDfZOyvHILAAA%3D)
- [Test flowapt.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABGD42kC%2F%2B1V227bOBD9FYJAkYfaim9xHQF5UOI0CFIHde202Q0MgxLHMhGKVEXKjhpkv32HknzbZLH7sA8Ftk%2BmNbczZ86Qz9RCkkpmgfrPNM30SnDIrjn16ULqNUutF%2BmENramW5agK%2F1YGdFgIFuJCMoQSJiQu2%2BHvuSytq4gM0Ir6rcbVOpY32USvZbWpsY%2FPmZp6rnS4rsnxQqOdSZioZicO1cvVTFm4GCiTKS2zEIvtFqIOM%2BADG8nxGhil8IQrrGcIhFTxIDihOV2CcqKCHvlpESKjpnO4yWpEXok4NwQRoY31yMyvZ%2BSDCKdYazFk8vizau0j1A0SCpz5xzqXEXQXDLFpVAxGd0TPJLJ549EK7QfucAjYvKwivXIUIMhSlsSYVAMCAMIS%2BHJheqsOmK4T%2BBJGOtyCuWqbGHrMiTTmKJuExvOFVssIMLuPEcyywQLJQwPqKq8b6DwyZdJQNI8lCIi2A1JkBaMkGSBCMr%2BjYgV1sY%2Bq9FzEhY7pqYIYCMd9IAUmzQlrKP07Mh9WYinahhANmCIsAbkAoeSZQI5cIXDwuJJK1k42KZQ0ec8RITDEuorHVYTMdR%2FeKYxTi8thccfhTPaInWCw8nhn6U2Fv%2B8GpzTD7MMTenZuy0h71y4RSF2%2B60WHp%2BskxWyY0fMRkskYqS5Sx5ISV8a%2B8V1bsvp7ACM7nf1XXW3P1ooa6baNQTAQxY9Nk1iUw%2Fy5hqMbbY9lrAfWhkw25UTKH5b4KK09sD9U3FUzuhVeZMuvuQSkDcqVCRzDv5fy%2B0KzF4aFE0w35E9a9TacVv%2BxHDuUIfVderdLoHNRRmzmcoWIiZJWcYS4%2B6aTbqHg3yzTcKHKuOsTvk36bbjc%2FbR9dViFLSuLibfrybXYXc4vjwPxndB0Lu6DYYX52J8cx6Phzzgg0%2Bh4H3UnZ1eTqZv%2FQbj4Jw6HnAJdAZztwzM4h1DfZvl0KBJLq2YszXbfeLRHC8vWSBtBq0ICTV6IElVXYivJOnV7G11%2BZ%2B3ciDuOY%2FcBITTT79z0oFuF5onvU672eudhs3wtNtvdk6j6KQ3%2BDDonPK96%2F%2BNl%2BGtB%2BBQFGCMu3mZLNdnzQpDX5yK97elpqYk5pCNf7suew0ebs5P1u6BFN7od3WGy9omb64p%2BYNJ%2BRMOc9bAG%2BKX2n%2Bp%2Ff%2Bhdnx5DFsBnzPn2ml1%2Bs1Wr9keTNtdv932eyded9DrfOi9b7X8Vst1gEOsGn7GN2X%2FNaFMD6JvX39vw8lovFoMmO5Ep4lQ5jx5%2FE2owfQTj%2BW64Gz4%2Fu6MvvwJHYX297ALAAA%3D)

## Additional context

- **Provider domain `flowapt.com`** is owned by Flowapt (Pty) Ltd. Registrar: GoDaddy. Admin contact: matt@flowapt.com
- **Public key TXT `_dckey.flowapt.com`** is live as of 2026-04-18; verifiable with `dig _dckey.flowapt.com TXT +short` — returns a 2048-bit RSA public key in base64-encoded DER (`p=MIIBIjAN...`)
- **Signing implementation** is in our edge function; signs the sorted query string (`domain=...&domainKey=...`) with RSA-SHA256, appends `sig=<base64>&key=_dckey`
- **Intended use** is programmatic: our app generates a signed apply URL per customer, opens it in a popup, customer authenticates with their DNS provider and approves in one click
