### PR TITLE
Add Ruhanix root-domain publish template

### DIFF
--- a/ruhanixcreations.in.publish.json
+++ b/ruhanixcreations.in.publish.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "ruhanixcreations.in",
+  "providerName": "Ruhanix",
+  "serviceId": "publish",
+  "serviceName": "Ruhanix Website Builder",
+  "version": 1,
+  "logoUrl": "https://ruhanixcreations.in/logo.png",
+  "description": "Connect your domain to Ruhanix Website Builder",
+  "syncPubKeyDomain": "ruhanixcreations.in",
+  "syncRedirectDomain": "ruhanixcreations.in",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "103.50.162.186",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new Ruhanix Website Builder publish template using the root-domain provider identity `ruhanixcreations.in`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- [Test ruhanixcreations.in/publish example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFZJ8GkC%2F%2B1TXW%2FaMBT9K5Ffm4R8N0Sa1IxN3YpAU9VuDwhFJjHgKrEj2wFSxH%2FfNZSmkWj32oc9xbHPOb7n3uM9UqSqS6wISvaoFnxDCyJ%2BFihBolljRne5IFhRzqRNGTJfIVNcAQXdn0BwIInY0JwcqXWzKKlcd7t9tPGHLCRVxPja0BK0ALchQsIlKHFNVPIVfxQl4NdK1TIZDC6UMtAou2YrIBdE5oLW6iiARpwxkiuj5Y0wCl5hygzFjffvli3LfzWLMWm%2FHdHvetfAe1JQAfL%2FgAKEi0KiZLZHqq21%2BRS211wqWN7oRnLKlHzg8Os6vh06tht5thtHcKYUuPcjxzmYr%2FTRNJ187yS2221f5KbHmx9M9MwZybpC5tCoc9Fkh2HqxM551UnCaiV4U2f0jK%2BxwJXUyTgzZz3q%2FMydIaRvpCvGBckkfLFqBJStRENMVDWlohne4m6ryDNc12ULBUo4BYl%2Bp9gpMdpVgRX%2BsEsmyopcV0l1%2BOLg%2BhrneGnhiLhWsAxyC8exby1IkYd%2B6EbDof8myB9k%2FXKku24RKQlTFOuopuUWtxIdLkzsxcppYi9m%2BgP4nE7mJmTg%2F1Q%2B21Tg0Um8IUWGNcxzvMhyAsuLH5wwCYIkDOzI8wM%2FuHKcxHG0DyLVyeAe3ujb14kiNV5P7latN%2Fnxe7Roprc7vBym42l0l4ZP9Onq0b1tnwcuT0fxF3T4C0OVNTstBgAA)

- [Test ruhanixcreations.in/publish example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJpJ8GkC%2F%2B1T0U7bMBT9lcivJKmThhAiTaIDNLEJhko3JKoqcmPTWktsy3bSplX%2FfTctpUQq7HWT9pTYPuf4nnuP18iyUhXEMpSukdKy5pTpG4pSpKs5EXyZa0Ysl8L4XCD3FXJHSqCg4Q4EB4bpmudsS1XVtOBmftjtop1HNjXcMudzxQvQAlzNtIFLUBq4qJAz%2BUMXgJ9bq0za6x0ppdeifCVmQKbM5JoruxVAl1IIllunkZV2qCwJF46Vzvt3m0bk99X0G2uutuh3vbfAIaNcg%2FwfoACRmhqUjtfINqo1P4DtuTQWfi%2FaRkourBlJWAa4759iP4hDP0hiOLMW3PdjjDfuK%2F3ybnB7fZBYLBZdkYsOb7Jx0UoKlh0KmUCj9kWzJYGpMz%2BX5UHSzKWC1UzLSmV8z1FEk9K06dizxx36ZM8f7wTam%2FlMSM0yA19iKw3lW10xF5VVYXlGFuSwRfOMKFU0UKiBU5DpdkzskvNSGyWWfNgwF2U0b4vlbQ7x2fMzIfjcC85x4kVJkntJP6BeGOVhxDCNKAvfZPqD2B9Pd7dxzBgmLCdtcgfFgjQGbY4M8MURDNDvumpXfncyf6%2BviQvh%2BD%2Bqf2JU8EQNqRnNSAsNcRh7OPLCZIRP0yhOcej3%2B0F8Fp1gnGLcemHG7pyu4TW%2FfceoeTRfk4fV9%2BuTp6dlPcL3%2BTIh8e2qHoTqZ29IH56H8Rc%2BFL%2Bubj6hzW8n%2FV1GXwYAAA%3D%3D)