### PR TITLE
Add Traaaction service provider — affiliate tracking CNAME template

### DIFF
--- a/traaaction.com.cname.json
+++ b/traaaction.com.cname.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "traaaction.com",
+  "providerName": "Traaaction",
+  "serviceId": "cname",
+  "serviceName": "Affiliate tracking",
+  "description": "Add a tracking subdomain that points to your Traaaction affiliate portal. This enables first-party click tracking and a custom-branded short-link domain.",
+  "version": 1,
+  "syncPubKeyDomain": "traaaction.com",
+  "hostRequired": true,
+  "syncRedirectDomain": "traaaction.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%track%",
+      "pointsTo": "cname.traaaction.com",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a sync template for **Traaaction** (https://traaaction.com), a SaaS that lets startups run their own affiliate-tracking program with a custom-branded subdomain on their customers' / partners' own domains.

The template provisions a single CNAME (`%track%` → `cname.traaaction.com`) on the customer's zone so affiliate links resolve under the customer's own domain — enabling first-party click tracking and ad-blocker-resistant short links.

- Live template: https://traaaction.com/.well-known/_domainconnect/cname
- Public key in DNS: `dig txt dc.traaaction.com` (RSA-2048, validated end-to-end)
- Service URL: https://traaaction.com
- Contact: contact@traaaction.com

This PR is part of the Cloudflare Domain Connect onboarding (step 1 per https://developers.cloudflare.com/dns/reference/domain-connect/).

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`traaaction.com.cname.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver — no `logoUrl` set in this template; will be added once we provide a hosted SVG to Cloudflare separately.

The signature flow has additionally been tested end-to-end against our private/public key pair (`dig txt dc.traaaction.com` reconstructs to a valid RSA-2048 public key with `e=65537`). HTTP-served template returns the JSON from this PR byte-identically.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`traaaction.com`) — TXT records published at `dc.traaaction.com`.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`.
- [x] `syncRedirectDomain` is set (`traaaction.com`) — sync flow uses `redirect_uri` for the post-apply callback.
- [x] no TXT record contains SPF content — only one CNAME record in this template.
- [x] `txtConflictMatchingMode` — N/A, no TXT records.
- [x] no variable used as a bare full record value — N/A, no TXT records.
- [x] no bare variable used as the full `host` label — `%track%` IS the only host component, intentionally. **Justification:** the entire purpose of this template is to provision a customer-chosen tracking subdomain (`<chosen>.<root>` → `cname.traaaction.com`); the customer must pick the prefix label themselves, so the host **must** be a single user-supplied variable. The associated linter info DCTL1037 (advising apex/empty host with `hostRequired=true`) does not apply here — our template is not a delegation template, it's a single-prefix CNAME provisioning template, and `hostRequired=true` is set precisely to force the customer to supply the prefix rather than defaulting to apex (which would clobber their MX/email).
- [x] no variable used in the `host` field to create a subdomain — `%track%` is the entire host, not a substring forming a subdomain prefix; the customer picks the literal prefix label.
- [x] `%host%` does not appear explicitly in any `host` attribute.
- [x] `essential` is not set — N/A, no records the user would safely modify or remove independently of the service.

## Online Editor test results

**Editor test link(s):**

[Test traaaction.com/cname example.com/track](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI2M92kC%2F91TXW%2FaMBT9K5alPo2w8JU2kfZAN6at1ehK2UeFUHRjG7BI7NR26DLEf98NEGAr0973lPiee8899%2Fh6TZ3I8hScoNGa5kavJBfmI6cRdQYAmJNaNZnOaOOADiHDbDo%2B4IhZYVaSiW0hU1XCIbZP789mMpXYiCAxW0o1xxQuLDMy35JgCucEDjCxRcJ1BlIRtwBHci2Vs8RpUurCkGN7AgfqXBsHaZOMF9ISoSBJhSUzaazzcjCuJCyVbHlsAarqyArrdOYlBo%2BCE7tAFi%2BVakl2%2FZuodCWM3aps4WClYp%2BL5FaU77b4ObMW2rqReCqkEeiJM4XY1Y0ExxBzf69EVBtuaTRZU1fmlXdvh%2F1Pgz0pHi%2B2%2Bi%2BqK9l6Mta1680XbM6lNOr4%2Fma6adCfWon4yD%2FFC6hliB%2BAeyBO1O%2B0sSUe50YXeSzrIrQSMlstTF0%2B%2Ba1%2BWhNM9gwY2P1ghFZC5FxpI2KLX3CFEbVDWZE6GcMzHEOcxZDnaYm6LaJI8dIXtVuxWi4HB%2F92pEFjzqohZLW0fi8MEhYEXpv3Ol43uGp7ECSBF7DQ73LohVft3skbOP9Czr2CP6wU1grlJKTVvqfPUFq62UwbaOt%2FOBbeu4WV4DFUuW2%2FHXh%2Bz%2FM749Zl1LuMOp1m2OoGYfeV70e%2BXw0hrNuNucYtOd0POsy%2Fd68%2FfBnIue6GN%2F3BcnX9%2FrH1cMvuXo%2B%2BBU939%2Bm97n99vMke%2Bm%2Fo5heADbCO2AQAAA%3D%3D)

> Per the editor template comment, the apex test is **not required** when `hostRequired=true` (which is the case here). Only the subdomain test (`host=track`) is shown above.