### PR TITLE
Add Elevayt website hosting template

### DIFF
--- a/elevayt.in.website.json
+++ b/elevayt.in.website.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "elevayt.in",
+  "providerName": "Elevayt",
+  "serviceId": "website",
+  "serviceName": "Elevayt Website",
+  "version": 1.0,
+  "logoUrl": "https://www.elevayt.in/icon.png",
+  "description": "Connect your domain to your Elevayt website. This adds a CNAME record so www.yourdomain.com points to your Elevayt site.",
+  "variableDescription": "",
+  "syncBlock": false,
+  "shared": true,
+  "shareServiceInSync": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/elevayt.in.website.json
+++ b/elevayt.in.website.json
@@ -3,13 +3,10 @@
   "providerName": "Elevayt",
   "serviceId": "website",
   "serviceName": "Elevayt Website",
-  "version": 1.0,
+  "version": 1,
   "logoUrl": "https://www.elevayt.in/icon.png",
-  "description": "Connect your domain to your Elevayt website. This adds a CNAME record so www.yourdomain.com points to your Elevayt site.",
+  "description": "Connect your domain to your Elevayt website. Adds a CNAME record so www.yourdomain.com points to your Elevayt-hosted site.",
   "variableDescription": "",
-  "syncBlock": false,
-  "shared": true,
-  "shareServiceInSync": false,
   "records": [
     {
       "type": "CNAME",


### PR DESCRIPTION
# Description

Adds a new service provider template for Elevayt (`elevayt.in`) — an AI-powered website platform for Indian service businesses. Connects a user's `www` subdomain to their Elevayt-hosted website via a single CNAME record pointing to Vercel's edge network (`cname.vercel-dns.com`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` → `elevayt.in.website.json`
- [x] Resource URL provided with `logoUrl` is actually served by a webserver → `https://www.elevayt.in/icon.png`

# Checklist of common problems

- [ ] `syncPubKeyDomain` is set — **Justification for omission:** This template uses only the asynchronous flow. No synchronous OAuth flow is implemented, so `syncPubKeyDomain` is not applicable. This is consistent with other async-only templates.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` — not required; template does not use `redirect_uri` in a synchronous flow
- [x] No TXT record contains SPF content — template contains only a single CNAME record
- [x] `txtConflictMatchingMode` — not applicable, no TXT records present
- [x] No variable is used as a bare full record value — template has no variables
- [x] No bare variable is used as the full `host` label — template has no variables
- [x] No variable is used in the `host` field to create a subdomain — template has no variables
- [x] `%host%` does not appear explicitly in any `host` attribute — template has no variables
- [x] `essential` — not applicable for CNAME records

## Online Editor test results

Template loaded and validated in the Online Editor with no errors. Single CNAME record (`www` → `cname.vercel-dns.com`, TTL 3600) applied correctly on both apex and subdomain configurations.

[Test elevayt.in/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACbl9WkC%2F91S0W7aMBT9lcivTYIJNM0i7QG1qGJVO21rV1UIRcY21FtiW7ZDmiH%2BfdcJlLLuYc97Ivjcc%2B89554tcrzSJXEc5VukjdoIxs2MoRzxkm9I62IhUfiK3JEKKtG0xwCw3GwE5R2j4UsroNPr62l18PiKb7ixQkmUD0NUqrV6MCXUPTunbT4YNE0TH6cPBFUy1nINPMYtNUK7josulZScuqBVtQmYqoiQgVP938PM%2FU5xMGHMBiS4vJvcTgPDqTIssCrwszyhp8dUVYFWQjr7Z6foWVnHgeO7eQnECLIs%2BdXJSgD0vS3K51vkWu0N6IYC5Ft4n5rGW9qNuVfwQCUYFYMplJcRk9avARXOgSujFOPdYheiX0ry4th8AW50O%2FtTvRA4It%2FT9lPga21UrQtxqNfEkMr6Qx%2BY8xPq4sCdI%2BQnirVUhhcWfomrDShxpuYhqurSiYI05PjEaEG0LltY0AIKLd6rl30aevWMOPIPykNUMOo3Fj5gaUI%2FsAtMoyRNh9E4zWiULckyGq3GNFtmo3GG8Zuwvo%2Fx39N6NIxby6UTxKdxUjaktWi3W4Rg3n8kB85syYazgviyBCdphM8jnNwPh%2Fn5MMdJnI2SdJSdYZx3CzhuXS9wC6l4mwf08KT5JL1hmNL64vbpc7salD%2BTs8cvP64%2BvUzTb6vv19c3eLb5Smcf0e43YoyxBW4EAAA%3D)

[Test elevayt.in/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI7l9WkC%2F91SXW%2FaMBT9K5FfmwQTwkcj7YHRTkNVmaZSdRpCkRNfqLXE9myHNEP899lJgbLuYc97iuJ7zz3nnnv2yEApC2IAJXskldgxCmpOUYKggB1pTMg48k%2BVBSltJ7rtaragQe1YDi2ihkwzO%2Bn0etntPZ3qO1CaCY6Svo8KsRWPqrB9z8ZInfR6dV2HZ%2FYeywUPJd9aHAWdKyZNi0UzwTnkxmtEpTwqSsK4Z0T3e%2BR81RR6U0q1R7zZYnp%2F6ynIhaKeFp7jcoAOHuai9KRg3Og%2FJwXPQhuwGDfNrUAUI1kBNxeSbKGbrVGy2iPTSGdAS2pLboTzqa6dpS3NUtiHnFujQmtKDkVAuXYybIcx1pXBCOPD%2BuCjX4JDeh6%2Btm60mt2pXog9IrzCLli2SlQyZUeIJIqU2t36CF5doNdH%2BKrFO1625UJBqu2XmErZfYyqwEdlVRiWkpqcn2ieEimLxsrUtmqnvPeAd5lwvncKKTHkHzzwUUpzJ5y5qGV9GsV4kweTzSgKYhhHwQRvsiAmk2w8HEw242vyJrbvA%2F333F5YB1oDN4y4aE6LmjQaHQ5r39r4%2F21l767JDmhKXGeEo1GAhwGOlv1%2BMoySeBRiPB6P%2BlcYJxi7DUCbbse9zcjbdCDKXuiP67uHQfXxoZTZlzpuPslFFs%2Fnd1eP4knOvt1%2Fxj%2Fp8ub71w%2Fo8Bvcfr4LggQAAA%3D%3D)

**Editor test link:** https://domainconnect.paulonet.eu/dc/free/templateedit?providerId=elevayt.in&serviceId=website