### PR TITLE
Add police cyberalarm uk domain TXT record verification

### DIFF
--- a/cyberalarm.police.uk.domain-verification.json
+++ b/cyberalarm.police.uk.domain-verification.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "cyberalarm.police.uk",
+  "providerName": "Police CyberAlarm",
+  "serviceId": "domain-verification",
+  "serviceName": "Domain Verification",
+  "sharedServiceName": true,
+  "version": 1,
+  "logoUrl": "",
+  "description": "Verifies domain ownership for Police CyberAlarm",
+  "variableDescription": "HOST: Host to create the TXT record for verification;VERIFICATION_CODE: Unique verification code provided for purpose of verification",
+  "multiInstance": true,
+  "syncBlock": false,
+  "syncPubKeyDomain": "keys.cyberalarm.police.uk",
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "%HOST%",
+      "data": "_cyberalarm-verification=%VERIFICATION_CODE%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/cyberalarm.police.uk.domain-verification.json
+++ b/cyberalarm.police.uk.domain-verification.json
@@ -3,7 +3,6 @@
   "providerName": "Police CyberAlarm",
   "serviceId": "domain-verification",
   "serviceName": "Domain Verification",
-  "sharedServiceName": true,
   "version": 1,
   "logoUrl": "",
   "description": "Verifies domain ownership for Police CyberAlarm",

--- a/cyberalarm.police.uk.domain-verification.json
+++ b/cyberalarm.police.uk.domain-verification.json
@@ -4,16 +4,16 @@
   "serviceId": "domain-verification",
   "serviceName": "Domain Verification",
   "version": 1,
-  "logoUrl": "",
+  "logoUrl": "https://member.cyberalarm.police.uk/favicon/web-app-manifest-512x512.png",
   "description": "Verifies domain ownership for Police CyberAlarm",
-  "variableDescription": "HOST: Host to create the TXT record for verification;VERIFICATION_CODE: Unique verification code provided for purpose of verification",
+  "variableDescription": "VERIFICATION_CODE: Unique verification code provided for purpose of verification",
   "multiInstance": true,
   "syncBlock": false,
   "syncPubKeyDomain": "keys.cyberalarm.police.uk",
   "records": [
     {
       "type": "TXT",
-      "host": "%HOST%",
+      "host": "@",
       "data": "_cyberalarm-verification=%VERIFICATION_CODE%",
       "ttl": 3600
     }

--- a/cyberalarm.police.uk.domain-verification.json
+++ b/cyberalarm.police.uk.domain-verification.json
@@ -12,7 +12,6 @@
   "syncPubKeyDomain": "keys.cyberalarm.police.uk",
   "records": [
     {
-      "groupId": "verification",
       "type": "TXT",
       "host": "%HOST%",
       "data": "_cyberalarm-verification=%VERIFICATION_CODE%",


### PR DESCRIPTION
# Description

Add a Domain Connect template for TXT record ownership verification for [Police CyberAlarm](https://www.cyberalarm.police.uk/)

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

[Test cyberalarm.police.uk/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM6I62kC%2F%2B1U227aQBD9FWulPAWDbUwAS5FKQiqh3CuSRo2QNV6PyTa2191dQwji3zsGEiBJ23xAHyyvd87czpzxnBnMihQMsmDOCiUnIkY1iFnA%2BCxCBSmorF7IVHCsl4%2Bs9oq5gIx82NXSZB1X4F4FJohGNaHLZZRYZiBye4JKJIKDETLfINYx%2BkuMdbuLIRddnQK3xlI5ljcqJeyDMYUOGo0MM8pY%2F6jIRgIUXOaNKUY2FIWdQS4S1MZuud4TPfUiH1OCGDVXolimC9gqO2prVbElpzkV8CAKK5HK%2BqjNCSgBUYr93Tgn3wZfB8e94eDyIjy%2B7J8E1k0ufpVobXNgcRmjteYyXqYoSlVIjZZMrDdsZWVqxCDXBnJOfBlVIlE4y%2FlRKvkjCxJI9frmqoxOcbYilIp5xJmu%2F2GQCrlUsWbB%2FZyZWVENYng3JMOD1IY%2BvlQUgQE6hpsQO5M83HvX7R55GUOTah44zmK0qLFnmWO4STaqrTVBcfEJSHxY5zLb5KXTWMmyCMULvgAFma4E%2BuJ5v%2BM6evG9Z9X5XU2VgXehGbXbTZt3va7t%2B53IjpJObLfa2AQv4k3%2FwGdVuWKcS4WhpjeYUr3yvRxCCFPYXMU8JHmlM%2BpOk5XSvKUyXwn8M1R%2BqsAtbmssjHnFiajWDOKu28U22NhK0PbBj%2BwONlt2EgFvu47rd9HdWt6%2FLfi%2Ft3czKNQacyOg2sxeOoWZZovFqEZD%2B89ExQSpUcME4xAqmOd4B7bj254%2FdFuB6weeV292236nte84geNUTdFvasXPnLS4rULWPzu6zRo%2Fcn4yyb4nWXJWnJ%2Ff%2FVTR0%2FVRb9%2BdnlLjF6eN63HLjA%2FZ4jezGGMO2QUAAA%3D%3D)

[Test cyberalarm.police.uk/domain-verification example.com/host](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN2I62kC%2F%2B1U2W7aQBT9FWukPAWD8QKxpUjN1gpVWRSRplWErPHMNUyxPe7MGOIg%2Fr3XQAIkadMP6IM127nbued6QQzkZUYNkGhBSiVngoMacBIRViegaEZV3i5lJhi0qylpvWCuaI425Gb1ZJ014JMGjBANaoaXKy9c5lQU9gyUSAWjRshii9j4OF9hrG%2F7GDTRzS7qtkgmx%2FJOZYidGFPqqNPJIceI7feS7KQUncuiM4fEpmVp57QQKWhjB133Eb92WYwxAAfNlChX4SKyjg7aWmdsyXmBCUxEaaVSWe%2BVOaNK0CSD830%2FF7eDz4Ozk%2BHg%2Bio%2Buz6%2FiKy7QvyqwNrlwGKSg7Xhkq9ClJUqpQZLptYrtvIqM2JQaEMLhnwZVQFSWBfsNJNsSqKUZnpzc1MlX6FeE4rJTKHW7T80UgGTimsSPSyIqcumEcPvQ3yYSG3w8KmhiBqK23jrYq%2BTxwdvqj1AK2OwU17PcZajZYs8yQLibbBRa6MJ9AuPFMUHbSbzbdzV0iJjJasyFs82JVU0141In60f9sxHz%2FYP6xXPb3JrHllIvaTf92wWuqHt%2B0eJnaRH3A764FE3YZ7f80mTthgXUkGscaWmUi%2B8r5oR0zndXnEWo8yyGqvU%2BIphXlNarIW%2BKe0jVv8pxx2aWyTmrKFGNBMHLEwhTQOb93sMrZln08BL7V7CgrSXcuoGdGeO%2FzbrHw%2Fyfs9AayiMoM2gnmRzWmuyXI5a2L%2F%2FhOwQgtrUdAY8pg3Uddye7fi26w%2B7QdT1I6%2Ffdvr9bi88dJzIcZrC8Oe15miBytzVJBHez3p4WAfhl%2FsLp%2BtW7PQH50UyP72cVvf5begNTDi5FP6A62Oy%2FA2XI2mP7wUAAA%3D%3D)