### PR TITLE
Add FieldPlan templates: site-hosting and site-hosting-subdomain

### DIFF
--- a/fieldplan.ai.site-hosting-subdomain.json
+++ b/fieldplan.ai.site-hosting-subdomain.json
@@ -1,0 +1,32 @@
+{
+    "providerId": "fieldplan.ai",
+    "providerName": "FieldPlan",
+    "serviceId": "site-hosting-subdomain",
+    "serviceName": "FieldPlan website hosting (subdomain)",
+    "description": "Connect a subdomain of your domain to your FieldPlan site.",
+    "variableDescription": "`cnametarget` is the FieldPlan site host the customer's subdomain CNAMEs to. `cfownership_apex` is the Cloudflare Custom Hostname ownership token, `cfacme_apex` the Let's Encrypt ACME challenge token. Both are minted by FieldPlan and substituted at apply time. (The `_apex` suffix is a naming holdover from the apex+www template; it identifies the records belonging to the customer's configured sub-host, not the zone apex.)",
+    "version": 1,
+    "logoUrl": "https://fieldplan.ai/logo.png",
+    "syncPubKeyDomain": "fieldplan.ai",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%cnametarget%",
+            "ttl": 300
+        },
+        {
+            "type": "TXT",
+            "host": "_cf-custom-hostname",
+            "data": "%cfownership_apex%",
+            "ttl": 300
+        },
+        {
+            "type": "TXT",
+            "host": "_acme-challenge",
+            "data": "%cfacme_apex%",
+            "ttl": 300
+        }
+    ]
+}

--- a/fieldplan.ai.site-hosting.json
+++ b/fieldplan.ai.site-hosting.json
@@ -1,0 +1,50 @@
+{
+    "providerId": "fieldplan.ai",
+    "providerName": "FieldPlan",
+    "serviceId": "site-hosting",
+    "serviceName": "FieldPlan website hosting",
+    "description": "Connect your domain and www to your FieldPlan site so visitors can reach it at your custom URL.",
+    "variableDescription": "`cnametarget` is the FieldPlan site host the customer's domain CNAMEs to. `cfownership_apex` / `cfownership_www` are Cloudflare Custom Hostname ownership tokens (DNS-01 verification). `cfacme_apex` / `cfacme_www` are the matching Let's Encrypt ACME challenge tokens. All five are minted by FieldPlan when the customer adds the domain in the editor and substituted at apply time.",
+    "version": 1,
+    "logoUrl": "https://fieldplan.ai/logo.png",
+    "syncPubKeyDomain": "fieldplan.ai",
+    "hostRequired": false,
+    "records": [
+        {
+            "type": "APEXCNAME",
+            "host": "@",
+            "pointsTo": "%cnametarget%",
+            "ttl": 300
+        },
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "%cnametarget%",
+            "ttl": 300
+        },
+        {
+            "type": "TXT",
+            "host": "_cf-custom-hostname",
+            "data": "%cfownership_apex%",
+            "ttl": 300
+        },
+        {
+            "type": "TXT",
+            "host": "_cf-custom-hostname.www",
+            "data": "%cfownership_www%",
+            "ttl": 300
+        },
+        {
+            "type": "TXT",
+            "host": "_acme-challenge",
+            "data": "%cfacme_apex%",
+            "ttl": 300
+        },
+        {
+            "type": "TXT",
+            "host": "_acme-challenge.www",
+            "data": "%cfacme_www%",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Add two FieldPlan templates for connecting a customer's domain to a hosted FieldPlan website:

- `fieldplan.ai.site-hosting.json` (apex+www): `APEXCNAME` at apex + `CNAME www` route the customer's domain to a Cloudflare-for-SaaS host (`<siteId>.fieldplan.site`); two `_cf-custom-hostname` and two `_acme-challenge` TXTs cover Cloudflare ownership and Let's Encrypt DNS-01 ACME validation for both names.
- `fieldplan.ai.site-hosting-subdomain.json` (`hostRequired: true`): same shape minus the `www` records, applied at a customer-supplied sub-host.

FieldPlan (https://fieldplan.ai) is a chatbot-driven website editor. The five (apex+www) / three (subdomain) template variables are minted at apply time by FieldPlan when the customer adds their domain in the editor.

Verification key published at `_dck1.fieldplan.ai`.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A: neither template uses `redirect_uri` in records.
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — N/A: each TXT record (`_cf-custom-hostname`, `_acme-challenge`) is per-host and reset per Custom Hostname; conflict matching is not applicable.
- [ ] no variable is used as a bare full record value — **Justification:** the four TXT records (two `_cf-custom-hostname`, two `_acme-challenge`) carry opaque tokens minted by Cloudflare and Let's Encrypt respectively. Both verifiers compare the token byte-for-byte against the value they generated; service-prefix wrapping (e.g. `fieldplan-token=%cfacme_apex%`) would cause Let's Encrypt's DNS-01 challenge and Cloudflare's hostname ownership check to both fail, and would be unique to FieldPlan with no upstream contract permitting it.
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain — uses the `host` parameter (subdomain template has `hostRequired: true`).
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A: removing any of these records breaks the customer's site (the CNAME) or its SSL certificate (the TXTs); none should be modified by the end user.

## Online Editor test results

**Editor test link(s):**
- [apex+www test (domain=bakery.com, host=)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH%2FR8GkC%2F%2B1Y%2B2%2FaOhT%2BV6xI0%2B4VhAYIT2nSKG23qQW1BaptXUUd5yTxbV61HRir%2Br%2FPToAAfcF0dXUr9RcIPm%2Bfz585udMEBLGPBWjtOy1m0YTawL7YWltzKPi2FIUlTLXiUtbHgdTVjpT0VEqliAObUAKpFacCdC%2FigoZuLto0QlOwlCbKNW3ghNFY0CiUmt0oDIEINIsShuwowDREOLTRdDpFIsqWc2%2BpKx6hCZVPEeOIyEUGmHiICoTnbkjCRRSg0flJScabYEax5cPBWtxrEspUBWYuiGtEORIebAZSOafrmUNg7%2FkixW6%2F0zuURlEJXRMnmobAuEfjMY7h5zXaW1%2BUtVwjzAB1%2FSixHT99zHL8LEOoRNBSW%2Fq8gZCjvw76A90oowkw6lCCVd5%2Fp9EwCWA1UPp7GUPlG2BBPLnb6ASEzPkwJGwWC9Tp9g4R8bDvQ%2BjCPFAJdXwfOXQCqXlAQwE2smYrmzH1IFzbB4RtO9ux%2BXbQTA626kraP55YsuEiUc5kX3Ac%2BzMkaABpS2SpaRvKRc2P3GjEfNkST4iYt%2Ff2VvG4p8SlOIPYLCSniXUMs4M06kPoqoadw21CGUiIOtjnUNQYkIjZXGtf3mliFit4dk4Pv6YdnNvIpY8K%2BZEsng8j%2BfPdCjzeSZEQMsOqYdwXl042HMgG7Oxi%2BHWYOxgTR882OD1WylidFixw6mwDZH%2FosZSl%2BZhXKdnKqYKbvkTRmrMlMv%2FA0YPMFrBe83V1X9R%2BRSGM865eSaMFHix8A2xWIlGQx5FPLouSeEwX6jFmOOCKBxeGl6uWVwvTS009r7RRLdkQRLGfBJY8X6Ucf4owUu2NPikTbGKzDLiqmzVLfThYxw2rrBtWhVhQrrVaVnXTVu2GNB1MR%2Bejk%2B%2Bnt%2BdDcPb1sXeM%2B41vN66Lud6rDH8lrl0xwa6OTtzMw7IFaVE1q1ZxLFOv1Yn6cCzdapKKXiZVmziVOsbEXDGbxxz%2BvBhc9PAZG4wct6vjLydWv%2Fnd9zxL6P3qCE88qNYcMC96nqb6Qd0wYjDm8huLhMlGC5bIgxckvqBjPMX5kk3GKRPI9nEpldEeP5Rhdo18zAHx3Lbn%2BChqY5uoxlJ1RRGoO7jSbOimYdm6SaCst6qkqjfMFjSbxGjVqo2VC%2B%2Bxy%2FCZGy%2BHF3AOoaBYkVjHn%2BIZ1%2B4fIYp5UWs4f8VlZYd5XtSz5LUV%2Fl95tev0tcuxfVWFP0X%2BWzHNK650vb27MOT%2FsuirorwH36j3jXrfqPeNet%2Bo9z%2BlXvl%2Fm%2BMJ2GOs1CpGpa4bpl5pDsu1dqXWrpVLtVajXm4VDKNtGKoI4CKr%2Fi59TieXZT5I%2FdkvpK9LQAW%2BW77wSPXWppcXOO%2Fh7LItfzyYXHY8hmtzy7aIXp1adsTF4wNjOiaqEfFevTVQA8qTbw3mUM3NS2to2%2BKKefaWKv07jl9kzhfC%2FNiq%2Fz80bUe2fjnuDvB5LvwGk7wYdhvk7RBvq1J3QK4KfSV5U9KPD0RIDsnO%2FJNsIFVX53Ktc%2BR2B%2BbnT8H%2BXq9QJ4f9Vvd2nxeO4VOSHEHrrG8XoNAj3wb%2FnH3Q7n8DFGAX2zQWAAA%3D)
- [subdomain test (domain=bakery.com, host=shop)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACvS8GkC%2F%2B1Xa0%2FjRhT9KyNLq25FbJzEAZOqUrNZquUVpZAguoDCeDx%2BCNtjZsYJWcR%2F7x07cZwAi2lXrbbaL07GM%2Bc%2Bz713%2FKBJGqcRllTrPmgpZ9PQpfzA1bqaF9LIha3EwKHWKPcGOIaz2u9qdwi7sCUon4aE5igRSqoHTMgw8XWROS6LcVg5tAlHM%2BooDFpg0PsS9DOgXCoID1MZsgRQfZYklEiEUXkIMQ%2FNWcbRYilZsVwpUNINEDXFPMRORD%2BuibwhCVgkMfepvEGhQDKgG%2BDctPw9yYRkMeU%2FiYoB%2FUHvZB9wzEA3xGOzhHIRhOkEp%2FS%2BlNiPWOZ6EebwNxeCPoFQpRqVCBBxS5OGkoJJTBcCFPqYSlC5nxA%2BTyXq9U%2F2EQlwFNHEpwXKQB%2BYDJCSH4eJpC5y5hU3cOIqiyHCMlObGGKYptEcyTCmBno%2FAiU3C4Ui87zwXhmOERiochKwyGVTypHHwXJlkTq6NZvN0JI%2Bv6BQIuBHIkMgTuE0p4RxVyCHRizxlSDIzkYcCUu80M84zQ3MmdNACSvi%2FYUlhSpDcQEMEHnSmg0tYj4b8wgSGEiZiu72dpWu22rbSBNf8W6ekGHmHNH5x4KKT5itdJ7SuywEI7Su5BltaAvTte7lgybnqaJsnufFcVj%2BpmqCQazFiMHyXYVH72BLSjCubZqPjVLA6GK0gk%2BIpxdhyH1WYEV3LHEubINHtSQq0uglL9aklXxaE3T92NBUiCcrb68BtQyTg28pnxuExSslImAprHzOsnQSLiEp5jgWqoMswZdV9PUSflngYV2Jlnrt0pilURY7QBJjlR5VffnpjXAoCLaw1aS4rVsdRz08rONdp6mbTos4tNnZ23PaBbZ0Pjer43RanmPpnR2iHp6jOzZp6U3SdonX2sGYWJoKTOgnjNOJgF8sgZ9LZsRZJMMJnuHVK5dM8mqCOArYBTVPWZMUfW8Rv0Vmvub2Kk8NbeISFdwwb8v2jkWdpq3bHdLRLdts6Rh7TR23iW13Oti1TFJp18%2B18lr9ej3hVAhV2lhVXC%2Ba4bnQHp8QceHjM9Q21v2ulbvvOADrlbjhfC0GfgfOXzeg9H8Q%2FQfR%2F%2FdEhyki8JS6E6yOtszWjm5aesseNTvdlt212oZt7zR397ZMs2uayiUqZBGEh%2Fx%2FPhpL66qXJ6X8obya5ufWRuMrlfN0MNalXBUJpgDwbDY%2BHR9%2FHt6djqj3QZ8ER3iw%2B%2Bet72Ohn7RGXzLfbVnUbY%2BPfW1jrNZN9QJU6Bvdn5%2Bdn%2BA%2F%2BNnY8%2Fs6Pjh2BvbnKAgcqQ%2FaYzwNaLvjUev8JNBeupXk9xB1B3lUVzY1fNeubL3h%2FsVGX1rBjTXu1WhUlSrYEAoOGd9G8Kv95RU1V7Xyf6W9SWcN967eQp%2Bvqd%2FoKK%2BqrcO8N%2Bir5eobmKtUK3Kuin%2F14fifVv%2FfqN7aHwYvF%2BQzl4R%2Fq3Dq6Prn1fPMQPx2HL6GQQxTLaIEvuEnBX1eZhacrX69aLe9w%2BGBs3VI%2FeSuP%2BQXU%2FPw3Or3mY0HF7y37R%2FZ0t2L9wYuZb9qj38BHpU%2FrhkSAAA%3D)