### PR TITLE
add StoreKin, StoreKin Storefront

### DIFF
--- a/storekin.com.website.json
+++ b/storekin.com.website.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "storekin.com",
+  "providerName": "StoreKin",
+  "serviceId": "website",
+  "serviceName": "StoreKin Storefront",
+  "version": 1,
+  "description": "Connects your domain to your StoreKin store with automatic SSL.",
+  "variableDescription": "No variables required — template uses fixed StoreKin targets.",
+  "syncPubKeyDomain": "storekin.com",
+  "syncRedirectDomain": "storekin.com",
+  "multiInstance": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the StoreKin Storefront template. StoreKin is a hosted e-commerce platform; this template lets merchants using a supported DNS provider configure the apex `A` record and `www` `CNAME` to point at StoreKin's infrastructure with one click.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: `logoUrl` is intentionally omitted until a stable logo asset URL is in place

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Note: This template contains no variables and no TXT records, so rules 4–9 apply trivially. Both records use `essential: "Always"` rather than `OnApply` because the apex `A` and `www` `CNAME` are infrastructure-critical — modifying or removing either one breaks the merchant's storefront. The template intentionally omits `logoUrl` until a stable logo asset URL is in place.

## Online Editor test results

**Editor test link(s):**
- Apex: [Test storekin.com/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAvf5GkC%2F%2B1TbW%2FaMBD%2BK5G%2FNkFJoAlEmrSq3TrWFnWl0146hIxtqLfETm2HwFD%2F%2B84hCWVj69d%2BmBQpZ99zj%2B%2Fuudsgw7I8xYahZINyJZecMjWkKEHaSMV%2BcNEhMkNu6xvhDLBobL0XXIBHM7XkhFVBJZtpDmTt7W9wpzLmSgoDmCVTmkuBksBFlGmieG6qMzqVQjBitLOWhXKozDDEGrk9tmRVik7Jzb2DCwMgw4kzHl92LDdWHM9SdrbHO5JO49COYg8FV4w634rQD3pO0wqn0OCd8xW42rcMVgtmtKXWa0Gui9kFW59Vif3ZLIu4YRTIifkbJitSw4dCGywItGiOU81cdC%2B1uanzai%2BBRiqqUXK3QWad24aeoC0WzNdWHcmF0bcSjnHUgS8M4AOHMSlKupHvu4hpzYThOLXhaYnXGj26LeHp6OTqzY60LMt9WiJAyQ4oRljqUaHrKp7hnzy66KcUbLorYQJaNy1hKwwtZzVX%2FTRYCyWLfMobfI4VzrSd0Cbybi900sTeIWvjxtDFrDGr9J%2BCzKo1s1V7WYm8PUHmfCFAsqmGPzaFgjYZVbBauiku8e6KkinO83QNhWrwAsW%2BVmK7B1Yrig3%2Bl05TSmyp3O5TROeDOCCxN4ji0OsR3PX6lB1784DSPsFBn%2FVnT5bz0OIeXs9drw%2FJdmAu6gK2c1GX8PxMvIRaJi7M0H81Xooadi%2FxktEptrDQDyPP73nB4DboJsdREsYdPwz8ODjy%2FcT3bQFMm22JG9jJp9uIeH79vh%2BcffVvjh6W0dvL%2BHP33acvwcercXc4WMmj2fn5964Zrha9D6%2FQ4y%2BhlDFi7QYAAA%3D%3D)
- Subdomain: [Test storekin.com/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABLf5GkC%2F%2B1TW2vbMBT%2BK0avi4OdxF5jGCxNuy10K6UpFNYFI0tKq82WPF3iXOh%2F35Fju82Wra99GBisc%2Fuk73zn7JBhRZljw1CyQ6WSK06ZmlGUIG2kYj%2B46BNZoF4Xu8QF5KK5i15wARHN1IoTVhdVLNMcwDrvb%2BlefVgqKQzkrJjSXAqUhD1EmSaKl6a20VQKwYjR3kZa5VFZYKg1cm92YPUTvYqbBw9bA0mGE28%2B%2F9x32FhxnOXs7AD3UnptQHuK%2FbRcMep9s4MgHHltKzyrIbrkawh1dxms7pnRDlpvBLmy2QXbnNUP%2B7NZLuOaUQAn5m85hc0NnwltsCDQoiXONeuhB6nNdfOuzgkwUlGNkrsdMpvSNXSC9rlwfO%2FUkVwYfSPBfBv34RuE8EHAmBwlwzgIeohpzYThOHfleYU3Gj32OsDp5eTL%2BRNoVVWHsESAkn1QjLDcp0I3LF7AXzz20FYKlj5RWIDWbUvYGkPLWYPVXK0fZAnWvZK2THlbU2KFC%2B2mtK2%2BOyhftPV3ewCwsTPcQdusPdY02kTnMOvuWKw7Zy323gIG%2FF6AdKmGPzZWQbuMsqyRMMUVfnJRkuKyzDdAWEMUIA41E%2Ft9aDhSbPC%2FJEspcYy5W604HJIoWlI%2FGsSRPxrHmX9yQgOfRcO3LKPjJc6Wz%2Fb02A4f39TDth9T8ciYNDxgTPqHXF6ek9dCatGDufqvzmtVx%2B0tXjGaYpc6CAaxH4z8cHwTDpMoToaj%2FkkQhtH4TRAkQeBIMG32NHews8%2B3FV1Ntx%2FVrbYftmNtA709XYnx7afTUzkd2vNiNh8QNVPfJ19vq8k79PgL%2Fw%2BtnxUHAAA%3D)
