### PR TITLE
Email Marketing DKIM/SPF - domainconnect.mail.codexsuit.com

### DIFF
--- a/codexsuit.com.emailDkim.json
+++ b/codexsuit.com.emailDkim.json
@@ -1,63 +1,27 @@
 {
-    "providerId": "codexsuit.com",
-    "providerName": "CodexSuit",
+    "providerId": "codexsuit.com",                                                                                                                                                                 
+    "providerName": "CodexSuit",                            
     "serviceId": "emailDkim",
-    "serviceName": "Email Marketing DKIM/SPF",
-    "version": 1,
-    "syncBlock": false,                                                 
-    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com",
-    "syncRedirectDomain": "app.codexsuit.com",                          
-    "records": [                                            
-      {
-        "type": "CNAME",                                                
-        "host": "%token1%._domainkey",
-        "pointsTo": "%token1%._domainkey.mail.codexsuit.com",           
-        "ttl": 300                                          
-      },
-      {
-        "type": "CNAME",
-        "host": "%token2%._domainkey",                                  
-        "pointsTo": "%token2%._domainkey.mail.codexsuit.com",
-        "ttl": 300                                                      
-      },                                                    
-      {
-        "type": "CNAME",
-        "host": "%token3%._domainkey",                                  
-        "pointsTo": "%token3%._domainkey.mail.codexsuit.com",
-        "ttl": 300                                                      
-      },                                                    
-      {
-        "type": "SPFM",
-        "host": "@",                                                    
-        "spfRules": "include:mail.codexsuit.com"
-      },                                                                
-      {                                                     
-        "type": "TXT",
-        "host": "_dmarc",
-        "data": "v=DMARC1; p=none;",
-        "ttl": 300,                                                     
-        "host": "_dmarc",
-        "data": "v=DMARC1; p=none;",
-        "ttl": 300,
-      {
-        "type": "CNAME",
-        "host": "%token3%._domainkey",
-        "pointsTo": "%token3%._domainkey.mail.codexsuit.com",
-        "ttl": 300
-      },
-      {
-        "type": "SPFM",
-        "host": "@",
-        "spfRules": "include:mail.codexsuit.com"
-      },
-      {
-        "type": "TXT",
-        "host": "_dmarc",
-        "data": "v=DMARC1; p=none;",
-        "ttl": 300,
+    "serviceName": "Email Service DKIM/SPF",                                                                                                                                                     
+    "version": 2,
+    "logoUrl": "https://cdn.codexsuit.com/frontend-contents/logos/codex/codex.svg",                                                                                                                                               
+    "description": "Configures DKIM, SPF and DMARC records to send authenticated emails through CodexSuit",
+    "variableDescription": "token1, token2, token3 are the DKIM selector names provided by CodexSuit",                                                                                             
+    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com",                                                                                                                                                       
+    "syncRedirectDomain": "https://ev.codexsuit.com/mail/domains",                                                                                                                                                     
+    "records": [                                                                                                                                                                                   
+      { "type": "CNAME", "host": "%token1%._domainkey", "pointsTo": "%token1%._domainkey.mail.codexsuit.com", "ttl": 300 },
+      { "type": "CNAME", "host": "%token2%._domainkey", "pointsTo": "%token2%._domainkey.mail.codexsuit.com", "ttl": 300 },                                                                        
+      { "type": "CNAME", "host": "%token3%._domainkey", "pointsTo": "%token3%._domainkey.mail.codexsuit.com", "ttl": 300 },                                                                        
+      { "type": "SPFM",  "host": "@", "spfRules": "include:mail.codexsuit.com" },                                                                                                                  
+      {                                                                                                                                                                                            
+        "type": "TXT",                                                                                                                                                                             
+        "host": "_dmarc",                                                                                                                                                                          
+        "data": "v=DMARC1; p=none;",                        
+        "ttl": 300,                                                                                                                                                                                
         "txtConflictMatchingMode": "Prefix",
-        "txtConflictMatchingPrefix": "v=DMARC1;",
-        "essential": "OnApply"
+        "txtConflictMatchingPrefix": "v=DMARC1;",                                                                                                                                                  
+        "essential": "OnApply"                              
       }
-    ]
+    ]                                                                                                                                                                                              
   }

--- a/codexsuit.com.emailDkim.json
+++ b/codexsuit.com.emailDkim.json
@@ -1,45 +1,63 @@
-{                                                         
+{
     "providerId": "codexsuit.com",
     "providerName": "CodexSuit",
     "serviceId": "emailDkim",
-    "serviceName": "Email Marketing DKIM/SPF",                                                                                                                                                                                     
+    "serviceName": "Email Marketing DKIM/SPF",
     "version": 1,
-    "syncBlock": false,                                                                                                                                                                                                            
-    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com", 
-    "syncRedirectDomain": "app.codexsuit.com",
-    "logoUrl": "https://app.codexsuit.com/logo.svg",                                                                                                                                                                               
-    "records": [
-      {                                                                                                                                                                                                                            
-        "type": "CNAME",                                    
-        "host": "%token1%._domainkey",                                                                                                                                                                                             
-        "pointsTo": "%token1%._domainkey.mail.codexsuit.com",
-        "ttl": 300                                                                                                                                                                                                                 
+    "syncBlock": false,                                                 
+    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com",
+    "syncRedirectDomain": "app.codexsuit.com",                          
+    "records": [                                            
+      {
+        "type": "CNAME",                                                
+        "host": "%token1%._domainkey",
+        "pointsTo": "%token1%._domainkey.mail.codexsuit.com",           
+        "ttl": 300                                          
       },
-      {                                                                                                                                                                                                                            
-        "type": "CNAME",                                    
-        "host": "%token2%._domainkey",
+      {
+        "type": "CNAME",
+        "host": "%token2%._domainkey",                                  
         "pointsTo": "%token2%._domainkey.mail.codexsuit.com",
-        "ttl": 300                                                                                                                                                                                                                 
-      },
-      {                                                                                                                                                                                                                            
-        "type": "CNAME",                                    
+        "ttl": 300                                                      
+      },                                                    
+      {
+        "type": "CNAME",
+        "host": "%token3%._domainkey",                                  
+        "pointsTo": "%token3%._domainkey.mail.codexsuit.com",
+        "ttl": 300                                                      
+      },                                                    
+      {
+        "type": "SPFM",
+        "host": "@",                                                    
+        "spfRules": "include:mail.codexsuit.com"
+      },                                                                
+      {                                                     
+        "type": "TXT",
+        "host": "_dmarc",
+        "data": "v=DMARC1; p=none;",
+        "ttl": 300,                                                     
+        "host": "_dmarc",
+        "data": "v=DMARC1; p=none;",
+        "ttl": 300,
+      {
+        "type": "CNAME",
         "host": "%token3%._domainkey",
         "pointsTo": "%token3%._domainkey.mail.codexsuit.com",
-        "ttl": 300                                                                                                                                                                                                                 
+        "ttl": 300
       },
-      {                                                                                                                                                                                                                            
-        "type": "SPFM",                                     
+      {
+        "type": "SPFM",
         "host": "@",
         "spfRules": "include:mail.codexsuit.com"
       },
-      {                                                                                                                                                                                                                            
+      {
         "type": "TXT",
-        "host": "_dmarc",                                                                                                                                                                                                          
-        "data": "v=DMARC1; p=none;",                        
+        "host": "_dmarc",
+        "data": "v=DMARC1; p=none;",
         "ttl": 300,
         "txtConflictMatchingMode": "Prefix",
-        "txtConflictMatchingPrefix": "v=DMARC1;",                                                                                                                                                                                  
+        "txtConflictMatchingPrefix": "v=DMARC1;",
         "essential": "OnApply"
-      }                                                                                                                                                                                                                            
-    ]                                                       
+      }
+    ]
   }

--- a/codexsuit.com.emailDkim.json
+++ b/codexsuit.com.emailDkim.json
@@ -1,18 +1,20 @@
 {                                                         
-    "providerId": "codexsuit.com",                                                                                                                                                                                                 
+    "providerId": "codexsuit.com",
     "providerName": "CodexSuit",
     "serviceId": "emailDkim",
-    "serviceName": "Email Marketing DKIM/SPF",
-    "version": 1,                                                                                                                                                                                                                  
-    "syncBlock": false,
-    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com",                                                                                                                                                                        
-    "records": [                                                                                                                                                                                                                   
+    "serviceName": "Email Marketing DKIM/SPF",                                                                                                                                                                                     
+    "version": 1,
+    "syncBlock": false,                                                                                                                                                                                                            
+    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com", 
+    "syncRedirectDomain": "app.codexsuit.com",
+    "logoUrl": "https://app.codexsuit.com/logo.svg",                                                                                                                                                                               
+    "records": [
       {                                                                                                                                                                                                                            
-        "type": "CNAME",                                                                                                                                                                                                           
+        "type": "CNAME",                                    
         "host": "%token1%._domainkey",                                                                                                                                                                                             
-        "pointsTo": "%token1%._domainkey.mail.codexsuit.com",                                                                                                                                                                      
+        "pointsTo": "%token1%._domainkey.mail.codexsuit.com",
         "ttl": 300                                                                                                                                                                                                                 
-      },                                                                                                                                                                                                                           
+      },
       {                                                                                                                                                                                                                            
         "type": "CNAME",                                    
         "host": "%token2%._domainkey",
@@ -22,20 +24,22 @@
       {                                                                                                                                                                                                                            
         "type": "CNAME",                                    
         "host": "%token3%._domainkey",
-        "pointsTo": "%token3%._domainkey.mail.codexsuit.com",                                                                                                                                                                      
-        "ttl": 300
-      },                                                                                                                                                                                                                           
-      {                                                     
-        "type": "TXT",
-        "host": "@",                                                                                                                                                                                                               
-        "data": "v=spf1 include:mail.codexsuit.com ~all",
+        "pointsTo": "%token3%._domainkey.mail.codexsuit.com",
         "ttl": 300                                                                                                                                                                                                                 
-      },                                                    
-      {
+      },
+      {                                                                                                                                                                                                                            
+        "type": "SPFM",                                     
+        "host": "@",
+        "spfRules": "include:mail.codexsuit.com"
+      },
+      {                                                                                                                                                                                                                            
         "type": "TXT",
-        "host": "_dmarc",
-        "data": "v=DMARC1; p=none;",                                                                                                                                                                                               
-        "ttl": 300
+        "host": "_dmarc",                                                                                                                                                                                                          
+        "data": "v=DMARC1; p=none;",                        
+        "ttl": 300,
+        "txtConflictMatchingMode": "Prefix",
+        "txtConflictMatchingPrefix": "v=DMARC1;",                                                                                                                                                                                  
+        "essential": "OnApply"
       }                                                                                                                                                                                                                            
     ]                                                       
   }

--- a/codexsuit.com.emailDkim.json
+++ b/codexsuit.com.emailDkim.json
@@ -1,7 +1,8 @@
 {                                                         
     "providerId": "codexsuit.com",                                                                                                                                                                                                 
     "providerName": "CodexSuit",
-    "serviceId": "emailDkim",                                                                                                                                                                                                      
+    "serviceId": "emailDkim",
+    "serviceName": "Email Marketing DKIM/SPF",
     "version": 1,                                                                                                                                                                                                                  
     "syncBlock": false,
     "syncPubKeyDomain": "domainconnect.mail.codexsuit.com",                                                                                                                                                                        

--- a/codexsuit.com.emailDkim.json
+++ b/codexsuit.com.emailDkim.json
@@ -1,0 +1,40 @@
+{                                                         
+    "providerId": "codexsuit.com",                                                                                                                                                                                                 
+    "providerName": "CodexSuit",
+    "serviceId": "emailDkim",                                                                                                                                                                                                      
+    "version": 1,                                                                                                                                                                                                                  
+    "syncBlock": false,
+    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com",                                                                                                                                                                        
+    "records": [                                                                                                                                                                                                                   
+      {                                                                                                                                                                                                                            
+        "type": "CNAME",                                                                                                                                                                                                           
+        "host": "%token1%._domainkey",                                                                                                                                                                                             
+        "pointsTo": "%token1%._domainkey.mail.codexsuit.com",                                                                                                                                                                      
+        "ttl": 300                                                                                                                                                                                                                 
+      },                                                                                                                                                                                                                           
+      {                                                                                                                                                                                                                            
+        "type": "CNAME",                                    
+        "host": "%token2%._domainkey",
+        "pointsTo": "%token2%._domainkey.mail.codexsuit.com",
+        "ttl": 300                                                                                                                                                                                                                 
+      },
+      {                                                                                                                                                                                                                            
+        "type": "CNAME",                                    
+        "host": "%token3%._domainkey",
+        "pointsTo": "%token3%._domainkey.mail.codexsuit.com",                                                                                                                                                                      
+        "ttl": 300
+      },                                                                                                                                                                                                                           
+      {                                                     
+        "type": "TXT",
+        "host": "@",                                                                                                                                                                                                               
+        "data": "v=spf1 include:mail.codexsuit.com ~all",
+        "ttl": 300                                                                                                                                                                                                                 
+      },                                                    
+      {
+        "type": "TXT",
+        "host": "_dmarc",
+        "data": "v=DMARC1; p=none;",                                                                                                                                                                                               
+        "ttl": 300
+      }                                                                                                                                                                                                                            
+    ]                                                       
+  }


### PR DESCRIPTION
# Description

New template for CodexSuit email marketing — configures DKIM (3 CNAME records), SPF (SPFM) and DMARC for domains using AWS SES via a relay on mail.codexsuit.com.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test codexsuit.com/emailDkim empresa.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ%2F1CWoC%2F%2B1Wa2%2FaMBT9K8jSPo1HEgiPVJUKpVWrLl0fTOpUIWRsAxZJnNkOLUXst%2B%2BahEcHbbVp2laJT7HvuQ%2Bf6%2BujzJBmYRxgzZA3Q7EUE06ZPKfIQ0RQ9qgSrotEhCi%2FAi9xCM7o2MC3AAOkmJxwwhZhLMQ8aI95uLZnEScGyflYjpnm0TDXvjj3S7dXp%2BA4YVJxESHPhqBpRFqBIGPkDXCgWGq5SvoXbNoWkAPcEF0siIgiRnTRJC7%2BfF4TdcMol%2BCxisNxvOUYiKH4IgNAR1rHyiuVCI2ee5UGUkSaRbRAFl%2BtSiZKlRZei3UxjoaQDKoJSRXy7mdIT%2BNFpy6b%2FglAI6E0bD9oMWaR%2FaHYS0mM2dR0V3DI2hG7HXYz1BoOXbasef71Ws5btZw%2FV6v8Vq3yb9WCMfHXpY7M9caDmyRg0GkEgxAklHk7km2k6Nx11hl6NMSSwJ5ijWE%2FOWz7zZtj%2ByAXH0YiYgcbx4DVoz4W0SDgRPtYkxFMrw9lIO5KsgF%2FRDtdMmwjOfgxpWB8ODbj9jlqxnEwRfPuPI%2BeoGpvPT3dfDbjiycVS6Zw1p2MAayGUiRxjy%2F9YyxxqMw7XkbePwvtLmPvkVmnU2Z2uE9sp7yyOcZG2aDiVle2srENR7xWbyBzWj6MhGQ9BV%2BsEwmt0DKBpxomgeY9%2FIDXJkp62NAEcgpQSLT9NKJUIdKDPB%2Bg7IK2oNdHJw83TEwruNGkKiF95tb7hQHGjUKFVAaFuuuSQpnW7RrFFu6X6xsKt1P%2BXtK49XVsXm0zeMBTheY7nkvGNW3wTq5b0Hvnmg7OTq5b0LvjmupKxvRoU1JAouzcy%2BKU%2B46DYMmtav3%2F5H5NNP8tl5W2zrt5EMe95OwlZy85e8n5S5IDv00KTxjtYePnWE61YLkFu9axa55V9cqNoluruK7z0bI8yzIcmNIpxRn8XW3%2BV6Gz869PwcNo3Gl8uxOfTvrDptNvOfy02pLX2A%2BsxnmlRc9sf3xxfYjmPwAQUI6r0Q0AAA%3D%3D)
