### PR TITLE
Add Domain Connect template for Instanto

### DIFF
--- a/instanto.connect-domain.json
+++ b/instanto.connect-domain.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "instanto",
+  "providerName": "Instanto",
+  "serviceId": "connect-domain",
+  "serviceName": "Connect Domain to Instanto",
+  "version": 2,
+  "hostRequired": true,
+  "logoUrl": "https://instanto.site/images/logo.png",
+  "description": "Connects your domain to your Instanto website. Adds a CNAME record so your domain points to your Instanto site.",
+  "syncPubKeyDomain": "instanto.site",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "instanto-proxy.instanto.site",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description
New Domain Connect template for Instanto (instanto.site) — a website builder
that turns a business's Instagram feed into an auto-updating website.
Adds a single CNAME record pointing the customer's subdomain to our proxy.

## Type of change
- [x] New template

## How Has This Been Tested?
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

## Online Editor test results

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEG9A2oC%2F91TXWvbMBT9K0avsx1%2FxE5iGCykLStduq10gy4Eo1g3rsCWNEmO44X898n23CQtDPa6JyPde8499%2Bj4gDSUosAaUHJAQvIdJSBvCUoQZUpjpjmyX%2B7vcWn60O2pokDuaAYdIOOMQaYdwktM2an4B7Xoy9ZVV7Y0t854diAV5QwlgY2eudIP8LOiEgytlhXYqOA5%2FyYLQ%2FOstVDJaDTIcxXVMKIlzkGN2jZXsNwwElCZpEJ3rMNwZTW8khZ5kdAdBx1WDZuWzbXmhCgLW4v7%2BfLakpBxSSzFL8CCU2b43nB0BO3yDcu%2BVJs7aPqFzxztJJuWnlihZHVAuhGdSe1E1Htgjh9a87tBj%2FyMwDEPsm%2Fc13xaG4PC2POO66ONfnEG6WnE2lgyCIE9No8ObsbL06y6rs0hl7wSKR0gAktcqjYbA3h1gV4P8FWHb%2BfSnHEJqTJfrCsJwxOWVaFpimt8uiJZioUoGiNTmapheesE69PTqyNY43%2FwwUYpyVrxtM3n1ItmfjyZOlEEW2ccbyfO1N9GDp4RPJ74Ex9m2VnYX%2F8Ef436hYegFDBNcRvXeVHjRqHjcW0bP%2F%2Fj9UwSFN4BSXHbGXhB7HiR4wePQZhEQRKG7jgMxoH%2FzvMSz2vXAKX7hQ8mNed5QU9XMlrGiwl98G%2BWX%2Bt48%2FlGfN9cy48inkj4EZbeff5pjPdPd9P36PgbpNuz7MQEAAA%3D

## Checklist of common problems
- [x] `syncPubKeyDomain` is set — set to `instanto.site`
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [ ] `syncRedirectDomain` — not applicable, async OAuth flow only
- [x] no TXT record contains SPF content
- [ ] `txtConflictMatchingMode` — not applicable, no TXT records
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label