### PR TITLE
added DNS template

### DIFF
--- a/newtoncelestial.com.website-creation-test.json
+++ b/newtoncelestial.com.website-creation-test.json
@@ -1,0 +1,71 @@
+{
+  "providerId": "newtoncelestial.com",
+  "providerName": "newtoncelestial",
+  "serviceId": "website-creation-test",
+  "serviceName": "Newton Celestial website creation",
+  "version": 1,
+  "logoUrl": "https://spark-ml-h9j7a4k3nr.b-cdn.net/tests/0fa2335a0e8c4d90820647ecf1067e8b.png",
+  "description": "Connect a domain to Newton Celestial",
+  "syncBlock": false,
+  "syncPubKeyDomain": "wls-domain-connect-test.info",
+  "syncRedirectDomain": "newtoncelestial.com",
+  "variableDescription": "`ipv4` is the IPv4 address provided by newtoncelestial. `dkim_value` Full DKIM TXT record value.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:mailgun.org",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "krs._domainkey",
+      "data": "%dkim_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mxa.mailgun.org",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mxb.mailgun.org",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "email",
+      "pointsTo": "mailgun.org",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; adkim=r; aspf=r; rua=mailto:dmarc_rua@onsecureserver.net;",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "None"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for Newton Celestial managed hosting and email configuration. Points a customer’s domain to their Newton Celestial deployment via the signed synchronous flow by configuring an apex A record and a www CNAME, while also provisioning Mailgun-related SPF, DKIM, MX, and DMARC DNS records required for email delivery and domain authentication.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test newtoncelestial.com/website-creation-test example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMGQDGoC%2F%2B1YbVPiOhT%2BK53O%2BGmlFspLqcOMFURZFwQRRR0HQxog25CWJG2XddzffhNeBFR27525c2fdyyfSJOflOefJOWd40gUahwQIpDtPesiCGHuI1Tzd0SlKREAhIogLDIgBg7G%2B%2F3KlAcbo7SV5gSMWY4hmKhLU51igFGQICBzQlJDXVncWOhozHVp5qURbiGlLMSkRI8bVyknv6yQYBh1GpORIiJA7Bwc8BMxPjUlqVPxaAFnfoszop6BHDYrEgTLKD8wByFhWDpjIhlmvaNoZM58tIDhIm%2FkCsvtGSIfSkIc4ZDicmXX0ckApgkIDmheMAaaaCLTX7io8UwqPSQB93RkAwtF8pxn1z9G0MhNUwSA8NdeSgnO1s3AYmA6ChY5L5GEmD15k3s9BDBgGfYIqG74%2B4jDOPmqYa2KEtFozzmrA8xjiXFskzdP6U%2B21Su3R8%2FG4FwMSoUetGhGiVc5rde2qe6VJXwLmabMzQxqef3PduX%2FSxTRUyXPl9iiQWXX0I0WPAFPBrwL5uaf82ZN7QshcWXnTfN5%2FESs33PrJSjRJkk3hoy1y7Wa1vmmRh4PLSIKRn5hCEnnIkcEjw4gaARuuq9nXZSwQneXM0S%2BoG4Zkqq8pl5BXun3Gjd48Xz6aKmYAARSsVbj2NrWLb0LyZUAwFHUg4AjTYT3wZgwPKFo3VO9ujdr4GzA2%2FQ8ZDhgWU8l985%2Bg%2BamR%2Fr9k5FUekdL6ytb7ydgW9p43Bgyuwh2XKnX3spw%2B1MLSJAIMSGcoOpTUlmkoMbmQBFC%2FLAIlZUsEzkxFT24cBZQjGMk3IAsOYqoaHP6aEb%2FO5MPzvv5drnqrB%2FEgPV6%2BWvQNyJqKFq91AUyuhiyIwh5e3pdFC4y5qrtLyfsN0Yel7L2u1uo5qXXayBiWkVVbKyqqA7%2FEOFBxqtdOB3XXPC23J6ftWt%2BqtE6O3VbHdbOnDbdSPsat8%2BNhq8KnOa8zGfETPj0zRy1%2F2picWJ%2B%2BNAk97zKYVAm%2FxNXOgBdB95qex21xUL6ZAJKD6atR1W%2F78Mb6Mgj9apIpJJlJ%2BcK1b%2B2OdXpnjsV13po0RkNKCzc34wmEECd3IWl%2FrcTNTrpab3Wt6femjy7PLoO7OOjUGmTy%2FaQryHGY5G7LdjObK3euLk6Hd%2BWL21v0OalV3JZ7rKu44yENGOpx%2BQuETK3uCBbJijuOiMA9kIDVlgd7QGVUponLUxmjzbpF5%2F3naMW2ZWw3ONLzoEoSVh2tn7chyg%2FSqUwxb6WylmWn%2BsVMPuUBuziA%2FXQhnQVrXfInjfTv9MkVddZ56pIETLn%2B%2FM4zXCCal9MFpk02fixc89LwNk9xSb76tPZOwdd%2BAEJ%2Bb5wvZXQb0G2t589%2F4B%2BNn7Me%2B5aeb5v4GqzNVvsRyLkVZf9PQvmqhi5HmSXYbUA%2FWhX9jwes3zfzD%2FtyCNsNBLuBYDcQ7AaC3UCwGwh2A8H%2FfCB4kHpAjLweUPcypvTEzKXSxat03rEsx8wZeTtjZ%2B1PpumYpoIlFc%2Bj9vQska39J6Ef3NyNuhRdJ5Bcx%2Flc%2FrPJ%2FK7VLpxFXdZqoeR8ZOcm3bbHRtmS%2FvwXGiKox4cXAAA%3D)

[Test newtoncelestial.com/website-creation-test example.com/host](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM2QDGoC%2F%2B1YbXPaOBD%2BKx7P9FPBsTGvzjBTB0JKEwgQSEg6GSJkAa6FbCTZrptJf%2FtJvARMk%2FZu7m6m6fBJ1svuavd5tLvjR5WjeYABR6r1qAbUj1wH0aajWipBMfcJRBgx7gKsQX%2BuZp6PtMEc%2FXhIHGCIRi5ESxUxGjOXoyykCHDXJ1kujm3PrHW0lzqU2kaJshZTNmJCIkKUyS%2FLyKjYn%2FoDioXkjPOAWUdHLADUy85xdlb5UgJ5zyRUG2ehQzSC%2BJE0yo70CciZZgHoqAzzTkUv5%2FRivoTgxNCLJVQeawGZCkMOYpC6wdKspdZ8QhDkClAcfw5conBf2b%2Bu9Cch8AT70FOtCcAMrVY64fgcJfWloAwGZtmVlixcqV2GQ3PJxF%2Fr6CHHpWLjWeZlDCJAXTDGqJ6664MbRPkHxWUKnyGl2YnyCnAcihhT1qA5yjhR9lUqD47nzkcRwCF6UBohxkr9vNlS%2BsO%2BIu7iU0dZ7mnC8GrOVOvzo8qTQIJni%2BWZL1C11A%2BSHr5LOOv7YvpO3uedWONcYGUWdf0p8yxWa9ut061oHMdp4Q%2BvyF11Gq20RRZMeqFwRkxdAnHoIEsED09Dovl0uqsmo4pYILLEzFIviR0EOFF3lAuXt7o9yrTRCi8PJZIZgAPp1jZc79La%2BVcu%2BDLBLuQtwOHMJdOW7ywZ7hO0a6g1fDVq869AS98%2FoK5PXZ4I7uv%2FxJufGhn%2FR0b2cERS656tl8F4LewjZw4o3IY7qtZbdq9mHCtBdRECCsRlCDoW1BYwVKn4EASQIw1BVdrivrVUMRILH3zCEAzFGxAJB1GZDY5%2FzYhfI3n%2FlFG%2Fia%2FR9kHcixtvXi36CkRORevXunZsOWTUKfXDYORuZETiAnMmc%2B9G%2BnNK%2FH4j%2F3k1irl8VnJuaDnN1PJyaUtJueFVKQMyXq3m2aRl62e1q8XZVXNs1runJ3Z3YNv5s7Zdr5243fOTabfOkoIzWMzYKUs%2B6rOul7QXp%2Bb7iw4m50MK4wZmPbcxmLAKGF6T8%2BiKH9VuFgAXoNGfNbwrD96YF5PAa8S5Upxb1C7t8m15YJ7d6XN%2BXTQX7dmUkNLNzXwBIXTjuwBffalHnYHRaHWHZvKt46Hex55%2FF%2FmDZhsvvp0OOT4J4sJtrdzJF2qD%2FuXZ9K52eXuLPsXNut21T1QZf3dKfIpGTIyAC4hVi9NQZN55iLk7AjHYLjlwBCSyAi4mdkWM0vmLrOrQGqE18TbhTdFl5ECJlSuL26RULJTK%2BUm2Ak09mwe5YnZcMIysqC5FfVwuGkVQ2imYP6mpf6dkplm0S1sbxyBh6tMLr3LtmMiuWto5OdPSNH17Xq7yxovgRVWRFQzlhYKgfAcY%2F%2F7uPqfa1%2FxNl6c9eP%2F8DPAW%2BbosyC%2FS9ceiv%2BNdujS%2FFbL%2BzNnxn%2BbsXr5ddkF7T%2FJVj99isl01adp%2Bzv1fO7Xfmwv3GdHNHbqKQ1dx6CoOXcWhqzh0FYeu4tBV%2FPuu4l7oAhFyRkCezeniSnoha1T6RtEyTcsoabmCWa7o73Xd0nXpmlC%2Bitzjk%2FBu5%2B%2BI6gG70gsu8Kc%2BHV%2FjbmPS1oe3p4Okdge%2B6EN%2B0RsUMQtJGAbNqvr0Fwdfiu8ZGAAA)