### PR TITLE
Add DiscoverWorthy managed-hosting template

### DIFF
--- a/discoverworthy.com.managed-hosting.json
+++ b/discoverworthy.com.managed-hosting.json
@@ -5,7 +5,7 @@
   "serviceName": "DiscoverWorthy Managed Hosting",
   "version": 1,
   "description": "Point your domain at your DiscoverWorthy managed-hosting site.",
-  "variableDescription": "target: the DiscoverWorthy Cloudflare Pages hostname, supplied by DiscoverWorthy.",
+  "variableDescription": "`target` is the DiscoverWorthy Cloudflare Pages hostname for the site (e.g. `my-site.discoverworthy.app`), supplied by DiscoverWorthy.",
   "syncPubKeyDomain": "discoverworthy.app",
   "records": [
     { "type": "APEXCNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 },

--- a/discoverworthy.com.managed-hosting.json
+++ b/discoverworthy.com.managed-hosting.json
@@ -1,0 +1,14 @@
+{
+  "providerId": "discoverworthy.com",
+  "providerName": "DiscoverWorthy",
+  "serviceId": "managed-hosting",
+  "serviceName": "DiscoverWorthy Managed Hosting",
+  "version": 1,
+  "description": "Point your domain at your DiscoverWorthy managed-hosting site.",
+  "variableDescription": "target: the DiscoverWorthy Cloudflare Pages hostname, supplied by DiscoverWorthy.",
+  "syncPubKeyDomain": "discoverworthy.app",
+  "records": [
+    { "type": "APEXCNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 },
+    { "type": "CNAME", "host": "www", "pointsTo": "%target%", "ttl": 300 }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **DiscoverWorthy** managed hosting. Points a customer's domain at their DiscoverWorthy Cloudflare Pages site via the signed synchronous flow: an `APEXCNAME` at the apex and a `CNAME` at `www`, both to the DiscoverWorthy Pages hostname supplied via the signed `%target%` variable.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A — template sets no `logoUrl`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`discoverworthy.app`) — mandatory, present
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` — N/A, the template does not use `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — the template has no TXT records
- [x] `txtConflictMatchingMode` — N/A, no TXT records
- [x] no variable used as a bare full record value — `%target%` is the `pointsTo` of type-constrained `APEXCNAME`/`CNAME` records (the canonical use for a hosting target), not a free-form value
- [x] no bare variable used as the full `host` label — hosts are fixed (`@` and `www`)
- [x] no variable used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential`/`OnApply` — N/A, both records are required for the service to function

## Online Editor test results

**Editor test link(s):**

Apex (root domain, host empty):
[Test discoverworthy.com/managed-hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG%2BFC2oC%2F%2B1Ua0%2FbMBT9K5YlpE1LuiS0BSJNGoNusAkoU6dNQlV6G98Wb0kcbKclVP3vu%2B6DQgfbZ6R9Sux7z8k595EZt5iXGVjk8YyXWk2kQH0qeMyFNKmaoJ4qba%2FrRqpy7t1nnENOCH68yvm%2ByKG4QT2RKS4IcihgjMK%2FVsbKYryJPglmZ8t0dnKfTjEjVcHj0OMCTaplaRdn3lWysKxWlWZC5SALBqvjFumWBmakxYajBi1hmOHxI9qBBT1GO2DSMHuN22RHmarEKAONrEushjnWgsywkdILgKNnr7AxbrBBXvuLr23VEcpy8NpjpirLTJLdYb31GSfP1EXarYZfsD5e2PuzHURDeRpTpYXh8dWM27p0VT3sdn4cnR%2BedSjs9NHVe9c4VzHTU3TcWbrcoVtrMx7vBsHcu8dvYafT6b%2FR%2FbnH71SByUZPn1q2lo63QDOGqxFaEdPbWKuqTOQ6vwQNuXFzuEZePYL219gr7t6XOtzp%2BUpzp0yOC6UxMfQEW2kyaXWFHs%2BrzMoEprC5EmlCqKwmI4aiRP50YYvlBLvCCrDghv15DZtCeTwRqTMo3X40Q7EXhcGBL0bByG9Cs%2BUPxUHqi9bBXhuC1l4YhQ9W7vml%2FPvSbeqNxmBhJWTOTTaF2vD5E51fmVt2%2FqXb63s0Wv%2Bb%2BMKbSOtuYIIiAZcWBVHbD1p%2BuN%2BLwng3infDxj6JjFpvgiAOAucGjV26ntEf4OHu85ujk8tfVTZsN28%2FXnzq3L79eYi99Fv364eLz7K8qdvdy%2FbZXS866XXe8flvdiUQ3CEHAAA%3D)

Subdomain (host set):
[Test discoverworthy.com/managed-hosting example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB2JC2oC%2F%2B1UXW%2FTMBT9K5alSSCSkmTrWkVCYmyVBvsgD2OgTVXqxLepIbEj22kJVf871%2F1Y17LB%2B8STZd97js%2B599pzaqGqS2aBxnNaazUVHPRHTmPKhcnVFPRMaTtpO7mqqPeQcc0qRNCzdc7XZQ7GDeipyGFJUDHJCuD%2BRBkrZLGNPgkmV6t0cv6QjjEjlKRx6FEOJteitss9TZSQlrSq0YSriglJ2Hq7R7qngRhhoeOomRYsK%2BFsh3ZkmS7AjogwxE5gn%2By0VA0fl0wDSZDVEMcq0QwZK70EOHryCjpFh4yq1l%2FetldHVtej1x4xTV2XAu1m7d41Tp5pZZ402QW0Z0t7f7YDaTBPQ640NzS%2Bn1Pb1q6qJ8ng2%2Bn1ydUAw04fHr13jXMVMzcKtwcrlwd4am1J48MgWHgP%2BD3sbDb7N3q48OgvJSHd6hliyzbS4SfDGYP1CK2JLeDi0UKrpk7FBlMzzSrjZnGDvt%2BBDzf4%2BxUB7ld63MnzFadOoSik0pAaXJltNJq1ugGPVk1pRcpmbHvE8xRRZYuGDEaR%2FOkCy9UkuwJzZpkb%2Buc1bAvm0ZTnzqRw7yTsR2M27oF%2F2IPMP2LjyO8fR5mfHUVdnrEsGIfBo6f3%2FOP8%2B%2BPbrTsYA9IKVjpH5Yy1hi6emIK1QZyCzhr4EnwOPZy1%2Fx19SR3Fj8CwKfCUudQoiI79oOuH%2FZsojI%2F6cXjY6R13e93emyCIAyfKsa2cz%2FFvePwr0FZfnnyafObBh7c%2FeuL8IuS3JpF34ZcgLMq7ZFDeTpPQfJeTyeAdXfwG%2BvBC6kMHAAA%3D)
