### PR TITLE
Add Novantt email sending template

### DIFF
--- a/novantt.com.email-sending.json
+++ b/novantt.com.email-sending.json
@@ -1,0 +1,67 @@
+{
+  "providerId": "novantt.com",
+  "providerName": "Novantt",
+  "serviceId": "email-sending",
+  "serviceName": "Novantt Email Sending",
+  "version": 1,
+  "logoUrl": "https://www.novantt.com/images/novantt-logo.svg",
+  "description": "Configure DNS records for sending campaign emails via Novantt (Amazon SES).",
+  "variableDescription": "verificationToken: SES domain verification token; dkim1: First DKIM selector; dkim2: Second DKIM selector; dkim3: Third DKIM selector",
+  "syncPubKeyDomain": "domainconnect.novantt.com",
+  "syncRedirectDomain": "novantt.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "groupId": "ses-verification",
+      "type": "TXT",
+      "host": "_amazonses",
+      "data": "%verificationToken%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mail-from",
+      "type": "MX",
+      "host": "mail",
+      "pointsTo": "feedback-smtp.eu-west-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "mail",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine;",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Domain Connect template for Novantt, a membership platform for creators. This template configures DNS records for sending campaign emails via Amazon SES (SES verification, DKIM, MAIL FROM, SPF, DMARC).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

> **Note:** `logoUrl` will be deployed to production (`https://www.novantt.com/images/novantt-logo.svg`) before template activation.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `domainconnect.novantt.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — using `SPFM` record type for SPF
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — set on DMARC record with `Prefix` mode and `v=DMARC1` prefix
- [x] no variable is used as a bare full record value — **exception:** the SES verification TXT record at `_amazonses` uses `%verificationToken%` as bare value; this is required by AWS SES which expects the exact verification token as the TXT record content at the `_amazonses` subdomain
- [x] no bare variable is used as the full `host` label — DKIM selectors use `%dkim{1,2,3}%._domainkey` pattern (non-variable `._domainkey` suffix)
- [x] no variable is used in the `host` field to create a subdomain — variables only used in fixed host patterns
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — set on DMARC record

## Online Editor test results

**Editor test link(s):**

[Test novantt.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJkzCmoC%2F%2B1XbW%2FiRhD%2BK6uVIrU6TGw4EuIoH0jIqXcRNA00jRRFaFmvYYXt9e0uEBrR394ZYwc74e56VT9cVD7B7rw%2BM7PPyE%2FUijiNmBXUf6KpVgsZCP0xoD5N1IIl1ta5imntWdRnMajS%2FkYIAiP0QnKRmYiYycgxIglkMtnKqjbkErXI4FlrIbSRKqG%2BV6ORmqjfdQTaU2tT4x8eLpfLeimVQxmziTCH%2BZWDBnWzQD%2BBMFzL1Ga%2B6IVKQjmZa0G6%2FQHRgisdGBIqTfL8CGdxyuQkIVnahiwkI0WOP3Vi9qdKyOBy8HMdc2RasnEkupUYkLkMJWd4HKqZSHw0IIEChwkpS4lF8SkJZjL2fPJBamNJ9%2BpjD7KJBLdKb2QN8ACpJsEuYdMnw6nUL2RY51XCr%2BfjK7HqZqEhtU0O4CkBpXq1l6h%2BIwIJRbHPBq9VziPFZ9QPWWREjeYVpP79E51oNU%2BzjhthnDJOMLWrFLs9vBvCYaqMhcOIZeUEbewTswzuDl5V7wCtLTS%2FeeS661o5DsLf%2Br7od3qXW%2B8HWVUP6qMN6JlY4cAqmVgzVCU5%2FtSfM8mR%2FuuAjW8EbPzXAZvfCNj8voDZWw21KkXt3W1DorgaJBQiGDM%2Bc0xs07qYO0thrOO9ipdqqbS0K3jQ7hejmzTcxh1cf%2Bi9igwaN%2FMIJsanMMjRPBB%2BNdKL%2BsVM8y%2BNXyHMR29x1u11bi68U5KefZ4zDYMvE3GK1o8WiSOS3PaY5VPgiZ4K0OG1FqF83K2Sy7aOQU0Y4BkrGXLZr0knTaNVpRcP6xoFMGK0fVgPtfzZIpU%2BAjtFIi9pjgP%2BZYBHstBPIfnYIHcXlvcV04fC9p7i%2F1dPDgUW2ug1mijPHgresTEvzg08ByIszk08T6aSIgKgT6XFyMAvs0C21Ld6DmwRzyMrR2zJtlcBHzGsAgA2IAUvwCSVbiWbPbGLLIocSxWsQVs5IpfYftY%2BPuLcPXGCMDh23vNm2zkRRy1n7IqgHbht5nqitMZ2bLivLbJt%2Fctt7URLtjJ0jYP44t3mUKCM1Tebw8H7r7%2FVt4AOhmInOrx%2F%2B%2BhgxHeiw%2Fs3iC7j9hxazrA5oH%2FK6yV8VYr%2FAdFWCKUKd3EGm8UjO3cK%2BYtFUQEVkL4BcN%2Bx236c%2BSwW4nr9UIM1tl8E%2B0WwXwT7RbBfBP%2FjRQCfF4YtRDBiqNdwG0eO23K842HD85ue77bqrZZ7ctJ%2B57q%2B6yIMmM4N1if4Eil%2Fg9C7c6k8%2FYeyzatpnLzn%2Fc9y%2BO62e9F%2FPP90%2FsuVmczGt7Nb85vb653R9d8%2F%2BthxBRMAAA%3D%3D)

[Test novantt.com/email-sending sub/example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMI1CmoC%2F%2B1XbW%2FqNhT%2BK5alSpsuSQO0pUvVD6z0Sl0Ht7fQqVqFkHEcsEjizHYCrGK%2F%2FR6HpCQFbrdpH9qJT5F9Xp9zjs%2BjPGPNwjggmmH3GcdSpNxj8sbDLo5ESiKtbSpCXHsR9UgIqri3FoJAMZlyyjITFhIeWIpFHo8mG1nVBl0bLdR%2F0UqZVFxE2K3XcCAm4kEGoD3VOlbu8fF8PrdLqRzzkEyYOs6vLGNgq9T48Ziiksc684WvROTzSSIZ6vT6SDIqpKeQLyTK80OUhDHhkwhlaSuUcoKKHH9oh%2BRPEaH%2Bdf9H2%2BRIJCfjgHUqMSBz7nNKzHEgZixyjQHyBDiMUFmKtBFfIG%2FGw7qLPnOpNOrc3nQhm4BRLeRa1gAPkGrk7RI2XTSYcvlKZuq8jOhdMr5ly04WGlJb5wCeIlCyq7006vfM41AU%2FWKwrfJzIOgMuz4JFKvhvILYfXrGEymSOOu4Ysoq4wRTvYxNtwePAzhMhdJwGJGsnKBt%2BkQ0gbujreodGWsNzW%2BeOc6qVo5j4G98X%2FXa3euN96Osqkf2aA16xpZmYAWPtBqIktx87JdMcqT%2FOmDjjYCN%2Fzpg842AzX8WMHurvhSlqN3HTUgjrgbxGfPGhM4sFerYZok1Z0pb9a14seRCcr2EB%2B3sja5ifxO3f%2Fe5uxUZNO6TACbGxTDIQeIxtxrpVf1CIum%2B8SuE%2Beill51u%2B%2F6qfoHiyz8SImHwecQujPVCm8URcKq7RNMp7Imu8IzDO8l8vtitkss2jkGNKdgzmhOzy75E7TgOlpVeDFc1DGDYaPOwhrX82Zr6JONN%2FmwBqypgeX0zzCNemMSQf6jM%2Bi6MnzLrYWH%2BVLEf1rbXltHR0Mx6o2nk2XMxd2RMi3PDnD3mF%2BemOU%2BmHBscsESFZCMFX6Jh5WJXywR2RpgEmo%2FInGyuPDoiphYAW4EUvMA%2BqfQsWrPFZmXYVfh5D4t8SzWtQaOpKQQ3A%2BHT86bXZGOL0NbYOvGdsXXukxOrxc4Icejp6bnvlYhtB%2Bd9j9p2dqbc83YwJ0uFV2ZKXz3qHCFUt%2FSgd6M0Ot9%2F1B8MNIzQm6CNzv8KNLyTN0EbnY8NOmOPHLFxtxvn32WREuwqobzvIlR22P4qpJdAb3W0k9jQXyQIigpAAT4W5jXX7kO9l3ff5ZAXvL1aDWtAtQemOjDVgakOTHVgqgNTvV%2Bmgh80RVLmjYgxaTiNM8s5teqtQaPunjhu%2Fdxunf7knDU%2BOY7rOAYRjPUa9jP8y5X%2F4rBgv7HkF9okrNVqL25vHx79371f%2BSf6MFv22NfuTbDoidmXQdpzLvHqG6G7isBNFAAA)
