### PR TITLE
Modified template: Modify Odin by Borg, Mjolnir Domain Verification

### DIFF
--- a/borghq.io.domain-verification.json
+++ b/borghq.io.domain-verification.json
@@ -4,7 +4,7 @@
   "serviceId": "domain-verification",
   "serviceName": "Mjolnir Domain Verification",
   "version": 1,
-  "logoUrl": "https://odin.borghq.io/logo-full.svg",
+  "logoUrl": "https://odin.borghq.io/logo-full-light-mode.svg",
   "description": "Verify domain ownership for a Mjolnir security assessment.",
   "variableDescription": "token is the unique verification value assigned to this domain.",
   "syncPubKeyDomain": "domainconnect.borghq.io",

--- a/borghq.io.domain-verification.json
+++ b/borghq.io.domain-verification.json
@@ -3,7 +3,7 @@
   "providerName": "Odin by Borg",
   "serviceId": "domain-verification",
   "serviceName": "Mjolnir Domain Verification",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://odin.borghq.io/logo-full-light-mode.svg",
   "description": "Verify domain ownership for a Mjolnir security assessment.",
   "variableDescription": "token is the unique verification value assigned to this domain.",


### PR DESCRIPTION
Updates the `logoUrl` with an image more compatible for use on light background. Cloudflare's dashboard defaults to lightmode, so we'll want to use a darker image for better contrast. The old one had white text, making it almost invisible on the Cloudflare dashboard.

# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test borghq.io/domain-verification example.com /@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEY7%2BmkC%2F%2BVTXU%2FbMBT9K5YlntYUk%2BajROJhDIYQ2qgqhsZYFTm203okcbCddlnV%2F77r9BOGtL1PyoNzfe69x%2Bfcu8RWlHVBrcDJEtdazSUX%2BprjBGdKT2fPfalwb3fxmZYAxLdcVihr0TlA4NYIPZdMdFlclVRW3lxomUtGrVTVHrFJ%2F%2FRDFZXU6KLDovuXWEg17pT4PVyoqfqiC8iZWVub5PhYQev%2BjtqxA3h5UxReIacz65WKi76ZO1ZcGKZl3VVNcNekRWt6SC0q6DKTNcqVRhRtGRnBGi1ti6gxwphSVLbvKFEtaVaIixclrXoSFZIG2ZlATSWfG4EO343mtIAQlJLTSnBkFSABvubg6pq2YqMmuxHtWoqdfkxVlWC2f%2BiBA48FlxoudvCXcmxQ54ViTzjJaWFED8%2BUsWPx3EAi3wWhiNLc4ORxiW1bO1fuvt5B%2FlSrpu6cfGWhKwPR1DVb29tC1FpnziAixClOLd0MzgZxdtSJdIRXk1UP%2F1KVSPedJ73NayFH%2FKQwhqLPVPm9IYSSfcctqVRus2qqaWncwG7zH98oMNlWeMTu3BFxPyzMBjwPqRcFwdAL2JB4p%2F7Q94LTk0jEMQv9LMSOLrimtEide9Q2GjSyugHtyqawMqULug9xltK6Llp4nYFbaPNa12o9%2Bq%2Fke0Oxf6K3Ed7p3sMpZ04L2S1tEA8zQiIv5FHkBUHIvVPmh14Qk3yQERaHET%2FY5z8W%2Fe%2BrvHcFFgT2Q1I3Ae%2BLBW0NXq0mPXDov308zJmhc8FT6mA%2B8SOPhPDdnQyTIE4GQf8kjCISviMk6VbGCmPXOixh4g5nDY%2Fq%2FPLb9Op2xO8%2FDPKryJfX44s4U8GDvH%2Bow49xFlejaHGjosszvPoNnctPCckFAAA%3D)

[Test borghq.io/domain-verification borghq.io/odin](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFU7%2BmkC%2F%2B1TXUvjQBT9K8OAT5u0SZp%2BBXxQhLWIq4grgpRwM5m0syaZODOpxtL%2F7p00ra27sPsDFvqQ3jnnfpxz75oaXlQ5GE6jNa2UXImUq1lKI5pItVi%2B9ISkzv7hBxQIpDepKEnSkHOE4KvmaiUYb1mpLECU7oorkQkGRsjyE9HRr3%2FJvBSKXLRY8nCMRaq2X1Hg0Fwu5E%2BVI2dpTKWjfl9i6d6%2Btb4FuFmd524uFkvjFjLlPb2yXaVcMyWqNmtE2yIN2bZH5GuJVZaiIplUBMiuI81ZrYRpCGjNtS54aXq2JVACkpxfHKU08pmXRGhilpzUpXipOTmcm6wgxxCmEouSp8RIRCJ824PNq5uS3dbJFW%2B2Uuz1Y7IsOTO9Qw8s%2BI6nQuHDHn4sR4c6zyV7plEGueYOXUpt7vhLjcR0H8QkUqWaRk9raprKunL%2FeI%2F8hZJ11Tr5xUKbBqOxLba1t8GoMdacwcjzrOJgoFucDnF60op0QjfzjUPfZcnjz8pzp5v2y7J1lexou4ZisWNUoKDQdll33KcD8nzHftrS8X%2FbgA0EYxYMPT9wGXiJG2ZDcJPE91w2GkOSDkdTPsiobRPdkorH1jUwtUJtjKpRs6LOjYjhFT5DKYuhqvIGp9L4imW%2B6lluV%2F5Qtl432R%2Fk%2BqceO9Wt6A6NU2bFENYx5rFsMghDl2fTsRuOPXDBD8fuJEtgMIFBNg28g2P%2B7cr%2FfsfH1uCF4IEIsCtwlr9Co%2BlmM3fQpv8q4OZpWPE0BgsNvGDkekP83fuTKBxH4bTnB4OJH3zzvKg9HsO12Wqxxh083D46449Xb3pxy8%2FPwofJuFr5VXAzq9%2BGl1e3z9dq9v2yqt7fJ2HRX5zSzQfJR2RJ0wUAAA%3D%3D)
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
