### PR TITLE
Add mailtactic.com email service

### DIFF
--- a/mailtactic.com.email.json
+++ b/mailtactic.com.email.json
@@ -3,10 +3,10 @@
   "providerName": "Mailtactic",
   "serviceId": "email",
   "serviceName": "Mailtactic Email Authentication",
-  "version": 1,
-  "logoUrl": "https://mailtactic.net/images/logo.svg",
+  "version": 2,
+  "logoUrl": "https://cdn.mailtactic.com/public/logos/512b-260427.png",
   "syncPubKeyDomain": "mailtactic.com",
-  "syncRedirectDomain": "app.mailtactic.com,app-staging.mailtactic.net",
+  "syncRedirectDomain": "app.mailtactic.com",
   "description": "Configures DKIM, SPF, DMARC, inbound MX, and bounces MX records for sending and receiving email via Mailtactic.",
   "records": [
     {

--- a/mailtactic.com.email.json
+++ b/mailtactic.com.email.json
@@ -28,7 +28,7 @@
       "groupId": "dmarc",
       "type": "TXT",
       "host": "_dmarc",
-      "data": "v=DMARC1; p=%dmarcPolicy%; rua=mailto:%dmarcRua%",
+      "data": "v=DMARC1; p=%dmarcPolicy%; rua=mailto:%dmarcRua%; ruf=mailto:%dmarcRuf%",
       "ttl": 3600,
       "txtConflictMatchingMode": "All",
       "essential": "OnApply"

--- a/mailtactic.com.email.json
+++ b/mailtactic.com.email.json
@@ -12,15 +12,15 @@
     {
       "groupId": "dkim",
       "type": "TXT",
-      "host": "%dkimHost%",
-      "data": "%dkimPointsTo%",
+      "host": "%dkimSelector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimKey%",
       "ttl": 3600,
       "essential": "OnApply"
     },
     {
       "groupId": "spf",
       "type": "SPFM",
-      "host": "%host%",
+      "host": "@",
       "spfRules": "%spfRules%",
       "ttl": 3600
     },
@@ -28,14 +28,15 @@
       "groupId": "dmarc",
       "type": "TXT",
       "host": "_dmarc",
-      "data": "%dmarcValue%",
+      "data": "v=DMARC1; p=%dmarcPolicy%; rua=mailto:%dmarcRua%",
       "ttl": 3600,
-      "txtConflictMatchingMode": "All"
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
     },
     {
       "groupId": "mx_inbound",
       "type": "MX",
-      "host": "%host%",
+      "host": "@",
       "pointsTo": "%mxPointsTo%",
       "priority": 10,
       "ttl": 3600
@@ -43,7 +44,7 @@
     {
       "groupId": "mx_bounces",
       "type": "MX",
-      "host": "%bouncesHost%",
+      "host": "bounces",
       "pointsTo": "%bouncesPointsTo%",
       "priority": 10,
       "ttl": 3600

--- a/mailtactic.com.email.json
+++ b/mailtactic.com.email.json
@@ -1,0 +1,52 @@
+{
+  "providerId": "mailtactic.com",
+  "providerName": "Mailtactic",
+  "serviceId": "email",
+  "serviceName": "Mailtactic Email Authentication",
+  "version": 1,
+  "logoUrl": "https://mailtactic.net/images/logo.svg",
+  "syncPubKeyDomain": "mailtactic.com",
+  "syncRedirectDomain": "app.mailtactic.com,app-staging.mailtactic.net",
+  "description": "Configures DKIM, SPF, DMARC, inbound MX, and bounces MX records for sending and receiving email via Mailtactic.",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "%dkimHost%",
+      "data": "%dkimPointsTo%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "%host%",
+      "spfRules": "%spfRules%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarcValue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "mx_inbound",
+      "type": "MX",
+      "host": "%host%",
+      "pointsTo": "%mxPointsTo%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mx_bounces",
+      "type": "MX",
+      "host": "%bouncesHost%",
+      "pointsTo": "%bouncesPointsTo%",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}

--- a/mailtactic.com.email.json
+++ b/mailtactic.com.email.json
@@ -3,7 +3,7 @@
   "providerName": "Mailtactic",
   "serviceId": "email",
   "serviceName": "Mailtactic Email Authentication",
-  "version": 2,
+  "version": 3,
   "logoUrl": "https://cdn.mailtactic.com/public/logos/512b-260427.png",
   "syncPubKeyDomain": "mailtactic.com",
   "syncRedirectDomain": "app.mailtactic.com",


### PR DESCRIPTION
# Description

*Domain Connect* template for mailtactic.com to enable email sendout through authenticated/verified domain names.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANmK8GkC%2F%2B1WXW%2FqOBD9K5Elnm6AEKClqZCaQm%2BFUO5CabXdrVBkEgesBjuNHS5s1f3tOzbQJC3crfapK%2FUp9syx5%2BvMOM9IkmUSY0mQ84ySlK9oSNJBiBy0xDSWOJA0qAV8icxX7Q%2B8BDTyXvWgEyRd0YDog0SdzGXv4MaVAhhuJheEwR5LyhngVyQVauU0TRTzOb9LYzi3kDIRTr0ehKxWdqmeZLOYBnWFFfV2w55V7ROrZZ%2FWEjZX9jcsGGWzIdn0OZxkh2JSmBsS0pQE8hWFk6T2DhkSEaQ00b46qMdZROdZSoTRHw4805iMvptG33NveqZB2YxnLDS8e9PA8FW7AJDevQF2eBoKI%2BKpIQgLKZtrCMgJXamdzp6xotjIM1YD%2B7uTyHl4RvOUZ4nOdfhIlXNyk6gc397fwmbBhYRNRekmJIbIeFqp%2BaEO75FsVDBYYoCsusr5xrnx2E0FPjeSrj4EGauoSyXkv3liWSYiQqhSYVWQ35ibJPEGvZhFR0QS5X5AMrzckQuV5yS6yWIilF%2F7dclG%2BbZwidPgSFz%2BXpkHodLe2LqvdCMOtNhUzo00w11dSO5sNTcZ1uLorTh6E7BcS1ViuEd6WAYLqIzHQ%2BWLGytu%2F3tClmt%2Fx4M8Du%2B%2BnJWEUybFLVdZWa5Hu11F9xrlKZUb5DSso1kCEztqHTaRK4uGdtKPWJu%2BmOgvzoifk28Ked%2F3CVljmB1k1yA7o7DSHvpU4%2FcM3fJjX7pScgphwO0JTvFSqGm0t%2FNQMjTdW3pAaq1t%2FRc7xe5Q5%2FOGb%2BzV0AdK4w2uI8%2B1rnuTp%2BvJYNbsj68u3fGd67auf7j93iUdDy%2Fn454%2BlvP8AVEWxFlIHB%2BEb%2BfJdOfjlqoKzSDPr2LgqY5Jrav44shhoG2Oig6gck7pCNcN7QbAY8r2mDd0OAYEJtA54ynxBXyxhNGHHJlmBKxksaQ%2B%2FolzURj4WPUEEEeAFi6FqVVqZrZ9FQpZ%2F%2BCE%2BnA1Sv3sh4GiFFVt0yDNMGyf2NXOaXRWbVnYqnY6LbtKQEpa4SywTjuF5%2B7wY3jowcs74OB4UM17KAcXxXCBKw3jF8wx%2FsZ6AH2O2Nz4J96I46H9alYrwpdG9GG2l8b1Eap%2F5lLrgfy%2B0gd6rBRFeSR%2FrhIXQ8rfmP9tYFMTXrWv%2BfQ1n77m09d8%2BozzSf1X4hUJfaxgtmWfVK1W1e7cNizHbjl2u9Y%2Ba7VO298sy7EsFQ4RchvuM%2Fy3Ff%2FYUCdZDyaLUTxzn3Bz9u3uint%2FRnX8O2W0Hok%2Fvg%2F77tCNPHr2NO6il38A66zKyB8QAAA%3D
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOiK8GkC%2F%2B1WUW%2FiOBD%2BK1EkngiQhJRtUyFtCr1eVWW3peypugpFjmPAarDT2KFwVe%2B33zgEQmi4W91T79SnxJ5xZr6Zbz7nVZdkkcRIEt191ZOUL2lE0utId%2FUForFEWFLcxnyhGzvrN7QAb93f2cEmSLqkmOQHiTpZ7r1z1y6Vg%2BZlck4YrJGknIH%2FkqRCvbldQ4%2F5jP9IYzg3lzIRbqeDI9auptRJsjCmuKN8RefEssOW3TMd%2B0s7YTMVf83wbRbekPWQw0lWh0n5jEhEU4LlzgslSfudZ0QETmmS5%2BrqA86mdJalRGjDm2vf0O5vfzG0oe%2BNBoZGWcgzFmn%2Bg6EheKoVBk%2F%2FQYM4PI2ENuWpJgiLKJvlLrBP6FKt8uppS4q0smJtiF%2Bc1N3HV32W8izJax09UZWcXCeqxuOHMSzmXEhYNJTtnsSAjKeNdhDl8J7IWoFBEoHLsq%2BSt861p34q0LmW9PNDULGG%2BqiE%2Bnd7pmnoRAjVKqQa8p15SRKv9TdjPxGRTMs8oBh%2BmchXVedkOspiIlRe2%2FdKjOrXogVK8RFcwdZYglBltzbpK9stB1qsG%2BdamqF%2B3kjubiyjDOXb08Pt6QFguZKqxfAd6SOJ59AZn0cqFy9W3P7ngixWQcGDEof%2FUK1KwimTYsxVVRar22LVyGeN8pTKte5a5tEqQYiCWvUhSuN%2BoGL3Z6JN3gz9D85IUJJvAnXfzglZIdAOUgxIEVQSeBibLAOan9mydMORbfsqBdqDAhESlKKFUIq0jfVYCTbZRnvchJsU8f5NrP0pUefLwbe2ZpgHZfGvr6a%2BZ14N7p%2Bv7q%2FD7vDu8sK7%2B%2BF5ztU3bzi4oHc3F7O7QX6s5PujThmOs4i4AWwe6sqkyHFDWeXNoN67beBrjkm9t9DXI4eBvqXXtMar5FaOcGXlaYB7TNnW54AWxxyBEXTGeEoCAU8kQQJ1V6YZgShZLGmAXlC5FeEAqdkAAgmwwkdBvSpDzTa3w17V95SqXZDpqFz9dEsqwx1EWHGLqhlCDsYnNnZaYTf80nJIdNYKbavbwrbp9MLwtGd3e3t3X%2F3NWHf7VcehVi%2FUNNcV4xA18MbS%2FoZF2p8oF6WPA9GLX9BaHEe40fD37d0JuZqCin7Xj0BFy4%2Fw%2F6O3Plfs2s7XzF8FTFW2P17L95EV8tL%2BPyCcGHANfgrZp5B9CtmnkP2nhUz9qaIliQKkXG3T7rVMp2Wfji3TtR3XMdtmzzqzT5qm6ZqmggRf20B%2BhT%2FB%2FX9APe5c3jw3L8b4mTebv%2FuoGX1HjHjit%2BHVkshTmya%2Fjl7CyJmfnfb1t78AOI1%2BcXkQAAA%3D