### PR TITLE
publish.law/site: bump to v2 (A records to AGA anycast, drop CNAME apex limitation)

### DIFF
--- a/publish.law.site.json
+++ b/publish.law.site.json
@@ -3,18 +3,23 @@
   "providerName": "Publish.law",
   "serviceId": "site",
   "serviceName": "Publish.law site",
-  "version": 1,
-  "description": "Connect this domain to your Publish.law site so visitors can reach your content at your own URL with automatic HTTPS. Sets the www CNAME automatically; the apex (root) record is added separately because DNS specifications do not allow CNAME at the apex.",
+  "version": 2,
+  "description": "Connect this domain to your Publish.law site. Visitors reach your content at your own URL with automatic HTTPS. Sets two A records (apex and www) pointing at our anycast edge.",
   "logoUrl": "https://publish.law/brand/mark.svg",
   "syncPubKeyDomain": "publish.law",
   "syncRedirectDomain": "publish.law",
   "syncBlock": false,
-  "variableDescription": "subdomain — your Publish.law subdomain (e.g. jane-smith from jane-smith.publish.law).",
   "records": [
     {
-      "type": "CNAME",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "13.248.190.8",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
       "host": "www",
-      "pointsTo": "%subdomain%.publish.law",
+      "pointsTo": "13.248.190.8",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
# Description

Updates the existing `publish.law.site.json` template (originally added in #1051) from CNAME-based to A-record-based records. Bumps `version` from 1 to 2 to signal the change.

**Background:** Publish.law previously used Cloudflare for SaaS / Custom Hostnames to handle apex domains for tenant sites, which required a CNAME at the customer's apex pointing at `%subdomain%.publish.law`. We've since migrated to a new architecture (AWS Global Accelerator anycast IPs fronting a Caddy reverse-proxy fleet that terminates SSL via Let's Encrypt). Customers now point an A record at our anycast IP `13.248.190.8`, and the same record format works at apex without registry-specific quirks.

**The records this template now writes:**

```
A   @     13.248.190.8
A   www   13.248.190.8
```

The `%subdomain%` variable from v1 is removed since the records are static (everyone points at the same anycast IP).

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in this template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (no TXT records — N/A)
- [x] no variable is used as a bare full record value (no variables at all in v2)
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` not needed — the records are required for the service to route correctly; CNAME-at-apex limitation no longer applies (we write A records at apex)

## Online Editor test results

**Editor test link(s):**

- [Test publish.law/site example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFeX82kC%2F%2B1TTW%2FbMAz9K4JOG5o4jp06joEBS7fD1g1D16a9FIHBSooj1JZcSY7rBfnvo5qm6ReK3bbDTpbEx%2BfHR3JNnajqEpyg2ZrWRq8kF%2BYrpxmtm6tS2mVQQkt7D6EfUCGUnjwJWmFWkom7NCuR6%2BHpJZzcA1bCWKkVzaIe5cIyI2t3d6eftFKCOeKW0hKuK5CKOE063RjynCggFxK%2F2lhiBLDlFsW0ckI5Am57160i56ffSSvdkkDjkNNJRr7MZidnATkTzhLXajJFDqYNt%2BQd1OKWgOKkbdv3pNZSOakKT%2Bj5QHUMrCOCFyLAWkpd6HNTovalc7XNBoNH5g2uDBINKjDXgV0V3ptOMSzkm%2Bg%2B31X3wmwPOBVcohz3BuSo1OyaZgsorejRe%2B00u1xT19Xe9ikCl9o6PH70PfRl2JnG6zAOolEaDCdhkGLEORQfJ2G46b2WjCb8Yfp806O%2FtBL5Xs0c%2B7urQdwCTpsImK727HgqjG7qXO7wNRiorJ%2FIXeblk9T5LveSUv9HWShtRG7xC64xqN6ZBi2pmtLJHFrYP3GWQ12XHQq0GEWKp3ap7cB6uzg4eKPWHs058xqlH%2Ft4kURpFMf9MUzS%2FmgcX%2FXTKF30eZKEyWHMhuFi8miNXtmwV5Zob5CwFgdagp%2BxadlCZ%2BnmWa%2FulW979c9rn%2Few0f%2Bt%2FyvW4%2FpYWAmeg4dFYZT0w1E%2FDmfDcXY4yuJhkMaHySQ9CMMsDL14Yd22rDVu2%2BM9oxN5IPTpWajr6QkrZnGV8PL4%2BOji5lsxnen2ZvAzUoO4GSsoPtDNbyBf7i9vBgAA)
- [Test publish.law/site example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALmX82kC%2F%2B1TYU%2FbMBD9K5Y%2FbSJN07RN00iTBkxoY2VjUKYhVEWu7bUWiR3Zl4as6n%2FfhbZAoUL7uEn75Nh39%2FLeu7slBZkXGQNJkyUtrFkoIe0nQRNalNNMubmfsYp6D6EvLMdUer4TdNIuFJf3ZU4h1sPTy3SySVhI65TRNAk9KqTjVhVwf6fHRmvJgcBcOSJMzpQmYEhtSkueA%2Fnku8LTWEesZHy%2BzuJGg9RAGKzvptLk6mJEKgVzwkpATFCcfByPzy99cinBEagMOUQMbqxw5A0r5B1hWpCqqt6SwigNSs8awAaP6ZozB0SKmfRRS2Zm5spmyH0OULik3X5iXntqEaidM3vru8Ws8abWHIV8lvWHe3UvzG4SLqRQSAdeSTnKDL%2BlyU%2BWOenRDXea3Cwp1EVj%2ByEmzo0D%2FHzf9LCR4cYGr52uH%2FZivzMM%2FBgjAEi%2BGwXByttXjCb8Yflk5dFfRsv0kc0E%2B7vVIO8YTpv0uckf0adoH95m1pRFqrY1BbMsd81Ubqtvdson2%2FqbNUDzZzXTxsrU4cmgtKgCbInW5GUGKmUVe3wSPGVFkdVI1GEUYXZt0%2BvB3XATDNgrsj2aCt5QVc0GDAexCPudYSsKu3Grx%2FuDVtwdslY8jaOgF%2FdiIcWTjdqzbHv2adcr6RzOt2LNyB1mFasdXT1r3UYAts7%2Fl0RMPGz%2B%2F1b8Fa3AFXNsIUXKmtQwCKNW0Gt1g3FnkPSjJBj6%2FSgIO8ODIEiCoBEgHaylLXEbn%2B4h7WTltbo64%2BU3OI4Hlz%2Bug9HJ6CC8iO3p15PRuYn6g7OjfJpFp9U7uvoNACxeaJcGAAA%3D)

The template passes "Check template" and "Test apply template" in both configurations: at apex it writes the A records at `@` and `www`; with a host parameter it writes them at `<host>` and `www.<host>`.

# Additional context

## Cloudflare proxy default — DNS only

This template's records must be **DNS only** (gray cloud), not Proxied. Our architecture terminates SSL at the Caddy reverse-proxy fleet behind the AGA anycast IPs; if Cloudflare's proxy is on, it intercepts the TLS handshake and prevents Caddy from issuing the Let's Encrypt cert.

After this PR merges, we'll email `domain-connect@cloudflare.com` to request the proxy default for the `publish.law/site` template be set to DNS only. Per [Cloudflare's Domain Connect docs](https://developers.cloudflare.com/dns/reference/domain-connect/) the default proxy state is configured per-template at onboarding time — not via a record-level property — so this is the correct path for our use case.

## Provider info

- Provider site: https://publish.law
- Logo (SVG): https://publish.law/brand/mark.svg
- Public key TXT at `_dckey-1._domainconnect.publish.law`: published, returns the SPKI public key (unchanged from v1)
- Architecture write-up: AWS Global Accelerator + Caddy reverse-proxy fleet (provisioned 2026-04-30); IPs `13.248.190.8` and `166.117.226.122` are documented as constant for the lifetime of the accelerator
