### PR TITLE
Add Gizmo Domain Connect templates

### DIFF
--- a/usegizmo.com.click-tracking.json
+++ b/usegizmo.com.click-tracking.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "usegizmo.com",
+  "providerName": "Gizmo",
+  "serviceId": "click-tracking",
+  "serviceName": "Click Tracking",
+  "version": 3,
+  "syncPubKeyDomain": "usegizmo.com",
+  "syncRedirectDomain": "usegizmo.com",
+  "description": "Configure a custom domain for click and open tracking.",
+  "logoUrl": "https://f2rxegjclexeggce.public.blob.vercel-storage.com/gizmo-wordmark-black.svg",
+  "records": [
+    {
+      "groupId": "click-tracking",
+      "type": "CNAME",
+      "host": "%clickTrackingSubdomain%",
+      "pointsTo": "%clickTrackingCnameTarget%.resend-dns.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "caa",
+      "type": "CAA",
+      "host": "%caaSubdomain%",
+      "data": "0 issue \"amazon.com\"",
+      "ttl": 3600
+    }
+  ]
+}

--- a/usegizmo.com.mail-send-and-receive.json
+++ b/usegizmo.com.mail-send-and-receive.json
@@ -1,0 +1,50 @@
+{
+  "providerId": "usegizmo.com",
+  "providerName": "Gizmo",
+  "serviceId": "mail-send-and-receive",
+  "serviceName": "Mail (Sending & Receiving)",
+  "version": 3,
+  "syncPubKeyDomain": "usegizmo.com",
+  "syncRedirectDomain": "usegizmo.com",
+  "description": "Full email configuration for both sending and receiving emails.",
+  "logoUrl": "https://f2rxegjclexeggce.public.blob.vercel-storage.com/gizmo-wordmark-black.svg",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "ttl": 3600,
+      "data": "p=%domainKey%"
+    },
+    {
+      "groupId": "outbound",
+      "type": "MX",
+      "host": "%spfDomain%",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "groupId": "outbound",
+      "type": "SPFM",
+      "host": "%spfDomain%",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "inbound",
+      "type": "MX",
+      "host": "%inboundMXDomain%",
+      "pointsTo": "inbound-smtp.%region%.amazonaws.com",
+      "ttl": 3600,
+      "priority": "%inboundMXPriority%"
+    },
+    {
+      "groupId": "click-tracking",
+      "type": "CNAME",
+      "host": "%clickTrackingSubdomain%",
+      "pointsTo": "%clickTrackingCnameTarget%.resend-dns.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/usegizmo.com.mail.json
+++ b/usegizmo.com.mail.json
@@ -1,0 +1,42 @@
+{
+  "providerId": "usegizmo.com",
+  "providerName": "Gizmo",
+  "serviceId": "mail",
+  "serviceName": "Mail",
+  "version": 6,
+  "syncPubKeyDomain": "usegizmo.com",
+  "syncRedirectDomain": "usegizmo.com",
+  "description": "Enable email signing and specify authorized senders.",
+  "logoUrl": "https://f2rxegjclexeggce.public.blob.vercel-storage.com/gizmo-wordmark-black.svg",
+  "records": [
+    {
+      "groupId": "outbound",
+      "type": "MX",
+      "host": "%spfDomain%",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "groupId": "outbound",
+      "type": "SPFM",
+      "host": "%spfDomain%",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "ttl": 3600,
+      "data": "p=%domainKey%"
+    },
+    {
+      "groupId": "click-tracking",
+      "type": "CNAME",
+      "host": "%clickTrackingSubdomain%",
+      "pointsTo": "%clickTrackingCnameTarget%.resend-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [X] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [X] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [X] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [X] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [X] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [X] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [X] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [X] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [X] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [X] `%host%` does not appear explicitly in any `host` attribute
- [X] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 

[Test usegizmo.com/click-tracking usegizmo.com/domainconnect.vercel.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJw5B2oC%2F%2B1UXU%2FbMBT9K5ElnmjSNKVdF2nSqg4GYjA0OoYGVXXjOME0sSPbaSlV%2F%2Fuu05a2UOB5Ek9R7sfxucfHd0YMy4sMDCPhjBRKjnnM1ElMQlJqlvLHXHpU5qT2lDuHHGvJd5vCsGZqzCmrOmjG6cg1CuiIi3SdXLb0bNrpr9NjpjSXgoRNLJ0KelFGp2z6TebAxUsCtuIXi7li1LxWEzNNFS9MhUp6UiQ8LRVzwKGlNjJ34qrRSaRyKrYOiNiRBRPOiraHMJlM5W%2BVIcSdMYUO6%2FUkUA8svacZw09KmVeUEfZ7USYjD%2BegLHPxAAUps1TqFSl3IlWcgxq5UYbgnh7bqZE%2FhjUJb2YkVbIsdmtnpkUl2nn37BB%2F76Q2%2BLtX1a00vCyjxUB79oIkF0b35YuqnkD9%2B6BSZvY8xTQTsRsLvZTMGJyz2fb9eW2LD8AGiW53kwLA1sExGMC473CtS%2BbcEsjhUQqLf0u2ThjMawQzbLjWYID9r1zm8rxFmkoh8OKXWi8rKrpDvgIqQEGurZFXkDfbmIMV6M3rqFizW2PblXEx0i9KNgR%2BKmo8V9o2bQhnC78SKwhPhVRsqPELBs1KQqNKViN5mRk%2BhAmsQzEdQlFkU9RPYxYx0EPPjCIWj60i4b2h3fLWdpJ9wyU1MoyplZhbl4CftDsd6ruddhS5By2auB2WgNtIggAjTR8CurE7du2VNxfI%2BxZgGpkaDvaxdrMJTDWZWydvOXepyftqvO%2Fh%2F2L%2BQQ2fw4c1Pqyxwxq4hzSMWTwE2x74Qdv1W26j1W%2B0wsbnsNX2PnVarWaw7%2Fuh79v5mDYLDWa4rTb3FEmPrkFM6j%2FbF5fiuHf89%2BC0uZ9eNQ6vLo58MYkefpz8uT44gfu%2BP%2FlC5v8AFQlT8mwIAAA%3D)

[Test usegizmo.com/mail-send-and-receive mail.usegizmo.com/domainconnect.vercel.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABo6B2oC%2F%2B1X72%2FiOBD9VyJLnO5UkiZ06S6R%2BmGvvb3dnlhVlNN1r0LIiYfgqxNHtgNHK%2FZv33EIEH605T72xAegeJ7Hb17ejOkTMZDmghog4RPJlZxwBuoLIyEpNCT8MZVeLFPSXMW%2B0hSx5HcbwmUNasJjKHeklAtXQ8Zcii8FMfAJrDHVzi6inJ9vEcazxPnJ6ZU4%2FPsXhE5AaS4zEp7htlkW3xTRHzC7kpg62%2BVkET1gHI8yz2EY6Fjx3JRZyadCCAcsUSeW2YgnhaI25IykciJpxo6uiGEJjlpSW2zRHuYTMpF%2FKoG5xsbkOjw9HbXUv5D8EwvAjyQGLy8iwWMvEjLysKAYUBUjFU3Acjot2blTqVhK1YMbCRo%2FeHqSYHI8EJc1Ce%2BfSKJkkZe6sgduKzGz3OrXv%2Bvjl7HUBr8osHy9ISurf4CZxRlkd3bu%2B1g8NRRR%2BUVjAUAtG2TerCeXhYlkkbH1Ad27df6GzkcLZRvWA5JnRvclBkYALELirk5N7jUUai6zhkdT%2BigzDbpSv8YlV1wqbmYkDPzXKNzefOo%2BR6KWEtd7hQDUi%2FAsFgWDcJPA5jk8e6nSKtq921tvFd1bLp2%2BWG4t9U21uP0QYvTLg2sUCopuWxO8%2FPqx%2B1uNY4nrV7DbImL7qG6iLjNsuz5VCZiGt7CLy7IdwvPBvEmwFhiuPThAAy27yvrf22qtitUCg%2B2UYRtWhq8QZYVDXmZb2rj2tNcPZEsAPDmniqbaTqUlh%2Fs9JAZLFvfP0xhUPP47h1XT2K27rTYoHXi1olchMjA2tPCIXS%2B0C1QbN7DLWzaz8WrJ29y%2FYxoLDXwb2m8DGxfITO9Aah5YgYJtM1gD8CSTCoYaP6kpFFrQqAKaJC2E4UM6peslFg9pnosZ%2BkVjFPPizNoYUdli3u%2Fo5r1gmNXAemWwDVlsrcFt80RncTQKOiO30xqN3Hdt8N0OC%2BzbeRS130MbOlC7wPZdbofcYq%2B7HTRuM5zay%2BGjmNKZJnPb5%2FVpsykKPuoD1NictSs3HTps36Za%2Bzx0mFyTC%2BzKwNl7IzjfqRD%2FLyvtTo8DNNq4zrYd9cp99lYdtbxMK93KKXiAVHun5Qs36VsSZ9DES%2F44t49z%2Bzi3j3P7OLffzty2%2F3rQCbAhtdtbfuvc9dtu0O4H7bDVCv2W97714Tz4cOL7oe%2FbMkGbhTBP%2BDu%2F%2Fguf9Ixg05PLq2%2BtX3t%2Fs8c08Mez6y9wGX2%2Bvnns%2Bn99HrPr00CcdKbfLsj8BznGJGUyEgAA)

[Test usegizmo.com/mail mail.usegizmo.com/domainconnect.vercel.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC86B2oC%2F%2B1WXU%2FjOBT9K5WlPk0T0tB2IBIPaGDRaLezo6GIkVBVOfFt8NaxvbZTNqDub9%2FrNLQpFAbN047EE5V9fD%2FOPfeQB%2BKg0II6IMkD0UYtOQPzmZGElBZyfl%2BoMFMF6W3uvtACseTCX%2BGxBbPkGdQvCsrF9qgBjteHSzCWK0mSEQIqmX0t09%2BhOlP4Rj5P5hHfgHEDmXsJw8BmhmtXRyXnkqYCOuBr6FieSy7zDpWsYzVkfF51aOluleH3gEcgsREbYhChcnVlBAa4dU7b5OBgHpt%2FIP8rE4B%2F8gxCXaaCZ2EqVBpiFxmIwDplaA6%2BkIO6pOBOGVZQswhSQbNFaJc5Bsfq8diS5OaB5EaVumZJlS5VpWQIcJWuKfqOv2%2BVdfi7a%2FV83XHXk664dHai8GIOwFKMHdjC6bBrkAsluyEt6L2SFmzDinPYzOEoivzEODbsKpL0o1Xv9RIuv%2F42fqmIVkg8%2F1YKwJYIl5koGSS7BezmYQtebHNMvk%2B2KQz4KYQzVqdZQLWbiFFHEaVPumsAaqX7JHiGU1kEziAnOOttmk9fTsfnrV5q3KSBXZYp28fuLuqTRO1OqMnBdcN1pQGTzyheTVc9gs3DbDvpKdb%2BKFivxfCJapuq1phMSYkKb2TVIOoOZ7yO1p5UQ%2BaTtjGfpoYW1u%2FvY%2BabPamnj7lvXk4%2BbbK%2FNfNGJv5BM1EJzl%2Bt9enPSxsAtS7okw03OM3Wi5YGpk2WZ%2BPycIEY%2BwzSmtUG1H86ND8o9ARlYOa9gbrSoFScKaFHilI4PqN3dHvEshnVWlQ4V4u3GBc3uL2scu1t25bDVwbaaHl3gTesvHWDe2TGMj9k7sU%2Fj4fRIJ2nwdG8nwaD4QCCo1H2MZh%2FHNJjxhjEMGiZ9j5D3%2BPcPxYnWOzYceod81Tc0cqSlV%2FLnRX%2FGXaWJyimfmevq3T%2BpULsMvOLcrGV%2Bhso0Sc%2FMMlfgIRHM25oqLfzDa3v3eJXnPh%2FzMW0h%2F8T3u3j3T7e7ePdPn7CPvxnFl0Cm1H%2FPI7iURANg%2F5w0h8mcZzEh%2BHo%2BCgaDj9EURJFviuwbs3DA371tL93yPnR9dUx16eX7s%2FxYd8KqK4v4msxPrPxWakv%2BrzQh1cfPtu%2F%2FxickNV%2F1YndnhwOAAA%3D)