### PR TITLE
Fix sendcanary.com DMARC template: use dmarc.sendcanary.com (was spoofcanary.com)

### DIFF
--- a/sendcanary.com.dmarc.json
+++ b/sendcanary.com.dmarc.json
@@ -8,12 +8,12 @@
   "description": "Configure DMARC monitoring to protect your domain from email spoofing and phishing. SendCanary receives aggregate reports to give you visibility into who is sending email on behalf of your domain.",
   "variableDescription": "token: Per-domain identifier for DMARC report routing; policy: DMARC policy (none, quarantine, reject)",
   "syncPubKeyDomain": "sendcanary.com",
-  "syncRedirectDomain": "sendcanary.com,app.sendcanary.com",
+  "syncRedirectDomain": "sendcanary.com,app.sendcanary.com,api.sendcanary.com",
   "records": [
     {
       "type": "TXT",
       "host": "_dmarc",
-      "data": "v=DMARC1; p=%policy%; rua=mailto:%token%@dmarc.spoofcanary.com; ruf=mailto:%token%@dmarc.spoofcanary.com; fo=1",
+      "data": "v=DMARC1; p=%policy%; rua=mailto:%token%@dmarc.sendcanary.com; ruf=mailto:%token%@dmarc.sendcanary.com; fo=1",
       "ttl": 3600,
       "essential": "OnApply",
       "txtConflictMatchingMode": "Prefix",


### PR DESCRIPTION
## Summary

The SendCanary DMARC template has been pointing `rua`/`ruf` at a legacy domain (`dmarc.spoofcanary.com`) that is being decommissioned. SendCanary migrated DMARC report ingestion to `dmarc.sendcanary.com` weeks ago. Cloudflare's DC authorizer is still serving the stale address to end users, causing reports to route to the wrong endpoint.

## Changes

```diff
-  "syncRedirectDomain": "sendcanary.com,app.sendcanary.com",
+  "syncRedirectDomain": "sendcanary.com,app.sendcanary.com,api.sendcanary.com",
...
-      "data": "v=DMARC1; p=%policy%; rua=mailto:%token%@dmarc.spoofcanary.com; ruf=mailto:%token%@dmarc.spoofcanary.com; fo=1",
+      "data": "v=DMARC1; p=%policy%; rua=mailto:%token%@dmarc.sendcanary.com; ruf=mailto:%token%@dmarc.sendcanary.com; fo=1",
```

## Why

1. `dmarc.sendcanary.com` is the canonical current DMARC reporting endpoint
2. `api.sendcanary.com` is an active DC callback host (cache-bypass route) missing from the previous `syncRedirectDomain`

## Verification

Template validates against the Domain Connect schema: templatePrefix unchanged, variable substitution (`%token%`, `%policy%`) preserved, `essential: OnApply` preserved, `txtConflictMatchingMode: Prefix` preserved.

## Follow-up

Will email domain-connect@cloudflare.com after merge to request registry re-cache so existing customers' authorize flows see the updated rua/ruf host.

Related: Domain-Connect/Templates#899 (original submission)