### PR TITLE
Add Domain Connect template for AddressTwo

### DIFF
--- a/addresstwo.com.mailgun.json
+++ b/addresstwo.com.mailgun.json
@@ -33,7 +33,9 @@
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=none;",
-      "ttl": 3600
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
     }
   ]
 }

--- a/addresstwo.com.mailgun.json
+++ b/addresstwo.com.mailgun.json
@@ -1,0 +1,39 @@
+{
+  "providerId": "addresstwo.com",
+  "providerName": "AddressTwo",
+  "serviceId": "mailgun",
+  "serviceName": "Email Verification",
+  "version": 1,
+  "logoUrl": "https://app.addresstwo.com/assets/images/adTwoAccessBarLogo.png",
+  "description": "Automatically configures DNS records so your domain can send and receive email via Mailgun.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.addresstwo.com",
+  "syncRedirectDomain": "addresstwo.com",
+  "variableDescription": "%dkimValue%: Full DKIM TXT record value; %dkimSelector%: Full DKIM Selector value",
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:mailgun.org",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "%dkimValue%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "a2email",
+      "pointsTo": "mailgun.org",
+      "ttl": 3600
+    }, 
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
- Added SPF (SPFM)
- Added DKIM template
- Added DMARC record
- Added CNAME record

# Description

New the Domain Connect template for  AddressTwo CRM (Mailgun). This template automates DNS configuration
(MX, SPF, DKIM, DMARC) for customers who use Cloudflare or other Domain Connect-enabled DNS providers.

**Note on bare variable usage:** `%dkimValue%` is used as the full TXT record value because DKIM public keys must be stored as-is in DNS (format: `v=DKIM1; k=rsa; p=...`). Wrapping it in a prefix would break.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACxgA2oC%2F%2B1W32%2FaSBD%2BV1Yr9SlgbAfS4ihSCaRSlRLlEpq7KkVoWC9kG%2BP17a5NKOL%2B9ps1BuOEXFPdSx7yEGXZ%2Beb3fDteUsNnSQSG02BJEyUzEXL1OaQBhTBUXGszlw6TM1rbSi9ghmjaWcsHc4kyzVUmGM8VZyCiaRqXt4XCmRWQG67ERDAwQlpIxpW2p8Cr0UhO5VcVIfTOmEQHjQYkiVONowFac6MbYgZTrhsQov8OYwg4BfUFDThJPEW7IddMiST3grGmRs7QJYMoWhAm44mYpmiV9C6uieJMqlATLclCpoqECBUxYRATzeOQAP4hhouME57nkAkg%2FXWWjk1zEbPTSLJ7Gkwg0nx9c5mOz%2FmilxvDENZW0XXMmXGeFNdqXPFQoCOz1XmCykAJGEe8V8nuXXgvZjcQpfxdQD6lUUR655%2F7ZPDXoMiNZFZ4THLgNY%2FQh1QV7OZyjURPRVFocLukZpHY%2Fl1ffuqj5E5qg78%2B2qCTyVUacURRTC1KQx4UzXeksl0wBrt5eOS6q9rWDIZVWqlG5IzWVbrnC9tCMFDN7hmL3YtO%2F6y0CX7eJTuxUsRGD2Q5lC%2BNaxTOQLEyiOyk1%2B9cdb1jkpzEMubHu0bw%2BGC6OFSRYKYPht2JeNqXobV6qfhEPNC9kEJWWqer4apGf6L9UVn%2FYa2YHQTyB0C28mIailjxNFUyTUZig09AwUxbRm80byuqw43uLbXn3R7YOxgzzz80XBvbiAKQdyA3lNY5aFP3qA1WTGOp%2BEjjfzBIKRoYlSIDZmlkxAjmUF6FbIR8jhaYm0Yp2rp9VPx4%2FVB83K07zphH9kwX%2BQe5XO3CKGQ2Z2EfoaMPY2j7APUJa7J60wW3DqHH6%2B0jb9z84E0mh6y986btf%2FH2v2pl2RHMYyPAPlmdaA4LTVdPJqpIqlLUvYNeFvZVZ7Vh2yavLduKNJ5h2itvz28S%2FnXkMqwh299I9EaiNxL9DxLhgtOQ8XAEFua7%2FlHdbdU9f%2BC9D7xW4Dcd733T8%2F0D1w1c16aA87fOcJmf803bCQfc%2BlluP9LWC7iyWx%2Bt1spmrYzuMxs%2F3%2FN2x6%2FsF5rdopUvtEozdjSdat2L7nz%2F1cPwndLfJaLzAq%2FbPKv291Pi1wZ3qfLfg%2Bm8qCSPRtYGOcSJx%2BGyXcQxMXmfNw1Hye7XD%2F3290V%2F3uq1G3%2Bed38ODlj%2FoN1tdb0v0OLdyR8%2Feu3ej5tz%2F%2Bvpt%2BzshK7%2BBV37QDiADQAA


https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAhfA2oC%2F%2B1WbU%2FjOBD%2BK5al%2FbRtmqRQIAjpuhSkvaUIQa9aiUWVa7vFIokj20kbUPe33zhJX1K6u9077WlP4gMitWeemcfPzNgv2PAoCYnhOHjBiZKZYFx9ZDjAhDHFtTYz6VAZ4cZq95pEYI275f5gJmFPc5UJygvHiIhwmsbr1crhwm6gIVdiIigxQlqTjCttvwKvgUM5lX%2BpEEwfjUl00GqRJHHqebSI1tzolojIlOsWYRC%2FSykYfCDqCgCcJJ4CLuOaKpEUUSDX1MgIQlIShjmiMp6IaQqoqHd9hxSnUjGNtES5TBViYCpiREmMNI8ZIvAHNlxkHPGCQyYI6pcsHUszj%2BmHUNInHExIqHm5cpOOP%2FG8V4BBCiUqhI45Nc6rw7Uet5wJCGRWPq%2BsMqIEGYe8V2P3jj2JaEjClL8L0GUahqj36WMfDT4PKm4os5unqDC84yHEkKpmu1wsLSFSdSg4uH%2FBJk%2Bsfnc3l33YeZTawK8%2FbNLJ5DYNOVhhoBamjAeV%2BI5UVgVjQM12x3UXjRUMpLVGqWfkjMpTeuK5lZAYUmf3DcTz627%2FYo1J%2FEIlW7FSxEYP5Loo981rxCKi6DqJ7KzX796ee6coOYtlzE83QeBzbs6hqEJBTZ8Y%2BijiaV8yi3qj%2BETM8U6Tam%2BNjhcPiwZ%2BBvzR%2BvwfGlXtgCGfE%2BhWXlVDlWtFdqpkmozE0ichikTadvXS%2B77m%2FrD0vy8BbJgNLew6GVPPbxuujRWkMiiUKMDSJifaND1skxbTWCo%2B0vCfGGgtHBiVQidEaWjEiMzIeonREfR1mANHDbuAdb8lQlwOjIrYSgIoNw%2FtKDT0Fdq6LsiIUUtd2Hk0aY8njHdY03UPvebBwcm4ecL4SZN5fmdMDmmb%2Bf7GeNs9%2FHYPuLoC4MBjI4idYN1wRnKNF68KrOJWO9uNunfqpNeH%2FNvTW3bhkmDZhVt8vtGG%2FwPByongbNfkd8fC70PqoQEz4a3N3trsrc1%2BaZvBJalJxtmIWFPf9TtN97Dp%2BQPvKPDcoO07R7573D5677qB61oaUJoly5fiu7ixN57W8Gv56Csv89odvXVF125oW9QzXhX1%2Fi8I%2B3pY2PefvZtr779dQ2NDhUqrLz%2BaIF8w%2FqfduivaimUd9%2Ftt8hpos2P2q83d1LcK1SZlj7PbG3B71P9KzdWI%2BiVqOhtgzn8r7T6hV%2Fz31vnHqD8p%2Bn4ntLMCFnaoWJ1hNJiiEpYlATubr2YsLrPhld%2F1Ju%2Bzk%2FyczdnTcSsTz9qbJ%2B1hdjt5Hh50%2Fjy%2Buji%2BvDjDi78BsRzw3MAPAAA%3D