### PR TITLE
Add Temple storefront Domain Connect templates

### DIFF
--- a/getemple.com.storefront-apex.json
+++ b/getemple.com.storefront-apex.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "getemple.com",
+  "providerName": "Temple",
+  "serviceId": "storefront-apex",
+  "serviceName": "Temple Storefront",
+  "version": 1,
+  "logoUrl": "https://admin.getemple.com/icons/temple-admin-192.svg",
+  "description": "Connect an apex/root domain to a Temple storefront.",
+  "variableDescription": "%IP%: Temple storefront IPv4 address",
+  "syncPubKeyDomain": "domainconnect.getemple.com",
+  "syncRedirectDomain": "admin.getemple.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": "3600"
+    }
+  ]
+}

--- a/getemple.com.storefront-subdomain.json
+++ b/getemple.com.storefront-subdomain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "getemple.com",
+  "providerName": "Temple",
+  "serviceId": "storefront-subdomain",
+  "serviceName": "Temple Storefront",
+  "version": 1,
+  "logoUrl": "https://admin.getemple.com/icons/temple-admin-192.svg",
+  "description": "Connect a merchant subdomain to a Temple storefront.",
+  "variableDescription": "%CNAME%: Temple storefront CNAME target",
+  "syncPubKeyDomain": "domainconnect.getemple.com",
+  "syncRedirectDomain": "admin.getemple.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%CNAME%",
+      "ttl": "3600"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds Domain Connect templates for Temple storefront custom domains:

- `getemple.com.storefront-apex.json` points apex/root domains to Temple's public A record.
- `getemple.com.storefront-subdomain.json` points subdomains to Temple's storefront CNAME target.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- [Test getemple.com/storefront-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPti%2FmkC%2F91TYW%2FaMBD9K5GlfmoSklACRJq0lkodqtayju3DEIoO2wVviZ3ZJpQi%2FvvOgRZop%2F2AfYhyunvv%2FO75vCGWl1UBlpNsQyqtasG4HjKSkTlvSjykqiT%2Ba%2B0OSsSScVPDvOG6FpQ3FGOV5o9aSRtAxZ8O1ROS9%2FUVhoiaayOUJFnsk0LN1TddIHJhbWWyVgtYKWR4LKUlqJKmtUsETT2I%2B0lo6jl2Y9xQLSrbdCQDJSWn1gPpOT0trZT1mCpBSM8qD7y9oIPu0CkCLWBW8OuTXmfD0Vn2nuANR%2FWFB4xpbowbeC3paDm75evr5hxk7g6kOy3hG1sd%2FoEzobH2yng%2FNSIRoTQzJJtsiF1Xzs9LTC%2BUsRh%2BdFekhLRmrPZqMWOtM7OdRhHZTrc%2BeVaS54dGU38vDkH8CY4O23fFaK7VssrFC74CDaVxy%2FLCnJxQpy%2FcCXHxcOSiuNcN4wS%2FThrGcZc4KWIu0cPc4B%2FsUuM4Vi%2B5T8plYUUOKzikGM2hqoo1KjdYxY6nFsjddjkLGFjA8O2BeyecET7JGXX6BWuc7vTjHvSDftztBBcAaQAAUdB7jKO0R2NGKT1a%2Fr89jH8%2FgIORuB9cWgHuRi6LFawN2W6nPpr6%2F0yDN26g5iwHB0uiJA2iThD1xkmSJWkWtcNO0m330%2FMoynAncRBu7G7KDe7E8TaQz6vnxfUgPf8pJes%2Fzr5%2Fqu%2Bjy5vfdfsqrX8N7r7QW%2FVw0%2F6xlle9D2T7B41JCNjJBAAA)
- [Test getemple.com/storefront-apex example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFFm%2FmkC%2F91Tf2vbMBD9KkbQv2o7tvPLNgzWrWsX2pVs7WBbCeZiXVJBLHmSkjQN%2Be47OWmTtGMfYGBj6%2B6907un05pZrOoZWGT5mtVaLQRHPeAsZ1NsUhiWqmL%2BS%2B4GKsKyuyZHcYN6IUpsKMYqjROtpA2gxsd99ojk3b7ACLFAbYSSLI99NlNT9V3PCPlgbW3yVgt4JWR4KKUlSiVNaxsImnwQZ0loFlOqxtGUWtS2qcg%2BKimxtB5Iz%2BlpaaWsx1UFQnpWeeDtBO11h04RaAHjGZ4f1ToZDE%2FytwRvMFx0POBcozGu4ZUsh%2FPxFa7Om32Iud2w3GoJX9nq8N%2BQC025F8bbrglJCKW5Yfn9mtlV7fw8o%2FCDMpZ%2B37sjUkJac6d2ailirTOz3YsithltfPakJBb7QiN%2FJ45A%2BAgHm%2B2qLpdLWky1mteFeKbUoKEybl6eyfdH7NEz%2Fb7h03IwdIs47YdxQm%2B3F8ZxnzlBYirJycLQF%2BxcU1NWz9Fn1XxmRQFL2Id4WUBdz1ak31CWKh4bIbcztpXMwQItXm%2B5c8QZ4rOCl64J4SY3idOMnkmQlpwHnXEKwTjFLJj025jxqANRNj64BH%2B7IP%2B%2BCEeG0qigtALc4ZzNlrAybLMZ%2BWTuf9YSnb2BBfICHDKJkl4QdYMovUuSvBPlcT9sZ72sHZ9GUU4zSr2gsdtG1zQdh3PBfiYXV0q1L6PTLxWWkcgefpSfJxdPl%2FDh6zn8%2FoU3%2FU%2Bt2%2B51d5i%2BY5s%2FiZOB%2FNkEAAA%3D)
- [Test getemple.com/storefront-subdomain example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP9i%2FmkC%2F91TXW%2BbMBT9K8hSnwoJkIYSpEmrmk6qqlZTlj1sVYQu9m3iDmxmm3Qsyn%2BfDflo2j3seU%2FI955zOef4ekMMVnUJBkm2IbWSa85Q3TKSkSV2LRxQWRH%2F0HuAymLJvOvZuka15hQ7ijZS4ZOSwgS6KZisgIsj5ITpfTlgLWKNSnMpSBb5pJRL%2BVWVFrkyptbZcAis4mLwWs%2BQUyn0sC8EXT%2BIJvFAr5d2GkNNFa9NN5FcSyGQGg%2B8ChVdgTDeQZxnpK3vFB3VD5wkUByKEqcnw86uH67ub86y9xyv63gGlBXqTLeCfm6KO2ynfQ4Z6f9Jez2DN%2Fk6%2FAwZV7Z3YLx3bpErqc0MfzYWakM3qkGfWJZUTJPscUNMW7ucOz07uD1%2BdHcouTB6Lo9GbNEYl%2FUoCUOyXWx98lsKzI%2FzFv5OtwXhL3ijw136Stb2tFSyqXO%2B59SgoNJuqfbsxxP6Ys9%2F7AfYcy%2FYFVyo%2BtS2U8aXwjZybb9gGoV781VTGp7DCxxLjOZQ12VrjWjbtVPfByP6fdzpZ2Bgv8L6beRdRi4in%2BSMOlfc7TtNgUZsNAmKKE6DCwYsKGhEA4wncJmMn%2BKLKHz1dP72rP7h%2BZzmjFqjMBzcpV2VL9Bqst0ufJv5%2F%2B3QLoiGNbIcHDQO4yQIx0GYzuM4i5MsvByMR8koSs%2FDMAudJoPa9JY3dndebw1Jh99DnbDpCnB6K5%2Fr8Hk8S3%2FcNZPifFx9k63%2BdCPvxw9p0qYfyPYPHJnz1CQFAAA%3D)

