### PR TITLE
Add Red Bricks Site template (launchpad.rbos.app/rbos-site)

### DIFF
--- a/launchpad.rbos.app.rbos-site.json
+++ b/launchpad.rbos.app.rbos-site.json
@@ -6,7 +6,6 @@
   "version": 2,
   "logoUrl": "https://launchpad.rbos.app/red-bricks-logo-square.svg",
   "description": "Connect this domain to your Red Bricks site so visitors land on it.",
-  "syncBlock": true,
   "syncRedirectDomain": "launchpad.rbos.app",
   "syncPubKeyDomain": "launchpad.rbos.app",
   "records": [

--- a/launchpad.rbos.app.rbos-site.json
+++ b/launchpad.rbos.app.rbos-site.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "launchpad.rbos.app",
+  "providerName": "Red Bricks",
+  "serviceId": "rbos-site",
+  "serviceName": "Red Bricks Site",
+  "version": 2,
+  "logoUrl": "https://launchpad.rbos.app/red-bricks-logo-square.svg",
+  "description": "Connect this domain to your Red Bricks site so visitors land on it.",
+  "syncBlock": true,
+  "syncRedirectDomain": "launchpad.rbos.app",
+  "syncPubKeyDomain": "launchpad.rbos.app",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 1800
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 1800
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template `launchpad.rbos.app/rbos-site` for [Red Bricks](https://redbricks.dev) — a SaaS that provisions websites for real-estate brokerages. Tenants connect their custom domains to their Red Bricks site through this template.

The template adds a single **A** record at the apex (`76.76.21.21`) and a **CNAME** at `www` (`cname.vercel-dns.com`). Both records point at Vercel's anycast edge, where the Red Bricks tenant sites are hosted. No other records are touched.

## Type of change

- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) (links below)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`launchpad.rbos.app.rbos-site.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver: https://launchpad.rbos.app/red-bricks-logo-square.svg returns HTTP 200

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`launchpad.rbos.app`) — public key TXT live at `dc1.launchpad.rbos.app`
- [x] `warnPhishing` is **not** set
- [x] `syncRedirectDomain` is set (`launchpad.rbos.app`) — used by signed-flow `redirect_uri`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` not needed (no TXT records in this template)
- [x] no variable used as a bare full record value
- [x] no bare variable used as the full `host` label
- [x] no variable used in `host` to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential: OnApply` not needed (no records the user would need to modify or remove)

## Online Editor test results

**Editor test link(s):**

- [Test launchpad.rbos.app/rbos-site acmerealty.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB2W%2BGkC%2F%2B1TXWvbMBT9K0avs135K0kNg7XdButo6LoWBiEYWVITrbbkSnKMG%2FLfd5WPplmX7bUPA4Fl6Z6je869d4ksr5uKWI7yJWq0WgjG9ReGclSRVtJ5Q1ioS2VC0jTIf44YkxoQ6IYz71wL%2BmDgznC9EJSvwQ4SGAG0z%2BevIN73zf2CayOURHnso0rN1J2uIG5ubWPyk5PXaZxozoJyTRG4%2BMA8tkTz0CxmwMa4oVo0ds2ILpSUnFrPzoXxmKqJkJ5VXq9a7b3IxGXqGeUtBOyUNl5FJPOU9IQNnYJeUogWGqg%2BrkmO%2BeMir9vyK%2B%2F%2FHgdMSjOD8skS2b5xxpzB8VwZC9sPzmklpDW3Cn6HgxBWHMGCC2vBnmiE8cp%2Fxl6Mz64%2B7fFd1x0yUAnmh2A05VXApAmpqg%2BopisfPSnJi31iU%2FByp4HQmmtOKttvkduHYDfTqm0KsYM0RJPauGbagSe%2Fo6c7%2BAQh966YSaV5YeBLbKtBj9Ut91HdVlYUpCP7I0YL8K%2FqIU0Dt0Bx6J%2Fc9JjzjxFLjnvno4JRl6Vw3UqzhMVRnAYJHURBikeDgGRpHJzeZwOcpGSUjZIXzX98PI6NwN4ubgyXVhDX4mdVR3qDVn8o5FbIppBbKf8q4tvSNPWhHf5X561WB4bQkAVnBXFhMY4HAc4CnN5GcZ7hPBmGcZKcRuk7jHOMnRBu7EbqEmb25bSiqr08vxn8HOO78vPD5besYRc33UOSlkMRP%2F7Al%2BWoy8j1Vd%2Fep%2B%2FR6hfJE54FcwYAAA%3D%3D)
- [Test launchpad.rbos.app/rbos-site acmerealty.com/condos](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADOW%2BGkC%2F%2B1TYU%2FbMBD9K5G%2FLglJaNoSadIYRRpiY2iUaROqIsc%2BWovEDraTklX97zsXWkpZt6%2BbNMlSEt%2B9l3fv7hbEQlWX1ALJFqTWqhUc9BknGSlpI9mspjzUhTIhrWvibzIuaIUI8gW4914LdmcwZkC3gsEK7CCBEUi7uX8F8a4e4y1oI5QkWeKTUk3VtS4xb2ZtbbKDg9cyDjTwoFhRBC4%2FMPcN1RCadopsHAzTorYrRnKipARmPTsTxuOqokJ6VnmdarS3pcQp9YzyWoFvShuvpJJ7SnrChq6CTjLMFhqpRiuSff64zMumOIfu93nIpDQ3JLtZENvVzphjvJ4pY%2FH1nXNaCWnNWOHnoB%2FiSWI8GLAW7YmHUbT0N9iTi%2BNPp8%2F4%2BXz%2BkoFJND9EoxmUAZcmZKp6QTVZ%2BuSHkpA%2FC5ugl%2BsaKKtAAy1t94R8%2BhFTkivX%2B6lWTZ2LNbCmmlbGjdSa4maXY7ImuVmzOA1iKpWG3OCT2kZjbVY34JOqKa3I6Zw%2BX3GWo5dlh5INRpHopZfycd42Ejm1dL%2BZPsk5c4KFG19gt%2BkgjlhQMMqDXlrEwbAPNBgepgn0C1pAPNjahv37sm8ndv0DY0BaQd3kH5dz2hmy%2FEV%2Fn2rC%2Foa7df2pxX9jgRMfh%2BV%2F1%2F61ruHqGtoCz6lLTqKkH0RpEPXGcZKlUZYehYe9XtIbvomiLIpcOWDsY8EL3PHt7SZnH7qvo%2B8f%2BRHVt%2FHo4Q4uv7Wfz1miajYaX99eWW1PeTqf3T9cvyXLn%2BbbmU6vBgAA)