### PR TITLE
Add nettingale connect email

### DIFF
--- a/nettingale.com.nettingale-connect-email.json
+++ b/nettingale.com.nettingale-connect-email.json
@@ -1,0 +1,58 @@
+{
+  "providerId": "nettingale.com",
+  "providerName": "Nettingale",
+  "serviceId": "nettingale-connect-email",
+  "serviceName": "Nettingale Email Sending",
+  "version": 1,
+  "logoUrl": "https://nettingale.com/favicon.svg",
+  "description": "Configures DNS records so a domain can send transactional email through Nettingale (Amazon SES DKIM + Custom MAIL FROM + DMARC).",
+  "variableDescription": "dkim_token_1, dkim_token_2, dkim_token_3 are the three Amazon SES DKIM tokens generated when the sending identity is created. aws_region is the AWS region the identity lives in (e.g. eu-central-1).",
+  "syncPubKeyDomain": "domainconnect.nettingale.com",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_token_1%._domainkey",
+      "pointsTo": "%dkim_token_1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_token_2%._domainkey",
+      "pointsTo": "%dkim_token_2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_token_3%._domainkey",
+      "pointsTo": "%dkim_token_3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "MX",
+      "host": "bounces",
+      "pointsTo": "feedback-smtp.%aws_region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "bounces",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}

--- a/nettingale.com.nettingale-connect-email.json
+++ b/nettingale.com.nettingale-connect-email.json
@@ -52,7 +52,8 @@
       "host": "_dmarc",
       "data": "v=DMARC1; p=none;",
       "ttl": 3600,
-      "txtConflictMatchingMode": "All"
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
     }
   ]
 }


### PR DESCRIPTION
# Description

Adds `nettingale.com/nettingale-connect-email`, a new template for configuring the DNS records required for an Amazon SES email sending identity.

Applied at `host=send` (or `host=send.<sub>` for deep-subdomain sites) it publishes:
- three DKIM CNAMEs (`%dkim_token_1|2|3%._domainkey` -> `*.dkim.amazonses.com`)
- a MAIL FROM MX + SPFM pair at `bounces`
- a DMARC TXT at `_dmarc` signed with the ECDSA key we already publish at `domainconnect.nettingale.com` for our other two templates

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

[Test nettingale.com/nettingale-connect-email example.com/send](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALG86GkC%2F%2B1XbW%2FiOBD%2BK5alSntaSJNAaZtVP3ClK1W7tFXp3q5UVZFxJhA1sXO2A0sr7rffOEAJ0JbuSXe6XfEBiO15fTwzD3mkBrI8ZQZo8EhzJUdJBOo8ogEVYEwiBiwFh8uM1p5OL1iG0vTi6RzPNKhRwmFNsc6lEMBNHTKWpEuxDQvkzAqQHogIN1BwBEonUtDAq9FUDuQXlaLC0JhcB%2Fv7q6HtxwyNSuHokVWNQHOV5KZUp6dSxMmgUKBJ56JHFHCpIk20JIxEEr0KwpkgGj0To5jQjFtNlpIyZmKGShaDIanE%2Bq6dsQcpSO%2BsRzqfzrvkPTkttJEZ6bbPP5OP15d2q9NtX5%2F%2B5thcmEpYP4XOSmDRfZKFRt6DCL0aqaz8lVWDMAUYhf0oALLuu5TSZAACFN5iRMZDEKW8noFJ8MqEScyEJJpwBVbIIWysQwUDDMVuW%2FH2V4tOuWOXT1ppMkLsEKZ34AwcAkWd44liad0rs9MTwa%2BK%2FieYdEo4bWrlw%2FzunY06shq%2Fp5Lf0yBmqYYaHUptruHPIlGABWRUgXvzm6LB7SMd4B3kZW1ZZNCEmeS2gE4v2t0zOtPH5V4V0z0nnMVxDxNbvDIRRt%2FITTG7clgJqwY9j9EYrLdGy3WntX%2Fk3n%2Bbe%2F9fct94m%2FvGj7m3DRErWQmh%2B23pvy8LwUGveosBoj7j93WdmdzZW5bd3obTXCVSYcVhz7s%2FEELv6mP3uSB0Hl8XKT4GFGsxLSIIVj2uQZsxxZdWb77dLI2Gi8OIGYbr0UnZ3N4Hkp8IKeBDFTJ8%2FG7s1EkTbrrM8CEWf1dG1mo7tUMQtLa9xexEuxTtPE8ndHo3rVEMDsJl3d%2FV5p2EcvCd4ZhedNA8LtvhuCqTCJNSZ1EiFZxmwaOxnCmWaTvnF2ZvV%2BzeLQzfzizfzU1vMVvtJivK%2BtzzGxHEzYPW5nPzYE3HL82%2FID17Pjxa02lYncEwOTw6funbc63Ost7KZCuzi1rAk4GQCkKNv8wgRyxmT1akJgnZmC23Ih4ye1NoTuMpmsO5tNaIYkZr2wCotKYzv8J5YW3VfL1ba1ip3N5vYiva9YAd931e562oX282uFc%2Fbvlu3XOP42O%2FGfs89iqs%2Fjznv5HXVwuyWuDtdMwmmk5ttz0P17a7fxmurZq%2FIlzbyv5luLZq%2FhJwlZQ0x2rOBms4rHJSdSi8lvwqPf0UUMxI7FUsRifIkx55liHJX6zkqxIExOCnTHvG3RtZv0rg%2F78sn%2F4mTO9q%2BL9gRz076tlRz456dtSzo57%2FkHrwhUqzEUQhs7K%2B67fqbrPu%2BzeeH3hHwcGh4zf9ln%2F03nUD17WJgTazvB%2Fxbav6nkW%2F5N3x%2FkhdXZw2u8M%2FXHl5OBrFvnp4kJOvk%2FNm56AJvfFkUnhdfkKnfwN61OfupxQAAA%3D%3D)