### PR TITLE
Update Resend's click and open tracking subdomain template

### DIFF
--- a/resend.com.click-tracking.json
+++ b/resend.com.click-tracking.json
@@ -3,7 +3,7 @@
 	"providerName": "Resend",
 	"serviceId": "click-tracking",
 	"serviceName": "Click Tracking",
-	"version": 2,
+	"version": 3,
 	"syncPubKeyDomain": "resend.com",
 	"syncRedirectDomain": "resend.com",
 	"description": "Configure a custom domain for click and open tracking.",
@@ -19,7 +19,7 @@
 		{
 			"groupId": "caa",
 			"type": "CAA",
-			"host": "@",
+			"host": "%caaSubdomain%",
 			"data": "0 issue \"amazon.com\"",
 			"ttl": 3600
 		}


### PR DESCRIPTION
# Description

Modify Resend, Click Tracking template to place the CAA record at the correct DNS level.

Per RFC 8659, CAA lookup walks up from the FQDN and halts at the first ancestor that has any CAA records. If an intermediate zone between the click-tracking subdomain and the root already has CAA records, a new CAA at the apex is invisible to certificate issuance for the click-tracking hostname. The host is now driven by the `%caaSubdomain%` variable so the caller can place the record at the discovered intermediate level (or at the apex when no intermediate CAAs exist). Template `version` bumped from 2 to 3.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Justification: bare variable in `host`

The CAA record uses `%caaSubdomain%` as a bare host label (and the existing CNAME similarly uses `%clickTrackingSubdomain%`). A fixed prefix is not possible here because the correct placement of the CAA depends on where existing CAA records are found in the DNS tree:

- If the apex has no CAA records and no intermediate ancestor of the click-tracking hostname has CAA records, the new CAA must be applied at the apex (`@`).
- If any intermediate ancestor already has CAA records, the new CAA must be applied at that exact label, otherwise the upward CAA walk halts before reaching the apex and the record has no effect on issuance.

Because the level is determined at apply-time by inspecting the existing zone, the host value cannot be expressed with a fixed prefix and must be supplied as a bare variable.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test resend.com/click-tracking example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALUg8mkC%2F%2B1Wa2%2FTMBT9K5GlfaJp0%2BfWSEiUAgI6BmwFJLaqurXd1jSxI9vpVqr%2Bd67TZ9bHtG8g8amJ773Hx%2BeeXHdOLI%2BTCCwn4ZwkWk0F4%2FoDIyHR3HDJilTFpLCJXEGMmeQ6i%2BG64XoqKM8KaCToxLca6ETI0Ta4qmm7sNfdhqdcG6EkCauYOpP0Szro8NkbFYOQj%2Fd38WvOhObUHs5g3FAtEpshkraSQzFKNffAo6mxKvZYVuYNlfYyph5I5qmES29NuYgwkRqpbzpCiLG1iQlLJcpkcbtTaaCxrrRc8O%2BVZjHoiT%2BIEKJopu5cyBGXDQlv52SkVZocVsfOkkyWq9ant%2Fg6Vsbi61mWt1bpJh0saZ%2B5Highremqvay2RIW7oEfcnq2o%2BkyalTDW4mmqjSBYFHJ8AHZItFq7FAByGzOwgOuBJ4xJuXdHIIbfSjr8O5LbobcoEIzw%2FlaDHtavG8YfAM3GV8RW2%2BFTxqovsvx9oRxTRElAQ2ycTdd4tznA3hrxlrjnDPMU3mGhXUUk5MTspeyovEkqP5a7l8Hn0IgTRYyk0rxv8Bcs2pKEVqe8QOI0sqIP97BdYrQPSRLNUEODUYRAHz0yi1x%2BUkuimwYdpHTCEAXSZ9QJKpwhmhVaHZwHQ5%2FRRsOv1SvUvxiWa37Q5JzVKrQBtdrOJNifESdnwbbZ3GCNFeC%2BsVZ0DzNDFs6aOSuuDvjqOe77i47TK6Dv%2F7ftn2sbfr4Gppz1waVVgkrDD2p%2Bpdkt18NyIwzqxWa5Xq42XwRBGATuFNzY5Unn2XM2n1oJfyh4Unn5UTAnU9ACBhHPso7Nn409jk%2BfI8Pn6KR9YhYu3J3lZs3yzjph2uIObjHfxOeY%2BZhvnkQ%2F4ia8dxau8xH%2BO8DmuUa4th5sAybujmHSfDftDNNfnWgc33ymZpJ0GnF9Ujn%2F%2BfHH5fvS13H7smu%2B31y%2Fvvxw8ZIs%2FgA25uo0MAkAAA%3D%3D)

[Test resend.com/click-tracking example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPcg8mkC%2F%2B1WbWvbMBD%2BK0bQT40dO8nSxrAPWbexdfSFLqNlbQhnW0lFbcmTZKduyH%2FfyXl181LKYKywT5F1d49Ozz13yoRomqQxaEr8CUmlyFlE5deI%2BERSRXnkhCIhtaXlHBL0JFelDfcVlTkLaRkQxix8sLWE8IHx0co4jzkxZqu3MudUKiY48ZvoWvDwMgu%2B0eKjSIDx5%2Bcb%2BxWNmKSh3u4RURVKluoSkZwIPmSjTFILrDBTWiRWVIZZQyGtMlMLeGSJlHJrkbKDMLEYiR8yRoh7rVPl1%2BthxJ3VSfVAYlx9tmGPhYwSkA92ECOEo3JzL8wRtxXxbydkJEWWbmdHF2lJy3n37BN%2B3gul8fOg9Fuw9D0LZmkfmBoIxrXqiQ2vE44M90COqD6Yp2pHXM2J0Rpv02y77rRWyQdgLYludz0FgMrBEWjAfddiSmXUuiOQwJPgBv%2BOVE7oT2sELXSw4qCP8YuC0UdAsdF5YvPjcFVmNWCl%2FyZRJlNESUFCooxMF3i3FcD%2BAvGWmHWJuQ9vO9EmImb8QW24rLG8dPKe090v4StoVOXE8MJGXEg6UPgLGpVJfC0zWiNJFms2gDGstqJwAGkaF0ijQiuioJSe6YXPumqW67JGW7Pao4kaGUSh4ZQZTbSg41G32bKHQdCwW8HxkR0Ex55Nh206jKANba%2B5Ngw2x8TecbCqN1UYoxmYNuvGYygUmRp1VtQ4v6Ch7xUS%2FIcu1K%2Bh%2BP8X7g0WDrtYQU6jARi3htto227LbnR63jvfO%2FI9zznudNrN1qHr%2Bq5rbkGVnt10Uq7LMdVN6WPN4sKqToQJyUEyCGJaeu0aQ0uB7B5CO2bQzoH7wkicmqfLzJvZ07VHts4arlMt4mvkvFM5L6HvUFP5%2FMxYHzN9%2F%2Fd5rx646IA3XgyVO39QkKlpxRj%2FtWE3mc4wfbajQui6%2FjqSYVGPR%2FpGnXbC4ubsml13h%2FB0evn54ia7PtRffqat8a8PFwXLx%2BF7Mv0NrWsuUcoKAAA%3D)

[Test resend.com/click-tracking example.com/esv](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABYh8mkC%2F%2B1WUW%2FaMBD%2BK5GlPo1ACBRKpD1QurXVtm7q2KStRcjYhlokdmQ7oQzx33dOQiGl0FWdplbaE8R39%2Fnuu%2FNnL5BhURxiw1CwQLGSKadMnVMUIMU0E7RKZIQqd5YLHIEnusxssK6ZSjlhWQAJOZm6RmEy5WKyNhYxPWt2%2BmtzypTmUqCgAa5zQb4kow9sfiIjzMX9%2Fa39klGuGDEPe1CmieKxyRBRT4oxnySKOdghiTYycmgW5oylcrJMHSyoI2MmnFXKVYAJ5UR%2BUyFA3BgT66BWI1RU1zvVRgriavmCO5OKRlhN3VEIEFWd2rogR1jWKLhaoImSSfwwO2YeZ7RcdD%2B9g88bqQ18HmR%2BK5a%2BJqM87QPbA8mF0X255dUTwHAfqwkzB0WqLhW6IMYYqKbR8rxlpZQPxhtJdLubKWBc2phig2Hdc7jWCXOuEY7wLyks%2FjUq7TBYVhBY2HDNwQDiVw1jtxiGjRWJFdsxncJHltiQZyHbXNlkASjGCkfaTuoK8qqEOViBXmWogwJ2H%2BTDdNuIkIup3nLZ4PrOqX6f9EEGX0IjMbLk8ImQig01%2FGID44kCoxJWQVESGj7EM7xeomSI4zicA5carAAC83RvaER%2BtLIsqjmRRbMeTGzPcFTQkBLLLLfD0R6xRtsnR%2B4RbWO32SBtt%2BPRhus3O%2B3xYWM0ZqyzoQrberFXF0qNZxrCDMf2yHXDGZ5rtLSTWprMok4Sl4t8fCJfVlmDChyH%2F1187V2E461xyugQW0%2Ff81uu13T9Tr9%2BGNTbQdOv%2Bq261zh643mB59lCmDZ5sYvsfyZh3ZjdVhwhnbJULFCKFcejkGVeu%2FSpkKd96rRDnHbq8SNaubQ3m1Wi%2FGbbO8Nr3Gq5j0%2BZ613z8yj6joHKbqec9Rk3N%2F%2Be9%2FKGxYi99mbotPqshtjz9kIaAnf0Ex4rf6c5f0LfsxqUq%2B1zerS0ihnCwxsUz6qXfRvvaBq4br5tEP98cvp9%2BpOfdXqHUdL92MLHp3TSf38c%2FaCtxJ9ddGjt%2FKw1OxvP3qLlb6RJ5sqNDAAA)