### PR TITLE
Add Xellux domain verification template

### DIFF
--- a/xellux.com.domain-verification.json
+++ b/xellux.com.domain-verification.json
@@ -1,0 +1,25 @@
+{
+    "providerId": "xellux.com",
+    "providerName": "Xellux",
+    "serviceId": "domain-verification",
+    "serviceName": "Domain Verification",
+    "version": 1,
+    "logoUrl": "https://cdn-edge.xellux.com/i/73f312de-3ea8-4063-8b6d-85af107d5b99-rem-0f395230",
+    "description": "Enables a domain to work with Xellux",
+    "variableDescription": "Unique verification code provided for purpose of verification",
+    "syncBlock": false,
+    "syncPubKeyDomain": "domainconnect.xellux.com",
+    "syncRedirectDomain": "xellux.com",
+    "hostRequired": false,
+    "records": [
+        {
+            "groupId": "verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "xellux-verification=%verifytxt%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "xellux-verification="
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a TXT record template for domain ownership verification.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test xellux.com/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJAU8WkC%2F91UXW%2FaMBT9K5GlPo2Ak0AIkSbto5PWTqwtaqduFYqMfQNWkzi1HT6K%2BO%2BzAw2kq9T3PRH7nnuvzzn3skUa8jIjGlC8RaUUS85AXjAUozVkWbXuUpGjThP5SXKDRPd1zNwrkEtOoU5gIie8cJcgecop0VwUR8Qh8bzGOL%2FaGJOi7FfsdVAm5uJOZga70LpUca9HWeECm0P3%2BKIe7w2DNPB8Bm4AJHL7OAzcaBYyNxqQ1MNDNpiNRq6E3MVpMBr4ATZ9GCgqeVl3jdG3gswyUA5x9i93tHBWQj46K64XTkNxSSS3wPNW8l3BnypwTsk6VDBwDkoxJxXSKStZCgWOSJ3XsmwK%2BiUT9BHFKckU7G%2Buq9kP2OxFahSloiiA6m7LEIueAOPSRBp8C7EQSk%2FgqTIQ1jQxcCGZQvHDFs2lqMrauVdv05vSenV7f3soYw6frHxEk6ZLy%2BePZ%2FVpo9f6zBbQxr8gxNh8rvVXUaQZp3pMNF3wYj42Mpky1xJSbgV%2BA3KIvd0L7aa7DnoWBSRHOtPOQS2TBGtiZhpOdDgQqBknvE5okzbpJZEkV3YNXgo9tCpNX0o9mFrTQ7G3CjVS2KCdCWTfy%2BeFkJAo80t0JY0CWlbGkbzKNE%2FIihyvGE1IWWYbQ0%2BZqClj3GqZUuy36R1T6t4tNxJGLUFuTfe9UTD0RpEbBrO%2B2%2Fe80J1hNnDxYAgpZUM6pIOTzf%2F3P%2BH93T%2BRHpSCQnNiF%2FtztiIbhXa7acf49r9yM5OgyBJYQizOx37o4r7rR7c%2Bjj0%2Fxrgb9UM%2FDD9gbA6WCyi9Z7w183I6KYhdTRaT8U1QjVnvuncVzRf68o%2B%2FDL77N%2BHlb56LaKMeV%2By5xy%2FMevwF5oxPJNUFAAA%3D)

[Test xellux.com/domain-verification example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALgU8WkC%2F91UXW%2FaMBT9K5GlPo2ASQiESJPWrtPUVV0Zoh9ahZCxb8BrsFPb4VP899mBAumq7X0PiNj33HN9z%2FH1BhmY5RkxgJINypWccwbqiqEELSHLimWdyhmqHSLfycwi0WMZs%2Fsa1JxTKBOYnBEu%2FDkonnJKDJfiiNgnXpYY776KsSnafSXNGsrkRN6pzGKnxuQ6aTQoEz6wCdSPJ2rwRidMw2bAwA%2BBxH4Lt0M%2FHreZH0ckbeIOi8bdrq9g5uM07EZBiG0dBpoqnpdVE%2FRFkHEG2iPe7uSekd5Cqmdvwc3UO7Q4J4o74GUl%2BU7wlwK802Y9Khl4e6WYl0rl5YXKpQZPpt5bWVaCXmSSPqMkJZmG3U6vGF%2FDaifSQVEqhQBq6hVDHLoPjCsbOeAriKnUpg8vhYWwQxELl4pplDxt0ETJIi%2Bde3M2s8qdV4PHwZ7GLj45%2BYghhyoVnz%2BelauVWZozR2Csf2EbY%2Fu5NJ%2BlSDNOzQ0xdMrF5MbKZGl6ClLuBH4Hso%2B9Xwtth9saWksBo2M7w9peLZsES2LvNJzoYDd1MbaLsucRL1OqbVuCnCgy024QXqmeKlzDV7Knkm24p3uP6iCHC7p7gdyZ%2BURIBSNt%2F4kplFXBqMK6Misyw0dkQY5bjI5Inmcr26K2UUtjHasYI3YTtevrL9aU1SuejBh1TXJnfdSOICYU%2BzRKqd%2BKYuyPm1HHjxlpdVrtZkjb8cn8%2F%2Fky%2FPsFqBgAWoMwnLgBP88WZKXRdjusWf%2F%2B5%2F7sjdBkDmxEHDLAQdvHLT%2BIBwFOmkHSwvUWbkbd4APGCXYvlQFtdj1v7L05vTFocXu77vH%2B%2BaXprK%2FNepLK7OHHz%2FHV48PX5cX94JsWv1b21%2Bve3dhR%2BQ2d%2BGCx4QUAAA%3D%3D)