### PR TITLE
Add PYRX CRM (Synapse CEP) email template

### DIFF
--- a/pyrx.tech.mail.json
+++ b/pyrx.tech.mail.json
@@ -10,9 +10,9 @@
   "syncPubKeyDomain": "synapse.pyrx.tech",
   "records": [
     {
-      "type": "TXT",
+      "type": "SPFM",
       "host": "@",
-      "data": "v=spf1 include:send.resend.dev ~all",
+      "spfRules": "include:send.resend.dev",
       "ttl": 3600
     },
     {
@@ -25,12 +25,17 @@
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=none;",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply",
       "ttl": 3600
     },
     {
       "type": "TXT",
       "host": "@",
       "data": "synapse-verify=%verifyHash%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "synapse-verify=",
       "ttl": 3600
     }
   ]

--- a/pyrx.tech.mail.json
+++ b/pyrx.tech.mail.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "pyrx.tech",
+  "providerName": "PYRX CRM (Synapse CEP)",
+  "serviceId": "mail",
+  "serviceName": "PYRX Email Configuration",
+  "version": 1,
+  "logoUrl": "https://synapse-api.pyrx.tech/images/logo.svg",
+  "description": "Automatically configure email authentication (SPF, DKIM, DMARC) for sending emails through PYRX CRM",
+  "variableDescription": "Domain ownership verification hash",
+  "syncPubKeyDomain": "synapse.pyrx.tech",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "v=spf1 include:send.resend.dev ~all",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "resend._domainkey",
+      "pointsTo": "resend.domainkey.resend.dev",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "synapse-verify=%verifyHash%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds Domain Connect template for **PYRX CRM (Synapse CEP)** email configuration. PYRX CRM is a customer engagement platform that sends transactional and marketing emails via Resend (Amazon SES). This template automatically configures SPF, DKIM, DMARC, and domain ownership verification on customer domains.

- Provider ID: `pyrx.tech`
- Service ID: `mail`

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.

See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A, no redirect flow used
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

[Test pyrx.tech/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMjk7WkC%2F%2B1VW2%2FaMBT%2BK5GlSavGJQmM0lRIZdBqXUvLKNM6VQgZxyRWk9iyHUqK2G%2FfMbdAR7Vqe1gfygO5nNv3nXM%2BZ4Y0jUWENUXeDAnJJ8yn8txHHhKZnJY0JSEqbAxXOAZH1P3Ru7VavY71%2FiZLsFDUap12D8BPUTlhhC7iY8yi%2FNV25KkxWS2ejFmQSqwZT8BxQqUyd55TQBEP%2BDcZQUCotVBeuayWhYpYsNIGWZnFOKCqbNxLahJAFp8qIplY5PRQM9U8hgIER1FmkVVFatEFApzqkCbGatyBTPesYLUvzjvw32n2WgfWmEtL0cRnSbCMUZYOJU%2BD0Fr3wCDHkuFRRNs7tdtQmSUWf0iAWMiEBQTZeF0sxMo0FmiRbjq6oNnSHeJWTEvb%2FZeUcOkr5N3NkM6E6SSANbVDrjQ8nZhcYtxLIwpeiCUkSn3qGewlSRcXn07ASWvoaqVm2%2FPCJlXrqtk5zXOt%2FIf%2BAtE9zcwCcJZo1ee5eWP9c%2F7%2BbT%2FPPvRjLImZFNYYnieNRa%2BdY0s0Ep7QY5Nkqs12RIzoDtYkhPZ3uL%2FYH0nHbLrfZWXLU4IbVcpMGJtVuk6aQkTZS0Ce5PjWi7eYXtZ4t7x%2BhvG9%2B3ekT5LvQBvMC%2BgRGjLMhz8AVOs1oVMMwqUlwuMcN9wFsJ5iyNb%2BAkscKyPudeTdTuhgHXuHzH3OzrzBI%2BK4FU3BbtCwIOGSDhVcsQYZIU%2FLlBZQnEaaDfEDzl%2F5ZIhNswG8Aisku3vS6WR5IJxsbwJssGM9s7vWT9DwdoMKsErEEGPmtBlXKqR25NeL1SM8KlY%2FknoRHx46xdq4XnN9SmzbrW4dZL%2BdcHtOrryn21vUjB5wptB8j35WlPbpZ0Xxhdp5PdR2ZvUi6f5nDmuRP0vieWlvbfsrmsWgADJ%2BE8%2BbeN7E8xfigU%2BawhPqD7Fxc223VrSrRbfWd2zPcTzXLrlH8Kt%2BsG3Ptg10YLBkOIMv3va3DrUrQjw47bNR77weZF9vr6LWNP7kXlx%2Bl4%2BHVXU9Pufk5v5L9xLfN9D8F5rK28VaCwAA)
[Test pyrx.tech/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAfn7WkC%2F%2B1Va2%2FaMBT9K5GlSasKIVCgJVWlItqpVUVLKds6VQi5zoVYS%2BzIdigZ6n77rsMj0IdWaZrUD%2F1CSO7rnHvvsefEQJxE1ADx5yRRcsoDUOcB8UmSqZlrgIWktDZc0hgdSe9H%2F9bp9LvO55tM0ESD0znt7aCfBjXlDPL4mPKo%2BLQZeWpNTkeKMZ%2BkihouBTpOQWn7z6%2BWSCQn8quKMCA0JtF%2BpaIXhco04e4aWYXHdAK6Yt1dPZ1glgA0UzzJc%2FqknRoZYwFGoyhz2LIiOJAjoKkJQVirdUcyvS8l5%2BTivIu%2F3Xa%2Fs%2BOMpXI0iICLySJGOyZUMp2EzqoHFjlVnN5HcLJV%2BwQrc%2BHIB4HEQp44SJCPV8VCqm1jkRbrpfcXkC3cMW7J1N3svwImVaCJfzcnJktsJxGsrR1KbfDt2OZKxv00AvQiXLAoDcC32F0F%2BSOAKToZg13da3reY2mdqnPZ7p4WuZb%2BoyBH9BMyuwCSC6MHsjCvrX%2FPP7gdFNlHQUwVs5OihuL79CjvdfXQSY6EFHBok8yM3Y6IM9OlhoXY%2Fq4M8v1RMOazl12WtiIluoHWdsLUrtKVaCdJlL0F5HGBb7V4%2BfSyo0%2BL5xmO79O%2FI32SfAva8LFEfmFDRsXwh4hqtSYwoyhccJmMC9xLzU1wRZMRX8UkVNFYW4Gvou%2B2woer%2BLtFgmEuxiVL%2B5Xes2ptzwD6WFR8IqSCkcYnNSgn4huVQonEaWT4iD7Q4lPARtQ2HUlotGKyuycdF4uDYYl8vRS4zFXnlTV2fqOcN3tVwq1ilh%2B3B0%2BrQYPWPoNy82AvKNfrtVb5oLoPZWBQb7Tqe%2Fu1Ot04054ddi8cYtvt3VyqdvRAM00eX5DTktkzObnbXN%2Bop%2FfFcWt2C0m7T0f4gq7fAZnVKfAqm20aTxS6oYR3NpthCaX%2BIa4PcX2I6z%2BIC69ETacQjKh1rXm1Ztmrl2vNQdXza57faLjNxn6z2tj1PN%2FzLHxksWA5xxtz864kZzfn4ns7SiG63r06CR8OrtpJdNG8uYDZoNUVZ6zR7nyb1a91Jo%2FI4x%2BtFfnxogsAAA%3D%3D)
