### PR TITLE
Add EnigmaSuite (enigmasuite.com) service templates

### DIFF
--- a/enigmasuite.com.custom-domain.json
+++ b/enigmasuite.com.custom-domain.json
@@ -1,5 +1,6 @@
 {
     "providerId": "enigmasuite.com",
+    "providerName": "EnigmaSuite",
     "serviceId": "custom-domain",
     "serviceName": "EnigmaSuite Custom Domain",
     "hostRequired": true,
@@ -7,8 +8,8 @@
     "records": [
       {
         "type": "CNAME",
-        "host": "@",
-        "data": "%TARGET_HOST%",
+        "host": "%host%",
+        "pointsTo": "%TARGET_HOST%",
         "ttl": 3600
       }
     ]

--- a/enigmasuite.com.custom-domain.json
+++ b/enigmasuite.com.custom-domain.json
@@ -1,0 +1,15 @@
+{
+    "providerId": "enigmasuite.com",
+    "serviceId": "custom-domain",
+    "serviceName": "EnigmaSuite Custom Domain",
+    "hostRequired": true,
+    "syncRedirectDomain": "app.enigmasuite.com",
+    "records": [
+      {
+        "type": "CNAME",
+        "host": "@",
+        "data": "%TARGET_HOST%",
+        "ttl": 3600
+      }
+    ]
+  }

--- a/enigmasuite.com.domain-ownership.json
+++ b/enigmasuite.com.domain-ownership.json
@@ -1,0 +1,14 @@
+{
+    "providerId": "enigmasuite.com",
+    "serviceId": "domain-ownership",
+    "serviceName": "EnigmaSuite Domain Ownership Verification",
+    "syncRedirectDomain": "app.enigmasuite.com",
+    "records": [
+      {
+        "type": "TXT",
+        "host": "_verify",
+        "data": "%VERIFICATION_TOKEN%",
+        "ttl": 300
+      }
+    ]
+  }

--- a/enigmasuite.com.domain-ownership.json
+++ b/enigmasuite.com.domain-ownership.json
@@ -1,5 +1,6 @@
 {
     "providerId": "enigmasuite.com",
+    "providerName": "EnigmaSuite",
     "serviceId": "domain-ownership",
     "serviceName": "EnigmaSuite Domain Ownership Verification",
     "syncRedirectDomain": "app.enigmasuite.com",


### PR DESCRIPTION
 # Description

  Two new service templates for EnigmaSuite (`enigmasuite.com`), a multi-tenant SaaS platform.
  Tenants connect custom domains that point to `app.enigmasuite.com`.

  - `enigmasuite.com.domain-ownership` — adds a TXT record at `_verify` to prove domain ownership before SSL issuance.
  - `enigmasuite.com.custom-domain` — adds a CNAME record routing the tenant's custom subdomain to the platform.

  ## Type of change

  - [x] New template

  # How Has This Been Tested?

  - [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
  - [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
  - [ ] resource URL provided with `logoUrl` is actually served by a webserver — N/A, no `logoUrl` used in these templates.

  # Checklist of common problems

  - [ ] `syncPubKeyDomain` is set — **not set**. EnigmaSuite currently uses the unsigned synchronous UX flow only. Signed flow infrastructure is not yet in place. Will be added in a follow-up PR.
  - [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
  - [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
  - [x] no TXT record contains SPF content
  - [ ] `txtConflictMatchingMode` is set on TXT records — not set. The `_verify` host holds a unique opaque token generated per tenant. The record is ephemeral and removed after verification, so label
  conflicts are not expected.
  - [ ] no variable used as bare full record value — `%VERIFICATION_TOKEN%` is used bare in the TXT record. The token is an opaque server-generated value (not user input), so a prefix would break the
  verification logic.
  - [x] no bare variable used as the full `host` label
  - [x] no variable used in `host` field to create a subdomain
  - [ ] `%host%` does not appear explicitly in any `host` attribute — present in `enigmasuite.com.custom-domain` with `hostRequired: true`. This is intentional: the host value is always passed by the caller
  (never user-supplied freeform input).
  - [x] `essential` is set to `OnApply` on records the end user may need to modify — N/A, neither record is user-modifiable after setup.

  ## Online Editor test results

  **Editor test link(s):**

  [Test enigmasuite.com/domain-ownership app.enigmasuite.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM7jDGoC%2F91SUYvaQBD%2BK7JwT01skjMxBvog1nKhNMJdkHIiYd2d0y1JNuxutDnxv3dWzyq1R9%2
  F7lM1833wz38zsiYGqKakBkuxJo%2BRWcFApJwmBWqwrqlthoM9kRZzfcEYrpJPpkfBkCQhqUFvB4JjKZUVF7cpdDUpvRHOBb1N7n4%2Fk3uxM7s1BiRfBqBGytpldzR6BCwXMnLgoQJumf9sgUqTimiSLPTFdYyvl33MENlIb%2FCm2VrrDAKeGYuBuPn1Mv6STcZ7OsiKffZ1
  md4gaU5Lk3vMOy4NDXmUNxUV56bzZe7eLt2L4WivZNoU45zVU0UrbQZ8VFn%2BVWJ41FsS%2Bb3s8IdibWNdSQaHxS02r0LBRLTikaksjCrqjlxBnBdYqO7SiEUWJP4dUn3ZzM6SrgTik4MwaEHbNvh8F94PVi7sact8dxIy5cTiK3Wg1CIH5LI4pvTqbd67qH4dzmSZoDbURFF
  sh43JHO00Oh6WDk%2F0%2FnOCqNd0CL6ilBV4QuV7o%2BqM8CJJgmARRfxSG0XDwwfMSz7NeQJuTsz3ewvUVkCCNH0aQf2wnP0K1eX6Kq6oN06ycPPtjmmXqYZj532av859%2B%2BokcfgGTgf%2FFBgQAAA%3D%3D)

  [Test enigmasuite.com/custom-domain enigmasuite.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMrmDGoC%2F91S0WrbMBT9lSLoU%2B0gO4m9GPZgutCsZR2k3sMWgrmTbjMx23IlOcUJ%2FvdJSdxkmO4D9iR
  077lH51ydPTFY1gUYJMme1EpuBUf1mZOEYCU2JehGGBwxWRLvrf0IpYWT%2BQHw5AC2qVFtBcPDKGu0kaXPZQmiOveGc1e3B%2BTVpx75S2qzxJdGKLRERjVop9uKLZHbEjMnYEKgrkdDhRYiFdckWe2JaWv32u1j%2BmV%2BYrbXa3deOzNSVEZn0tWydHk3z%2FLF16fMtYwp
  SDKOKO3WnUd2ssL8TLz2CO9FDAWcXrHq7GWjZFPnoh%2BrQUGp3Z57gtWAYd1TrA4c9nqh7VQd%2BHYqxaaSCnNtTzCNwn55ZVMYkcMrnEuc5ZalaK0pbbuWdbit6vhV7rWjFw4G3l3728I8knPmHAoXA%2Fg5jsYwDfwwisCf8CDwZxGLfJzyGcQY8zgMLmL1Tur%2BFay%2F1
  o1aY2UEWC0kLV6h1aTr1p5d%2Ff%2Fsz0ZEwxZ5Dg4Z0jDy6dQPZlkYJhOaBHREo%2BkkpjeUJpQ6M6jN0e3e5uYyMWT3rOPF4kcas%2BcMl8X24f5FfY91Oja%2Fs93u4dtNdL9p6d0i%2FEA%2Fku4P1E89VzwEAAA%3D)
  - `enigmasuite.com.custom-domain` — CNAME record routing the tenant's custom subdomain to the platform.

  ## Type of change

  - [x] New template
  - [ ] Bug fix (non-breaking change which fixes an issue in the template)
  - [ ] New feature (non-breaking change which adds functionality to the template)
  - [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

  # How Has This Been Tested?

  - [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
  - [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
  - [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A, no `logoUrl` field used in these templates.

  # Checklist of common problems

  - [ ] `syncPubKeyDomain` is set — not set. EnigmaSuite uses the unsigned sync UX flow only. Signed flow infrastructure is not yet in place; will be added in a follow-up PR.
  - [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
  - [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
  - [x] no TXT record contains SPF content (`"v=spf1 ..."`)
  - [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A; verification token is unique per-tenant and ephemeral (removed after verification).
  - [ ] no variable is used as a bare full record value — `%VERIFICATION_TOKEN%` is used bare in the TXT record. The token is an opaque server-generated value, not user-supplied input; a prefix would break the
   verification check.
  - [x] no bare variable is used as the full `host` label
  - [x] no variable is used in the `host` field to create a subdomain
  - [ ] `%host%` does not appear explicitly in any `host` attribute — present in `enigmasuite.com.custom-domain` intentionally with `hostRequired: true`; the host value is always caller-supplied, never
  freeform user input.
  - [x] `essential` is set to `OnApply` on records the end user may need to modify — N/A.

  ## Online Editor test results

  **Editor test link(s):**

  [Test enigmasuite.com/domain-ownership app.enigmasuite.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM7jDGoC%2F91SUYvaQBD%2BK7JwT01skjMxBvog1nKhNMJdkHIiYd2d0y1JNuxutDnxv3dWzyq1R9%2
  F7lM1833wz38zsiYGqKakBkuxJo%2BRWcFApJwmBWqwrqlthoM9kRZzfcEYrpJPpkfBkCQhqUFvB4JjKZUVF7cpdDUpvRHOBb1N7n4%2Fk3uxM7s1BiRfBqBGytpldzR6BCwXMnLgoQJumf9sgUqTimiSLPTFdYyvl33MENlIb%2FCm2VrrDAKeGYuBuPn1Mv6STcZ7OsiKffZ1
  md4gaU5Lk3vMOy4NDXmUNxUV56bzZe7eLt2L4WivZNoU45zVU0UrbQZ8VFn%2BVWJ41FsS%2Bb3s8IdibWNdSQaHxS02r0LBRLTikaksjCrqjlxBnBdYqO7SiEUWJP4dUn3ZzM6SrgTik4MwaEHbNvh8F94PVi7sact8dxIy5cTiK3Wg1CIH5LI4pvTqbd67qH4dzmSZoDbURFF
  sh43JHO00Oh6WDk%2F0%2FnOCqNd0CL6ilBV4QuV7o%2BqM8CJJgmARRfxSG0XDwwfMSz7NeQJuTsz3ewvUVkCCNH0aQf2wnP0K1eX6Kq6oN06ycPPtjmmXqYZj532av859%2B%2BokcfgGTgf%2FFBgQAAA%3D%3D)

  [Test enigmasuite.com/custom-domain enigmasuite.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMrmDGoC%2F91S0WrbMBT9lSLoU%2B0gO4m9GPZgutCsZR2k3sMWgrmTbjMx23IlOcUJ%2FvdJSdxkmO4D9iR
  077lH51ydPTFY1gUYJMme1EpuBUf1mZOEYCU2JehGGBwxWRLvrf0IpYWT%2BQHw5AC2qVFtBcPDKGu0kaXPZQmiOveGc1e3B%2BTVpx75S2qzxJdGKLRERjVop9uKLZHbEjMnYEKgrkdDhRYiFdckWe2JaWv32u1j%2BmV%2BYrbXa3deOzNSVEZn0tWydHk3z%2FLF16fMtYwp
  SDKOKO3WnUd2ssL8TLz2CO9FDAWcXrHq7GWjZFPnoh%2BrQUGp3Z57gtWAYd1TrA4c9nqh7VQd%2BHYqxaaSCnNtTzCNwn55ZVMYkcMrnEuc5ZalaK0pbbuWdbit6vhV7rWjFw4G3l3728I8knPmHAoXA%2Fg5jsYwDfwwisCf8CDwZxGLfJzyGcQY8zgMLmL1Tur%2BFay%2F1
  o1aY2UEWC0kLV6h1aTr1p5d%2Ff%2Fsz0ZEwxZ5Dg4Z0jDy6dQPZlkYJhOaBHREo%2BkkpjeUJpQ6M6jN0e3e5uYyMWT3rOPF4kcas%2BcMl8X24f5FfY91Oja%2Fs93u4dtNdL9p6d0i%2FEA%2Fku4P1E89VzwEAAA%3D)