### PR TITLE
add StoryPages, StoryPages Website (subdomain), StoryPages Website (apex only), StoryPages Website (apex + www), StoryPages Email Authentication

### DIFF
--- a/storypages.ai.email.json
+++ b/storypages.ai.email.json
@@ -1,0 +1,33 @@
+{
+	"providerId": "storypages.ai",
+	"providerName": "StoryPages",
+	"version": 1,
+	"logoUrl": "https://platform.storypages.ai/_next/static/media/storypages-logo.2dfb6f9c.png",
+	"syncPubKeyDomain": "storypages.ai",
+	"syncRedirectDomain": "storypages.ai,api.storypages.ai,platform.storypages.ai",
+	"syncBlock": false,
+	"serviceId": "email",
+	"serviceName": "StoryPages Email Authentication",
+	"description": "Adds SendGrid email authentication CNAMEs (mail branding + DKIM) for sending branded email through StoryPages.",
+	"variableDescription": "%emHost%: SendGrid mail branding label; %sendgridMailTarget%: mail CNAME target; %sendgridDkim1Target%: DKIM s1; %sendgridDkim2Target%: DKIM s2",
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "%emHost%",
+			"pointsTo": "%sendgridMailTarget%",
+			"ttl": 3600
+		},
+		{
+			"type": "CNAME",
+			"host": "s1._domainkey",
+			"pointsTo": "%sendgridDkim1Target%",
+			"ttl": 3600
+		},
+		{
+			"type": "CNAME",
+			"host": "s2._domainkey",
+			"pointsTo": "%sendgridDkim2Target%",
+			"ttl": 3600
+		}
+	]
+}

--- a/storypages.ai.site-root-www.json
+++ b/storypages.ai.site-root-www.json
@@ -1,0 +1,27 @@
+{
+	"providerId": "storypages.ai",
+	"providerName": "StoryPages",
+	"version": 1,
+	"logoUrl": "https://platform.storypages.ai/_next/static/media/storypages-logo.2dfb6f9c.png",
+	"syncPubKeyDomain": "storypages.ai",
+	"syncRedirectDomain": "storypages.ai,api.storypages.ai,platform.storypages.ai",
+	"syncBlock": false,
+	"serviceId": "site-root-www",
+	"serviceName": "StoryPages Website (apex + www)",
+	"description": "Points the apex domain (A record) and www (CNAME) to a StoryPages site hosted on Vercel.",
+	"variableDescription": "%vercelApexTarget%: Vercel A-record IP for the apex domain; %vercelCnameTarget%: Vercel CNAME target for www",
+	"records": [
+		{
+			"type": "A",
+			"host": "@",
+			"pointsTo": "%vercelApexTarget%",
+			"ttl": 3600
+		},
+		{
+			"type": "CNAME",
+			"host": "www",
+			"pointsTo": "%vercelCnameTarget%",
+			"ttl": 3600
+		}
+	]
+}

--- a/storypages.ai.site-root.json
+++ b/storypages.ai.site-root.json
@@ -1,0 +1,21 @@
+{
+	"providerId": "storypages.ai",
+	"providerName": "StoryPages",
+	"version": 1,
+	"logoUrl": "https://platform.storypages.ai/_next/static/media/storypages-logo.2dfb6f9c.png",
+	"syncPubKeyDomain": "storypages.ai",
+	"syncRedirectDomain": "storypages.ai,api.storypages.ai,platform.storypages.ai",
+	"syncBlock": false,
+	"serviceId": "site-root",
+	"serviceName": "StoryPages Website (apex only)",
+	"description": "Points the apex domain (A record) to a StoryPages site hosted on Vercel. Does not create a www record.",
+	"variableDescription": "%vercelApexTarget%: Vercel A-record IP for the apex domain",
+	"records": [
+		{
+			"type": "A",
+			"host": "@",
+			"pointsTo": "%vercelApexTarget%",
+			"ttl": 3600
+		}
+	]
+}

--- a/storypages.ai.site-subdomain.json
+++ b/storypages.ai.site-subdomain.json
@@ -1,0 +1,22 @@
+{
+	"providerId": "storypages.ai",
+	"providerName": "StoryPages",
+	"version": 1,
+	"logoUrl": "https://platform.storypages.ai/_next/static/media/storypages-logo.2dfb6f9c.png",
+	"syncPubKeyDomain": "storypages.ai",
+	"syncRedirectDomain": "storypages.ai,api.storypages.ai,platform.storypages.ai",
+	"syncBlock": false,
+	"serviceId": "site-subdomain",
+	"serviceName": "StoryPages Website (subdomain)",
+	"description": "Points a subdomain (CNAME) to a StoryPages site hosted on Vercel. The subdomain is specified via the host parameter in the apply URL.",
+	"variableDescription": "%vercelCnameTarget%: Vercel CNAME target for the subdomain",
+	"hostRequired": true,
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "@",
+			"pointsTo": "%vercelCnameTarget%",
+			"ttl": 3600
+		}
+	]
+}


### PR DESCRIPTION
## Type of change
- [x] New template
## Summary
4 templates for StoryPages (storypages.ai) -- a website builder that hosts sites on Vercel and authenticates email via SendGrid. Site and email templates are separate so users can apply only what they need.
- **site-root-www** -- apex A record + www CNAME (most common site setup)
- **site-root** -- apex A record only (no www)
- **site-subdomain** -- subdomain CNAME via `host` parameter (does not touch root)
- **email** -- SendGrid mail branding + DKIM CNAMEs
# How Has This Been Tested?
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file names follow the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
# Checklist of common problems
- [x] `syncPubKeyDomain` is set — set to `storypages.ai` on all 4 templates
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` — set to `storypages.ai,api.storypages.ai,platform.storypages.ai` on all templates. The list covers the root domain plus the actual callback hosts (`api.storypages.ai` for the api-gateway callback endpoint and `platform.storypages.ai` for the storypages-next user-facing callback page). While signed requests are technically exempt per spec Section 4.1.2, we include it defensively per Quality Guideline Rule 3 (syncPubKeyDomain is set), so per spec Section 4.1.2 the redirect_uri is protected by the signature
- [x] no TXT record contains SPF content — no TXT records
- [x] `txtConflictMatchingMode` — no TXT records
- [x] no variable is used as a bare full record value — only `pointsTo` fields use variables
- [x] no bare variable is used as the full `host` label — **Justified exception in email template only:** `%emHost%` is the SendGrid-assigned mail branding label (e.g. `em1234`) which varies per domain and has no predictable prefix or suffix. The value is constrained to SendGrid-generated values at the API level.
- [x] no variable is used in the `host` field to create a subdomain — `site-subdomain` uses the standard `host` query parameter, not a template variable
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — not applicable; all records are integral to the service

## Online Editor test results

**Editor test link(s):**
###email
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKRyDWoC%2F%2B1U207bQBD9FWslpFY4ju2Qm6s%2BpFwKjaC0gESFkDXxbpwlvml3E3Cj%2FHtnDYkdMFX6ViSe4sw5c%2FbM7OwsiGJxFoFixFuQTKRzTpk4ocQjUqUizyBk0gJOzDV4BjGSyYWGzzWM2JwJydOEeI5JojRMr0SElIlSmfSaTa0%2FTkVsbUg2%2FYQ9qKZUoHjQjBnl0CwJDS1juXQ86oz7gZUlIR4j8yQ4n42GLD9IY%2BBJjUtN%2BYlaggWqnmRCxjedmPUGn9S%2BRGkwJd4YIskwwsScB6zoEEP5iKxjLxpjHGqCMZipCUuwSCwUe2QSymQgeFb888iAUmlcsIR%2BFZwahaYBGynG%2Ftng9FAaHwpsJCChPAmNXeNgeHL60UDnhmSPsQJkKxk1EeksnBilJUtfFggOo4gdbNjYYfFxKtWOV3rZPC6CEYs%2BGTv6qBDhU0QvQYRM5xTUwqahiliFeDDlsbNmas%2BGdJ7h7jPcRZ94hamgkng3C6LyTPe2OAGhCTqteNbTmfJEyctUR2scIkMpnMlWx7aX5mt60rF8WgzNlOWviFar2VLV3U7VrVO9XZrkd5owv%2BzGLU7QarLZA%2BDzZVaQxuWB%2BBXixWc%2BX%2FEzEBBL%2FcRXmTcbqber3Buivx%2FbWpDidqfb07GXTdX4rOXsOe2%2B27HuI8dtWSuWlSBeyap0Tac51roh1r9IuKUEdnVbDWwhD5NUMF%2FiL6iZwFtSYobPOZ5FivtwD2WIBj5kWZRjxyWieNbL%2BUsen%2FpTdzAHFOD%2Fv9qo3KpJfBro2%2BB6jcC432%2BNabcx6kGrsdfttBs91u02ADdff9QF6raCyv6tXc51a6mcBial3iagl%2FIguodckmXNvD5V9fwVPBW39Z29nULd2kK3n6z%2FrdJbEx%2F7%2B7S%2BT%2BvbmFa93GHOqA%2Ba5tpup2G3G659affQpdd2rVa75%2FR7u7bt2bb2z6R6LHuBO726zclx8yGeniRH8fWQ9SdHuZjuztVDcH3YHJ7d0fywD%2Ft3Fz%2B%2Bq29Xvz6T5R8o2UY49woAAA%3D%3D

###site-root-www
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPFyDWoC%2F%2B1Ua0%2FbMBT9K5alSSCaNC2lj0yTlgGTGIyVUdgQqqLb%2BDZ4S%2BLIdh9Z1f8%2BO2lpC9U%2B82FSpLq%2B55577ssLqjHNE9BI%2FQXNpZhyhvKCUZ8qLWSRQ4zKBU5rz8ZrSA2Y3lpz35qNbYpScZFRv1GjiYjFnUwM5EnrXPn1uuUfC5m6O5T1MMO5risNmkf1FBmH%2BgbgWBq3ycaj9rgXuXkWmzCqyKL%2BZHSJxZlIgWd7VFrId8MlMdL7QTXI%2Ba6S2n6BK7ZPiYh%2BU38MiUJzg3LKI6wqxDU6UgjtzGYz%2Bmx7VSDyA0cWSw4gxzk5IgZ%2BaPAMVSR5rsvK0b7gmVZEPyEpYaxUTw4CYnIRkh0SyJh1JQen18HX80OiBQGyFaaM8SSURkZERu5RRpi4tj0gOYwSPNsJ%2BG5aAgITbAAyRv3OX%2FmQwKlikos%2BMYV5Keo9WfmeZibXl86lOqLL29K7qk7FqKj%2FuKC6yG2JAnNt9ZrjRzthZQUGYq82Y9faTNVx2%2FOWtWeKMtiGpgr1mmhb6A7TcFmjf0SG4Ube0HRmPTk4B7Me6EYi3QQxp1iKSR7yNT4HCamyK7T2fNxxHa59H6k9v0zO3nfarvmaDfNtIFuyLSayf93K5LBMVdwmAx5nQmKozC%2FoiTSF0XJipjWdJJqHMIPNFYtCyPOkMAkrYzW0u%2F3Iqum1%2FWCgwRy3lW2VrkZDFtmUud2FEbQxYifgtHrgOS2PNZ0ea42dXq8VsWavAZ1GY%2BsR2fvC%2FGu3NqVHpTDTHOwLEyQzKBRd7hmIVR6V9yqTvfV7qykNa2ay%2FvfmbfbGbKiCKbIQLKzpNduOd%2BI0vYHX9Y%2B7vtdz252u1%2B0eeZ7veTYPVLrKdGH2dXtTaSc5%2FzKP7oKY3bYub25%2BPtynd6PBBQ9ajRh%2FXRWT4vPV0ewq73x7%2BECXfwErOMRtsgcAAA%3D%3D

###site-root
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABFzDWoC%2F9VTDWvbMBD9K0JQaGlsK59tDIOlKx3dIISla1lLMIp8TkVtS5OUDzfkv%2B%2BUNE3SZT9gYPBx9%2B7d3bvTkjoodM4d0HhJtVEzmYK5TWlMrVOm0nwCNuSS1t6DfV4gmA59eODDGJuBsVKVNK7XaK4m6qfJEfLsnLZxFHn%2BTJkiPKCMkhIWLrKOOymiAlLJox0g8DRhI83GnawrQl1OsIytSjGYjr9Dda0KLssjXXrID%2BQyINxxUI1redhJ7XiDb2xXuRIvNM54bgE9YGZSwEYh6SAwSjn67v9LHPIAY48jp1zDgqgyr84QnoIVRmq3Fo0OlCydJe4ZyBqVrhsnpz2CYyiTnhGnCCd7rGvKZ2UdpMhJ7sEIyENyrTBWKkeEAdwp5szn8zeS0O%2BJG8nHOVwflD%2BZrdN7WPqOmwm4k%2FiNkfSCTTK5HRBU6GOLSLmJWxo%2FLamrtJ%2B%2Bh27fG5qf%2FeGsp7tTRyth3Dk8lmaHsdVoVaOvqoRkRzpCrbZrhAXHW4VQqGJXAa2JUVOdyC1ec8ML6%2B95m%2Fl0kDra5j5Rb39syfsvOiF%2BjTp%2B1DclJ6UykFj8czc1OKQzU7yGYpo7mfA537lSkXCt8wpnsBhFtkNhys2FeGFS7jia%2B8X21KjRJBV%2BCulv7bLTZs0uQMC7WSNoderNoAtZFnTq0BYZQKvVbe890qMv%2BF%2B3u1MSrIXSSe5fby%2Bf88rS1WpUQ1X%2F%2ByFw05bPIE24hzVYoxOwdtBgd%2Bwybl7GrXrIWKvN2ueMxYz5GcC6zXBLvID93dObx%2BGXfNG%2F%2BtWPoptofv8AYvhyYdLz38Nb%2FXjeeI3qXf3tq6gv2Ce6%2BgOVOokGZAUAAA%3D%3D

###site-subdomain
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFRzDWoC%2F91Uf2%2FaMBD9KpalSa2WhJAGCpEmrWs7bVpXdQzabRWKHOcAq4md2YbCEN9951B%2BqWgfYH9B7p7fvXt39pJaKKuCWaDJklZazUQO%2BnNOE2qs0ouKjcEETFBvm7xlJYLpd5e%2Bc2nMzUAboSRNmh4t1FgNdIGQibWVSRoNxz9SugwOKBuphLltGMus4I0ScsEaO4DvaIIoH2XtUZcHlRxjGbOQ%2FG6afYHFlSqZkEdUOkgPuTRwexzksUocKvGOC3xh%2B1Ao%2FkSTESsMYAT0THBYOyQs%2BGaa5es62%2BQrh8gDZA5MTrboU4TnYLgWla2do3dKSGsII1sMObm8vfh6fUqswvAeXc01UcZCTpQk96A5FAHpT2DvsEBcBVyMBKJmghE7WR8iFdOo0IImCHNRVlXFggx6N4GbJdOCZQVcHah7M6uLXEo82Wd6DPZN8lKY1CqJraMEfaw5931xVXvwe4pTQd%2BsnqKROCClc0OTxyW1i8oZVvO8wPHzvVu62pS%2BOq4AAdbipp21w3A1XHn0j5KQ7piH6PFmB2DOcNEh4KrclbBgbP3Xo2OtplUqNudqj4y7FBuGxwOK4YbjcUcyrC%2FCoUYH4O4zWKf8XJo1AcoVY6k0pAZ%2FmZ1q2HhTTgsrUvbMdqGcp%2FWUsDuDWaR97Ztc791eUzmzDCNHBex559E0565X4db6LOKjDotjH6Is9OO4O%2FK7rRb3z6Nuk53zNo%2B7zb334Ohj8c9r8tp8MAakFcy9GhfFM1sYuloNPRzE%2F98lbo1hM8hT5uBRGLX9sOVHYT%2FsJGfdJO4EcbN11mm9DcMkDF1DyLhueYk7tL89VMKPan6d5d3BUzsqmw%2BMXXy7%2F%2Fizd%2FlLzItPnba87We9m0ErPg%2Ff0dVfLmW%2FOP0FAAA%3D