### PR TITLE
Update TTL record to auto for novu.co

### DIFF
--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -15,7 +15,7 @@
       "host": "@",
       "pointsTo": "%mailServerDomain%",
       "priority": 10,
-      "ttl": 1
+      "ttl": 300
     }
   ]
 }

--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -15,7 +15,7 @@
       "host": "@",
       "pointsTo": "%mailServerDomain%",
       "priority": 10,
-      "ttl": 3600
+      "ttl": 1
     }
   ]
 }

--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -3,7 +3,7 @@
   "providerName": "Novu",
   "serviceId": "inbound-email",
   "serviceName": "Inbound Email",
-  "version": 1,
+  "version": 2,
   "syncPubKeyDomain": "domainconnect.novu.co",
   "syncRedirectDomain": "dashboard.novu.co,eu.dashboard.novu.co",
   "syncBlock": false,


### PR DESCRIPTION
Changed TTL value for MX record from 3600 to 1.

# Description

Updating the TTL to use the Auto mode in Cloudflare

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->
[Test novu.co/inbound-email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJaD8GkC%2F91T7W7aMBR9lchSfy2BEGiASJP2VVWoa7tubUdVocjYl2CR2KntpAPEu%2B%2Baj4VRaQ%2BwX3HOPffa5%2Fh4TSwUZU4tkGRNSq1qwUGPOEmIVHXVYor4f%2BAbWiCN3GABUQO6Fgy2XCGnqpI8gIKKvKntG0a7qnexr9agjVCSJBEyl5J9q6ZXsPyisIwg4dsFU1ICs63mGI76HbjQCDdkauZTRTU%2FEH2oWm%2FAffenXLEFSWY0N%2BCTXGXqQec4ZG5taZJ2%2B01fWxQ0A9N2v4HjB5zqRcvUGU7kYJgWpd1KIZ%2BVnIms0uBdjz08otLceEZ5zi2PUekwEDV4e6%2B8rVfeTGnPzoXxdqpbOHffTJLnNbHL0jl4PUZ8rozF9Qd3I0pIa%2B4V%2Fp65MT%2FQb9A7U862NyaUFnZJkk7oE2tRZDcMN5ONT1ZKQtpsMfH3fuMo%2BEUxC4C6i2Y7XGVaVWUqDvySaloYl5dD5%2FNfrZND7zNx69PzOXzrQXM77lwik0pDavBLLdpIEqsrvKWiyq1I6SttIM5SWpb5EmUYrOLAE6fkLnfOKU4tPQT0OA4HT069SjlzyoRL9XkMcRwzHsSDuBP0%2BgyC4aA3C9is24XzqDOYdvpHz%2BPk1fzrfTTegjEgraAuhh%2FzV7o0ZLOZ%2BOjz%2F6YJo2BoDTyljhaFURyEvSAa3IfD5LybRHErGvbifv9dGCZh6OSAsTupa8zHcTLIitePlz%2BfBi%2F17eX9I73uPeQP%2FRc9urB3tV2Z8dPV1zKD%2FO5xvHhPNr8Bps0fQOUEAAA%3D)

[Test novu.co/inbound-email example.com/dima](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK2D8GkC%2F91Tf2%2FaMBD9KpGl%2FtUE3JBSiDRpv7qpG1TVxlCrCkXGPsBrYke2k5YivvvOEJaWSvsA%2Byvx3b3zvXfPG%2BKgKHPmgKQbUhpdSwHmSpCUKF1XHa5J%2BDd8zQosI9eYwKgFU0sOu1qp5rpSIoKCybzNNYCrfTa4bLI1GCu1ImmMlWvFb6r5d1h%2F1pjGIBG7H66VAu467Ri%2B9AcIaTDcFjO7mmtmxKEwhKrzJtigP%2BaaP5B0wXILIcn1Uv8yOTZZOVfatNt9g%2BvKgi3Bdv0x8vWRYOahY%2BsldhRguZGl21Ehn7RayGVlIBjfBjiiNsIGVgderYAz5WMgawgarYKdVsFCm8CtpA32rDvYtwGT9H5D3Lr0Co5vMb7S1uH%2Fe78RLZWzE43HE9%2FmJ%2BoNZi%2FKyW5jUhvp1iQ9oyFxDkn2KN3OtiF51gqy9opZ2OiNreCJoRcAeRftdQIlwNPS6KrM5AFTMsMK6z1zQN%2B%2Fgs8O%2BPt9Azwfz%2BlzOy3aLfn55FJpA5nFL3MoJ0mdqXBbRZU7mbFH1oYEz1hZ5mukYzGLDY8UU3v%2FNRQEc%2Bzg1ZfOOMhzLFsmuCcovcEHlA6GNJlHPI6TKLm46EdD0VtEot%2Fr9dli0KcJffFSjh7Qv57Ka5nBWlBOMu%2FKD%2FkjW1uy3c5ClPw%2FpYbGsKwGkTFfGtO4H9EkigcTOkzPe2ky7JzTHh2cnVKaUj%2BHA%2Bv2dDfolpc%2BITdnj9P6K9w9XcR33eEi5306tdXv0eiJ28sp0PHk%2BsspH9Hxt%2BQd2f4BFXPONvsEAAA%3D)
**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
