### PR TITLE
Add magitch.app custom domain template

### DIFF
--- a/magitch.app.customdomain.json
+++ b/magitch.app.customdomain.json
@@ -9,6 +9,7 @@
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.magitch.app",
   "syncRedirectDomain": "dev.supgen.ai,app.magitch.com,supgen.ai",
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",

--- a/magitch.app.customdomain.json
+++ b/magitch.app.customdomain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "magitch.app",
+  "providerName": "Magitch",
+  "serviceId": "customdomain",
+  "serviceName": "Magitch Custom Domain",
+  "version": 1,
+  "logoUrl": "https://magitch.s3.eu-north-1.amazonaws.com/assets/images/icons/magitch_logo.png",
+  "description": "Connect your domain to your Magitch site",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.magitch.app",
+  "syncRedirectDomain": "dev.supgen.ai,app.magitch.com,supgen.ai",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "proxy-fallback.magitch.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Domain Connect template for Magitch (magitch.app) custom domain service. Magitch is an AI-powered web and mobile application builder that allows users to publish sites with custom domains. This template enables one-click CNAME setup for supported DNS providers.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — N/A, only CNAME record
- [x] `txtConflictMatchingMode` is set on every TXT record — N/A, no TXT records
- [x] no variable is used as a bare full record value — no variables used
- [x] no bare variable is used as the full `host` label — no variables used
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — N/A, single static CNAME

## Online Editor test results

**Editor test link(s):**
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADEh%2FmkC%2F91TUU%2FbMBD%2BK5VfSVInDZBGmjRWQCBW2Bh7Gaoi17mlFont2U5LWvW%2F79IQSrdp2vOerPN93913n88b4qDSJXNA0g3RRi1FDuY6JympWCEcXwRMa%2BK9pm5ZhVAy7ZKYsGCWgsOOwmvrVJWrigm5Tx1SBpMdaHDeo5ZgrFCSpKFHSlWor6ZE9MI5bdPhsFdhRwHUvlTGLfwwYBVbK8lWNuCqGjJrwdmhQCzgwZW0PS9rKwZaFtgoB8uN0G7XjEyUlMDdoFG1GXSSB051YS%2FVCvQF52gk%2F1Aq%2FkTS76y00N18quc30LyMkZKuBO%2BqBofmtfB7yIXB1J4Ay8DWugAZMOEh8JWEM3mvGaQvlHX38KNGPrrsTI0KsJQyuSXp44a4RrcGT27PphcvcAzft6%2BmhHT2QWGID%2Fjc%2BKi%2FnDP%2B9ItA59Dz0Qml29nWI2gtZPsGM%2B9lOKwCzwzXBVqJ%2B06r1QqDwqhaZ6KnaGZYZdut6smPB%2BxZT3%2Fc8du%2BosD3hcziyVxtoJ%2B1qksnMrZi%2B6ucZ6i8bFCmxSxW%2Bd0H2e1dpy5njv2zCx7Jct5KF%2B1WRzllSRgnfnh6Qv14nCT%2BPAHwx3Q0HiejmCbj6M0P%2BcPn%2BcsfObAQcJGlE6z9AGflijWWbLczD%2B38f6fDPbBsCXnGWmREoxOfHvs0eQhP0%2Fg4jcIgpDQK4yNKU0rbOcC6bt4N7szbbSGX0d2kPr%2BcjppJkcTx6OrbR309%2F6KnR%2BOHek1vLj%2FD5EqytZlevCPbnyG%2F56L8BAAA