### PR TITLE
Add new Feature to Xellux Domain Template

### DIFF
--- a/xellux.com.domain-verification.json
+++ b/xellux.com.domain-verification.json
@@ -1,0 +1,25 @@
+{
+    "providerId": "xellux.com",
+    "providerName": "Xellux",
+    "serviceId": "domain-verification",
+    "serviceName": "Domain Verification",
+    "version": 1,
+    "logoUrl": "https://cdn-edge.xellux.com/i/73f312de-3ea8-4063-8b6d-85af107d5b99-rem-0f395230",
+    "description": "Enables a domain to work with Xellux",
+    "variableDescription": "Unique verification code provided for purpose of verification",
+    "syncBlock": false,
+    "syncPubKeyDomain": "domainconnect.xellux.com",
+    "syncRedirectDomain": "xellux.com",
+    "hostRequired": false,
+    "records": [
+        {
+            "groupId": "verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "xellux-verification=%verifytxt%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "xellux-verification="
+        }
+    ]
+}

--- a/xellux.com.domain-verification.json
+++ b/xellux.com.domain-verification.json
@@ -1,25 +1,32 @@
-{
-    "providerId": "xellux.com",
-    "providerName": "Xellux",
-    "serviceId": "domain-verification",
-    "serviceName": "Domain Verification",
-    "version": 1,
-    "logoUrl": "https://cdn-edge.xellux.com/i/73f312de-3ea8-4063-8b6d-85af107d5b99-rem-0f395230",
-    "description": "Enables a domain to work with Xellux",
-    "variableDescription": "Unique verification code provided for purpose of verification",
-    "syncBlock": false,
-    "syncPubKeyDomain": "domainconnect.xellux.com",
-    "syncRedirectDomain": "xellux.com",
-    "hostRequired": false,
-    "records": [
-        {
-            "groupId": "verification",
-            "type": "TXT",
-            "host": "@",
-            "data": "xellux-verification=%verifytxt%",
-            "ttl": 3600,
-            "txtConflictMatchingMode": "Prefix",
-            "txtConflictMatchingPrefix": "xellux-verification="
-        }
-    ]
-}
+  {
+      "providerId": "xellux.com",
+      "providerName": "Xellux",
+      "serviceId": "domain-verification",
+      "serviceName": "Domain Verification",
+      "version": 2,
+      "logoUrl": "https://cdn-edge.xellux.com/i/73f312de-3ea8-4063-8b6d-85af107d5b99-rem-0f395230",
+      "description": "Verifies domain ownership and points a chosen subdomain at Xellux ID so the customer's branded login lives on their own domain.",
+      "variableDescription": "Subdomain to host Xellux ID under (e.g. 'auth') plus a one-time verification code supplied by Xellux.",
+      "syncBlock": false,
+      "syncPubKeyDomain": "domainconnect.xellux.com",
+      "syncRedirectDomain": "xellux.com",
+      "hostRequired": false,
+      "records": [
+          {
+              "groupId": "verification",
+              "type": "TXT",
+              "host": "@",
+              "data": "xellux-verification=%verifytxt%",
+              "ttl": 3600,
+              "txtConflictMatchingMode": "Prefix",
+              "txtConflictMatchingPrefix": "xellux-verification="
+          },
+          {
+              "groupId": "routing",
+              "type": "CNAME",
+              "host": "%authhost%",
+              "pointsTo": "auth.xellux.com",
+              "ttl": 3600
+          }
+      ]
+  }


### PR DESCRIPTION
# Description

Adds a TXT record template for domain ownership verification.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test xellux.com/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOMH8mkC%2F91UYW%2FbNhD9KwSBIBtm2ZJlK5aAAeuaoE27pEGWDt0Cw6DIk81NIlWScuwF%2Fu87yoptbQH6fZ9EHd%2Fdvbt7vGfqoKpL5oBmz7Q2ei0FmGtBM7qBsmw2Q64rOjjc3LIKkfRLe4d2C2YtObQOQldMqmANRhaSMye1OiI6x8sWQ37rY9DF%2BlM2HtBSL%2FVnUyJ25Vxts9GICxWAWMLwyGgkRxdxEUdjAUEMbBZMwiQOZnkigtmUFVF4IaZ5mgYGqiAs4nQ6jkPMI8ByI%2Bs2a0b3JMCSPXGinxTyWMmaMCVIraVyljDCV9qCIrbJOxxzZF8%2Fub4kVhO3AsIb63QF5tyS3KA7CIKFILiUa8yglUdJ43N06Ya%2BbmYky0u47PH69ZDJaYLJT9M1GNqQ72C4HJJz1rjV%2BfekLhvPUysInKyAnA6AcC0Audd1KZFTvu1i%2Bex2q%2FjPpeZ%2F0axgpYW95a7JP8J2P6fDULlWCrgb9jTh0fcgpMGbA76H8OTv4WuDEHFIgnBthKXZ4zNdGt3UrXj%2BpRq3rb1cHr48dGHw5yc%2FQebYIUtPaj%2BetX9bt3FnPoBDCcVJGOJx495qVZSSuxvm%2BEqq5Q12BcPcGSikl%2FErkO7u9Vx0NzgljweHLkfeb2%2Ff3FwdmZ%2F5SfmzZ7YX1oNGuzf3e3qgvZvvBvRvnOni2K%2F5oBsHusKG4buFk0Z3HWpZLWTr0O8qutfMsMr6p%2F4S6LEXaf4S6hFjzbtgrwU69Npfeo1540uV3kY9f7lU2sDC4pe5xmBnnGlQAlVTOrlgT%2BxoEnzBUKRbLNfiLYZAefRUoPYb5BsqaLn0xr8Q3Bcs%2FaBYLJIwKiCYRkURTKZ5EuRhwoMIZpCnSZikbHKy7f67B7%2B9705GARYXh5PML7M35RPbWrrbzQc4x%2F9rbSgCy9YgFszjxuE4CcJJME4fojiLwyyKhuPoIpklP4RhFvqN7MC6fcXPqJdTpdD06%2FWVGU1uP6UX7P5Jf%2FzweVOu%2BTu4u7p%2Bt9Effvk0ep%2F%2B8Weh3qvf8T3%2BA00itj7JBgAA)

[Test xellux.com/domain-verification example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPgH8mkC%2F91UYW%2FbNhD9KwSBIB1q2bJoO7aAAm2TAgvWtEHrFu0Cw6DJk81NIlWScuwE%2Fu87So5tdcH2vZ9EHd%2Fdvbt7vEfqoShz7oGmj7S0Zq0k2GtJU7qBPK82XWEK2jncfOAFIum3%2Bg7tDuxaCagdpCm40tEarMqU4F4ZfUTsHa9qDPnaxqCLC6c06dDcLM0XmyN25X3p0l5PSB2BXEL3yKinehcsY%2F1EQsSAj6NBPGLReDGS0XjIs358IYeLySSyUERxxibDhMWYR4ITVpV11pQ2JMCRhjgx9xp5rFRJuJakNEp7RzgRK%2BNAE1ct9jjuSVM%2Fub4izhC%2FAiIq500B9tyRhUV3kAQLQXCu1pjB6IBSNuTYp%2BuGurlVfJHDVYvX50MmbwgmP01XYWhLXkB32SXnvPKr899ImVeBp9EQeVUAOR0AEUYCci%2FLXCGnxXYfK2R3Wy3e5kb8TdOM5w4ay221%2BAO2zZwOQxVGaxC%2B29JEQH8CqSzeHPAtRCD%2FCX5UCJGHJAg3Vjqa3j3SpTVVWYvnJ9X4bRnkMv023YfBn9dhgtzzQ5aW1F6d1X9bv%2FFnIYBHCbFRHONx4y%2BNznIl%2FA33YqX08ga7gmFuLWQqyPgZyP7u%2BVx01zkljwePLkfelx%2Fe3Lw7Mj8LkwrnwKwR1tSgPZjbPT3Q3s12HfqAM50f%2BzXr7MeBrrDh%2BG7hpNFoRI3iT81rrmqXdl8xQMktL1x47E%2Bh7lqxZk%2FB7upos32450Id%2Bh0ug86C8anSYKOhBrXUxsLc4Zf7ymJ3vK1QBkWVezXn9%2FxokmLOUahbLNnhLYZAibSUoJst0tT5H1qo2bREMJciFK3CuMYM5AhGImJZn0WDjPFoMhlcRJNxzNlgMGJDlp3svH9vw%2F%2Ffeq2BgMMF4hUPS%2B1Nfs%2B3ju52sw7O81euD8Xg%2BBrknAdkEiejKB5EyWTaZymLU5Z0k0k8HiYv4ziNw3b24HxT8yPq5lQxVG9%2Bf%2Fvxxj98%2F5h%2F7728vp16%2B%2F5Bm6%2Brv1wfLtd%2FJu99v5d8uV9X7%2FBt%2FgMIAR8g1QYAAA%3D%3D)