### PR TITLE
Add configuration for CodexSuit email service

### DIFF
--- a/codexsuit.com.mail.json
+++ b/codexsuit.com.mail.json
@@ -1,0 +1,46 @@
+{
+   "providerId":"codexsuit.com",
+   "providerName":"CodexSuit",
+   "serviceId":"mail",
+   "serviceName":"Email Service DKIM/SPF",
+   "version":1,
+   "logoUrl":"https://cdn.codexsuit.com/frontend-contents/logos/codex/codex.svg",
+   "description":"Configures DKIM, SPF and DMARC records to send authenticated emails through CodexSuit",
+   "variableDescription":"token1, token2, token3 are the DKIM selector names provided by CodexSuit",
+   "syncPubKeyDomain":"domainconnect.mail.codexsuit.com",
+   "syncRedirectDomain":"ev.codexsuit.com",
+   "records":[
+      {
+         "type":"CNAME",
+         "host":"%token1%._domainkey",
+         "pointsTo":"%token1%._domainkey.mail.codexsuit.com",
+         "ttl":300
+      },
+      {
+         "type":"CNAME",
+         "host":"%token2%._domainkey",
+         "pointsTo":"%token2%._domainkey.mail.codexsuit.com",
+         "ttl":300
+      },
+      {
+         "type":"CNAME",
+         "host":"%token3%._domainkey",
+         "pointsTo":"%token3%._domainkey.mail.codexsuit.com",
+         "ttl":300
+      },
+      {
+         "type":"SPFM",
+         "host":"@",
+         "spfRules":"include:mail.codexsuit.com"
+      },
+      {
+         "type":"TXT",
+         "host":"_dmarc",
+         "data":"v=DMARC1; p=none;",
+         "ttl":300,
+         "txtConflictMatchingMode":"Prefix",
+         "txtConflictMatchingPrefix":"v=DMARC1;",
+         "essential":"OnApply"
+      }
+   ]
+}


### PR DESCRIPTION
# Description

New template for CodexSuit email marketing — configures DKIM (3 CNAME records), SPF (SPFM) and DMARC for domains using AWS SES via a relay on mail.codexsuit.com.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test codexsuit.com/mail codexsuit.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN0%2FC2oC%2F%2B1WbW%2FbNhD%2BKwKBfpps68VvcRGgQdxlQes0SzygQBAYNElLhCWSIynVcuD99h1txXZarUGGAVuxfBEp3stzdzw%2B5AOyLFcZtgyNHpDSsuSU6UuKRohIylam4LZNZI78vfAK56CMzp34FsQgMkyXnLCtWY55dliqld%2B7Ve92t%2BaNP1xOOrfXP4NaybThUqBR6KNMJvI3nYF6aq0yo06HUNF%2BEkZnoaWwTNAW2Y7WdJyV6Wy1dt%2B2KRPwTJkhmiu79Q7RigVPCs3MFt33AN7DgnrjydnNuacZkZoaz0rPgHcPFzYF75xAYajHXPQgTLUsktQ7zrzEmuN5xsZP0KxcMhH63naM6jH2sGbgZJc%2F4GSMWKk9ASUyXl1d6s2rJwCmEuS6mH9g1VhCGM473U6gAAIctF1s7a%2F3ylndMMohL7u3Y%2BU3enXeaHT3gGyltvt6dTZ5D6JUGgu%2Fb3a5vGnPdrBLVrlekBxqP5XNCs0xWQtbGwfBxv8%2BVvQcVvTPYcXPYcV%2FCwuaa3KAeuc2RC1uioxBpRFsXVZQNmpwduRi%2Bnl68DCjOdbENTW2GP7L023bhm89dSqkYG%2BPwoDZyrp2zzixE2xJykUyARiwu9ZswVeoUaWWHTkHPWaMOwbYHcpP4kyprEKb%2B42P1oA6O3TPvV93ZQNv1DnALIHzo2b80UJhjXPjeOfR9u4r4%2FtH6zvk5rtOc395xtYpLgf5qhBq1S2SLC5NzPOBKJLV7znea0dOW6l0sR4oE2U67fG5GizKdZ4v11W%2B1JpavdeOnbZNSGWXFquslOmKKpxX2hJB5qqwiSqXyOXPEyE1mxkYsQVaQSOrC%2BajvMgsn%2BEv%2BLBEyQy7wkG5DEgB4tvDJnY0%2BVxaT5u1boYXGH2%2FgX3oM%2BK2gzseDyIyHw6jeQv3%2Byetbp%2BetHAY9FrDsMfC%2BTzEgwU9uhUar4yGe%2BHQDce9dZZ9wZVBm4bzWpfmuT1sLM0LjH7g0jzXsI2leYHRj1SaHW3WhXl3zJjAwKH319zr%2FYGz7DGtfvCfzutl18G%2Flsb%2Bwtjc%2B8D3r6z3ynqvrPfKev8f1oNnpcElozPs9KIg6rcANRxOw%2F4o7o26Ybs3DLv97k9BMAoCFz4zdpfdA7wxj1%2BXaHChxoJdXE5%2F6aeL8a9xGn8ulwsmr8jFYF11TviqF63WxfnHj5enaPMn8DdXutcPAAA%3D)
[Test codexsuit.com/mail codexsuit.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPo%2FC2oC%2F%2B1Wa2%2FbNhT9KwKBfqpsy1JkJyoCLKizLQucZkkKDAgCgyYpibAeHEkplgPvt%2B9S8jNVamQYsBXwF1HifRzey8NDvSDNUpFgzVDwgoTMS06ZvKIoQCSnbK4KrrskT5G9Md7gFJzRZ2O%2BBzOYFJMlJ6wOSzFPtlMr50sza903c9bo%2Bmrcu7%2F9GdxKJhXPMxT0bZTkUf5VJuAeay1U0OsRmnX3ltELZZ5pltEOqUeteiZK9Wqv5tlVZQSZKVNEcqHr7LDaLORRIZmq0W0L4C2cUWs0vrj7bElGckmVpXNLQXYLFzqG7JxAY6jFzOrBGMu8iGJrt%2FISS46nCRvtoel8xrK%2BbdWjuxo9C0sGSZr6ASdhROfSyqBFylp1l1rTag9AVRm5LabXrBrlsAyTndYv0IAMEnTN2rqv98pE3THKoS69iWPlN36rulHw%2BIJ0Jep9vbkYX4IpzpWGzw9NLR%2B6kwZ2xirDhZxD7x%2Fydof2NWkNW%2Bs5ztL%2BPpZ7CMv997C8Q1jeP8ICco23UD%2BZDRHhXZEw6DSCrUsKyoKWZDspHv542GaY0BRLYkiNNYbv8rymbf%2BTJc6zPGOfdpYBb3Nt6J5wosdYk5hn0RhgIO5WspDPUavLyraTHPyYUuYYYHMov2QXQiQVWj4tbbQA1MmWPU%2F2ipUturGqYaULEZwhMeHrKIElTpXRnnX846sET%2BsMj00K%2BG4YV88kbBHjcpjOi0zMT4oo8Url8XSYFdH8zxRvvF3jLUQcLoZCuYmMfT4Vw7BcpOlsUaUzKamWG2%2FPeOuIVHqmsUjKPJ5TgdNKapKRqSh0JMoZMn3gUZZLNlEwYg3yggItC2ajtEg0n%2BBnvJ2iZIJNA6FtCqwA8e2hyxq5PFTWa05umfHeyDfZbAPpiNkXbkTdd6gfTn2vMxy6pHNC%2B37njJzRTjg4ZXjqh%2B7UoztXROv90XJJ7FNjl2wXyTOuFFq2HOBVjw5t5ts9em%2Fkj9ujQxR%2Bu0fvjfyBetQo6%2Fqk7VVdnoNO9623Fdr6CyfJurqB878vr7k4uq%2Br%2FN7t8Z%2FWs7ljlk82XA9HgTwK5FEgjwJ5FMgWgYSfVYVLRifY%2BLqOO%2Bg4fqd%2F%2BtAfBN4g6Dtdx%2Fdd3%2F3oOIHjmBKY0k2FL%2FDnuvvPisqQ8DA%2B%2Ff3ryXN0faI%2Fxr%2Bc%2FTp05u5vZZVesdtZQS%2FPxkl1MxqQc7T8G47DRsU1EAAA)