### PR TITLE
Added mailtactic.com email service

### DIFF
--- a/mailtactic.com.email.json
+++ b/mailtactic.com.email.json
@@ -3,10 +3,10 @@
   "providerName": "Mailtactic",
   "serviceId": "email",
   "serviceName": "Mailtactic Email Authentication",
-  "version": 1,
-  "logoUrl": "https://mailtactic.net/images/logo.svg",
+  "version": 2,
+  "logoUrl": "https://cdn.mailtactic.com/public/logos/512b-260427.png",
   "syncPubKeyDomain": "mailtactic.com",
-  "syncRedirectDomain": "app.mailtactic.com,app-staging.mailtactic.net",
+  "syncRedirectDomain": "app.mailtactic.com",
   "description": "Configures DKIM, SPF, DMARC, inbound MX, and bounces MX records for sending and receiving email via Mailtactic.",
   "records": [
     {

--- a/mailtactic.com.email.json
+++ b/mailtactic.com.email.json
@@ -1,0 +1,52 @@
+{
+  "providerId": "mailtactic.com",
+  "providerName": "Mailtactic",
+  "serviceId": "email",
+  "serviceName": "Mailtactic Email Authentication",
+  "version": 1,
+  "logoUrl": "https://mailtactic.net/images/logo.svg",
+  "syncPubKeyDomain": "mailtactic.com",
+  "syncRedirectDomain": "app.mailtactic.com,app-staging.mailtactic.net",
+  "description": "Configures DKIM, SPF, DMARC, inbound MX, and bounces MX records for sending and receiving email via Mailtactic.",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "%dkimHost%",
+      "data": "%dkimPointsTo%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "%host%",
+      "spfRules": "%spfRules%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarcValue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "mx_inbound",
+      "type": "MX",
+      "host": "%host%",
+      "pointsTo": "%mxPointsTo%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mx_bounces",
+      "type": "MX",
+      "host": "%bouncesHost%",
+      "pointsTo": "%bouncesPointsTo%",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMZa72kC%2F%2B1WbW%2FiOBD%2BK1Gk%2FXQBEqDQpkK6FPbYqpdeaemqEkKRSUzwNbGztpPCVt3fvuOQAKFQne50Uu%2FUT7HH43nm5ZlxnnWJ4yRCEuv2s55wlpEA88tAt%2FUYkUgiXxK%2F7rNYNzan1ygGbd3dnMOZwDwjPs4vYnVzK3ulrn1WCpqTygWmsEeSMAr6GeZCrWzL0CMWsnsewb2FlImwG40ddyiWDRKjEIuG0quLLFRwK%2BrfpLMrvBowUKaHQlA6tzggHPtyo4WSpF7VNEBUExKFhIb1KjAYCbDwOUlyr229z%2BichCnHQhtcXbqGdnfzm6ENXOe2b2iEzlhKA819MDQEX7XzQdN90MAFxgOhzRnXBKYBQOUqIMckU7s8j1pGkLbNXR3wi5u6PXnWQ87SJM968EhUhHKVqGyPH8awWTAhYfNJnX2B9SflPZKolN0wQqUYMyWXErLd6pimoWMhVGGQSv8f1EmSaKW%2FGLtgIplvsSBgdwdsUQCBzm0aYaFk5boCVDUZxIj7RwLwysON82r%2FFUUp3nNdLqUqSER86SLpLyCPLguUQSeK9oKIl15Rny2s%2B3AgkqRIk5LFy92kJZwwTuQKOGsejQxwirofwSlOvxyAK47%2BCub0xdC%2FM4q9LT%2BmkLGS5XiJoNFx0QgFtMRCMTr31SP5nZJI6xKXia%2FkaicgQEgQR7FQ46PEmlTApiXaZA03LfD%2BDlZJ5NxY3hBW3VvDPuJVqXGzSeBEz3qqK61z7bHHBTrXkp57OZy7jjns330b3l3OWoPR5wtndO847eG1M%2BhfkNHVRTjqnyhrWw5PdEL9KA2w7YFwb17kwBtKFrBqAlgKkEJR4OvLnmWa59DwPRBz0lNVg0WKerk1Zochl7%2FmdmocJ4zLHAb2EaEK5lzhbAm4dipPlGnV4%2BUBp3aYpbRjWdtJ5h63lMIc42CG%2FMdD1oBeJKSMY0%2FAF0kYeboteYrBpzSSxENPaCsKfA%2BpwQFsFHAKxmFaVXqbrt%2BF12WsF6wsmv0fVLAyGrzAVyQlqiVnQdA5nZ81a82TM1xrmyet2mknmNc6Qdufn52aVvfU33nxDr%2BHh968al8dHKRqOBxMBNx5FTpwzdLeYJ72A0XRu4rTiZ7QShwPcz3LX9f432iXd56X%2FBE4Xv23ersSWfVFeN9xbkfQXrRvjJ7%2FQLBTAx7bjwn3MeE%2BJtzHhPt%2FTjj1O4wyHHhIqTbNZqdmtmvN7thq2u2ubTbrTbPdbFu%2FmKZtmioksLYO%2FRn%2BHXf%2FGvVGf%2FV94Zz9Obxuja9GGD2Zosuo%2Bbs8ofhrF7l4SFr3A5ktY7%2Bnv%2FwERt874aUQAAA%3D
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAuo72kC%2F%2B1WW2%2FiOBT%2BK5GleZpAE8qtqZAmhS5TddMrzKBBVWQSE6wmTtZ2KEzV%2Fe17HBIITFqtdrVSV%2BpT7OPj853r5zwjSaIkxJIg6xklPF5Sn%2FALH1kowjSU2JPUq3txhPTt6RWOQBs523M4E4QvqUeyi0Td3Ml%2BUdfOlYJmp3JBGOyxpDED%2FSXhQq0sU0dhHMRjHsK9hZSJsI6OSu4wIo9ohAMijpReXSwDBbdm3k06uyTrQQzKrCoEpXNHfMqJJ7daOEnq%2B5o6iGpC4oCyoL4PDEZ8IjxOk8xrC%2FVjNqdByonQBpcXjq7d3%2FymawPHvuvrGmWzOGW%2B5kx0DcNX7TzQdCYauBBzX2jzmGuCMB%2BgMhWQE7pUuyyP2pJibZe7OuDnN5E1fUYBj9Mky7r%2FSFWEcp2obI8mI9gsYiFh80mdfYX1J%2BU9lriQ3cSUSTGKlVxKyPZx2zB0RIRQhcEq%2FdfMTpJwjV70MphI5jssCNgpgS1yINC5S0MilKxY7wHtm%2FQjzL1XAnCLw63zav8Nhyk5cF2upCpISD3pYOktII9O7CuDdhgeBBGt3Lw%2BO1hnUhFJkqdJyaJVOWkJpzGncg09a7waGeDkdX8FJz%2F9WgGXH%2F0dzIcXHf2MGXF3%2FfEAGSu6nKwwDDrJByGHhlXmp0sz%2FaKJNuUtkr6Xp1IwYD3BHEdCUUeBM90DeiiQpkitM6x%2FglM0sLq7GQSz7m4gH8m60LjZJm6Klj01jeap9tjjAp9qSc%2B5GM4d2xj27%2F8Y3l%2FMjge352f27di2m8Mre9A%2Fo7eXZ8Ftv6Ws7Xp3iijzwtQnlgvCA57IgLetmMOqyTcVIINiwNeTPdMwTmHQeyDmtKeqBYsU9zJrsRUEXH7J7NQ4SWIuMxjYh5QpmFOFs2u8jVNZogyzHq0qnCp1lNKOZK2UzIOeUgpzQvwZ9h6rrEFb0YDFnLgCvlgC1SFL8pSAT2koqYuf8E7key5WhAFdKOAUjANL7c0027wHFWXczve%2FKN4eG7i%2Bp3qTZq%2BS2Ww3mu1OzZ%2F581qza3ZrXcNo12bYaBvN9onfaXmlR676Cax65najVMmbiguq4v9SDhday9TeaDTtTxyG7yY2O3zCa%2FF6aId0%2FR8NxTtOR0bvvxb6randi2af499vbCVi2Qb5Bpe88xgfdHgxP%2Bjqg64%2B6OqDrv4HdKV%2BVPGS%2BC5Wag2j0a4ZzVqjMzK7ltm2msf1k8ZJq936bBiWYahwiJCbsJ%2Fhr678P4d%2B2P639e%2F0epLKzoiNxz9bzGklC3H9%2FdwfPj3x8dWPLouuWcc%2B76GXvwBYMKdENxAAAA%3D%3D