### PR TITLE
Add publish.law.site template

### DIFF
--- a/publish.law.site.json
+++ b/publish.law.site.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "publish.law",
+  "providerName": "Publish.law",
+  "serviceId": "site",
+  "serviceName": "Publish.law site",
+  "version": 1,
+  "description": "Connect this domain to your Publish.law site so visitors can reach your content at your own URL with automatic HTTPS. Sets the www CNAME automatically; the apex (root) record is added separately because DNS specifications do not allow CNAME at the apex.",
+  "logoUrl": "https://publish.law/brand/mark.svg",
+  "syncPubKeyDomain": "publish.law",
+  "syncRedirectDomain": "publish.law",
+  "syncBlock": false,
+  "variableDescription": "subdomain — your Publish.law subdomain (e.g. jane-smith from jane-smith.publish.law).",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%subdomain%.publish.law",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for [Publish.law](https://publish.law), a hosted Open Legal Publishing Network (OLPN) identity + publishing platform for individual attorneys. Pro subscribers connect a custom domain to their site, which is served via Cloudflare for SaaS / Custom Hostnames. The template auto-configures the `www` CNAME:

- `www` CNAME → `%subdomain%.publish.law`

The `%subdomain%` variable is the user's chosen Publish.law subdomain (e.g. `jane-smith` from `jane-smith.publish.law`).

The apex (root) CNAME is intentionally NOT in this template — DNS specification disallows CNAME at the apex (conflicts with SOA/NS records), and Cloudflare's Domain Connect implementation explicitly rejects apex CNAMEs in templates. Apex routing for Publish.law sites is handled separately via our manual-records flow.

Signed flow: `syncBlock: false`, `syncPubKeyDomain: publish.law`, `syncRedirectDomain: publish.law`. Public key is published at `_dckey-1._domainconnect.publish.law` TXT.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (we use `redirect_uri` in the synchronous flow)
- [x] no TXT record contains SPF content (no TXT records at all in this template)
- [x] `txtConflictMatchingMode` not applicable (no TXT records)
- [x] no variable used as a bare full record value
- [x] no bare variable used as the full `host` label
- [x] no variable used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` not needed — the single CNAME is required for the service to route correctly

## Online Editor test results

**Editor test link(s):**

- Apex test (domain=example.com, host=empty, subdomain=jane-smith): [Test publish.law/site example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMnj8GkC%2F91U627aMBR%2BFctSpVaFEMK1mfajLZs6rWUVUGlVh5BjG%2FDq2JHtkKWId98xtFxW1AfYr%2Fic8%2Flcvu84S%2Bx4mkniOI6XODN6IRg33xiOcZYnUth5IEmBK9tQn6QAxfcHQcvNQlC%2BvmYF5Nq63sPRK2DBjRVa4bhewYxbakTm1ja%2B1kpx6pCbC4uYTolQyGlU6tygfxMhq9FCwEkbiyhRyHBC5xss1cpx5RBxG1sXCj0MblEh3ByR3EFmJyi6GY3uhwEacmehJEdFUaDr%2FuXdlx2GSFl%2BWgdJxv%2BgU6O1O4NSVBuGoEnCGGfI8owYYFKWKOGU5JajXn%2BIbMapmEISP54fCCkNTUmpt3XcNncAzEg90w9GAhNz5zIb12p7UtQSQxSrpcQ8B3Yx80yXigIt33nZW3P1TjoPGHAmoF%2F3AeRKavqM4ymRloM8xAiSSN47kMbmyasgv%2FIorDePiLJFnPJgFqDfRPGqTT3lU6PTPTvYa%2BHMz73h0%2BL4aYldmfm9WfMDobm2DkyQxq%2BiFsrZkQbHybbcSXA4kXNAYKMdhqvxqoJftOKTXf4xrNxxIl4LwWlmdJ5NxBveS5ta%2F0jebj4dXB2%2F3X3C%2Frztyzt2M2PfjJgpbfjEwpe43MCczuRAeZpLJyakIDsXoxOSZbKE3i1EIdl7btTmiW24YcQRMI6zvE9LBU8Y9eMI%2F2jbnSipt7rtaoc3aLXZbrNqchGFVRZ162GHti46AK589H848gvYccmthYcoiN%2FpS1mQ0uLValwBXv%2BjcbzqZMHZhHhYFEbtatisRt1RvR03G3GrEXQ6jW6rcR6GcRj65rl1mwGXsBX7%2B4Bvyk6PJ8NHd04y8%2FVHq5CDMrp97JdX9fpgdDf4%2BXI%2BfbkIb2dZ9zNe%2FQXSdmkIxQUAAA%3D%3D)

- Subdomain test (domain=example.com, host=blog, subdomain=jane-smith): [Test publish.law/site example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP3k8GkC%2F91UbW%2FaMBD%2BK5alSq0KIZQU2kz70Jdpq9qxqgVpVYeQYx%2FgNbEj2yFNEf99ZyhvK9oP2BfIvd%2Fz3J1n1EGWp8wBjWc0N3oqBZgbQWOaF0kq7SRIWUlra1OXZehK73eMFsxUcliEWYm51qqP7uTdYQrGSq1o3KxRAZYbmbuFTK%2B0UsAdcRNpidAZk4o4TSpdGPJ3ImI1mUr80sYSzhQxwPhk6cu1cqAcYW4p61KR%2FsMdKaWbEFY4zOwkJ996vfvHgDyCs1gSSFmW5Kp78f3LxoelafVpYWQ5vJJDo7U7wlJcG0GwSSYECGIhZwaZTCuSAGeFBXLdfSQ2By5HmMTD84CI0thUmup1HbfOHSAzqR7rvkmRiYlzuY0bja1RNBLDlGhkzLwEdjr2TFeKIy23UF0vuPowOu%2FwAEJiv%2B4fLpep5i80HrHUAo6HGcmSFK53RmOL5H0gv4qTsBntGcra4xCCcUB%2BMwV1m3nKR0ZnW3Kw1cKRx73k09L4eUZdlfu9WfCDpom2DkUcjV9FLZWzPY2Kg3W5g2AXkXNIYKsdhvPBvEbftILhJv8AV25FBLwyPAAIuM42hRKcAUpjo4t8KFcxfryZ9Yeyin7eCR%2Bs4p%2BXCVBe9%2BeVG%2BzUNyXHShsYWvxnrjCI15kCqc%2BK1MkhK9lGJfiQ5XlaIQaLVkz2kSO1PDXkKHhvXzDHULOf8m2OanQouMcl%2FQWHSacdRlGnHgHgj%2F9KwvOo3jodnY3avNNqw%2FnWi7DnsdjzHuwSC9biZUrml%2FwiLVll6Xw%2BqCHJ%2FyMuvwdsCmLIvOtJeNKuh1H95KzXbMfReRw2g7AVnXZax2EYh6EHANYtQc5wT7Y3hN7cPF3%2BYELfmrtjNsnKt6zVeIq6Udnuy%2BnPftG8GquvSrZFL%2FpM538Ajp8mjN8FAAA%3D)

The template passes "Check template" and "Test apply template" in both configurations. With apex (no host), the `www` record installs at `www.example.com` — the intended behavior. With a host parameter, the result is `www.<host>.<domain>` which is spec-correct but only meaningful for apex users in practice; subdomain users don't typically need DC since a plain CNAME at any subdomain is valid DNS.

# Additional context

- Provider site: https://publish.law
- Logo (SVG): https://publish.law/brand/mark.svg
- Status of `_dckey-1._domainconnect.publish.law`: published, returns the SPKI public key