### PR TITLE
Add Drite Studio hosting verification template

### DIFF
--- a/dritestudio.co.th.hosting-domain-verification.json
+++ b/dritestudio.co.th.hosting-domain-verification.json
@@ -15,6 +15,8 @@
       "type": "TXT",
       "host": "_drite-verify",
       "data": "drite-domain-verification=%verification_token%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "drite-domain-verification=",
       "ttl": 300,
       "groupId": "verification"
     }

--- a/dritestudio.co.th.hosting-domain-verification.json
+++ b/dritestudio.co.th.hosting-domain-verification.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "dritestudio.co.th",
+  "providerName": "Drite Studio",
+  "serviceId": "hosting-domain-verification",
+  "serviceName": "Hosting Domain Verification",
+  "version": 1,
+  "logoUrl": "https://dritestudio.co.th/img/logo.svg",
+  "description": "Adds the TXT record required to verify ownership of an existing domain before claiming a Plesk hosting subscription in Drite Studio.",
+  "syncPubKeyDomain": "domainconnect.dritestudio.co.th",
+  "syncRedirectDomain": "dritestudio.co.th",
+  "syncBlock": false,
+  "variableDescription": "%verification_token%: TXT token generated for the signed-in customer and domain",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_drite-verify",
+      "data": "drite-domain-verification=%verification_token%",
+      "ttl": 300,
+      "groupId": "verification"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Drite Studio Domain Connect template for hosting domain ownership verification. The template creates a TXT record at _drite-verify with a generated drite-domain-verification= token.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality in the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern <providerId>.<serviceId>.json
- [x] resource URL provided with logoUrl is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] syncPubKeyDomain is set - **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] warnPhishing is **not** set alongside syncPubKeyDomain - the two must not appear together
- [x] syncRedirectDomain is set whenever the template uses edirect_uri in the synchronous flow
- [x] no TXT record contains SPF content ("v=spf1 ...") - use the SPFM record type instead
- [x] 	xtConflictMatchingMode is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. @ TXT "%foo%") unless necessary - prefer @ TXT "service-foo=%foo%"; if bare, justify in the PR description
- [x] no bare variable is used as the full host label - the non-variable parts are fixed to limit misuse (e.g. %dkimkey%._domainkey, not %dkimhost%); if bare, justify in the PR description
- [x] no variable is used in the host field to create a subdomain - use the host parameter or multiInstance instead
- [x] %host% does not appear explicitly in any host attribute
- [x] essential is set to OnApply on records the end user may need to modify or remove without breaking the template (e.g. DMARC)
  - Not applicable: this is a temporary ownership verification TXT record.

## Online Editor test results

**Editor test link(s):**
[Test dritestudio.co.th/hosting-domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABorAWoC%2F%2B1UXW%2FaMBT9K5alPpVASKF0kfrQrdO%2B1A61XbWpQpFj3wSvSZzZDpAh%2FvuuEyiw0ml73xMmPvf4nnOPvaQW8jJjFmi4pKVWMylAfxA0pEJLC8ZWQqouV107pZ0nwDXLsYBeOgi5bTC4a0DPJIemeqqMlUXqCZUzWXgz0DKRnFmpii1yTfO%2BxZLLBkvu97FYatwq7HdoplL1RWeO39rShL3esy57Mk97Dtc1sxTLBRiuZdmQhfRCCEPsFMjd1zuigSst8OdHJTUIYhVp%2BqyJmhd46lSWRCWEFQQWsm2xlUNiSJQGwjMmc%2FeZkXEG5pGsVRNTxU%2BnEsTvGtV1%2BuuCj6v4E9StZmd3s%2BCqKIDb7iHzXdENCGyV223ZC8DXmeKPNExYZgA9ZFqyOIPLPTOOdqcSWfUIxVHYONOsSQroAkZDEFTbuGZkWoDwUBGvjFU5aHRHrF3Bk1tHDQ0fltTWpRsu0uGGMwb%2FRE27bRpqNxxm2UbEoaicH2oR6%2BzCvlFFkklur5jlU%2FT8Sgl33FhDIheHIeu9P53nCi3m68T3OzTVqiqbNO%2FFdzVZdehPVUC0lTvprAeIYFgwvFKA48i3yumaLpINfp8Rq0umWW7cJdzwPOwRTTZMD9StG65DPM%2F9cigXkY3edcS8dtNpwaFimiM3XGYrjTZaXWFq8iqzMmJztv0keMTKMqtRusFd5P590kV7p%2F950i%2B3uDuSSHDnkWweqCGLRyeJ8LhgiTcIwPdeJcnI68d95kPCAh4EO2%2FWi4%2Fa3z9b21mCMVBYydxTdJHNWW3oajXpYA7%2B%2B7H1A%2FNo2AxExBws8INTzx96%2Ff6d3w%2F9QRicdoNgeDYYHft%2B6PtOGPbSOrPEXO4mkl5AfZyIs2pYyfk3K2wvVQPG77%2F3ssHtWfkx%2F3yj3o1Hce8qfntOV78AeMV6jdgGAAA%3D)
[Test dritestudio.co.th/hosting-domain-verification example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABwrAWoC%2F%2B1UXW%2FaMBT9K5alPkEgUKBrpD70Y9Wqiqrd2DStQpGxL8EiiTPbIVDEf991EgqsdNsP2BMmPvf43nOOvaYWkixmFmiwpplWCylA3wkaUKGlBWNzIVWLq5ad0eYr4IElWEBvHIR8KTG4a0AvJIeyeqaMlWnkCZUwmXoL0HIqObNSpTtkTfOpwpKbEku%2BHWKx1LhV0GnSWEXqq44dv7WZCdrtN122ZRK1Ha5lFhGWCzBcy6wkC%2BilEIbYGZDR9xHRwJUW%2BPMzlxoEsYqUfa6IKlI8dSYzoqaEpQSWsmqxGodMYKo0EB4zmbjPjDzGYOaknpqYfPJ6KkH8vlAtN%2F8q5Y%2F55B5W1cxO7nLBVZoCt61j4ruizyCwVW53Ze8Ar2LF5zSYstgAasi0ZJMYbg7EONl3JbRqDulJUCpTrkkEqAJGQxCctlTNyCgF4eFEPDdWJaBRHVGrgidXihoaPK%2BpXWXOXKTDDScM%2FgnLdqs0rJw5zLLtEMeicnGsRayzS3ut0mksuR0yy2eo%2BVAJd9yjhqlcHofUe386zxVazNep7zdppFWelWk%2BiO9mvGnSF5VCuBt33KwNRDAsGV4pQDuS3eRFUdCaMZRlySEpEmRMs8S4e7ilej7gGm%2FJnku2cU13jOqtag7lgrKdug6aV226idBazHToLGY21yim1TlmJ8ljK0NWsN0nwUOWZfEKBTC4i9y%2F%2B51WN%2FvA71alwV89f7%2FNfXNCwZ1U0tnT6%2FDzAT%2BfeBN%2FMPB6ne7AY%2F3pucdOz077A%2B5Pun2293q9%2B7z9%2BwN24CoYA6mVzL1Ll3HBVoZuNuMmhuK%2FLG9kwXQatgARMofs%2BtiU3%2Fc6nZHfCfxe0P3QOut3fH%2FQ8P3A991s2E4lzhpTup9P2rWj2493MhbDh3vVj2fDdqMnC5vGP1hjXrzcRqOrRn72dF3kxQXd%2FAJ0kR9J7AYAAA%3D%3D)