### PR TITLE
Add DKIM/SPF configuration for CodexSuit email service

### DIFF
--- a/codexsuit.com.emaildkim.json
+++ b/codexsuit.com.emaildkim.json
@@ -1,0 +1,27 @@
+{
+    "providerId": "codexsuit.com",                                                                                                                                                                 
+    "providerName": "CodexSuit",                            
+    "serviceId": "emailDkim",
+    "serviceName": "Email Service DKIM/SPF",                                                                                                                                                     
+    "version": 2,
+    "logoUrl": "https://cdn.codexsuit.com/frontend-contents/logos/codex/codex.svg",                                                                                                                                               
+    "description": "Configures DKIM, SPF and DMARC records to send authenticated emails through CodexSuit",
+    "variableDescription": "token1, token2, token3 are the DKIM selector names provided by CodexSuit",                                                                                             
+    "syncPubKeyDomain": "domainconnect.mail.codexsuit.com",                                                                                                                                                       
+    "syncRedirectDomain": "ev.codexsuit.com",                                                                                                                                                     
+    "records": [                                                                                                                                                                                   
+      { "type": "CNAME", "host": "%token1%._domainkey", "pointsTo": "%token1%._domainkey.mail.codexsuit.com", "ttl": 300 },
+      { "type": "CNAME", "host": "%token2%._domainkey", "pointsTo": "%token2%._domainkey.mail.codexsuit.com", "ttl": 300 },                                                                        
+      { "type": "CNAME", "host": "%token3%._domainkey", "pointsTo": "%token3%._domainkey.mail.codexsuit.com", "ttl": 300 },                                                                        
+      { "type": "SPFM",  "host": "@", "spfRules": "include:mail.codexsuit.com" },                                                                                                                  
+      {                                                                                                                                                                                            
+        "type": "TXT",                                                                                                                                                                             
+        "host": "_dmarc",                                                                                                                                                                          
+        "data": "v=DMARC1; p=none;",                        
+        "ttl": 300,                                                                                                                                                                                
+        "txtConflictMatchingMode": "Prefix",
+        "txtConflictMatchingPrefix": "v=DMARC1;",                                                                                                                                                  
+        "essential": "OnApply"                              
+      }
+    ]                                                                                                                                                                                              
+  }


### PR DESCRIPTION
# Description

New template for CodexSuit email marketing — configures DKIM (3 CNAME records), SPF (SPFM) and DMARC for domains using AWS SES via a relay on mail.codexsuit.com.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

Name	Type	TTL	Data
abc123._domainkey.empresa.com.	CNAME	300	abc123._domainkey.mail.codexsuit.com
def456._domainkey.empresa.com.	CNAME	300	def456._domainkey.mail.codexsuit.com
ghi789._domainkey.empresa.com.	CNAME	300	ghi789._domainkey.mail.codexsuit.com
empresa.com.	TXT	6000	"v=spf1 include:mail.codexsuit.com ~all"
_dmarc.empresa.com.	TXT	300	"v=DMARC1; p=none;"

**Editor test link(s):** 
[Test codexsuit.com/emailDkim empresa.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANcmC2oC%2F%2B1XbW%2FaMBD%2BK5alfVqAJBBoU1UqKptUdbSI0m1SVSFjG%2FAIcWo7tLRiv33nJOVl0Fabpm2V%2BgU7vtfn7vzIPGDDp0lEDMfhA06UnAnG1QnDIaaS8TudClOmcoqdpfCMTEEZH1vxBYhBpLmaCcozMz4lImpNxHR1Xlh8sBJ0kZ%2Bh1ulJu3LR%2BQhqM660kDEOfQdHciQvVQTqY2MSHVYqlMXljVwqQyVjw2NWotlqdMVa6Uqmlf%2BW9WwEnhnXVInEZN4h5XgoRqniOovuIAiPSMxQq93sHiPFqVRMIyORBu%2BIpGYM3gWF6jCU4QLhWMl0NEbr8GdECTKIeGsjmpETHnsOyla%2FWKuIKA5OcvwQJ%2BLUSIViKJFGRYkZGsw3Auh5TDvp4JTPWxLSsN5ZtoECxOCgbHMr%2F9wwa9XlTAAus7Tjsy29AjcOrx6wmSdZc8%2Ba7Q8gGktt4PNdjuVduZ%2BHnfC5HQgpoPY9uVthd07GQGurrrtwno%2FlvxTL%2F3Oxqi%2FFqv5WLBiu9irUkW1IMuymEYdKY2hdlDIe7nC25qL3tbfy0GdToqgdamIIfM8Os7H1DlByGMuYH6ylAbs7Y8c9EtS0iaFjEY%2FaEAbsOooPxR3eqVLI1pyDHtfaXgNiL%2BV53EySaI4X1wsH30PU%2Fmp6rp1iKjMWSOCakaI6BQLYjeD2JH3xqJ8QRabaUs%2Bj5dWG6fWj7RW2%2B3zK7BcZUM%2BvLs98e8b4sBbUl2dVezYai8bePrbZilEsFe9rWIkBEsChUSl38DSNjOiTW7I6YrRPLEwAp0EKjravRpyTWp7I5gAVDdoSPT86DnSY2lIIS6ODhheQfb9ecmsDt1Qb%2BrREgqBeGlTdvRoPhoQ3%2FDVS3snYT9Hyqh3rrW1Gt2Su8WLHdSmw5gXeiXVL9Nqx5oOzE%2BuW6NVhzXmlQHq0TilAUR56mpzQdxJFj9jq7v8P7tdI899iWXLr4toBcnyjnDfKeaOcN8r5S5QDzyZNZpz1idXzXZtGUPL2el4trO2FQVCu1j2vUXvvuqHrWgxcmxziA7yu1t9V2A%2B60c23z%2FedS%2Fhb1Es%2BfWxfTrzzU60aZ5VmY1g7vQ2%2BdCbH9e6NPMSLH7FhaY2EDgAA)