### PR TITLE
Add DKIM/SPF configuration for CodexSuit email service

### DIFF
--- a/codexsuit.com.emaildkim.json
+++ b/codexsuit.com.emaildkim.json
@@ -1,0 +1,46 @@
+{
+   "providerId":"codexsuit.com",
+   "providerName":"CodexSuit",
+   "serviceId":"emailDkim",
+   "serviceName":"Email Service DKIM/SPF",
+   "version":2,
+   "logoUrl":"https://cdn.codexsuit.com/frontend-contents/logos/codex/codex.svg",
+   "description":"Configures DKIM, SPF and DMARC records to send authenticated emails through CodexSuit",
+   "variableDescription":"token1, token2, token3 are the DKIM selector names provided by CodexSuit",
+   "syncPubKeyDomain":"domainconnect.mail.codexsuit.com",
+   "syncRedirectDomain":"ev.codexsuit.com/mail/domains",
+   "records":[
+      {
+         "type":"CNAME",
+         "host":"%token1%._domainkey",
+         "pointsTo":"%token1%._domainkey.mail.codexsuit.com",
+         "ttl":300
+      },
+      {
+         "type":"CNAME",
+         "host":"%token2%._domainkey",
+         "pointsTo":"%token2%._domainkey.mail.codexsuit.com",
+         "ttl":300
+      },
+      {
+         "type":"CNAME",
+         "host":"%token3%._domainkey",
+         "pointsTo":"%token3%._domainkey.mail.codexsuit.com",
+         "ttl":300
+      },
+      {
+         "type":"SPFM",
+         "host":"@",
+         "spfRules":"include:mail.codexsuit.com"
+      },
+      {
+         "type":"TXT",
+         "host":"_dmarc",
+         "data":"v=DMARC1; p=none;",
+         "ttl":300,
+         "txtConflictMatchingMode":"Prefix",
+         "txtConflictMatchingPrefix":"v=DMARC1;",
+         "essential":"OnApply"
+      }
+   ]
+}


### PR DESCRIPTION
# Description

New template for CodexSuit email marketing — configures DKIM (3 CNAME records), SPF (SPFM) and DMARC for domains using AWS SES via a relay on mail.codexsuit.com.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 

[Test codexsuit.com/emailDkim empresa.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANcmC2oC%2F%2B1XbW%2FaMBD%2BK5alfVqAJBBoU1UqKptUdbSI0m1SVSFjG%2FAIcWo7tLRiv33nJOVl0Fabpm2V%2BgU7vtfn7vzIPGDDp0lEDMfhA06UnAnG1QnDIaaS8TudClOmcoqdpfCMTEEZH1vxBYhBpLmaCcozMz4lImpNxHR1Xlh8sBJ0kZ%2Bh1ulJu3LR%2BQhqM660kDEOfQdHciQvVQTqY2MSHVYqlMXljVwqQyVjw2NWotlqdMVa6Uqmlf%2BW9WwEnhnXVInEZN4h5XgoRqniOovuIAiPSMxQq93sHiPFqVRMIyORBu%2BIpGYM3gWF6jCU4QLhWMl0NEbr8GdECTKIeGsjmpETHnsOyla%2FWKuIKA5OcvwQJ%2BLUSIViKJFGRYkZGsw3Auh5TDvp4JTPWxLSsN5ZtoECxOCgbHMr%2F9wwa9XlTAAus7Tjsy29AjcOrx6wmSdZc8%2Ba7Q8gGktt4PNdjuVduZ%2BHnfC5HQgpoPY9uVthd07GQGurrrtwno%2FlvxTL%2F3Oxqi%2FFqv5WLBiu9irUkW1IMuymEYdKY2hdlDIe7nC25qL3tbfy0GdToqgdamIIfM8Os7H1DlByGMuYH6ylAbs7Y8c9EtS0iaFjEY%2FaEAbsOooPxR3eqVLI1pyDHtfaXgNiL%2BV53EySaI4X1wsH30PU%2Fmp6rp1iKjMWSOCakaI6BQLYjeD2JH3xqJ8QRabaUs%2Bj5dWG6fWj7RW2%2B3zK7BcZUM%2BvLs98e8b4sBbUl2dVezYai8bePrbZilEsFe9rWIkBEsChUSl38DSNjOiTW7I6YrRPLEwAp0EKjravRpyTWp7I5gAVDdoSPT86DnSY2lIIS6ODhheQfb9ecmsDt1Qb%2BrREgqBeGlTdvRoPhoQ3%2FDVS3snYT9Hyqh3rrW1Gt2Su8WLHdSmw5gXeiXVL9Nqx5oOzE%2BuW6NVhzXmlQHq0TilAUR56mpzQdxJFj9jq7v8P7tdI899iWXLr4toBcnyjnDfKeaOcN8r5S5QDzyZNZpz1idXzXZtGUPL2el4trO2FQVCu1j2vUXvvuqHrWgxcmxziA7yu1t9V2A%2B60c23z%2FedS%2Fhb1Es%2BfWxfTrzzU60aZ5VmY1g7vQ2%2BdCbH9e6NPMSLH7FhaY2EDgAA)
[Test codexsuit.com/emailDkim codexsuit.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOw4C2oC%2F%2B1W%2FW%2FaOBj%2BVyJL%2B2kBQkIhZaq0quzudju6qrDdR4WQcUziI7E920kJFfe33%2BuQAt3YUE8n3U1CQtjJ%2B%2FH4ff34cR6QoZlMsaGo%2F4CkEgWLqHoboT4iIqJLnTPTJCJD7tZ4jTNwRlfWPAIzmDRVBSO0CqMZZulgwbLd%2BzrijbU4o807Z%2FDu7bA1uvkB3AqqNBMc9X0XpSIWH1QK7okxUvdbLRLx5pO1tOZKcEN51CDVaHTLRulW5bX5b%2BoihswR1UQxaarssGQ%2BZ3GuqK7QXQfgHcwjZzC8vL1yFCVCRdoxwtGQ3cG5SSA7I9CdyKnqAmOiRB4nzn75BVYMz1I6eIJmxILytutUo1%2BPgYMVhSSb%2BgEnpcQI5XBokXbqFkfOrHwCoEtObvLZO1oOBCzDZo%2BqCTSAQ4KmXVvz8w2zUbc0YlCX2cbR4gu%2Fum7Uv3tAppTV5l5fDt%2BAKRHawOOLTS0vmtMN7IKWlhCCQe%2FH4rDD4TUZA1sbeN7a%2FTaWfwzL%2F%2FewgmNYwT%2FCAnINd1Cv7YbI%2BW2eUug0gq1L84j2DyTbSzH%2BbbzLMI0yrIglNTYYnouLirbtV4684ILTV3vLgNnSWLqnjJghNiRhPB4CDMTdKDpnS3TQpbbtJQc%2FqrU9Btgeyvf8Usq0ROvJ2kUrQJ3u2DNxa1YeEI%2B6BpjFcH7klD1GSKxwpq34PMbefRY8eYy%2BQ3a%2BYZp9ylK6SnDRy5Y5l8tOHqdBoQOW9XgeLz9leOvtW28pk%2FmqJ7WfquSMzWRvXqyybLEqs4VSkVFb78B6m5iUZmGwTAuRLCOJs1IZwslM5iaWxQLZ%2BlnMhaJTDSM2ICuob1ROXZTlqWFTfI93ryIyxbZx0C4NVoD48rDxjUweK%2BspWWsyPCPo2wR2gWfEbgezYt7zSdAOu2GDEq%2FX6Jyfhw3c8cNGGHY752EvCHAw37saDt4bX7scdpTYJ9hleo9LjdYHDm3dn2MbebA%2Fzwj63vtzjLoH%2B%2FOMoO%2BuPxsVrbvzel9AQZDbztel2PkLp%2BljbV3v%2F1%2Fc866I%2F7aW7U2ynrhwEZzk8CSHJzk8yeFJDifwIapxQaMptn6%2B53cb3lmjHY7b3b4Hv06z1zvrBJ2Xntf3PFsD1WZT4gN8le5%2Fj6KXrZ81%2FTikozz7cB2%2B%2F2Mhzpfdq1%2FGOrwfUf7nj6W%2FSO%2FPfvo1%2BPj7BVr%2FDWHXF1MOEAAA)
