### PR TITLE
Add proofly.ae.edge template

### DIFF
--- a/proofly.ae.edge.json
+++ b/proofly.ae.edge.json
@@ -6,14 +6,13 @@
   "version": 1,
   "logoUrl": "https://proofly.ae/logo.png",
   "description": "Front your Framer site with Proofly's reverse proxy — adds an A record so visitors hit Proofly Edge.",
-  "variableDescription": "We will add a single A record pointing your domain at our edge proxy.",
   "syncBlock": false,
   "syncPubKeyDomain": "proofly.ae",
   "records": [
     {
       "type": "A",
       "host": "@",
-      "pointsTo": "%ip%",
+      "pointsTo": "51.89.33.47",
       "ttl": 300
     }
   ]

--- a/proofly.ae.edge.json
+++ b/proofly.ae.edge.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "proofly.ae",
+  "providerName": "Proofly",
+  "serviceId": "edge",
+  "serviceName": "Proofly Edge",
+  "version": 1,
+  "logoUrl": "https://proofly.ae/logo.png",
+  "description": "Front your Framer site with Proofly's reverse proxy — adds an A record so visitors hit Proofly Edge.",
+  "variableDescription": "We will add a single A record pointing your domain at our edge proxy.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "proofly.ae",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **Proofly Edge** — a reverse-proxy service for Framer sites. The template adds a single A record at the user's chosen host (apex or subdomain via the `host` parameter) pointing at the Proofly edge proxy IP.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Linter run (both standard `-cloudflare` profile and strict `--merge-or-fail` mode):
```
dc-template-linter -cloudflare proofly.ae.edge.json     # exit 0, no warnings
dc-template-linter --merge-or-fail proofly.ae.edge.json # exit 0, no warnings
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`proofly.ae`). Public key published as TXT at `_dcpubkeyv1.proofly.ae` (RS256).
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` omitted — Cloudflare-specific linter (DCTL5003) flags it as unsupported. Our `redirect_uri` host (`proofly.ae`) matches `syncPubKeyDomain`, which the spec accepts as the redirect-allowlist anchor when `syncRedirectDomain` is absent.
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` — N/A (no TXT records)
- [x] no bare variable as record value — IP is hardcoded (`51.89.33.47`) per strict-linter rule DCTL1040
- [x] no bare variable as full `host` label — uses literal `@`
- [x] no variable creates a subdomain in `host` — uses `@` and relies on the URL-level `host` parameter
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` not set — single A record is mandatory for the service; users removing it disables the integration entirely (no partial-functionality case to preserve)

## Online Editor test results

**Editor test link(s):**

- [Test proofly.ae/edge example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADglA2oC%2F9VS247aMBD9FcsvfSgE50aWSJVKtbtiW3WLVPqwoigysSFWEztrO0CK%2BPeON6WBXj6gL77MmTOXM3PElld1SS3H6RHXWu0E4%2FqB4dR91KZsPcrx4BfySCvwxPMOA8BwvRM5f2FwtuW96doV3XXgjmsjlMSpP8Cl2qovugSnwtrapKNRn3PkQK%2BWW%2BAwbnItavvCw%2FdaSYta1Wh0ryGHRkZYjvbCFuhnslcGae4ycQQRDy362gTEjxBlzCAq0RTgXGmGjEI7AXSlDSqERZfFeq6VVubvSpV%2Fw%2BmGloZ3lnmz%2FsDbW1VRIX8XqgtscLo8YtvWToEpmAtlLDzfOimVkNYsFHxj37uZeGHoRQkA1oIUISGn1WmAvyvJsz7YClQ45%2BMHCiPjXq6qPjK8tlo1dSbO%2FjUFdYwb65m5vKKuztwlxi6j2EqleWbgprbRULnVDXRcNaUVGd3T3sTyjNZ12UKBBlAIcd2t7EbvumXU0n92OsAZy12Fwq3POA%2FJJsqjYZQEcIyTeLgONnTI2Zgkfj5Zk4RdrOKfS%2FqXXezV4cZwaQV16zYt97Q1%2BHRaDUCp%2F7V2GKChO84y6twCEoyHJB76wcIPUxKmceBFcXgT%2B68JSQlxpXNju56OMO%2FLSePR4YlBqCe2r%2BPn5%2FeTRTsrg%2BIhkbMq%2BHRnbg%2BfZ9VGzz%2By4uENPv0A0UqIKzYEAAA%3D)
- [Test proofly.ae/edge example.com/members](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAConA2oC%2F91SXW%2FTMBT9K5ZfeKBNna%2BuREKiDLYhtK1oHZNWqsh17lpDEgfbaZtV%2Fe9cr3RpGfwBnhLf43vuPcdnQy0UVc4t0GRDK62WMgP9KaOJO6iHvPE40M4zcsULvElHOwwBA3opBTx1QDaHtnR8lXzcgUvQRqqSJn6H5mqubnWOlxbWVibp9dqZPQd6VTnHngyM0LKyT330TKvSkkbVmpxpnKGJkRbIStoF%2BT3slSEa3CQgyLhuyLc6YH5EeJYZwksyRFgonRGjyFJiu9KGLKQlh8t6TkpTive5Ej9o8sBzA7vKqJ59huaDKrgs%2FzRqR2xoMtlQ21TOgSGWF8pY%2FH3nrFSytGas8Bj73uCNF4ZedIKAtWhFyNh2uu3QR1VC2pJN0YX9PFhzfDLwhCpa5gKKGQrGwlyrukrlvq3iaJJxr7snmBwxTPcUk2cON1%2FOS6UhNfjlttaow%2Boa9Rd1bmXKV7wtZSLlVZU3uK5BFJmOtZe7ILQbZtzyf6rv0DQTbl3pIhUD4xDEs64fDfrdKALRnYXxSZcJP%2BKCx7Mwig7i%2BTK4f8nnC8fAGCit5C6Jw3zFG0O322kH3fsvhOALG76ELOXudsCCfpfFXT8Y%2B2HiB4nPPNbv%2B4P%2Ba8YSxpwCMHYnbYNJOMwAHS5Woh7%2FrEwcXn%2FtiZvvlzfNuLwYFbPT0%2Fur%2B7tLdXG%2Bvj6%2FvRt%2FeUu3vwCyKzrUXgQAAA%3D%3D)

---

Target deployment: [Cloudflare Domain Connect](https://developers.cloudflare.com/dns/reference/domain-connect/). After merge, will email `domain-connect@cloudflare.com` per their onboarding process.