### PR TITLE
Add novu.co domain connect flow

### DIFF
--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "novu.co",
+  "providerName": "Novu",
+  "serviceId": "inbound-email",
+  "serviceName": "Inbound Email",
+  "version": 1,
+  "syncPubKeyDomain": "domainconnect.novu.co",
+  "syncRedirectDomain": "dashboard.novu.co, eu.dashboard.novu.co",
+  "syncBlock": false,
+  "description": "Configure MX records so Novu can receive inbound email for this domain.",
+  "records": [
+    {
+      "type": "MX",
+      "host": "%fqdn%",
+      "pointsTo": "%mailServerDomain%",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}

--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -7,6 +7,7 @@
   "syncPubKeyDomain": "domainconnect.novu.co",
   "syncRedirectDomain": "dashboard.novu.co, eu.dashboard.novu.co",
   "syncBlock": false,
+  "logoUrl": "https://dashboard.novu.co/images/novu-logo-dark.svg",
   "description": "Configure MX records so Novu can receive inbound email for this domain.",
   "records": [
     {

--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -5,7 +5,7 @@
   "serviceName": "Inbound Email",
   "version": 1,
   "syncPubKeyDomain": "domainconnect.novu.co",
-  "syncRedirectDomain": "dashboard.novu.co, eu.dashboard.novu.co",
+  "syncRedirectDomain": "dashboard.novu.co,eu.dashboard.novu.co",
   "syncBlock": false,
   "logoUrl": "https://dashboard.novu.co/images/novu-logo-dark.svg",
   "description": "Configure MX records so Novu can receive inbound email for this domain.",

--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -12,7 +12,7 @@
   "records": [
     {
       "type": "MX",
-      "host": "%fqdn%",
+      "host": "@",
       "pointsTo": "%mailServerDomain%",
       "priority": 10,
       "ttl": 3600


### PR DESCRIPTION
# Description

Adding a new template for the domain connect at novu.co used for adding MX records for end users to be able to auto configure with Cloudflare/Vercel

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

[Test novu.co/inbound-email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANL%2B7WkC%2F91T7U7bMBR9lcgSv5a0biihjTRpYx9Sx4rQAI0JVZFrX1KPxI5sJxCqvvuu25SwIu0B9ivOuede%2Bxwfr4mDsiqYA5KuSWV0IwWYmSApUbqpB1yT8AW%2BYCXSyAUWELVgGslhy5VqqWslIiiZLPpa1zDbVYMvXbUBY6VWJB0hs1X8sl6eQ%2FtZYxlBIrYLrpUC7gb9MTz1BwhpEO7JzK6WmhmxJ4ZQD96AXfdZofkDSe9ZYSEkhc71jSlwyMq5yqbD4Zu%2BoSxZDnbofyPPjwQzDwPb5DhRgOVGVm4rhXzS6l7mtYFgfhvgEbURNrA68G4FnCmPgWwg6LwKtl4F99oEbiVtsFM9wLldM0nv1sS1lXdwfov4SluH6w%2F%2BRrRUzl5r%2FD3yY67QbzA7U462Nya1ka5Fi2lInEORxwmlm8UmJM9aQdbvsQg7w3EWPDEMA6Dwst8PV7nRdZXJPb9ihpXWB2bfefdX62Lfe0f8%2BvCAHu9MeLkffzCZK20gs%2FhlDo0kqTM13lNZF05m7JH1kOAZq6qiRR0WqzjxwCu1S573SjDH%2Boi%2BSsSLLYd%2BZYJ7cdInOxHHNJ6eTCPBEx6NxxMRLWHKovFoOlkej%2BjpyWj86okcvJx%2FvZHeXrAWlJPMR%2FFj8chaSzabRYhW%2F3%2BqMA%2BWNSAy5mkxjZOIjqM4uR7FKY3TOBnElCajk3eUppR6PWDdTuwaM%2FI6HcT9nLNh%2FO2mfLj6%2FjxznMuzXxe%2FJ8acMj1prfx6VlRP0%2Fh85vL3ZPMHuLAkI%2BsEAAA%3D)

[Test novu.co/inbound-email example.com/dima.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL%2F%2B7WkC%2F91Tf2vbMBD9KkbQv2Ynyo%2FGrWGwtiula1O2tRspJRhFuiSituRJsrs05LvvlDhxlsA%2BwCAQ%2B93ds967pyVxkBcZc0CSJSmMrqQAcytIQpSuyhbXJNzBDyzHNvKABUQtmEpyWPdKNdGlEhHkTGZNrR643VSD67pagbFSK5J0sHOh%2BNdycgeLzxrLCBKxfuBaKeCu1RzDt34HIQ3CTTOz84lmRmwbQyhbR2A9fZlp%2FkqSKcsshCTTM%2F3DZEgyd66wSbt9NNeWOZuBbfvXyPdHgpnXlq1myCjAciMLt5ZCrrSayllpIBiOAjyiNsIGVgferYAz5TGQFQS1V8Haq2CqTeDm0gYb1S3krYdJ8rIkblF4B4cjxOfaOnz%2B5DeipXL2SePriad5RL%2FBbEw5WW9MaiPdAi2mIXEORfYGlK7Gq5C8awVp841xWBuOXPCbYRgAhefN9wR6UCMzo8sildu5ghmWWx%2BcLcPLXxTjLcdLQ4LY4YF9vTZlty9%2FUDlT2kBq8Z85NJYkzpS4t7zMnEzZG2sgwVNWFNkCdVmsIuOBd2qTxD0tgjnWJHcvKDu3Dm1MBfdapQ887fIz2olFNKWsF%2FXhlEeT%2FvkkikU%2F5nFnyuPzs72bc3Ch%2FnV1jl0Ha0E5yXxSL7I3trBktRqHuIH%2FXiSmxbIKRMp8e5d2BxHtR93BU6ebUPzFLTroxv34A6UJpV4XWLcRvcQE7WeHFNXbXX7Zuyju6f2k7H0Z%2FvrZu74aXasLe3oJw%2BlN%2F%2Bb5%2BdvD6P3x9iNZ%2FQE8mNZiGQUAAA%3D%3D)

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
