### PR TITLE
added DNS template

### DIFF
--- a/newtoncelestial.com.website-creation-test.json
+++ b/newtoncelestial.com.website-creation-test.json
@@ -1,0 +1,71 @@
+{
+  "providerId": "newtoncelestial.com",
+  "providerName": "newtoncelestial",
+  "serviceId": "website-creation-test",
+  "serviceName": "Newton Celestial website creation",
+  "version": 1,
+  "logoUrl": "https://spark-ml-h9j7a4k3nr.b-cdn.net/tests/0fa2335a0e8c4d90820647ecf1067e8b.png",
+  "description": "Connect a domain to Newton Celestial",
+  "syncBlock": false,
+  "syncPubKeyDomain": "wls-domain-connect-test.info",
+  "syncRedirectDomain": "newtoncelestial.com",
+  "variableDescription": "`ipv4` is the IPv4 address provided by newtoncelestial. `dkim_value` Full DKIM TXT record value.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:mailgun.org",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "krs._domainkey",
+      "data": "%dkim_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mxa.mailgun.org",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mxb.mailgun.org",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "email",
+      "pointsTo": "mailgun.org",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; adkim=r; aspf=r; rua=mailto:dmarc_rua@onsecureserver.net;",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "None"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x ] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [ x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [ x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [ x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x ] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [ x] `%host%` does not appear explicitly in any `host` attribute
- [x ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
[Test newtoncelestial.com/website-creation-test example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMOIDGoC%2F%2B1YW2%2FiOBT%2BK1GkeZqGBsIlTYXUAIVhO1BoobdRRR3HhAyOHWyTDFN1f%2FvaXAq0ZWZXWq2mszzh2D7n%2BDvfuYlHXaAoxkAg3XnUY0aT0Ees6euOTlAqKIEIIy5CgDOQRvrB85U2iNDrS%2FICRywJIZqrSJHHQ4EMyBAQISWGkNfWd5Y62nMdWnWlRFuKaSsxKZEgxtXKyR7omAa0z7CUHAkRc%2BfwkMeAjY0IG6OjryWQH1uEZTwD%2BiRDkDhURvmhOQQ5yyoAE9kw7x%2BZds4s5ksIDrNmsYRsLxOTQBryEYcsjOdmHb1KCUFQaEDzaQRCogmqvXyuwjMjsIIpHOvOEGCOFjudqXeGZrW5oHIG5sZCiwEXaufuyIRkSJc6LpAfMnnwLPM2BwlgIfAwqm299SGMk%2FyDFnJNjJDW7CR5Dfg%2BQ5xrS9J8zZtpL1VqD%2F44jAYJwFP0oNWnGGu1s2ZL6930NPkWynxtfpaRhhffXHe%2BPOpiFivyXLk9opJVRz9R4UFDIniPys8P6j0f5J4QkiuraJpPB89i1bbbOl2Lpmm6LXyyQ%2B6yU29tW%2BTx8GIqwcjPkEA89ZEjnYeDKclQFmyqOdClLxCZc%2Bbo58SNYzzTN5RLyGvdY8YzgwVfYzRTkQEEULDW7vqwrV18EzJehjiEogUEHIUkaFF%2FHuGUoE1DrZudXou%2Bgcz2%2B2MWUhaKmYx985%2Bg%2BaER718y8oJHpLS%2BsPU2GbvcPvAjwODa3Um51nIvqtljLS5PpoAB%2BRiCjmVoSxrKTC5kAKhfNgVlZUtQZ65iIDdOKOEITmUOyIKDmKoGxz%2BPiJ8zef90oH%2BXq8E6Ie7li1dZi74BWVPRMluXwOQqYHQaD8LVfVm0QMRV3V1JftkSvV%2FJftHVWqWTWmczuYyVyautdSiqg3GZcaD81Go2hi3XbFQvJ43LpmfVuqcVt9t33Xyj7daqlbB7Vgm6NT4r%2BP3JiJ%2Fy2Sdz1B3P2pNT6%2BPnDiZnNwymdcwvwnp%2FyI%2FAzRU5Sy7FYfV6AnABZnuj%2BvhyDK%2Btz8N4XE9zpTQ3qZ679q3dtxp3ZiSuitakPQoIKV1fRxMIYZjexfjyay3p9LP1VvfGmn3vjNHFpwt6l9B%2Bs40n309vBK7EaeG2anfyhWq%2Fd94I7qrnt7foj7RZc7tuRVd%2BDwNCGRpw%2BQuEpFZ3BJvKihtNsQgHIAXrLR8OgGJU0sTlqfTRdt0ii%2F5zso62lW%2B3YmTgQ0VSqDpaLp8d2hCWjCG0LSNfLALDy9ueUfLyWehnbRMOvY0u%2BYNG%2Bnf65Dp0NuPUxSmYcf3pjTRcIlqU0yWm7Wh8X7gWpeE1T0lZZn1We6Pga38CjH9tnM9ldBfQXa3n90%2Fw9xaf8x77OjxfN%2FENWNut9j0E506U3u%2BE8kUNXY0yK7C7gL63KvofD1i%2FLvP3B3II2w8E%2B4FgPxDsB4L9QLAfCPYDwf98ILiXekCC%2FAFQ93JmrmiYBSN71MsWnILtFI4yVs6yi4WPpumYpoIlFS%2B89vgkkW38J6G7vaBf6raDO06EyE26EbydFOlVh5xXAn903m%2BV7EbNDorgU1DWn%2F4CYPUNbocXAAA%3D)
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
