### PR TITLE
Add listblast.mailgun-email template

### DIFF
--- a/listblast.mailgun-email.json
+++ b/listblast.mailgun-email.json
@@ -1,0 +1,46 @@
+{
+    "providerId": "listblast",
+    "providerName": "List Blast",
+    "serviceId": "mailgun-email",
+    "serviceName": "Email Sending via Mailgun",
+    "syncRedirect": "https://listblast.com/domain-connect/callback",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "@",
+            "pointsTo": "%spf_value%",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "%dkim_selector%._domainkey",
+            "pointsTo": "%dkim_value%",
+            "ttl": 3600
+        },
+        {
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "%mx_value%",
+            "priority": 10,
+            "ttl": 3600
+        }
+    ],
+    "variables": [
+        {
+            "name": "spf_value",
+            "description": "SPF TXT record value from Mailgun (e.g. v=spf1 include:mailgun.org ~all)"
+        },
+        {
+            "name": "dkim_selector",
+            "description": "DKIM selector prefix (the part before ._domainkey in the record name)"
+        },
+        {
+            "name": "dkim_value",
+            "description": "DKIM CNAME target value from Mailgun"
+        },
+        {
+            "name": "mx_value",
+            "description": "MX record hostname from Mailgun (e.g. mxa.mailgun.org)"
+        }
+    ]
+}


### PR DESCRIPTION
## New Template: listblast.mailgun-email

Adds a Domain Connect template for List Blast (listblast.com) to configure Mailgun email DNS records automatically.

### Records configured
- **TXT** `@` — SPF record (`%spf_value%`)
- **CNAME** `%dkim_selector%._domainkey` — DKIM record (`%dkim_value%`)
- **MX** `@` — Mailgun MX routing (`%mx_value%`, priority 10)

### Variables
| Name | Description |
|------|-------------|
| `spf_value` | Full SPF TXT value from Mailgun |
| `dkim_selector` | DKIM selector prefix (part before `._domainkey`) |
| `dkim_value` | DKIM CNAME target from Mailgun |
| `mx_value` | MX hostname from Mailgun (e.g. `mxa.mailgun.org`) |