### PR TITLE
add studio360, studio360 Artist Website

### DIFF
--- a/studio360.art.website.json
+++ b/studio360.art.website.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "studio360.art",
+  "providerName": "studio360",
+  "serviceId": "website",
+  "serviceName": "studio360 Artist Website",
+  "version": 1,
+  "logoUrl": "https://studio360.art/admin/favicon.ico",
+  "description": "Connect an artist-owned domain to a studio360 public artist website hosted on Vercel.",
+  "variableDescription": "apexIp1 and apexIp2 are Vercel apex A record targets; wwwTarget is the Vercel www CNAME target.",
+  "syncPubKeyDomain": "domainconnect.studio360.art",
+  "syncRedirectDomain": "studio360.art",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%apexIp1%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%apexIp2%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%wwwTarget%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for connecting artist-owned domains to studio360 public artist websites hosted on Vercel.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Additional local checks:

- `check-jsonschema --schemafile template.schema studio360.art.website.json`
- `curl -I https://studio360.art/admin/favicon.ico`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** [Test studio360.art/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOY78GkC%2F%2B1WbWvbMBD%2BK0LQT7Mdx3ETx2Mw0xbWdu1G17UdJQTFUhINW%2FIkOWkW%2Bt93sp1XwuhgH%2FqhYJKz7rmX5%2B50eIkNy4uMGIbjJS6UnHHK1DnFMdampFx2ur5HlMHOWnlNcratBpVmasZTVpnN2UhzcLc%2B3cejRBmuDbpfA2dMaS4FjtsOzuREflcZGEyNKXTcau3k0SI056I1JuBZCg9%2BwJ4ynSpemMoHPpFCsNQgIhCpIrlyLhhFVOaEC2QkImiTTFGOMp42SNQkj6ZSGzCRAt0xlbLMs1kSxckoY6c70UjBns6LNkSjqJYDcMYau%2BoIJUixVCqKDFETZvR7NJ%2FPbysZcY3MdA2Hc3RynVydNVAbVy9E%2BrUcXbLFacUAgtZU0pqot98oa3DDKIegZm2yD7IMb9ivElDQtTHJNHNwnabG8eMSm0Vh25Y0WBA%2F2iGQXBh9K%2BH1qKF%2BBMfGQMfAue9gpjUThhPbwi8iKYpsgZ%2Bdl%2FsL%2Fs1fVa2NTyjgntd1qV%2Fid%2FDs4N9SsOGmEgOnKTfg2BOBy8K8VOabkCBNlCyLIV%2FhC6JIru2FWlk%2B7pgOVraP2MpNHe1rr%2BvBE7Th2WiCXU1gNWtWVpcKuGLerBohlwpdBwEqfCKkYkMN%2F8SUCuplVAl9zsvM8CGZk80RTYfE1gCYa9CC290ZEPUttj2jxBAQt3PdqeyQppY7t9uAhjQcR6O2Owr7zA2jyHcj4gdu%2FziM%2Bh2%2F1%2B%2BNulu75eDiObxdNtU%2F2Mm9kftb%2BsHrTn814Q2FesIbEgc7%2FwrZDBy4F28D9TZQ%2F22gYAdqMmN0SCwu8IOu64duEN36YRz24k7o9Y%2F9IIze%2BX7s228Uw7SpSS5hM27vRPzwM3roXPRan34kl2GhzjrX%2BYWUD%2FfFN%2Fpk7nQ%2BFld38vOsfTNNPuDnP2mTUQIzCQAA)
[Test studio360.art/website example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK498GkC%2F%2B1WbW%2FaMBD%2BK5alfiqEJCW8TZPG2q1bu7ZTxda1FUJOfIDXYGe2gTLU%2F75zCNCgauq%2BTJvUL2Df%2B%2FPc%2BZQltTDJUmaBdpY002omOOiPnHaosVMu1EHD95i2tLJRnrMJPFajyoCeiQRytznERmC4jXTXnnS1FcaSq43hDLQRStJOUKGpGqkvOkWHsbWZ6dRqpTpqjE%2BErA0ZRlbSwx%2F052ASLTKbx6CHSkpILGGSsDxTVc0lcMLVhAlJrCKMbIvJpnEqksKSFMWTsTIWXZQkX0EnkHquSqYFi1M4KmVjGdx%2FzALMxsnqHGIwKPxyEekSDYnSnFimR2DNKzKfz3v5mQhD7HhjjnJyeN49e1eYurxmIZPP0%2FgUFkc5Aky6gpKsgHq7jXIOl8AFJrUbl10jh%2FASfkzRCrs2ZKmBCl2VaWjndkntInNt6xa2eHzjhkAJaU1P4XWvgL6HYmuxYxjcr1AwBqQVzLXwQnazLF3Qh8rz44V%2FFi9naxsTCdyJuqH6OXH7DxX6U0kYbJnoVwq60Q7uGT4W8BI12aa0YByhI62m2UCsfTKm2cS4R7X2vi2599f%2Bt6sAeC%2F4dKIwaHhB5HuBF2w1YUnTWKk28JyyGUAT6vUDqEdt3mpG3iwfqyqXpuqjR54YIYqRVBoGBv%2BZnWrk0eop9n8yTa0YsDnbingyYI4bZMSgFrOUZ0OuXndBAmeW4e1x%2BSXSBzxxlAi3KNpJGA45C6sQ16FabyXNahz49WrUjpOk7Q%2FjZhI%2FWjtP7qSnF0%2B5MU82emcif4%2Bi8T%2FAWD%2BEAgrOhVeG85zh%2BEdR9iv4pF7m7mXu%2Fvbc4YI1bAZ8wJxt6IeNKiYPWz2%2F3omiTuB7B81GPWru%2B37Hd19CLtwK9xL37OMNS08vzt6fnF3vq%2BNvjegqOj65y27gvjtn4d31ERt%2BumyNJ%2B23N70P3%2B9e04dfHmN5v5kJAAA%3D)
