### PR TITLE
Fix discoverworthy.com.managed-hosting: APEXCNAME -> CNAME (hostRequired) for Cloudflare

### DIFF
--- a/discoverworthy.com.managed-hosting.json
+++ b/discoverworthy.com.managed-hosting.json
@@ -3,12 +3,11 @@
   "providerName": "DiscoverWorthy",
   "serviceId": "managed-hosting",
   "serviceName": "DiscoverWorthy Managed Hosting",
-  "version": 1,
-  "description": "Point your domain at your DiscoverWorthy managed-hosting site.",
-  "variableDescription": "`target` is the DiscoverWorthy Cloudflare Pages hostname for the site (e.g. `my-site.discoverworthy.app`), supplied by DiscoverWorthy.",
+  "version": 2,
+  "description": "Point a subdomain at your DiscoverWorthy managed-hosting site.",
   "syncPubKeyDomain": "discoverworthy.app",
+  "hostRequired": true,
   "records": [
-    { "type": "APEXCNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 },
-    { "type": "CNAME", "host": "www", "pointsTo": "%target%", "ttl": 300 }
+    { "type": "CNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 }
   ]
 }


### PR DESCRIPTION
# Description

**Bug fix to the existing `discoverworthy.com.managed-hosting` template** (added in #1110).

The apex record was `APEXCNAME`. Cloudflare does not support the `APEXCNAME`
custom record type and rejects it during Domain Connect onboarding (confirmed
by the Cloudflare Domain Connect maintainer). Cloudflare auto-applies CNAME
flattening at the zone apex, so the correct primitive is a standard `CNAME`.

Per the Domain Connect schema, a `CNAME` at `host: "@"` requires the template
to also set `"hostRequired": true`. This PR therefore:

- replaces the apex `APEXCNAME` with a single `CNAME` at `host: "@"`,
- adds `"hostRequired": true`,
- drops the separate `www` `CNAME` (under `hostRequired` the request host is
  the subdomain, so a hardcoded `www` record would mis-apply as
  `www.<host>.<domain>`),
- removes the optional `variableDescription` (not required; its only purpose
  was describing `%target%`, which `description` already conveys),
- bumps `version` 1 → 2 (template modified after being merged).

The resulting shape is identical to the already-merged
`magicpages.co.website-cname.json`. The record resolves to the customer's
hosting target supplied via the signed `%target%` variable.

## Type of change

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A — template sets no `logoUrl`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`discoverworthy.app`) — mandatory, present
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` — N/A, synchronous flow uses no `redirect_uri`
- [x] no TXT record contains SPF content — the template has no TXT records
- [x] `txtConflictMatchingMode` — N/A, no TXT records
- [x] `hostRequired: true` is set (required by the schema for a `CNAME` at host `@`)
- [x] no variable used as a bare full record value — `%target%` is the `pointsTo` of a type-constrained `CNAME` record
- [x] no bare variable used as the full `host` label — host is fixed (`@`)
- [x] no variable used in the `host` field to create a subdomain; `%host%` does not appear in any `host` attribute
- [x] `essential`/`OnApply` — N/A, the single record is required for the service to function

## Online Editor test results

**Editor test link:**

Host set (subdomain — the only applicable case for a `hostRequired` template):
[Test discoverworthy.com/managed-hosting example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIFIDGoC%2F91S7W7aQBB8Feuk%2FKqdnG0C2FKl0qZS2ygpqSKhCiFr41vgWuwzd2eIi3j37gEO%2BewD9Ndpb2dWM7uzYRaLagEWWbphlVYrKVB%2FFSxlQppcrVCvlbbz5jRXBfMfENdQEINdHDCjHYb6BvVK5rgbUEAJMxTBXBkry9mx%2ByrZu9rDvS8PcOoZqUqWRj4TaHItK7ur2VDJ0nrgmfpOqAJk6YH1GlVr79nQZxo8Iy2eOiVNmQ%2Fru0tsLnb8l36hqgjneD9wWUuNZMnqGn2mMVdaGJaON8w2lbPy6Xpw9fkAp%2FKD25STaG4VlScW9AztCf1au2BpzPl2svXZH1Vidpw2IZetGLwHOgsetn4Ya5Een820qqtMtpwKNBTGna9lj5%2FQJy1%2FvB9A9V6P%2B3nlyE6ZnJVKY2boBVtrbK0X9cLKDNZw%2FBJ5RqtaNGTEUJeGvlxLuT%2F4Qb8AC2%2Flq92PzzKRO0%2FSJambQBT34zAQMfCgE%2BfTIOmGPIC8F0dTFL3oHB%2BF8%2B34%2FjueT9eMxmBpJZAgNlisoTFsu534tPL%2F2iDFw8AKRQYOGvGoG%2FDzIExuwzCNOmknOe0nSRR233Gecu4c0bS94w0l53Fm2JRfQtP%2F%2BPNMf%2B813Cb3kb75ZXF0M1K%2F52ogTWg6w%2BVy%2Be1s8J5t%2FwJRTkFvjAQAAA%3D%3D)
