### PR TITLE
Add fineartform.com custom domain template

### DIFF
--- a/fineartform.com.custom-domain.json
+++ b/fineartform.com.custom-domain.json
@@ -1,0 +1,42 @@
+{
+  "providerId": "fineartform.com",
+  "providerName": "Fine Art Form",
+  "serviceId": "custom-domain",
+  "serviceName": "Custom Domain - Fine Art Form Portfolio",
+  "logoUrl": "https://www.fineartform.com/static/images/brand/icon-faf.png",
+  "description": "Connect your custom domain to your Fine Art Form portfolio. We will set up the DNS records needed to point your domain to your portfolio and prove ownership.",
+  "variableDescription": "We will create one apex pointer, one www pointer, and one ownership-verification TXT record on your domain.",
+  "syncPubKeyDomain": "fineartform.com",
+  "syncRedirectDomain": "fineartform.com",
+  "syncBlock": false,
+  "shared": false,
+  "hostRequired": false,
+  "version": 1,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "3.148.31.190",
+      "ttl": 600,
+      "essential": "Always",
+      "groupId": "apex"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "custom.fineartform.com",
+      "ttl": 600,
+      "essential": "OnApply",
+      "groupId": "www"
+    },
+    {
+      "type": "TXT",
+      "host": "_fineartform-verification",
+      "data": "fineartform-verification=%dcvValue%",
+      "ttl": 600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "All",
+      "groupId": "dcv"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for Fine Art Form, a portfolio-hosting service for visual artists. Connects an artist-owned domain to their Fine Art Form portfolio: apex routing to our edge, www CNAME, and a per-claim ownership-verification TXT (server-side checked against a token issued at claim time).

`dc-template-linter` is clean at info loglevel except for `DCTL1021` on `_fineartform-verification` (underscored label not registered with IANA). The label is intentionally non-standard per RFC 8552 section 4.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test fineartform.com/custom-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPtk%2BWkC%2F%2B1U72%2FbNhD9VwgC%2FTRLlqxajQ0UqBMnzTbEDVJnSRYEAkOdbDaSqJKUHTfw%2F76jJP9Qm6wF9qUDChiwzTu%2Be%2Ffu8Z6ogaxImQE6fKKFkgsRg%2Fo9pkOaiByYMolUmctlRjvb8IRlmE5PMIGMlCEnmIJhDWohOFSXeamNzJxYZkzku1hz86iKknEVJQ5pIZFzaaumQuK9VM7kpUrxztyYQg%2B73eVy6X5FrasNM4J3RcZmoLv3iuVxV3CZOwlL3CKfIVAMmitRGCFzS0DmOXBDVrJUpOZKaq7EyPq0zanYcHLJFZClSFOiwZCyIGYOZDz5SBRwqWJNcoAYYgtTSJE3Jb7C3qIRZEqsrEDkMgel56Jwke2CKcHuUxi3WG8qcwU4MCKRICvgsS4EqlOdoD67AwtvD7fgzgKUSARnFpJMr6cNb8zaZ2o56FXOz8v7P2FVz%2BlZS9ikC4gFopjvpB2mkj%2FQYcJSDXgyZwri7d%2B51OYCPpdi%2FxC56qpzv0Mbeenw9omaVWFdNKL1Pfz5zrrTNq2nEv8Grv%2F6wA181x94GDEGDRR6XoeC1pAbwayhRumSrTSGZ0qWReVaqyZdd7YVjiajs%2BNdFZS2Xad2jvttv89X%2FJCPiiJdtUpazL2KOJFdvWgPuDU462dmWFvqVsbbVzFf%2FMXSEl79AB3zaPBFJKng5owZPhf57EzGlcZp2qKLqHR9t%2B7QL2iraDeUO2S0GT88Mlwp0EjR9LJBiUSVX0vdaSS1qIhQMMUybRfRBuu2BXa3Qbul9neF9xLWpn0bH3xZFYNzR%2BjRp0Cd9gcfT%2F%2B4OImugsPDm%2Fl04f9NbUNilksFkcZvZkqFF40q0YRZmRoRsSXbHcU8YlY57F9jFEu0TZnXW%2B7dbkwvGjKKue1XWG29wAsh4aETePfMed33fGdwwEKHHyQ96IHvx3Gyt4VfWNL%2FtoV3s3jmIayfMX7TSaNs3csPmP5n6Grj7vU3r6tp6r%2B8ru866udV466Dj%2FWXX3%2F59f%2FiV1zmmi0gjpjN63m90PH6%2BJl6wTAIhn7fDcPwTdj%2FzfOGXuVW0KYW5An3%2Bv5Gp5ez9w9LOLoOR58%2BPBwwaS7f96bH%2Fuh0kl9NTsSNvB732Jux7t0cv6XrfwCqHZ6qHQsAAA%3D%3D)
[Test fineartform.com/custom-domain example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKxl%2BWkC%2F%2B1U74%2FaOBD9VyxL%2FVQSAuxygFTp2HKr9vbg9hbutr0VQsaZEN8FO7WdsHTF%2F95xEn6kXa792JMqIQEe%2B82bN2%2FmiVpYpwmzQAdPNNUqFyHotyEd0EhIYNpGSq99rta0cQhP2Bqv02u8QIbakmu8gmEDOhccisc8M1atvVCtmZDHWPXydREloyJKPFJDIrfKZU2EwneJWqk%2FdYJvYmtTM2g2N5uN%2Fxm1prHMCt4Ua7YC01xqJsOm4Ep6EYv8VK4QKATDtUitUNIRUFICt2SrMk1KrqTkSqwqT%2Buc0j0nn9wD2YgkIQYsyVJiYyCjyZRo4EqHhkiAEEIHkyohqxSfYR%2FQCDIlTlYgaiNBm1ikPrLNmRZsmcCoxnqfmWvAhhGFBFkKj2Ui0I3iBPU5Hjh4d3gA93LQIhKcOUgyezereOOtU6aOg9lKfpstb2Bb9ulZS7hLdxAKRLFfuXaVKP4vHUQsMYAnMdMQHv7Gytg7%2BJCJ00PkaorKWw1ayUsHD0%2FUblPnoiEt3%2BHPn507XdFmpvBvx29d9PxOy2%2F1A4xYiwbqBkGDgjEgrWDOUMNkw7YGwyutsrRwrVOT7hqHDK8nw%2FEvxywobT1P6Rz%2Fy3qfz%2Fi7HKZpsq2ldJgnGbEjx3yLE%2BBa45yfmWV1qWs3Xr0Ief4XSzJ48Q107KPFiYgSwe2YWR4LuRqrsNA4SWp0EZXu5rsG%2FYi2WhybMkdG%2B%2FbDI8OVApUUVS0mW%2B6BFqJ4UqrdqFR1wAiSMs3Wxu2iPdxDDW%2B%2BB3woEOcV5Dm4vQgu3v%2B4Tfu3njDDfzr6zWV%2F%2BubXu%2BvFfefq6n08y1t%2FU1eWWEmlYWHwm9lM40OrM7TiOkusWLANOx6FfMGcfqiCwSimqFtTlruuLLxq11ljLkLuihZO4z4seRSxntfrdC%2B9i3YQeL2Lfs%2FrQLTkQfui2%2BnDyTY%2Bs6z%2FaxvXevLMTOyemYGqHLd%2BayV9wwx8J8Xt%2Fb77Yt6q2s7OW73iszP3VYd916LMGzjFPyz8w8L%2FYwvjyjcsh3DB3NV20O56wSV%2BZkFn0OkOWm2%2FG%2FRbP%2FVeBsEgKOwLxpaaPOH2P9379P7mKgzScTqNJzeTIGfv1fTD7I%2FR5chES%2FlbHI%2BnTf0ul2%2Fz%2B%2BEruvsE%2BZ87wEkLAAA%3D)
