### PR TITLE
add DataCops, First-party tracking

### DIFF
--- a/joindatacops.com.firstparty.json
+++ b/joindatacops.com.firstparty.json
@@ -5,8 +5,8 @@
    "serviceName": "First-party tracking",
    "version": 1,
    "logoUrl": "https://app.joindatacops.com/logo.svg",
-   "description": "Adds a CNAME so DataCops loads as first-party from your domain. Required for accurate ad-fraud analytics — bypasses ad blockers and Safari ITP without sharing user data with us beyond what your visitors already send.",
-   "syncPubKeyDomain": "_dc-key.joindatacops.com",
+   "description": "Adds a CNAME so DataCops loads as first-party from your domain. Required for accurate ad-fraud analytics, bypassing ad blockers and Safari ITP without sharing user data with us beyond what your visitors already send.",
+   "syncPubKeyDomain": "domainconnect.joindatacops.com",
    "syncRedirectDomain": "app.joindatacops.com",
    "records": [
       {

--- a/joindatacops.com.firstparty.json
+++ b/joindatacops.com.firstparty.json
@@ -1,0 +1,19 @@
+{
+   "providerId": "joindatacops.com",
+   "providerName": "DataCops",
+   "serviceId": "firstparty",
+   "serviceName": "First-party tracking",
+   "version": 1,
+   "logoUrl": "https://app.joindatacops.com/logo.svg",
+   "description": "Adds a CNAME so DataCops loads as first-party from your domain. Required for accurate ad-fraud analytics — bypasses ad blockers and Safari ITP without sharing user data with us beyond what your visitors already send.",
+   "syncPubKeyDomain": "_dc-key.joindatacops.com",
+   "syncRedirectDomain": "app.joindatacops.com",
+   "records": [
+      {
+         "type": "CNAME",
+         "host": "datacops",
+         "pointsTo": "cdn.joindatacops.com",
+         "ttl": 1800
+      }
+   ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **DataCops**, a privacy-first ad-fraud analytics platform. The template adds a single CNAME (`datacops` to `cdn.joindatacops.com`) so the DataCops tracker loads as first-party on the customer domain. This is required for accurate measurement against ad blockers and Safari ITP, and shares no user data beyond what visitors already send.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`joindatacops.com.firstparty.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (verified at https://app.joindatacops.com/logo.svg)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`domainconnect.joindatacops.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.joindatacops.com`)
- [x] no TXT record contains SPF content (the template adds only a CNAME)
- [x] no TXT records need `txtConflictMatchingMode` (the template adds only a CNAME)
- [x] no bare variable used as a full record value (the template uses no variables)
- [x] no bare variable used as a full `host` label (the template uses no variables)
- [x] no variable used in the `host` field to create a subdomain (`host` is the fixed literal `datacops`)
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` not needed; the single CNAME is core to the service

## Online Editor test results

**Editor test link(s):**

- Apex test (no host): [Test joindatacops.com/firstparty example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADE9C2oC%2F91TXU%2FbMBT9K5Zfl5S0lLZE2gMrIMEAVQyQAFXRje20HkkcfJ12WdX%2Fvut%2B0G4Dac97iuNzjn3P8b0L7lRR5eAUjxe8smampbIXksf8u9GlBAfCVNgSpuDBG34DBfH5KaFDQglBZWdaqJUw0xZdBdY1O2CjOPdQuMKYsyBedDkh0kxZ1KbkcTvguZmYe5sTeepchfHBAVRV689iDjythTOvlgqF1ZVbncBPpEQGbHhzcn3G0LBtkSw34BFk2V4RmTUFa0xtmTQF6LLFbtVrra2SLDOWgRC1pXAYyDCzUEsGJeSN0wIDljYVIJIDQlmaG%2FFCNogg2TfIwGp2cTdic%2B2mpnYMp7RD1JoCYd7JCqFflqrGkGY%2BBbeuZKZRO%2BOPyq0C2TBUpWz5LJtSjOr0q2pOV8WS23XVwpSlEq71zpN5za2S5Ei4N9V7iRKXOMZK5PHzgrum8g%2B2ipGgqUHnr9sIfC%2BQ3uGdoV0hy%2FeOc45esT2IouV4GfCfplTJ7oZxsKmd9OoHUA%2BqjWxzFa0m1tRVord8ejEo0PfpVvn8m3S81T5z7m%2FUk9JYlSB9wdWW7Dhbq4AXde50AnPYbUmRUCZ5QwUioXTE3xGU6xbei8Av%2F8F%2BwBMpfNnaT8eh6g1k1umEKh20w25X9kOA434osuMBdI8hPUrTvVH7aBQ%2FHLhdfAqpcZwGP0sn%2BRwa5MvlOKAo%2F1tz1AIIMyUT8LRO1OmF0VHYHty1e3GnG7f7re5R7zDqfIqiOIq8D4Vu7XRBHbPfK%2Fz6%2BvXyvDk3%2Fa55Gj7B6OHyYVjg4Ko5U%2FKx%2FnKPnx4er66aUVVPPvPlL0ag4GRJBQAA)
- Subdomain test (host set): [Test joindatacops.com/firstparty example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMI9C2oC%2F91TXU%2FbMBT9K5Zfl4Q0ytoq0h4Q3SaYYMCoGEJVdGs7rSGxg%2B20M1X%2F%2B677wccG0p73FMXnHvucc%2B9dUSeatgYnaLGirdELyYU55rSgd1oqDg6Ybm3CdEOjJ%2FwMGqynI0SPEEXECrOQTGyIlTTWtWCcfwZ2jC8BijcYcQbYvVQzLFoIY6VWtOhFtNYzPTY1Fs%2Bda21xcABtm%2Fwp5iCUJXYR2FxYZmTrNjfQQ84tAXJ0dnj6mVhN9iJJrSEgllQvRFRGN8TrzhCuG5AqIZfioZNGcFJpQ4CxzmA4BHhcGeg4AQW1d5LZiEx9C9aiA0TJtNbsHm1gASc%2FoAIjyfHVOVlKN9edI3aOJ1jaYSAkONkg%2BEumwmvkLOfgtkoW0kqnw1W1EcA9sULxJGTpFTvvpt%2BEH23EotutaqaVEswlb7QscC4FR0fMPbHeShRrsUYbbmlxu6LOt6FhmxgRmmvrwnM7QpgF5Dt7pfGUcfXWdc5hF3vDNF1P1hF91EqUzy9Mop125ItfgDModrTdUxhoaO7M6K4t5Z6DXYPGhlnds29f0Sd7%2Fu32gvCynCltRGnxC64zaMuZTkS06WonS1jC8xFnJWZTexRqEcVr%2Fo5CbUf5yexOaPj%2FhywiWnIW9MuwKkxUOa%2FSPGaDjMV5zvN4OswhzqpsMISMZSn0X%2Bzde3v57va9zlJYnCQnISzXYb0Eb%2Bl6PYkw1%2F%2FfJQ6GhYXgJYTSLM36cfox7g2vev0i6xd5lgwGvX5%2F8CFNizQNXoR1W7crnKGX00MfOZxc%2BOuH9i4bD%2F21Hunxhcp%2FjszDzc3wZPDVT8%2B%2B8%2BvTauxmn%2Bj6NxnPy15jBQAA)
