### PR TITLE
Add crawlfix.ai domain-verification template

### DIFF
--- a/crawlfix.ai.domain-verification.json
+++ b/crawlfix.ai.domain-verification.json
@@ -8,6 +8,7 @@
   "description": "Verifies that you control this domain so Crawlfix can run external AI-readiness audits and unlock paid reports.",
   "variableDescription": "Adds the TXT record required by Crawlfix to confirm domain ownership.",
   "syncPubKeyDomain": "crawlfix.ai",
+  "syncRedirectDomain": "crawlfix.ai",
   "syncBlock": false,
   "records": [
     {

--- a/crawlfix.ai.domain-verification.json
+++ b/crawlfix.ai.domain-verification.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "crawlfix.ai",
+  "providerName": "Crawlfix",
+  "serviceId": "domain-verification",
+  "serviceName": "Domain Verification",
+  "version": 1,
+  "logoUrl": "https://crawlfix.ai/brand/crawlfix-logo.png",
+  "description": "Verifies that you control this domain so Crawlfix can run external AI-readiness audits and unlock paid reports.",
+  "variableDescription": "Adds the TXT record required by Crawlfix to confirm domain ownership.",
+  "syncPubKeyDomain": "crawlfix.ai",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_crawlfix",
+      "data": "crawlfix-verification=%token%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the DomainConnect template for `crawlfix.ai` / `domain-verification`. Crawlfix runs external AI-readiness and SEO audits and needs users to prove domain ownership via a single TXT record (`_crawlfix.<domain>` = `crawlfix-verification=<token>`). This template lets users on participating DNS providers add that record in one click instead of copy-pasting into their DNS dashboard.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`crawlfix.ai.domain-verification.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://crawlfix.ai/brand/crawlfix-logo.png, 200 OK)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `crawlfix.ai` (public key TXT lives at `_dc1.crawlfix.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — confirmed absent
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `crawlfix.ai` (added in 14fccdb)
- [x] no TXT record contains SPF content — the only TXT is `crawlfix-verification=%token%`, no SPF
- [x] `txtConflictMatchingMode` — N/A, host is the fixed label `_crawlfix` which is unique per template
- [x] no variable is used as a bare full record value — value is `crawlfix-verification=%token%`, prefixed
- [x] no bare variable is used as the full `host` label — host is the fixed string `_crawlfix`
- [x] no variable is used in the `host` field to create a subdomain — host is fixed
- [x] `%host%` does not appear explicitly in any `host` attribute — confirmed
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A, this verification record must stay in place for the service to function

## Online Editor test results

**Editor test link(s):**

[Test crawlfix.ai/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIHuCWoC%2F%2BVTW2%2FTMBT%2BK5alPS3pkl63SHvYGEMDNGAqE2OqopP4pDVz7GA77bKq%2Fx27XZcWEPDOky%2FnO%2Bd837ksqcWyEmCRJktaaTXnDPUVownNNSxEwR87wGnwYrqG0kHpq2ejsxjUc57j2oepErgM56h5wXOwXMkW8ex6scaQ232MczH%2BlsQBFWqqPmvhsDNrK5McHe1wOco0SPbyE3pwp5JTF4OhyTWv1hETukmAhtgZWNKomuRKWq2E%2B%2BCGbKgSo8hWC8lBEl1Lgo8WtQRBzq5CjcC4RGMI1Ixbd0hGailU%2FkAq4IxorJS2puM1gOaQCbzY43HGmOeAZPxl7NC50t7pe801MpI1bXqrPMOC63JLTi2kK8uMVz66aWT%2Bsc7eYbOp4C8t8oAbZC5ubv8AOffcaVKAMBjQDSFDk%2FsltU3lG%2BR4OuhMGesead52moGFnZB7bT49sOoB5YGDWeta14ui1WQV0CclMW2TTILnGXFx8BHc6GEnV2Wbz92mWtVVyrf4CjSUxo%2Fn1vN%2Bz3Wy9b2n%2Fr6m4R8WjY27vT71NPhUKo2pcSfYWjuZVtdOflkLy1NYQPvF8hSqSjSOtXFWF%2Brn0sjNIP9zaV6YtLUJaMpyr4n7tSmKUXcAJ1nYK9go7GMWhRDHvXCQFScYQwbDHtvZwd%2Bs59%2BXsK2vG2aUloNfsDOxgMbQ1WoSuFr%2FF0LdjBiYI0vBw7pRdxhGgzAejeNh0hsm8ajTO4773dFhFCVR5KU4VRvZSzdJuzNE%2Byhu%2Bdeb6nZwXt8dvuFvx8dicPfUvP72vnnqdj9dCrg0Hy4u4aR%2FSlc%2FAHOOyDJtBQAA)

[Test crawlfix.ai/domain-verification example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHvvCWoC%2F%2BVTbW%2FaMBD%2BK5alfhqhCS8FIvUDayet2tqtHZs2VSi62AdYDXZmO1CK%2BO87Q2lgm7ofsE%2BJ7ee5e%2B65uzX3OC8L8MjTNS%2BtWSiJ9krylAsLy2KiHpugeOPl6QbmBOUXz4%2F04tAulMAtR5o5KB0t0KqJEuCV0TXimXq5xbBvxxiiuPCXJg1emKn5agvCzrwvXXp6eqDlNLeg5ctNFMDNUk8phkQnrCq3EVO%2BS4CO%2BRl4tjIVE0Z7awq6UI7tpDJn2L4WJkAzW2mGjx6thoINryKLIJVG5xhUUnn6aMkqXRjxwEpQklksjfWuGWoAqyAv8PJIx1DKoAHZ6PuI0MLYQPpZKYuS5as6vTdB4UTZ%2BV6cWWqyZabKEN2ttPhc5R9wtXPwjxYFwB1Kiiv8K5C3QTtPJ1A4bPCdIMfT%2BzX3qzI0iHQSdGacp0Mm6k5L8HAQ8qjN5yfePKA%2BIZj31Lp2HG%2FGmwZ%2FMhqzOsm48TwjFAcfgUYPm8LM63xQlnSYWlOVmdpTSrAwd2FC9%2BT7I%2FZ4T7%2Ff8um4FRPOHp1PWu0OD2LUVBuLmaMv%2BMpSsd5WZMK8KrzKYAn1lRQZhSpWpN3RK4X63SC9G%2Besdngr%2FVWTXtTULjV4JkUoTYUF6iZtISEeRHlbdKNOS%2FSifpwPol67BSBgMkj6ycE2%2FmVR%2F72OR07TZKP2CsK2DYslrBzfbMYNcv1%2FqpcmxsECZQYB2YpbZ1HcjZLeKDlLO3Ha6jW7g85ZO34Tx2kch2qosF3la5qrw4nid6Pk6e7H4uOtu76VfXPdkTdfuu0r%2B6l%2FMSgvKxQCh%2Fm7fDl9b8755hcsI%2ByxgQUAAA%3D%3D)