### PR TITLE
breachme.ai: fix syncPubKeyDomain prefix (Cloudflare verifier returns 502)

### DIFF
--- a/breachme.ai.domain-verification.json
+++ b/breachme.ai.domain-verification.json
@@ -5,7 +5,7 @@
     "serviceName": "BreachMe Domain Verification",
     "syncPubKeyDomain": "breachme.ai",
     "syncBlock": false,
-    "version": 1,
+    "version": 2,
     "logoUrl": "https://breachme.ai/logo.svg",
     "description": "Use this DNS record to verify your domain ownership with BreachMe.",
     "hostRequired": false,

--- a/breachme.ai.domain-verification.json
+++ b/breachme.ai.domain-verification.json
@@ -3,7 +3,7 @@
     "providerName": "BreachMe",
     "serviceId": "domain-verification",
     "serviceName": "BreachMe Domain Verification",
-    "syncPubKeyDomain": "domainconnect.breachme.ai",
+    "syncPubKeyDomain": "breachme.ai",
     "syncBlock": false,
     "version": 1,
     "logoUrl": "https://breachme.ai/logo.svg",


### PR DESCRIPTION
## Summary

Move the `domainconnect.` prefix out of `syncPubKeyDomain` and into the apply URL's `key` parameter. Originally submitted in #1011; the prefix-in-template version was a misconfiguration on my side that surfaced once Cloudflare started actually verifying signatures against our key.

## Problem

Cloudflare's Domain Connect verifier (the dashboard at `dash.cloudflare.com/domainconnect/...`) constructs the public-key TXT lookup target as **`<key>.<syncPubKeyDomain>`**. With the previous template:

| | Value |
|---|---|
| `syncPubKeyDomain` | `domainconnect.breachme.ai` |
| URL `key=` | `domainconnect` |
| Cloudflare's lookup target | `domainconnect.domainconnect.breachme.ai` ❌ |
| Where the TXT actually lives | `domainconnect.breachme.ai` |

The doubled `domainconnect.` prefix → NXDOMAIN → upstream verify service throws → **502 Bad Gateway** from `/dns/domainconnect/v2/verify` → the dash JS shows the generic *"Cloudflare cannot proceed with applying new DNS records for BreachMe because this URL is not verified"* error to users.

Smoking gun from a HAR captured 2026-05-03:

```json
POST https://dash.cloudflare.com/dns/domainconnect/v2/verify
{
  "domain": "domainconnect.domainconnect.breachme.ai",
  "sig":    "<our base64url signature>",
  "hash":   "domain=…&verification=…&redirect_uri=…"
}
→ 502 Bad Gateway
```

## Fix

Change `syncPubKeyDomain` from `"domainconnect.breachme.ai"` to `"breachme.ai"`. The apply URL keeps `key=domainconnect`, so Cloudflare constructs `domainconnect.breachme.ai` — exactly where the TXT record lives.

The TXT record at `domainconnect.breachme.ai` is unchanged; only the template metadata moves.

## Verification

- TXT at `domainconnect.breachme.ai` still resolves to two correctly-chunked `p=1,a=RS256,d=…` / `p=2,a=RS256,d=…` records.
- Local `openssl dgst -sha256 -verify` against the reassembled key still returns `Verified OK` for our signed payloads.
- After this template change merges and the CDN cache picks it up, Cloudflare's lookup target should land on the right host.

## Notes for reviewers

- `providerId` and `serviceId` are unchanged — same template identity.
- Logo / records / agreements / hostRequired all unchanged.
- Our (BreachMe-side) signing code is being updated in lockstep to send `key=domainconnect` once this template is live.

cc @kerolasa — happy to provide the full HAR off-issue if helpful for tracing your verifier's behaviour. The 502 response (vs a clearer 4xx with "key configuration mismatch") made this a tough one to diagnose without the network capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)