### PR TITLE
add Bundly, Bundly Bundle

### DIFF
--- a/bundly.innolope.com.bundle.json
+++ b/bundly.innolope.com.bundle.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "bundly.innolope.com",
+  "providerName": "Bundly",
+  "serviceId": "bundle",
+  "serviceName": "Bundly Bundle",
+  "version": 1,
+  "logoUrl": "https://bundly.innolope.com/icon.svg",
+  "description": "Connects a customer domain to a Bundly bundle by adding ownership verification and service host records.",
+  "variableDescription": "%serverIp%: Bundly VM IPv4 address; %verificationToken%: Bundly domain ownership verification token",
+  "syncPubKeyDomain": "domainconnect-keys.bundly.innolope.com",
+  "syncRedirectDomain": "bundly.innolope.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_bundly-verify",
+      "ttl": 600,
+      "data": "bundly-verification=%verificationToken%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "bundly-verification="
+    },
+    {
+      "type": "A",
+      "host": "sign",
+      "pointsTo": "%serverIp%",
+      "ttl": 600
+    },
+    {
+      "type": "A",
+      "host": "book",
+      "pointsTo": "%serverIp%",
+      "ttl": 600
+    },
+    {
+      "type": "A",
+      "host": "meet",
+      "pointsTo": "%serverIp%",
+      "ttl": 600
+    },
+    {
+      "type": "A",
+      "host": "admin",
+      "pointsTo": "%serverIp%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Bundly Domain Connect template for connecting customer-owned domains to a Bundly bundle.

The template creates:

- `_bundly-verify` TXT ownership verification record.
- `sign`, `book`, `meet`, and `admin` A records pointing to the customer's Bundly VM IPv4 address.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Local checks performed:

- JSON schema validation against `template.schema`: passed.
- `curl -I https://bundly.innolope.com/icon.svg`: returned `200` with `image/svg+xml`.
- Repository GitHub Actions lint/schema checks passed on the initial PR revision.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

No `essential` records are set because all records in this template are required for Bundly service routing/verification and are expected to remain managed as part of the Bundly connection.

## Online Editor test results

**Editor test link(s):**

Apex/no host test:

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOSx%2F2kC%2F%2B1WXW%2FaMBT9K5GlPpWEEL5Kpj3QUU3TRttNdJpUocg4N%2BA1sSPb0Gao%2F33XkPDR0mrqG1rfEvse33PuvT7ykhjI8pQaIOGS5EoueAzqS0xCMpmLOC08LoRMZQ4ekxmpbUIuaYYQcr4KwnUNasEZbJGwXdyLdc6r3QUozaUgYaNGUjmVNyrFqJkxuQ7r9QPp65xJ4enFFMExaKZ4blYHkE9SCGBGO9Rhc21kBsqJZUa5cIzExTL1mpgzKRwax1xMHXkvkMSM5w6S4Qln1B7oUBE7JXdnJrVxFDCpYu1Z1lRxOklhsEfgxIZj4fKTsEr2c%2Bh8uV60bCoFWn9wTnZzjOQdiG1wSfYFPsYG23oWgl3PJ1%2BhGKziMfEayNb63TsotHe4cRb7A2KOUswG%2FXLoeSrZHQkTmmqokVI%2FCW%2BXxBS57ebo1whDbXXwJ1of5K5Y23EwBnvZ8X1sFDV0k8ndlfXxQEEs9MFgO5OUMzOkhs2wT0MZ25TXChL%2BcDik3DuciDzWNrz7W9aaT21Vc8mF0SO518YdDYfBEynv3gzOAMybwTTO%2BD%2FxHj%2FWyB8pINq2b1wrJwZB8EDx6ldNLw%2FHr6mS8zziVXxOFc20tYcKebsHHVfYW2K%2FKyb2P%2FCbnu81Gk2v4du9Z%2F22QQa0cVcT7jaCJrGksS9SQWT7Q81coX6j5jiG2Tw1PKL3dLsUs4jmeVqgRo27eODTERVr93k2oq8M5hNKu%2BMcxcyWglufo7QN4NOu22mfnbkt6LbdCXQ77lmvk7STVqvLeq0dy3zFVQ%2B657YjaB8gDKfWH%2FvpPS00eXwyG6XKcqRLbXv1PyIV5d06chXlJT9yFZXbHI%2BMcQ1t690F3l3g3QX%2BZxewbxG6gDiiZsU46Lh%2B2%2FV7oyAIG%2B3Q970gCDqd3qnv449Vgfd9rW%2BJb5Dd1wcZyOR3Ib5fyc%2FD1mlmVP2qP0wWTT3k4uLiohuMpsElu%2FnWHcz7%2BNj8C0PuT79VDQAA

Host test:

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOSx%2F2kC%2F%2B1WXW%2FaMBT9K5GlPo2EEL5Kpj30Y5uqqh2q6NStQpGxDXgkdmY7pAz1v%2B%2BahI90tJr61opH2%2Ff4nnPv9ZGXyLAkjbFhKFyiVMk5p0xdUBSiUSZovPC4EDKWKfOITFBtE3KNE4Cg01UQ7Gum5pywLZJtNyuxzun6dM6U5lKgsFFDsZzIWxVD1NSYVIf1%2Bp70dU6k8PR8AmDKNFE8NasL0JkUghGjHeyQTBuZMOVQmWAuHCNhs0xdEHNGCwdTysXEkbkAElOeOkCGjznB9kIHC%2BqU3J2p1MZRjEhFtWdZY8XxKGbnFQJHNhwKlx6F62Tfr5yL%2FrxlUymm9UfnaDfHQM6Y2AaXZJ%2FhY2ywredCkH42umSL81U8JC6ApNDvzthCe%2FsbZ7E3jHKQYjbo50NPY0lmKBzjWLMaKvWj8H6JzCK13RzcDSDUVgcWUXGRu2Jtx8EY6GXH96FR2OBNJndX1qc9BbHQBwPtHMecmCtsyBT6dCWpTdlXbMwf9oeUZ%2FsTocfahvfJlrXmE1vVVHJh9EBW2rijYT94JOXs1eCEMfNqMKYJ%2Fy%2Few8ca%2BiMFi7btG9bKiQEQe8Dw9NdNLy%2FP8xwWEyWzNOJrSIoVTrR1iDX4voIeruH3K%2FywePmWj90K%2FKbne41G02v49uyfrtsgw7RxV3PuNoImstShO1KxyHYJm0xBFYzKYBiTLDY8wjneblES4TSNF6BUwylc%2BHRQReFB1UH1CrUvjOgTWruDHVFiK8Kt4zVHTdprt3puGwcdt0VJ1%2B3hbuAGnaDT7BBMuz1%2Fxzxf8Ne9PlrpDXgJE4Zja5YncY4XGj0%2BGZRSrK1cVWKlFW9LjH1v70aMff%2FvRszKj96immENzO1gFAejOBjFwSheNAr7o8FzRiNsVqSBht92%2Fd4gCMJGO%2FR9r9M9bnSPP%2Fg%2BLKwQsINC4hJ%2BMrt%2FGNSKv3y9PAsY7l%2F%2FCAQl7Lie%2Fr79NujdZSefcxMkv%2BjNvPVzbK5y%2BLj%2BBXEQDyKhDQAA
