### PR TITLE
Add Borg domain verification template

### DIFF
--- a/borghq.io.domain-verification.json
+++ b/borghq.io.domain-verification.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "borghq.io",
+  "providerName": "Odin by Borg",
+  "serviceId": "domain-verification",
+  "serviceName": "Mjolnir Domain Verification",
+  "version": 1,
+  "logoUrl": "https://odin.borghq.io/logo-full.svg",
+  "description": "Verify domain ownership for a Mjolnir security assessment.",
+  "variableDescription": "token is the unique verification value assigned to this domain.",
+  "syncPubKeyDomain": "domainconnect.borghq.io",
+  "syncRedirectDomain": "odin.borghq.io",
+  "syncBlock": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "TXT",
+      "groupId": "verification",
+      "host": "_borg-verify",
+      "ttl": "3600",
+      "data": "borg-verify=%token%"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

We are adding Domain Connect support to [Odin](https://odin.borghq.io) (by Borg) to make it easier for our users to verify domain ownership during security assessments.

Our platform (Mjolnir) requires a single TXT record for domain ownership verification. The record format is:

- **Host**: `_borg-verify` (relative to the domain/host)
- **Data**: `borg-verify=<token>` where `<token>` is a UUID v4 unique to the verification request (36 characters)

The template uses `hostRequired: false` to support both apex domain and subdomain verification.

## Type of change

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, our TXT record is not unique per label (multiple domains can have their own `_borg-verify` records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — we use `borg-verify=%token%` (prefixed)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description — host is static: `_borg-verify`
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — N/A, the verification TXT record is temporary and should be removed as a whole after verification

## Online Editor test results

[Test borghq.io/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACrU9GkC%2F%2BVTXW%2BbMBT9K5alPi0kQIAkSH1YVU3aonVrl3btqggZYxK3xKa2IWVR%2FvuuyXc3aXvfG1yfcz%2FOuXeFDVuUBTEMxytcKlnzjKmPGY5xKtVs%2FtLlEnf2D1dkAUD8JeMCpQ26AAi8aqZqTlnLyuSCcOHUTPGcU2K4FAfElv75SRaCK3TZYtHdKRao2n7FXgcXciZvVQGcuTGljns9CaW7%2B9Z6FuDkVVF0dW1byZimipdtqhi3mRu06QnJpYDUc16iXCpE0K4NzWiluGkQ0ZppvWDCdG0fRHGSFuzyJKWRz0wgrpGZM1QJ%2FlIxdDwsqkkBIUjFZ4JlyEhAAnzTg82rG0G%2FVumYNZv596JRKQSjpnssvAXfsIwreNjDTzXYoi4KSZ9xnJNCsw6eS21u2EsFxGwfhCRSZRrHjytsmtJaMbmfAH%2BmZFW29r3xzaaBaGKLbTxtIGqMdaQfua5VnBiy3ZYt4vysFekMr6frDv4pBUsOlaed7bTAYa8Edo91qVwcau3aSfgOXxJFFtru5475eEKd7riP2H63xe0PDdN%2BlofEiYJg6AR06Dojf%2Bg7wciL2GBAQz8NsW0RnJKKJdYxYioFuhhVgV6LqjA8IUtyCGU0IWVZNDCRhlco81ZLsdnxN5L9QaV%2Fam8rttW6g5OMWhW4NSonnkdHAA%2BZHwA7SJ3Ui0Inyt1h3ifDAQ3Co8P97aL%2FfrMHP%2BAo4CY4sa6%2FL5ak0Xi9nnbAm%2F92eNgzTWqWJcTCfNePHDd0XG%2FiRbEfxd6w2w89dxS%2Bc924PRPDtNnosIKNO941PK4%2FTKLbT8F14JcPd0vhjh%2Buyu%2FN%2FWDIb9n1%2BMe353m%2FVzf9%2B6fgHK9%2FASuu9uOyBQAA)

[Test borghq.io/domain-verification borghq.io/odin](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGPU9GkC%2F%2B1TYW%2FaMBD9K5alfmoCSSBQIvVDq2rSNK0tVddurVDkxBdwa%2BxgO3QB8d9nh0Chm7T9gH1Lzu%2FdvXt3t8YG5iUnBnCyxqWSS0ZBfaY4wZlU09miwyT29g%2FXZG6B%2BIYygbIaXVqIfdWgliyHhkXlnDDhL0GxguXEMCneES3964vkgil01WDRwzHWUrX7SkIPczmV3xS3nJkxpU66XWlLd%2FbSug7gFxXnHb10UijoXLGySZXgJnONtpqQfBM29YyVqJAKEbSToSGvFDM1IlqD1nMQpuN0EMVIxuHqKKWRryAQ08jMAFWCLSpAh82iJeE2ZFOxqQCKjLRIC99qcHl1LfLbKvsC9bb%2FvWm5FAJy0zk03oHvgDJlH%2FbwYw9a1CWX%2BStOCsI1eHgmtbmDRWWJdB%2B0SaSiGifPa2zq0o3i%2Fvu95U%2BVrMpmfB%2Fm5tLYaOqKbWda26gxbiK9QRA4x4kh7ba0iPOTxqQTvJlsPLySAtL3yhOv7fbDhrWVXGs7QSnbMUqiyFy7Dd1xnw%2FIkx37eUu3%2F40AF4iGeRQHYeTnJMj8fhETP8vCwM8HQ5LReDCCXoGdTDstqSB1UyOmUtYboyrr2bzihqXkjbyHaJ6SsuS17UrbV1vmo59iu%2BeHtnXazv5g1z9pbF13pns4pbkzgzUHB724PwpjfzAqQr%2Ff72V%2B1iPgF%2FSsn4cRUIjh4IJ%2FO%2B2%2FH%2B%2FxaOyF2ANhxK3ABX8jtcabzcSzY%2Frvgt08TZZAU%2BKgURAN%2FCD2g%2FA%2BHCTRMAnjztkwDoe90yBImuMxoM3Wi7XdwcPtw2z0YzVW3Ue%2BOK1v6kf1dPe4EuPZ9dPP8erl4oVH4%2B7Np1t98XArz%2FHmF%2B9tNsDIBQAA)