### PR TITLE
Add MaxOut AI custom domain template

### DIFF
--- a/maxout.ai.custom-domain.json
+++ b/maxout.ai.custom-domain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "maxout.ai",
+  "providerName": "MaxOut AI",
+  "serviceId": "custom-domain",
+  "serviceName": "White-label custom domain",
+  "version": 1,
+  "description": "Connects a reseller subdomain to MaxOut AI white-label hosting.",
+  "variableDescription": "siteId is the Firebase Hosting site ID returned by MaxOut AI. The standard Domain Connect host parameter is the customer subdomain label.",
+  "syncPubKeyDomain": "dcsig.maxout.ai",
+  "syncRedirectDomain": "staging.maxout.ai,preprod.maxout.ai,maxout.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%siteId%.web.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for MaxOut AI white-label custom domains. The template creates a customer subdomain CNAME pointing at the MaxOut Firebase Hosting site ID supplied by MaxOut AI.

The template uses signed synchronous apply URLs with `syncPubKeyDomain=dcsig.maxout.ai`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

No `logoUrl` is provided in this template, so the logo URL check is not applicable.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

There are no TXT, DMARC, SPF, or user-editable records in this template.

## Online Editor test results

**Editor test link(s):**
[Test maxout.ai/custom-domain xoqbtenqdvjb.xyz/dc-test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAObz8GkC%2F91Tf2vbMBD9KkLQv2a7tpslqWGwrOlYGO1K6VZGKeFsXRMNR3IlOT8a8t13ihMnpds%2BwP6TdO%2FevXd3WnOHs6oEhzxb88rouRRoRoJnfAZLXbsIJA%2FawDXMCMivYPmtdmwwopBFM5cFblOK2jo9C4WegVSH2C7rfiodhiXkWLIGyVrkHI2VWvEsCbhAWxhZue2dX2ilsHCWATNosSzRMFvnTSZzmrVi2OKowFRbJ9Uk8txgJOQlDl%2FxWsKOBJOWuSmyz9JgDhbZlyaP%2BTAbDammq41CwfLVoVLE7ijHOlACjGDDRstO6bY0q8CQa0didxUax6%2FEb5V6hXalips6%2F4qrhorkicLKSXQ8Aw%2B6RUFCC9fCSMPE22yBQWWQpiWOXo5JvLZbfK6JhQbmTI0BJ0JthOXZw5q7VeVHdXE9uLrcwen60a%2BAlsrZO03Xk6Z3J9EC8wiqiqLOlTw768bx5nET8BetcHygfaSZ7gUv9XPuUD2L%2Ba88Wq5eDkVEETqkU8AnRtfVWO5zt620fj%2F3LA9vaR73PA8tET01Qv1j04QQZPjUxyfgXqacKG1wTI1WQFPGfUNmdenkGBZweBLFmIyWK3JlKUqMb5ulmjU%2F%2BBDgoP1Ibek%2FdS3gY1F4h3L7jbpwDnk%2FD3u5EGGnKM5D6GAcJnmBKYgkSQkc%2FP23%2FutLvmk2WovKSSAlfFAuYGX5ZvMYUOP%2Fb4d%2BO2COYgwencZpN4w7Ydq%2FS3rZ%2BzQ760fdXtxNeu%2FiOItjb4XYGr9r2p3jreGd06%2Fmvpx%2Bmp6%2BDNRFsnDfp1f4s5%2F2Z%2FLc4M2PqlpMVZ0OL5PJB775DZfGvqd0BQAA)
