### PR TITLE
Add Genitor template (genitor.net.web.json)

### DIFF
--- a/genitor.net.web.json
+++ b/genitor.net.web.json
@@ -1,0 +1,17 @@
+{
+  "providerId": "genitor.net",
+  "providerName": "Genitor",
+  "serviceId": "web",
+  "serviceName": "Genitor Website",
+  "version": 1,
+  "logoUrl": "https://genitor.net/logo.svg",
+  "description": "Connect your domain to a Genitor website. Adds the Cloudflare-for-SaaS apex A records, the www CNAME, and the per-cert SSL ownership validation CNAME issued for this hostname.",
+  "syncPubKeyDomain": "genitor.net",
+  "syncRedirectDomain": "genitor.net",
+  "records": [
+    { "type": "A",     "host": "@",               "pointsTo": "188.114.96.3",         "ttl": 300 },
+    { "type": "A",     "host": "@",               "pointsTo": "188.114.97.3",         "ttl": 300 },
+    { "type": "CNAME", "host": "www",             "pointsTo": "fallback.genitor.net", "ttl": 300 },
+    { "type": "CNAME", "host": "_acme-challenge", "pointsTo": "%DCV_TARGET%",         "ttl": 300 }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **Genitor** (https://genitor.net), a website builder. The template lets a customer whose domain is on Cloudflare DNS one-click attach that domain to their Genitor-hosted site.

Genitor uses **Cloudflare for SaaS** to terminate TLS for customer custom domains. Attaching a domain needs three things: the Cloudflare-for-SaaS apex `A` records, a `www` `CNAME` to our fallback origin, and the per-hostname certificate-ownership (**DCV**) validation `CNAME` — the only dynamic record, surfaced via the `%DCV_TARGET%` template variable.

- **Synchronous flow** only (`syncBlock` not set → default `false`).
- **Public key** is published at `_dck1.genitor.net` per the spec (`syncPubKeyDomain: genitor.net`).
- **Proxy intent:** all records DNS-only (gray cloud) — Cloudflare-for-SaaS apex IPs and the DCV CNAME both require DNS-only mode; proxying breaks them.

Note on the bare `%DCV_TARGET%` value: it is the RDATA of a `CNAME` (the certificate-validation target hostname), which by definition cannot carry a fixed prefix, so a bare variable is necessary here.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
[Test genitor.net/web — apex, no host](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANu0GWoC%2F%2B1VbU%2FbMBD%2BK5YlPi1Jk76mkSatKoxNAzZoB5NQFbnxtTUkdmQ7CV3V%2Fz67L2sLY2jfkManOHf33D13vkdeYA1ZnhINOFrgXIqSUZCfKY7wFDjTQnocNHZ%2Buy5IZkLx6dppHApkyRJYQSoY7yyHkegGxoqZMg4uQSomOI4CB6diKr7L1MTNtM5VVKvtla1Zr6fKqQFRUIlkuV4BcV9wDolGc1FIREVGGEdaIIK21ap1NQ%2F1KFVIzwD1U1HQSUokuBMh3QEhA0RyeEA9JCERkipnFVdVFepf9M5PHEQ4XZlykG4CUqPB4AyJihv%2BM5ajkqSMEstoDUBMqQIoMukNjCk0E0pzMwXPDmXOk2%2FF%2BAvMj1d0nwzYBlwBZYaMfiZkwxNHtwus57mdbs%2BYbRlz%2FGBvSTCu1VCY3yAMvSBoet221zAerc2QG76%2FdP4F23kOu2p4hzdDO8wwIWk6Jsm9d9jBy5likmTgJjODBz6Fw6xHx%2F3reNi7Oj0ZHu1nGy0d%2FFNwiHcTGpmV2U4RHojZcfASke0KmdNUiiKP2TY%2BJ5Jkyupgi7w9gI622Ftszzsu1kKT8qBXS4lNuZAQK%2FMlupCmWy0LcHBWpJrFpCI7E01ikufp3HSgjNdkPLxjvhaTvSezcuT5%2B3VwTBPbA7OCnIxJtznp1N1mm47dZmfSdcPmJHAbSb3Tgm439IPWnrj%2FoPun8t7ND5QCrhmx8u2lFZkrvHy0X3%2Fh3XmtvLcbueG%2B3u0N%2Bxf2%2BvV28VRXm44eL%2B4rambkGFm%2B6eBNB%2F%2B7Dsxro0gJNCY2rO7X267fcuvdYdCKmu2o0fIa9UYQ%2Bu98P%2FJ9Sx2UXve1MO%2FQ%2FguEa7T1FdI7NbsX3XbaKQdnOpzT8FMYVD%2Byu8v%2B4Oz68uPxzflJWb3Hy19MdDODIAoAAA%3D%3D)
[Test genitor.net/web — subdomain, host set](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB61GWoC%2F%2B1V32%2FaMBD%2BVyxLfWqShl%2BBRpo0RLtq2tZWQLtuFYpMfIC3xI5sQ6CI%2F30XKIPQtdXe%2BtAn8N19d%2Fed74uX1EKaJcwCDZc002omOOjPnIZ0DFJYpT0Jljp%2FXZcsxVB6sXGiw4CeiRjWkByGO0s5knyHoRFYxqEz0EYoScOKQxM1Vjc6wbiJtZkJT072yp4UXs%2FMxgjiYGItMrsG0o6SEmJLFmqqCVcpE5JYRRjZVss31TzS5twQOwHSSdSUjxKmwR0p7fYY6xGWwZy0iYZYaW6cdVye56Rz2f527hAm%2BdqUgXZj0Jb0el%2BJyiX2PxEZmbFEcFZ0tAEQYcwUOMH0CBOGTJSxEqfgFUNZyPh6OvwCi7N1u08GXAR0gQtsxj4T8tgnDe%2BX1C6yYrptNBdl8O%2FH4paUkNb0FR4rrZZXqdS908CrocdaHHLN91fO%2F2Cbz2HXhHd4HFo5w4glyZDFv70yg9czRSxOwY0niAc5hnLWo7PObdRvdy%2FO%2B0f72QYrhz4oCdFuQgNcme0UYc5wx8GLVborNMTlwtNYq2kWiS0mY5qlptDCFn1fgg%2B2%2BPtNAjzveiqsPJ6VOBetibFUGiKDv8xONbK2egoOTaeJFRHL2c7E44hlWbJAJga9mLF813IjqsfmcfvY81ft0IjHBRVRaNPnvFZp%2BS03COojt%2B43R26rGVTdZqNW4WzIqn6tvqfzf3wCniq9PEowBqQVrFBzO8nZwtDVwbq93H7zLbe%2F3dNHCrjxXpnGKyv%2FtukcyO6A2uFSvzFWAwel%2B66Td5286%2BRlneBrZdgMeMSK0KpfDVy%2F4VZP%2B5VGWG%2BG9ap32vCDavPY90PfL9oHYzfclviO7b9g9Pb6x91xlo%2F8Ydo2n36O55NfCUuD43T%2BcHXV6nVv7joP3c4kOIvrH%2BjqD9lOx%2FtoCgAA)

Tested in the Online Editor with `domain=example.com` (apex) and with a host set (subdomain). Output records match exactly what Genitor's backend issues: apex `A` 188.114.96.3 and 188.114.97.3, `www` `CNAME` → `fallback.genitor.net`, and `_acme-challenge` `CNAME` → the per-cert DCV target supplied via `%DCV_TARGET%`.