### PR TITLE
Add Vohtrah Domain Connect templates

### DIFF
--- a/vohtrah.com.email-sender.json
+++ b/vohtrah.com.email-sender.json
@@ -1,0 +1,83 @@
+{
+  "providerId": "vohtrah.com",
+  "providerName": "Vohtrah",
+  "serviceId": "email-sender",
+  "serviceName": "Email sender authentication",
+  "version": 1,
+  "logoUrl": "https://vohtrah.com/logo.svg",
+  "description": "Adds the DNS records needed to authenticate a Vohtrah email marketing sending domain using Amazon SES DKIM, custom MAIL FROM, tracking, DMARC, and Vohtrah ownership verification.",
+  "variableDescription": "%awsRegion%: Amazon SES region, for example us-east-1; %dkimToken1%, %dkimToken2%, %dkimToken3%: SES DKIM tokens returned by Amazon SES; %verificationToken%: Vohtrah sender verification token; %dmarcReportMailbox%: mailbox that should receive DMARC aggregate reports.",
+  "syncPubKeyDomain": "domainconnect.vohtrah.com",
+  "syncRedirectDomain": "vohtrah.com,www.vohtrah.com,app.vohtrah.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkimToken1%._domainkey",
+      "pointsTo": "%dkimToken1%.dkim.amazonses.com",
+      "ttl": 3600,
+      "groupId": "dkim",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkimToken2%._domainkey",
+      "pointsTo": "%dkimToken2%.dkim.amazonses.com",
+      "ttl": 3600,
+      "groupId": "dkim",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkimToken3%._domainkey",
+      "pointsTo": "%dkimToken3%.dkim.amazonses.com",
+      "ttl": 3600,
+      "groupId": "dkim",
+      "essential": "OnApply"
+    },
+    {
+      "type": "MX",
+      "host": "bounce",
+      "pointsTo": "feedback-smtp.%awsRegion%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600,
+      "groupId": "mail-from",
+      "essential": "OnApply"
+    },
+    {
+      "type": "SPFM",
+      "host": "bounce",
+      "spfRules": "include:amazonses.com",
+      "groupId": "mail-from",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "track",
+      "pointsTo": "track.vohtrah.com",
+      "ttl": 3600,
+      "groupId": "tracking",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "vohtrah-verify",
+      "data": "vohtrah-sender-verification=%verificationToken%",
+      "ttl": 3600,
+      "groupId": "verification",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "vohtrah-sender-verification=",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; sp=none; adkim=r; aspf=r; pct=100; fo=1; rua=mailto:%dmarcReportMailbox%",
+      "ttl": 3600,
+      "groupId": "dmarc",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/vohtrah.com.lead-magnet.json
+++ b/vohtrah.com.lead-magnet.json
@@ -1,0 +1,34 @@
+{
+  "providerId": "vohtrah.com",
+  "providerName": "Vohtrah",
+  "serviceId": "lead-magnet",
+  "serviceName": "Lead magnet custom domain",
+  "version": 1,
+  "logoUrl": "https://vohtrah.com/logo.svg",
+  "description": "Adds the DNS records needed to connect a customer-owned hostname to Vohtrah lead magnets and verify ownership inside Vohtrah.",
+  "variableDescription": "%verificationToken%: Vohtrah site verification token for this hostname.",
+  "syncPubKeyDomain": "domainconnect.vohtrah.com",
+  "syncRedirectDomain": "vohtrah.com,www.vohtrah.com,app.vohtrah.com",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "ingress.vohtrah.com",
+      "ttl": 3600,
+      "groupId": "routing",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "vohtrah-verify",
+      "data": "vohtrah-site-verification=%verificationToken%",
+      "ttl": 3600,
+      "groupId": "verification",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "vohtrah-site-verification=",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds Vohtrah Domain Connect templates for lead magnet custom hostnames and Amazon SES-backed email sender authentication.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality in the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- Lead magnet host test: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADvkBWoC%2F%2B1UbW%2FaMBD%2BK5GlfWpCkwBdG6nSWMu0l0K7jk6VKhSZ%2BCBWg53a5m2o%2F31nEiC00H2dpn0C%2B5473%2FPck1sSA%2BM8owZItCS5klPOQH1hJCJTmRpF01oix8TdhLp0jFDyswhiQIOa8gRWKRlQ5o3pSIDZRsqMK4w5RcxJJtrIscPkmHKByCkozaUgUeCSTI7kncowIzUm19HxcaWRYxut6ekIkxjoRPHcrBJJizHtmBScy%2B4PR0EiFZ4FAAPmGOkkUghIjEPLt0F5ciYwlkptBHZoQSUpJ9u2qh0qmIP98eHCsRlKpzx3uNAoxjqhZilQxekgg8udrt6tMnlC7bknH0G8izbPaG7AqQKwB0Q4Q6mQCdeb3mx9vRDJzWTwDRaXhWoRKeQrmdV2x2Xht8A4KmE2CRWIO5vNqikuzfM9JT5mMnkk0ZBmGlxi%2B7mFpwlWxWkbNcG7UmoSPSyJWeR20hfdVqdNCjgeP1j3SC6M7kk8cjFSoPWLx4zBiddPfN8lIyUn%2BcpO%2BMcgHMOYAMJwam1xLVp5ni3Is7t5sXff275XFvaKoVmjUEMr91Z2ryr7%2BZ4pHWqpirSYubmQYpjxxHSoSVLstiOZbelGwZDP90PK2FstHeLcf3bJLykg3ured0snIA7mFL9mKEUtBZHDIdqWlDRivsqqiLvDCavlVNGxtvtgXfdhp3B%2FXflhXbpf1n677iuVLdx%2Ba7EBbeKV%2BeMgrBNLko%2BEVBBr%2FKVmomDtt%2FEkMzymM7q9YklMrTqoicYoVn3tRVEsoY0UpSf%2BaMaYJVYIbmc%2FZNBsMtrwGuGg6TXOznzvNDwdeKdnSeAHLGyw%2BvvKptyzRA%2Fvypej2jv8V44vWe06vvaS5GGX7RP%2FL6bfd9Hs%2F2f7b84WF4SmU2AxtejQD088v%2BkFjV7QjPx6FNZrzXoQBP6R70e%2Bb6kgt0KFJe6L6qYg7Tu2uPqeZiH9ZFqyKb5mi%2BvBUZCqoNuZ6s%2BNp9ujcH5974%2Fa7XPy%2FBu8angvBAkAAA%3D%3D
- Email sender apex test: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALLlBWoC%2F%2B1XbW%2FbNhD%2BK4SAfKrkyHYS2yoMzE1SLGudZok3BCsCg5ZONmFJFEjKjhd0v31HSrYlR0m67q0B%2FEkS78h7nrvj3enBUhCnEVVgeQ9WKviCBSAuAsuzFnymBJ01fB5b9kZ0SWNUtX7NhSiQIBbMB7MFYsoiR0KCiltRseVcC0kuJDRTM0gU86liPEHdBQip37ymbUV8yn8REe6ZKZVK7%2FCwhOVQSxtyMcVNAUhfsNQc4VmDIJAEjyVnlzdEgM8FficAAQRE8bJJIJQUDIjBTGIq5qBYMjUA9TPgKEhIJvXHIKa%2F84TcnN%2BQsw8XQ5v4mVQ8JsPBxUfy%2FvoTruBh%2Fhx1bXI2HFyf2oQmwcYIXybIb8ZSgjxZWNBuaN5UMDqJ4KxC5YAu5TVM8ePAKxsXZs0mIRcE7ilGDhChA1Qqp%2FmWHARzFo%2F4HJLmgV36alW%2B2njmmgk6BlckHqwykaCjJquSPTyxjNfsxs1rVkUsyyr5eRoJetS%2FhpQLNUQHT%2Fg9bozzNwwSVUTOeBYFOlDAFpB7jdDpFDnqCAmzV2ofyVXiX2WTD7A6M0FBB%2BXR8XmSgK8a1VTV6tcQMDxZbTaUVOzlclneYtM0rTniXcT9ueWFNJJgW0U%2BWd7nB0utUp3Qp5eD4Tkqz7hUOmYl5zfGOcA5rPTd4SxRcsR3lfR7gxpvS5CFaaUw8dsnrmtbU8Gz1FwsrYkykFJnMNVX41MySNNoZX2xXwbU%2BhpArf8QUPtrALX%2FeUDD2y2aCc8SH6rGQ6wWE7zHjoxV2ijdwkcgUsG4YGqFBct9ApIphqHgX4Hr5ur9sAaZTMPrLALMOguTPcoC8HZxfJO5nbiY0lV1hFnauRS1JNdl72Wjo9vR1mRxsmNqh86AgCpaWs9Li1MuLf2aWvQUqrKm1rlXpzwJI%2BZjMVL%2BDPEOeaBBXQkI2X29SiF7HtRf5D02dbHEt2%2FqHtbutJ%2FwBN4SuX6hOqX7Al8wDfQz9VW%2F6bpvsfr3cYPIaF%2FHXHGvrto%2BeVEKAH%2FXJwXwp%2FjffbEtTFQYbwvnnV2UbT0p5M2ryKzCOet0HjOjv77T5cQupdtOjHNeaCOlgsZSjzNra58r5u7W9j5b%2Bt1Y%2FHZr23quz6ATv9lq6zWkXhG3jAkIj45P9Jpa8oq4rcXTGet0e0Y8E2D2byqQlm86vZY8ugxaI8%2FQsQKpxqYTjxGOMfQoQQwevfpDxTkYNjZNuICxxCfFqQBTQokMW2CcRYqN6ZJulwJ%2FTHW8McoSpXjm4%2FaY5ONfxTXV6l%2FcharGS6V%2FHPg6xkznNHW7fq913HN6k7DjHLmdrkNpz3WCE2gCPeqehF2%2FNMPWjLfPTLHb5KxN9JqyWjCuRLuWcVXj9TPeSeBazrs6r5C1mSIKypteXdCrThCbG%2Fscw%2Boo8R3yzTvYE4QXfWxPTVI7n5A%2FaBStySLXV5HE62mo4PfCJPS9h%2BtbBq36LvKqaP87c9bjfvl9OuXOxmFr34n3nXjfifedeN%2BJ951434n%2Fr06M%2F96SLiAYU63XclsnjnvsNI9GzWPP7XntbqPdbTbb3Teu67muZoGxzl31gP%2Fi5b9wK52%2Fe%2B9G4W9XIxnCm%2B4o7rGfP7aBz%2BPT8x%2Bhc3vRYbxz1fkJ3vG%2B9eVPZweELtsZAAA%3D
- Email sender subdomain test: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAATmBWoC%2F%2B1YbW%2FiOBD%2BK1akftqEJoHSJRXScaU9VV3ainZXq6tQ5CQGciRxznagbNX77Td2AiQ0Lb291Wl74hOxZ8bz9nj8iEdNkDiNsCCa86iljM7DgLCLQHO0OZ0KhqcNn8aavhZd4RhUtS%2B5EAScsHnoE2VCYhxGBicJKG5EhcmZFKJciHAmpiQRoY9FSBPQnRPG5Zdj6VpEJ%2FQzi8BmKkTKncPDUiyHUtrg8wkYBYT7LEzVEY7WCwKO4FjUv7pFjPiUwTohJCABErTskiCMigyQihnFmM2ICJOJClD%2BBhQECcq4XPRi%2FI0m6PbsFvUvLwY68jMuaIwGvYtP6Hx4DTtwmD8DXR31B73hqY5wEqyd0EUC%2BU3DFEGe4bhIuyHzxizEXkT6lVQO8IIPyQQWB07ZOVN7OhpThsgDhs4RiNAgmAvDOkEHwSyM7%2BiMJNaBXlrZlVUTzlxlAoWBHQ4Hi4wlUChvWfIHJ5bjVdZgvMqq6GVZJT9PRgIV9YckpUwMoMAefQDDOP%2BCJmGB%2BJRmUSAbRcI5yauG8GQCOcoOMWXLZY34MvFvMu%2BSLPuqKVCgvDs%2BTRLii0YVqlJ9SIIQThZrg5KKvlgsyiY6TtOaI36NqD%2FTnDGOONG1Ak%2Bac%2F%2BoiWUqAX161RucgfKUciF7Vip%2Bw80DnJGlvDs0TAS%2Fo9tK8ruBVbU54YVrIQD4zbZp6tqE0SxVF0tqgoxwLhGM5dW4TnppGi21J313QPZbArL%2Fw4Cabwmo%2BeMDGnzdROPRLPFJ1fkYpoUH99jgsUgbpVv4LIiUhZSFYgkDy3whJDUMx4y%2BIa7bm%2FNBTWQ8HQ%2BziADqNAB7lAXE2Y7ju9xt9UWNrmoh1NbWpahNcjX2dju9%2B3q3cVmcbKjZIREQYIFL%2B%2FloMcqjpVszi16KqqwpdR7EKU3GUejDMBL%2BFOId0EAGdcPIOHyoVylkrwf1D%2FN21Vws5dtVcw9md9pNaEJOEF99YAnpLoMPgIH8TX3RtUzzBKZ%2FFwxYhruy54I6ddP2xYtSBPBva1IE%2FlL%2BoyddA6ASdzM4R3oxtiVTyB%2BvAllFcdaP8ArXbqgMV5e7jPAS7raanScIzlLMcMwlr1m5va%2F4Ha0c35c8jwrX3%2B92M%2BHlGdjzLbsp96AYFbGtXJBx66gt98SCVsRNKZ5Mw%2BOPHSWeMqLs1zNJytdvv5Q8ux5SI8esKwgXrnqbXQhHOXoGGRWP3P2lUiVoZDhJKCMuh18MPAFAIlgGj2KcRSJ08QJvtgLfxRIB0HcOUjjz%2BYOZ5ISwUprSe9Ao46C4J1XdXc%2BCG%2Fiy7aHEu03GndbRuG1gz2obrVbn2PCOWrbR7uAm9mzrqN1ulfhtDfV9heHWALf2NtTM3qIIFQDsKEJV939UhC2Y7yjDtvZ7LoQiJEUV8me%2FLuMqLVlf%2BteSrvKTn7kE%2Bfu4swbzLjyDFqrlQegvHEWr%2FCH994X%2BnGvVpLyDhL2bplbJXm1zX2FY9S%2FY%2B6xETv%2Fq4f0jiODz5%2Fsnr9NIB1q4Zwh7hrBnCHuGsGcIe4awZwh7hlBlCCM4B89J4GJpYJt22zCPDKt1Zx05luWYZsNumc2O%2BcE0YSHTARzkNXt8goxK%2F1pop8e%2FJx%2F%2FJJ%2BD2y%2B965uL80F2dvbhD3Eep%2F2F792Mf7tsdzw7%2BxbNLrra09%2B9kkCNHRsAAA%3D%3D
