### PR TITLE
New template: treadcommand.com / custom-domain

### DIFF
--- a/treadcommand.com.custom-domain.json
+++ b/treadcommand.com.custom-domain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "treadcommand.com",
+  "providerName": "TreadCommand",
+  "serviceId": "custom-domain",
+  "serviceName": "Custom Domain",
+  "version": 1,
+  "logoUrl": "https://www.treadcommand.com/logo.png",
+  "description": "Connect your domain to your TreadCommand-powered tire shop storefront.",
+  "variableDescription": "`target` is the CNAME destination for your TreadCommand storefront (e.g., your-store.up.railway.app).",
+  "syncPubKeyDomain": "treadcommand.com",
+  "syncRedirectDomain": "www.treadcommand.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **TreadCommand** (`treadcommand.com` / `custom-domain`).

TreadCommand is a SaaS platform for mobile tire shops. Tenants bring their own domains and point them to their TreadCommand-powered storefronts hosted on Railway. This template automates CNAME configuration for subdomains (e.g., `www.joestires.com` → `<tenant>.up.railway.app`).

- **Provider**: [treadcommand.com](https://www.treadcommand.com)
- **Template**: Creates a single CNAME record for the `host` parameter pointing to a per-tenant `%target%` destination
- **Signing key**: Hosted at `_dcpubkeyv1.treadcommand.com` (DNS TXT records, 2-part RSA 2048-bit key)
- **Redirect domain**: `www.treadcommand.com`
- `hostRequired: true` — subdomain is always specified by the caller

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

**Test performed**: Domain=`example.com`, Host=`www`, target=`my-store.up.railway.app` → produces CNAME `www.example.com.` → `my-store.up.railway.app` (TTL 3600). No errors reported by editor.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — set to `treadcommand.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `www.treadcommand.com`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — N/A (template only contains CNAME)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A (no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — N/A (no TXT records)
- [x] no bare variable is used as the full `host` label — `host` is `@`
- [x] no variable is used in the `host` field to create a subdomain — uses `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute — confirmed, uses `@`
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — N/A (single CNAME managed entirely by template)

## Online Editor test results

**Editor test link(s):** [Test treadcommand.com/custom-domain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALhtDGoC%2F91T7W7TMBR9lcjSJBBJ6q4f6yIhMbUgjY0JlQ4QU5W58V1rSGzPdhpC1XfnOlm3jg0egD%2BJru859jn3Y0McFDpnDkiyIdqoteBgTjlJiDPAeKaKgkke45%2BE9%2FkLViCezDxi3CIwa8GsRQYNOSutU0XEVcGEfMjdEcdNNpjssmswVihJkm5IcrVUlyZH1Mo5bZNOp6qq%2BE8xHQ%2BLtVwim4PNjNCuuYGMlZSQuaBWpQna9wOn2nBfcKRVBQZ44ISBwK6UDlCUgRujpIu9KGYEW%2BQweXT9tWNmCe46EDZwKwjGFycf3gYowQnJPCa4Uebpa3t3By8gXsZhg4ma47jUsWEir1gdM61f%2BtdtLbOP5eIM6rsqPdsQj5oCRweZu8c9Vy%2FErpR1U7gtEYwdcqaEkCBPGW5JcrUhrtZNb7yhOziGb3zblZDOzhSGB639Azx1DpvUG1K6nW9D8ktJSB%2Bum2NbdnrgJ8MRgz0ZrUgMlkaVOhU7imaGFdZP4o589Yg939GvGj6GrRx%2FUNTPFpN4cWIpMZNa%2FDNXGtjZL8rciZRV7OGIZymy8hq9WMzizU9LI9spbi1w5hgGf3t%2Br04hSXnmzQm%2FIUc92hsyPoj6wEb46S6iBetheHQ4GvI%2BzUbA91bubyv5r6V7VGqwFqQTzG%2FWiZdnyXY7D7Hs%2F7VBnBHL1sBT5pGH9HAY0UHUPZ51%2BwntoeyY0sHgaPSK0oRS7wZXubW8wcnZnxny%2FVP3y2wypRfvp5eu%2F5WdVZ1308630%2FPbohK9H%2BfifPJ5qll%2BfGpfk%2B1viLFf8lsFAAA%3D)
