### PR TITLE
Add any.market.store.json

### DIFF
--- a/any.market.store.json
+++ b/any.market.store.json
@@ -1,0 +1,25 @@
+{
+    "providerId": "any.market",
+    "providerName": "Any Market",
+    "serviceId": "store",
+    "serviceName": "Store Custom Domain",
+    "version": 1,
+    "logoUrl": "https://us.any.market/icons/logo.svg",
+    "description": "Connect customer's domain to their Any Market store hosted on Vercel",
+    "syncRedirectDomain": "any.market",
+    "syncPubKeyDomain": "any.market",
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "76.76.21.21",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "cname.vercel-dns.com",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Our platform, https://us.any.market, allows customers to create online stores. By default, stores are available under our platform URL (e.g. https://us.any.market/captain-whites-seafood-oxon-hill). We are introducing a feature that allows customers to map their own custom domains to their store (e.g. https://my-fancy-store.com).

Our platform is hosted on Vercel. The template configures records pointing the customer's domain to Vercel's infrastructure so that traffic is routed correctly to their store.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test any.market/store example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJx7%2FGkC%2F%2B1TXWvbMBT9K0Yve5jtKB91UsNgISu0Gy1la0uhBKNIt4moLRlJjueG%2FPddOUndbB177MtAYFn3nnuPzj3aEAdFmTMHJN2Q0ui1FGAuBEkJU01cMPMEjoQvkStWYCaZqia4PMQsmLXk0IKs0wa6s336D38azCqMFsEXXTCpMGcNxkqtSNoPSa6X%2BtbkmLtyrrRpr1fZuGPQk1wr2%2FNZsV0vESzAciNL1xYgM60UcBfwtgWYDzYQbZvA6cCtQJqgoxy0JIOVtg5EoFVwB4ZD7lk3in8HIQ3W2tP8TQefcV0tvkHzdhyR2ghL0ocNcU3ZaoXHvhduP3sltVTO3mj8HScxrkEfFwacw%2BsPE0q34Qt2djW9POvwdV0fV%2BAKBY7XLf9IKBtzXRyVmm9D8qwVZB2xOYp34A4%2FGU4f9rB9F9wtja7KTB7yS2ZYYb1DDsiHI%2Bj8gH0gxHeUS4UKZxa%2FzFVoiNSZCkJSVLmTGatZdyR4xsoyb5CgxSiWOFZO7RzklRPMsb%2BrFpJMcE9Reh%2BeDsePk2Qwik4XkESjMYyixfAUIgGcTRacUuCTV7b%2B0%2FBvmbrTB6wF5STzhp3mNWss2b4xtj353dj29P81sve%2FxzzEmf%2BfwntPAR%2BVZWsQGfNpAzpIInoS0fFNv5%2BOEmQZnyTJZDz6SGlKqScP1u2ut8E3%2BPr1kbP8vMh1fc8uR%2Fy8rx9Xt%2BLClsP%2Bcz6Z0adE11%2F5%2Fd1jDwydfiLbX90UcdsVBgAA)


[Test any.market/store example.com/abc](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFJ9%2FGkC%2F%2B1TXW%2BbMBT9K8gvexgQQ0JJkSatajupXdZ99EOaqgg59m3qDGxmmzAW5b%2FvQpOm2TrttQ%2BTkADfe%2B4999zjFXFQVgVzQLIVqYxeSgHmTJCMMNWGJTPfwBH%2FMXLBSswkR6r1PmxjFsxScuhB1mkDu7NN%2BmV36h3XGC29E10yqTBnCcZKrUgW%2BaTQc31tCsy9d66y2WBQ23DHYCC5VnbQZYV2OUewAMuNrFxfgBxrpYA7j%2FctwLyynujbeE577h6k8XaUvZ6kd6%2BtA%2BFp5d2A4VB0rFvFv4CQBmttaP6mQ5fxqZ69h%2Fb5OCK1EZZktyvi2qrXCo%2B7Xvj5tlNSS%2BXslcbf9CDEJ47wwYBzOP7wgNK1%2F4g9vjj6cLrDN02zX4ErFDhc9vwDoWzIdblXarr2yU%2BtIN8Rm6J4W%2B7wg%2BH2YQPbdGEzjj9zo%2Bsql1tIxQwrbWeSLfh2Dz3dwm97fNdXzhXqnFt8M1ejLTJnavBJWRdO5qxhuyPBc1ZVRYs0LUaxyr5%2B6sFHD8wEc%2Bzv6vkkF7zjKTs%2FRjFPhgmNg%2BGYjYPRHUuDWXw4CsRsHHF6l47Su9ETe%2F9p%2FOfMvacTWAvKSdZ596hoWGvJ%2BpkNbibADYZ7U%2Fxrgy9inKmPFvi%2FkZe0Ebxvli1B5KzLjGl8ENAkoOlVFGXJMEtG4eE4HSXpa0ozSjv%2BYN3DhCu8m09vJfm6OBFn7xr4PjlvLtnHiF4sFnQueTWJrtxNc32eLCaTz4ensaFvyPoXK7gBuDMGAAA%3D)

