### PR TITLE
CyberAlarm: Change from TXT to CNAME domain ownership verification

### DIFF
--- a/cyberalarm.police.uk.domain-verification.json
+++ b/cyberalarm.police.uk.domain-verification.json
@@ -6,15 +6,15 @@
   "version": 1,
   "logoUrl": "https://member.cyberalarm.police.uk/favicon/web-app-manifest-512x512.png",
   "description": "Verifies domain ownership for Police CyberAlarm",
-  "variableDescription": "VERIFICATION_CODE: Unique verification code provided for purpose of verification",
+  "variableDescription": "VERIFICATION_CODE: Unique verification code provided as a subdomain prefix for CNAME verification",
   "multiInstance": true,
   "syncBlock": false,
   "syncPubKeyDomain": "keys.cyberalarm.police.uk",
   "records": [
     {
-      "type": "TXT",
-      "host": "@",
-      "data": "_cyberalarm-verification=%VERIFICATION_CODE%",
+      "type": "CNAME",
+      "host": "_cyberalarm-verification",
+      "pointsTo": "%VERIFICATION_CODE%.verify.cyberalarm.police.uk",
       "ttl": 3600
     }
   ]

--- a/cyberalarm.police.uk.domain-verification.json
+++ b/cyberalarm.police.uk.domain-verification.json
@@ -3,7 +3,7 @@
   "providerName": "Police CyberAlarm",
   "serviceId": "domain-verification",
   "serviceName": "Domain Verification",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://member.cyberalarm.police.uk/favicon/web-app-manifest-512x512.png",
   "description": "Verifies domain ownership for Police CyberAlarm",
   "variableDescription": "VERIFICATION_CODE: Unique verification code provided as a subdomain prefix for CNAME verification",


### PR DESCRIPTION
# Description

CyberAlarm: Change from TXT to CNAME domain ownership verification


## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

[Test cyberalarm.police.uk/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM5p%2B2kC%2F%2B1UXW%2FaMBT9K5GlPpVACBAg0h4otBObStnUrqoqFN04N%2BA1sTPbATLEf58TaOl3%2BwP2gHDsc%2B85Pvdeb4jGNEtAI%2FE3JJNiySKU44j4hBYhSkhApvVMJIxiPb8jtQfMBFITQ6bVkTUswYMSbCAK5dJsVlkikQLj9hIlixkFzQQ%2FIPY5RhXG%2BvUUY0JUufLdGknEXFzJxGAXWmfKbzRSTA1j%2FTWRjRhMcsEbKwxtyDI7Bc5iVNruNN21%2BdUzPjcEESoqWVbR%2BWTHjsraKbbEihsBC5ZZsZDWa9dcgmQQJjh6muf05%2FhsPBxcji8mwfBidOpbV5z9ydF67IFFRYTW3svIAmWBpfJwz51JjNm6Ih5OBuen1jP70jzRbMyVBk6NgVrmaDwtOD1JBL0jfgyJ2u9M8%2FA7FjuHjbo7LFT9jcpKpEJGivi3G6KLrKxMxW6OFkJp8xkcIp9XNBOMa3UpDOrohQVH9QpdvMWstSlty3Oc7WxbI38Fx%2BAgZlbbN5FJjWsw3Yp1KtKDKrOaS5FnAbvHZyAhVWVH30fePgmd3cfeknL9Qm95QPvQCrvdlk37bt9ut3uhHca9yO50sQVuSFttr01KuWzOhcRAmX%2FQuXyoR1WkAFZw2IpoYPoxKcztlDk1NC%2Bt5ruZeMfqCDSU8%2FkJgZ%2F1vUaCiJZ%2BsXJmHUTaj72m3QQa2%2B2W49q9juvYsUmKYbtP%2By3v0Uvw3mvx8VNwKCIqhVwzKMd8kKygUGS7ndVMQf%2B79JFLposVLDEKoIS5juvZTsd2vMum5zd7vuvWna7b7HnHjuM7Tnkp8x7uLNqYHn7cvWTKQriZnnSvzprTa44qvC7Ov%2F64OL7xMoy6d99GAyrWvxcdNel9Idt%2FUAhs4EIGAAA%3D)

[Test cyberalarm.police.uk/domain-verification example.com/host](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANxp%2B2kC%2F%2B1UXW%2FaMBT9K5GlPkFCCJCSSHtg0E6sKmVrmSZVKLqxHWqR2JntABniv88JtJR%2BbP0Be0Am9rn33HvOtbdI0yxPQVMUblEuxYoRKscEhQiXMZWQgsycXKQMU6dYouYTZgKZiUHT%2BsgaVuBBBTYQReXKbNZZiMiAcXtFJUsYBs0EPyIOOUY1xvpxijEhqvoXek2UioWYydRgH7TOVdhqZTQzjM5bRbYSMMkFb61pbEOe2xlwllCl7V7b25ifk%2FOFISBUYcnymi5Ee3aqrH3FllhzU8ADy61ESOutNlcgGcQpHZ3mufg%2BvhwPB3fjm0k0vBldhNaMs18FtZ5rYGFBqHXQkligLLBUER%2B4c0kTtqmJh5PB9YX1Qr6sSDUbc6WBYyOglgU1mpYcf04FXqIwgVQddqZFfEXLvcKmuiUtlfOOs5JiIYlC4f0W6TKvnKnZzdGDUNp8RsfIl47mgnGt7oRBnb2S4Myp0eV7zFobazu%2B6%2B7muyb6LTiNjsXMm4chMqnpBsy0UgeL7FhVvTTRQooij9hjTA4SMlVN9WP0%2FUn4%2FDH%2Bfr%2Ba71d1V4c4gE58ft6xceAFdrfbj%2B046RO7d0474MW40%2FW7qCqbLbiQNFJmBV3IJ19qsyJYw3GL4MjMZVqaLpU5NTSvJef7u%2FGe5M6hawIaqsv6gSo%2FakITRQRXwrHqAndxTIgbdGzo%2B77d7SU9OwZKbULabg%2F3SRJA99mz8Len49%2FvwqmjVCnKNYPq3g%2FSNZQK7XbzpnH3v1wflsvMtYIVJRFUUM%2F1fNvt2a5%2F1%2FbDdt904AR%2B0AvchuuGrls1Zl7KvUxbM9XP5xltfjby28ai0U5vs1l6nX0ZeNP%2BaCSWMzFMLr2r5fobnX5dc6Jnn9DuD9qUxoNcBgAA)