### PR TITLE
Add flowapt.com.email-receive template

### DIFF
--- a/flowapt.com.email-receive.json
+++ b/flowapt.com.email-receive.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "flowapt.com",
+  "providerName": "Flowapt",
+  "serviceId": "email-receive",
+  "serviceName": "Flowapt Email (Receiving)",
+  "version": 1,
+  "logoUrl": "https://app.flowiq.live/original_logo.png",
+  "description": "Enable inbound email on this domain so mail sent to any address on the root domain is captured by Flowapt. Replaces the apex MX record: ONLY apply this if the domain does not already have email configured elsewhere (Gmail, Outlook, etc.), otherwise existing email delivery will stop working.",
+  "syncPubKeyDomain": "flowapt.com",
+  "records": [
+    {
+      "groupId": "inbound",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound-smtp.eu-west-1.amazonaws.com",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Second Domain Connect template from Flowapt: `flowapt.com.email-receive.json` — enables cold inbound email on a customer's root domain. Companion to the already-submitted `flowapt.com.email.json` (sending) in PR #1015.

This template writes ONE DNS record:
- `MX` at `@` — `inbound-smtp.eu-west-1.amazonaws.com` priority 10 (SES receiving endpoint used by Resend's inbound routing in our account region)

It is explicitly a separate template (not bundled with the sending template) because applying an apex MX record is destructive to any existing inbound email on the domain. Customers with an existing Gmail / Outlook / cPanel mailbox on the domain should NOT apply this template — it replaces the MX and mail delivery to the root breaks. The flowIQ app checks for existing MX records before offering this template and warns the customer explicitly before a destructive overwrite.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `flowapt.com`; public key already published at `_dckey.flowapt.com` TXT (shared across all Flowapt templates, including the sending template in PR #1015)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — absent
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — template does not use `redirect_uri`, correctly omitted
- [x] no TXT record contains SPF content — template has no TXT records at all (MX only)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A, no TXT records in this template
- [x] no variable is used as a bare full record value — no variables in this template
- [x] no bare variable is used as the full `host` label — host is fixed to `@`
- [x] no variable is used in the `host` field to create a subdomain — no variables used anywhere
- [x] `%host%` does not appear explicitly in any `host` attribute — correct
- [x] `essential` is set to `OnApply` on records the end user may need to modify — N/A, the single MX record is the reason for the template; if the user wants to remove Flowapt's inbound they should remove the whole template

## Online Editor test results

**Editor test link(s):**

- [Test flowapt.com/email-receive example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPyY42kC%2F%2BVT72%2FTMBD9Vyx%2F2kSTJWubtZGQYGIbCLZBN6RVU1W58TW15tqZ7TQNVf93zumvDRDiO5%2Fi%2BN49v3t3t6IO5oVkDmi6ooXRC8HBfOI0pVOpK1a4MNNz2tqHbtgcofRyE8SABbMQGTQpMGdCBgYyEAs4xF7nkAuPIkeDBiZUfozIBRgrtKJp3KJS5%2Fq7kZgxc66w6ckJK4rQyxHPoUTmE21ELhSTYw8NC5UjAwebGVG4hoVeKDaRQISa6FJx0ggjWhE3E5Zwjb%2BKWE2aawvKEacJUzVhnBuwdgMFYrR2OzgmZii%2FNMDJpCbbakIyAPQvA9sksAKW5PqBoAfa8JTc3nwZ4mUh683TYtrAtpRcY5rCJ5g0wHhNZmwBW7GZVlORN6%2BBtFDNwAA5uvKxFrktndT6qUXAZeFxi2gkNZWwmLwU1qGpWxYO3jBTk0pIrNTpglTaPCEg9P2pVfa1nHyG%2BkMj6Leub8qwNH1c0dzosmjavHUV464ufGevH%2FA809bh%2BZ0fFi2Us%2Ff6gA3s3BUhlEEF1gVxyObsh1assvvxEthUV%2BMAREjrsPvtJIrWo3WLIhDGByUj7PVOLSwZTi9sSbYK8NRoHYsGv5eLiQUzbG79qO8oHl9xjHYkj9SfG5pXFChH5EobGFv8Mj8NNHWmhBadl9KJMavY4Ypn46b3qN5iFJnQx5eeqc1meM84c%2Bzf%2Fdo79Kt1Y5758oTv02Ta68ZxLw667Uk%2F6LSnvYAl8SRIzrIk63T7LOn2X6z2H7b%2Bb8t9cBsXBldIML%2By72XFakvX61ELO%2FUflYvjYnF7%2BZh52Gl0mgRRJ4h793En7XTTOAl7%2Fd5ZdPYmitIo8jVhqRsXVjhVL%2BeJyoflXXLBz%2BO2Ggw%2FPc2u7p87w2dVXucfB%2BfF8pJF8tvdcnjp6vwtXf8Eo%2FclfcQFAAA%3D)
- [Test flowapt.com/email-receive example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADWZ42kC%2F%2BVUbW%2FaMBD%2BK5Y%2FtVqSJpBCiTRpU1%2Bmir5sHZVaVSgy8QEeiZ3aDmmK%2BO%2B7hEDLNk37vk%2FEvuceP%2FfcHStqIctTZoFGK5prtRQc9CWnEZ2mqmS59RKVUWcXumEZQunFJogBA3opEmhSIGMidTUkIJbwFtvPIec1ihzcNTAhZ4eIXII2QkkaBQ5N1Uzd6xQz5tbmJjo6Ynnu1XLEs5ci85HSYiYkS%2BMa6uVyhgwcTKJFbhsWei7ZJAUi5EQVkpNGGFGS2LkwhCs8SmIUaa4NSEusIkxWhHGuwZgNFIhWym7hmJig%2FEIDJ5OKtNV45A7QvwRMk8ByeCHXDwQ9UJpH5Pbm6hEv87TaPC2mDayl5ArTJD7BUg2MV2TOltCKTZScilnzGqQGyjloIAdf6phDbgubKrVwCNjEO3SIQlJdCoPJL8JYNLVl4VAbpitSihQrtSonpdILBHh1fyqZfC0mQ6jOGkG%2FdX1ThqHR04rOtCryps2tqxi3VV539voBv%2BfKWPz%2BVA%2BLEtKakXrDuiazuQeFW4KxbuCxjL0qyUqzGy%2BBTbUVDoCPtBa73%2B35%2Fnq8digCIX5TMsZeb9XCC8PphZakVVAXjqdGbyyanJ1kTM6ZZpmpx31L87THM94SPW2Yxi3VHg3KEjOpNMQGf1k9FTSyugCHZkVqRcxK9nbFk7iZAazCYBSZ0M%2F33snNhrTKObPs363bmfWrizFP6ipF3TLmT9m0exK6vUG%2F74bsxHcn014fj7wTsPA48Hnn3Zb%2F4Q%2Fgb3u%2BbzzuD26UYPUGf05LVhm6Xo8dbNz%2FVzUOj8Gd5jGroR2%2F03P90A1ORkEYhb0o6HqDfmdwHH7w%2Fcj367qw3I0TK5yx99NFH5%2BHxbfj84fvpwO4%2F%2FF6WS6GZhHko%2B5pMR%2BeXSTydHjGu1ciHIUf6fony%2FHZNtoFAAA%3D)

## Additional context

- **Provider domain `flowapt.com`** is owned by Flowapt (Pty) Ltd. Registrar: GoDaddy.
- **Public key TXT `_dckey.flowapt.com`** already live (published for the companion sending template PR #1015).
- **Companion PR (sending):** https://github.com/Domain-Connect/Templates/pull/1015 — all checks green.
- **Destructive nature** of this template is flagged in the `description` field and enforced in flowIQ's UI (DoH check for existing MX + explicit conflict acknowledgement before allowing apply).
- **Region `eu-west-1`** matches the AWS region our Resend account uses for inbound routing. Resend uses AWS SES under the hood; the pointed-to host `inbound-smtp.eu-west-1.amazonaws.com` is SES's standard inbound endpoint for that region.
