### PR TITLE
Add AppointsHub booking template

### DIFF
--- a/appointshub.com.booking.json
+++ b/appointshub.com.booking.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "appointshub.com",
+  "providerName": "AppointsHub",
+  "serviceId": "booking",
+  "serviceName": "Custom Booking Domain",
+  "version": 1,
+  "logoUrl": "https://appointshub.com/icon.svg",
+  "description": "Connect a custom domain to an AppointsHub public booking and membership storefront.",
+  "variableDescription": "ROUTING_VALUE is the Railway CNAME target returned by AppointsHub. TXT_NAME is the Railway ownership TXT host label returned by AppointsHub. TXT_VALUE is the Railway ownership TXT value returned by AppointsHub.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.appointshub.com",
+  "syncRedirectDomain": "appointshub.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "routing",
+      "host": "%fqdn%.",
+      "pointsTo": "%ROUTING_VALUE%",
+      "ttl": "3600"
+    },
+    {
+      "type": "TXT",
+      "groupId": "ownership",
+      "host": "%TXT_NAME%.%domain%.",
+      "ttl": "3600",
+      "data": "%TXT_VALUE%"
+    }
+  ]
+}

--- a/appointshub.com.booking.json
+++ b/appointshub.com.booking.json
@@ -15,7 +15,7 @@
     {
       "type": "CNAME",
       "groupId": "routing",
-      "host": "%fqdn%.",
+      "host": "@",
       "pointsTo": "%ROUTING_VALUE%",
       "ttl": "3600"
     },

--- a/appointshub.com.booking.json
+++ b/appointshub.com.booking.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://appointshub.com/icon.svg",
   "description": "Connect a custom domain to an AppointsHub public booking and membership storefront.",
-  "variableDescription": "ROUTING_VALUE is the Railway CNAME target returned by AppointsHub. TXT_NAME is the Railway ownership TXT host label returned by AppointsHub. TXT_VALUE is the Railway ownership TXT value returned by AppointsHub.",
+  "variableDescription": "ROUTING_VALUE is the Railway CNAME target returned by AppointsHub. TXT_NAME is the Railway ownership TXT host label returned by AppointsHub. TXT_VALUE is the Railway ownership verification token returned by AppointsHub without the railway-domain-verification= prefix.",
   "syncBlock": false,
   "hostRequired": true,
   "syncPubKeyDomain": "domainconnect.appointshub.com",
@@ -24,7 +24,7 @@
       "groupId": "ownership",
       "host": "%TXT_NAME%.%domain%.",
       "ttl": "3600",
-      "data": "%TXT_VALUE%",
+      "data": "railway-domain-verification=%TXT_VALUE%",
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "railway-domain-verification="
     }

--- a/appointshub.com.booking.json
+++ b/appointshub.com.booking.json
@@ -23,7 +23,9 @@
       "groupId": "ownership",
       "host": "%TXT_NAME%.%domain%.",
       "ttl": "3600",
-      "data": "%TXT_VALUE%"
+      "data": "%TXT_VALUE%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "railway-domain-verification="
     }
   ]
 }

--- a/appointshub.com.booking.json
+++ b/appointshub.com.booking.json
@@ -8,6 +8,7 @@
   "description": "Connect a custom domain to an AppointsHub public booking and membership storefront.",
   "variableDescription": "ROUTING_VALUE is the Railway CNAME target returned by AppointsHub. TXT_NAME is the Railway ownership TXT host label returned by AppointsHub. TXT_VALUE is the Railway ownership TXT value returned by AppointsHub.",
   "syncBlock": false,
+  "hostRequired": true,
   "syncPubKeyDomain": "domainconnect.appointshub.com",
   "syncRedirectDomain": "appointshub.com",
   "records": [


### PR DESCRIPTION
# Description

Adds the AppointsHub Domain Connect template for connecting custom booking and membership storefront domains.

The template receives Railway-provided DNS values from AppointsHub:

- `ROUTING_VALUE` for the CNAME target.
- `TXT_NAME` for the Railway ownership TXT host.
- `TXT_VALUE` for the Railway ownership TXT token without the static `railway-domain-verification=` prefix.

Provider ID: `appointshub.com`
Service ID: `booking`
Sync public key domain: `domainconnect.appointshub.com`
Host required: `true` (subdomain hostnames only; apex/root domains use manual DNS)

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.

- [x] digital signatures are used and `syncPubKeyDomain` specified (yes, `warnPhishing` is an option, but some providers reject such templates by policy, so signing shall be a default)
- [x] `syncRedirectDomain` is specified when intended to use `redirect_uri` parameter in the synchronous flow
- [x] no TXT record with SPF content (i.e. `"v=spf1 ..."`) instead of using SPFM record type on APEX
- [x] `txtConflictMatchingMode` is set on TXT records which shall be unique on a label (like DMARC)
- [x] variables are set to the smallest scope needed (i.e. limit possibility to be misused to set any arbitrary record and conflict with other template). Too broad scope example: @ TXT `"%verification%"`. Better usage: @ TXT `"foo-verification=%verification%"`.
- [x] no variables as a host name to apply template on subdomain instead of standard `host` parameter
- [x] no explicit usage of `%host%` variable in `host` attribute
- [x] `essential` setting is used on records, which the user shall be able to change or remove manually later without dropping the whole template (like DMARC)

Note: no non-essential records are included; both records are required for Railway routing/ownership verification.

## Online Editor test results

**Editor test link(s):**

- [Test appointshub.com/booking example.com/booking](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFwFDGoC%2F%2B1UbW%2FTMBD%2BK5alfqJNs4x2bSQkSofGBHuhdIhpmiLHubZmiR1sp12Z9t85J%2Bkb3SY%2BIsSnpr67x8899%2FgeqIUsT5kFGj7QXKu5SECfJjSkLM%2BVkNbMitjjKqPNdficZZhOB3XChyLGoAE9FxzK0lipOyGnm9O6YlgYqzLyrgqTY5UxITFrDtoIJWl40KSpmqornWL2zNrchO32b0TagivpmbmDT8BwLXJbFtOhkhK4JYzw6qKkvIBYRZgkW3RJXsSp4KTmidGEZJDFSGMmcoK1GiZaSes5ckwLFqdwvHPX6OJqfHp%2BEn0dfLp6T4QhdgZkxES6YEsyPB%2BcvSeW6SlYosEWWkJC4uU2B4%2BMv42jMvG3arWQNRHMIDNlLElZDOnLSE8S2UChxGIiOHP0UZA7kM%2FBkYWwM1XYEkhXQK1KydY2yhuSo0ri3mlklpK%2FSxW%2Fo%2BGEpQaa1NEewY9CaEBHWF1AlXVZxB9hWU8%2BpBUurwbn7VvOlYwgQRRu10X7aRhWOjE0vHmgdpmXXnPSYmiqVZGXrsQPW7nSkcODt87TJdJY4d%2FGzkwbGLTW%2BfCw6%2Fv0sblGRrV3cNcib5Abq9k2vEbVYsPbxUPvMsscqxcUbqwHW7K5t%2BjwCRrXnjHLZ9jLmUoco8tyEE%2Bn1LGXL6KPt49N%2BlNJiDZS3jbr8WAx3DNcE1DLXXe5eealGJFYleVMs8y4jbICuNlBuF1B3Kwx8GhHfhdjMT8IDr0i92ruziAuc6WuS4pWsS2ktWwuoTQ7df2JqcSHHRn8ZWh9WPkyK1IrIrZgm6OER3hXukQ5DEYRZ99ZslpqGxXqiT5Nu56%2BG36TRgl36ghnn2TCIOj0%2FBYEXb%2F1%2BqCftFgvPmr5QT9O4qBzxOPO1vJ9Zjc%2FvX73BgXGgLSCOR8OHDdDH%2FesXTe2p%2BwfebaS%2By%2Fu9raJFv0%2FzX9lmvjcDZtDEjGXHfhBt%2BV3Wgf9sd8ND3th4Hu9XtDp9l%2F5fljuXQvGVp0%2F4E7Y3gb0%2BkNv3m%2BPJulx76s%2B%2Bf658z0o7vIhfBHt9umni%2BHVYKhmfVhcn%2FRwZf4C99M71TwJAAA%3D)
