### PR TITLE
Add jetemail.com.outbound-domain template

### DIFF
--- a/jetemail.com.outbound-domain.json
+++ b/jetemail.com.outbound-domain.json
@@ -1,0 +1,38 @@
+{
+  "providerId": "jetemail.com",
+  "providerName": "JetEmail",
+  "serviceId": "outbound-domain",
+  "serviceName": "JetEmail Outbound Sending Domain",
+  "version": 1,
+  "logoUrl": "https://cdn.jetemail.com/assets/images/logo.svg",
+  "description": "Authenticates an outbound sending domain for JetEmail by adding the return-path CNAME, DKIM CNAME and DMARC TXT records.",
+  "variableDescription": "%returnPathId%: numeric id portion of the per-domain return-path subdomain assigned by the JetEmail dashboard (e.g. 56816, producing em56816 on the customer's zone).",
+  "syncPubKeyDomain": "dc.jetemail.com",
+  "syncRedirectDomain": "dash.jetemail.com",
+  "records": [
+    {
+      "groupId": "returnpath",
+      "type": "CNAME",
+      "host": "em%returnPathId%",
+      "pointsTo": "return.jetsmtp.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "jetemail._domainkey",
+      "pointsTo": "dkim.jetsmtp.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add a Domain Connect template for JetEmail's outbound sending domain authentication service. The template creates the three records a customer needs to authenticate a sending domain with JetEmail:

- Return-path CNAME `em%returnPathId%` → `return.jetsmtp.net` (envelope sender / bounce routing)
- DKIM CNAME `jetemail._domainkey` → `dkim.jetsmtp.net` (fixed selector across all customers)
- DMARC TXT `_dmarc` → `v=DMARC1; p=none;`

JetEmail uses CNAME delegation (Mailgun-style) rather than the SES-style TXT+MX pattern: customers do not publish their own SPF — SPF check follows the return-path CNAME to JetEmail-controlled infrastructure (`return.jetsmtp.net`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://cdn.jetemail.com/assets/images/logo.svg returns `image/svg+xml`, HTTP 200)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`dc.jetemail.com`; public key TXT records published at `_dck1.dc.jetemail.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`dash.jetemail.com`) — template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — SPF alignment is via CNAME delegation, not a TXT record
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`Prefix` / `v=DMARC1`)
- [x] no variable is used as a bare full record value
- [x] no variable in the `host` field creates a customer-arbitrary subdomain — `em%returnPathId%` is anchored with the fixed `em` prefix, and `%returnPathId%` holds a JetEmail-assigned numeric id (not a customer-typed value)
- [x] `%host%` is not used explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

Also passes `dc-template-linter` with `-merge-or-fail` clean (exit 0).

## Online Editor test results

**Editor test link(s):**
- [Test jetemail.com/outbound-domain — jetemail.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGlyC2oC%2F%2B1U227bOBD9FYJAsbuoLEuOryryYOQCJIHbIHWxAYLAoMmxzUYiVZJy4w387zuU5Cuy2d23PPSN0sycmTNzZl6ogyxPmQOavNDc6KUUYK4ETeh3QBOTach1RoOt7TPL0Jdeg7vwVrRYMEvJoQzShZvqQomG0GhVO%2BtRGPlSO5KvoIRUc3K%2BCViCsVIrmsQBTfVcfzMpBi6cy23SbHKhwv3KmsxacLYpMzYH2%2FQBoV3OEUeA5UbmrsSiw8ItQDnJkaolTJFNpcTWBVQVk5k2ZFvldEWYKK0YTQy4wqhGztyCnH0eji4Ccn5zNareiCnI%2BWh4d0bG92P05doIG3pCzEg2TeH8oKAPFdotgl2JDwlRRQZGciIFybXxTkTPyrQ5mLqdBxXYYlr%2FxRbIuQLhy%2FUB2%2FIFs4upZkaQ3yGch6TT7cfdgOAoRcE9K8jKXwST%2BUBeWKexjN8s%2BUsr%2BMNXb1eK3xbTG1jVE0qo4OGROLzTHQiJrN3ODbMfO9ZtocnDC50bXeSlaipanhW6uFXulVI2FT8X2jr8hOywYV6RWipnx3oL4JPZzOWhAueBHArnpBtF62A%2FmXiS2T%2Bm2ZY7qXr7BKvDTD76P%2BbJmOG7RCiKXZrJxiiYY%2Fi9PC2VE38i%2BanCzn%2Fah8XnszvTapZK7kbM8QWObqSFR701MJPP9FWX2rZDRzfAbcEtYH6lvqhhnqcrun5cB9TPe7KbziOWtpnj0QhrCvgquU5kGXA4w7rHFUvEyplhmfUnZoP6cAj7uMF9oP5dIv8r6r4gvHPcOml3qGeD66ANTPxaMPTBTjlTQECzInVywn6y3S%2FBJ8y3AclbtCIOSvNIHKo6XpBVGbZje1t2AY6Ze87Sy2HWbWF0NGuctNqs0e7P4sZ0IOJGu9fu9%2FqDuMNZZ%2B%2FMvnaC3z60u7nsD3mY%2FmQrS9dem6%2Bzel3yNcO35P5e%2BVWbVrP7n5v2Dhht13L9GOAe%2FlLjLzW%2BDzXixbVsCWLCvF8ranUbUacR98etKInjpBWHUa%2FXHQw%2BRlESRZ4JWFcRfcGbvH%2BN6Xd99WN%2BeXPx48%2FBXXrds1%2FH9yfTZ3n97SPPn4ZjyNqD9P5ynl2y6JSu%2FwZQawOjpgoAAA%3D%3D)
- [Test jetemail.com/outbound-domain — jetemail.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABx3C2oC%2F%2B1U32%2FbOAz%2BVwQBw91hjmM7adp66EPQ7oDekLXYpcDtiiCQLcZRa0uGJKfzivzvR9nOT3TdPfZhb5ZJfuRHfuQztVCUObNA42daarUSHPQ1pzF9ADQxkfupKqi3tX1mBfrSv8B%2BdFa0GNArkUITpCqbqEryHldolTvrURi56RzJ3yC5kBm52gSsQBuhJI1Dj%2BYqU3c6x8CltaWJ%2B%2F2US3%2B%2Fsj4zBqzpi4JlYPouwDerDHE4mFSL0jZYdFzZJUgrUqRqCJNkUykxXQFtxWShNNlWmdSE8caK0USDrbTslcwuyeXn8eSjR64%2BXU%2Fab8Tk5Goy%2FnJJpv9M0TdVmhvfEWJasCSHq4OC3rVotwh2zd%2FFRFYFaJESwUmptHMiatGkLUF37TyowFRJ9xdbIDIJ3JXrArblc2aWiWKak9%2FBz3xyMjoLRx7BUfIqdaygaH4RTOYC08pYhWX8Zsh3JeEPV72pZXpbJZ%2Bg7iYUU576R%2BJwTl%2BAC2Rtd26Y%2FdixawuN759pplVVNqppaTlW6GLr0imlaSo%2Bl8pYfEJx2DCnSCWkNVO1BXDJTGFLX4J1QBaFMxgFwdrbT8YfRfHDNNty521vH6E%2BzOSi%2F2eegul0lwhFsUsz3xg5swzfq4tGOeEHUl5I7PyHfVj8%2FGYvlVzkIrUTZtMljm6iuEO91bAQ3%2BiLLp1th45ugNuCW8DcSt3IcVnmNV3P1h51857vpjPD0jZzPBphR6Fb%2FobvXDRBh3Ps%2BtwyRbySaVYYd2Y2yPeH0LMN9n0LPuvQf4q8LwznHEaD4Ql1rHAtlIa5Ww%2BGPtgxqyvwaFHlVszZE9v94umcuXZgEwxaEQcleiQS2R4xKJoMfteCboava9DDmaeOvHDaSBNgYToY9c746Lw3TE4XPQYnrMeGw8FZdL4YhCzZu7kv3ePXr%2B7hkPanPs6fWG3o2on1ZXov7MAR1deW4C0TbXewo9nu4BGznyziG6G23dz1zMNV%2FSXUX0J980LFO23YCvicOd8oiEa94KQXnk2jIB6EcTT0o9F5GEXvgyAOAscGjG3JPuMl37%2FhdDB5P8pCG9YF%2B%2Fp0mpR19XAz7f%2BrZPB098Cyx%2BpOf8%2F5bXH6p7mg6%2F8AtGUHOuQKAAA%3D)