### PR TITLE
Add diamondhost.tw.minecraft-hosting.json

### DIFF
--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -1,6 +1,7 @@
 {
   "providerId": "diamondhost.tw",
   "serviceId": "minecraft-hosting",
+  "serviceName": "DiamondHosting",
   "providerName": "DiamondHost",
   "records": [
     {

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -1,7 +1,7 @@
 {
   "providerId": "diamondhost.tw",
   "serviceId": "minecraft-hosting",
-  "serviceName": "DiamondHosting",
+  "serviceName": "Minecraft Hosting",
   "logoUrl": "https://r2.diamondhost.tw/logo.png",
   "syncPubKeyDomain": "v1.domainconnect.diamondhost.tw",
   "syncRedirectDomain": "diamondhost.tw",

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -13,7 +13,7 @@
       "type": "SRV",
       "service": "minecraft",
       "protocol": "tcp",
-      "name": "%name%",
+      "name": "",
       "priority": 0,
       "weight": 0,
       "port": "%port%",

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -2,6 +2,10 @@
   "providerId": "diamondhost.tw",
   "serviceId": "minecraft-hosting",
   "serviceName": "DiamondHosting",
+  "logoUrl": "https://r2.diamondhost.tw/logo.png",
+  "syncPubKeyDomain": "diamondhost.tw",
+  "syncRedirectDomain": "diamondhost.tw",
+  "version": 1,
   "providerName": "DiamondHost",
   "records": [
     {

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -3,8 +3,9 @@
   "serviceId": "minecraft-hosting",
   "serviceName": "DiamondHosting",
   "logoUrl": "https://r2.diamondhost.tw/logo.png",
-  "syncPubKeyDomain": "diamondhost.tw",
+  "syncPubKeyDomain": "v1.domainconnect.diamondhost.tw",
   "syncRedirectDomain": "diamondhost.tw",
+  "syncBlock": false,
   "version": 1,
   "providerName": "DiamondHost",
   "records": [

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "diamondhost.tw",
+  "serviceId": "minecraft-hosting",
+  "providerName": "DiamondHost",
+  "records": [
+    {
+      "type": "SRV",
+      "service": "minecraft",
+      "protocol": "tcp",
+      "name": "%name%",
+      "priority": 0,
+      "weight": 0,
+      "port": "%port%",
+      "target": "%target%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -13,7 +13,7 @@
       "type": "SRV",
       "service": "minecraft",
       "protocol": "tcp",
-      "name": "",
+      "name": "%host%",
       "priority": 0,
       "weight": 0,
       "port": "%port%",

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -11,8 +11,8 @@
   "records": [
     {
       "type": "SRV",
-      "service": "minecraft",
-      "protocol": "tcp",
+      "service": "_minecraft",
+      "protocol": "_tcp",
       "name": "",
       "priority": 0,
       "weight": 0,

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -13,7 +13,7 @@
       "type": "SRV",
       "service": "minecraft",
       "protocol": "tcp",
-      "name": "%host%",
+      "name": "",
       "priority": 0,
       "weight": 0,
       "port": "%port%",

--- a/diamondhost.tw.minecraft-hosting.json
+++ b/diamondhost.tw.minecraft-hosting.json
@@ -18,7 +18,8 @@
       "weight": 0,
       "port": "%port%",
       "target": "%target%",
-      "ttl": 3600
+      "ttl": 3600,
+      "essential": "Always"
     }
   ]
 }


### PR DESCRIPTION
# Description

Add a new service template for Diamond Hosting (diamondhost.tw) Minecraft services. 
This template allows users to quickly configure their domain to point to our 
Minecraft hosting nodes via SRV records.

- **Provider**: Diamond Hosting
- **Service**: Minecraft Hosting
- **Reason**: To simplify the DNS configuration process for our customers using Domain Connect compatible DNS providers (e.g., Cloudflare, GoDaddy).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results
[Test diamondhost.tw/minecraft-hosting example.com/play](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKE9BGoC%2F%2B1T227bMAz9lYFAn2Y7jhPnYmAPTYuh69qu6NYBQ2AYisWkWm3LlZRkbpB%2FH2Xn0nTZMGCve7JEHh6R59ArMJiXGTMI0QpKJReCo%2FrAIQIuWC4L%2FiC18cwSHNCoFiLFOpmLAlPFpsa1eVHM9vkblhMZXG8Rby52iEzO5L3KKPtgTKmjVksF3uE7LYvxyoawKtLb%2BeQjVucyZ6KgukXb4%2FU5lQXxG%2B%2FXLqnoDrlQlN2VHUWNMpk%2BQjRlmUYHFqi0kARuOzsdNqOcN9V2DiolYqm4hmi8AlOVFvD57ut%2BfronO3mgJjMylXbqxKQlRYqGts4JqYSpIPIdWKKYPZj6WEpFBzix3xPCGaZmWEeaUx0zRNnp%2BQRHrbEwgtk3TrMlqzSs47UDz7LAZN9v7ADfKoI%2FGPmOXipz4rLCUJAWoaLbTMl5mYhtTckUy7Xdj231%2BKA83taPG4J43%2B%2B4FgXVa5vi7YhjCMKwF4LtVswKqTDR9GVmrkgio%2BbkTD7PjEjYku1DPE1YWWYVDacpSzyvzdhovJmIM8PodryZAylfuNWY9VtX%2F%2BRcPZQDCU%2BtbML%2BMYOg38Ye67i8H6LbTcOJOwiGE3fYxUHIQ%2Bx3OwE4%2F%2FgLHvp4bC3WsUOe%2Flfrb9WiTdVsgTxhFhr4Qc%2F1Q7fd%2BeIPI9%2BP2n2vGwwGne5buvi%2BVQe1aQRc0U6%2F3GZoP4dn18vWd3y8wun907dlvzsa3Xy6LZ7ys8thKiR7P%2BxdXV6cloN3sP4JOMamI5sFAAA%3D)


I noticed that when I host without including data, it displays “Error! A problem has been occurred while submitting your data: Invalid data for SRV host: _tcp.@”, but I don't think this is an error. Or is there a better way to use it?

<img width="1005" height="905" alt="img" src="https://github.com/user-attachments/assets/9475daff-da1c-4ed9-8d09-aee89a07ad5d" />
