### PR TITLE
add bce.email, bce.email inbound email

### DIFF
--- a/bce.email.bceemail.json
+++ b/bce.email.bceemail.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "bce.email",
+  "providerName": "bce.email",
+  "serviceId": "bceemail",
+  "serviceName": "bce.email inbound email",
+  "version": 1,
+  "logoUrl": "https://bce.email/favicon.svg",
+  "description": "Configure DNS records so bce.email can receive and route inbound email for this domain.",
+  "variableDescription": "value is the Amazon SES domain verification token for this domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.bce.email",
+  "syncRedirectDomain": "bce.email",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_amazonses",
+      "data": "%value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound-smtp.us-east-1.amazonaws.com",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a bce.email Domain Connect template for inbound email routing. The template creates the Amazon SES domain verification TXT record and the apex MX record required for bce.email to receive inbound mail for a customer domain.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality in the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Tested locally with:

```bash
dc-template-linter -loglevel error -tolerate info -logos bce.email.bceemail.json
```

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Bare TXT value justification: Amazon SES prescribes the exact TXT record value for domain verification at `_amazonses.<domain>`. Adding a service-specific prefix would make SES verification fail.

`essential` justification: the TXT and MX records are the activation records for this service and should remain managed as part of the template.

## Online Editor test results

**Editor test link(s):**

[Test bce.email/bceemail onwardtravel.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALGSDWoC%2F%2B1VW2vbMBT%2BK0bQp8WuHbe5GAbtkjK6kbRdMyi0wSiynIjIkifJzrKQ%2F74j555e6J7GYE%2FW5dy%2B8306XiBDs5xjQ1G0QLmSJUuouk5QhEaEejTDjKPa9qKPM3p0pakqGaEbl6PjYweHiZEsROJs7EqqNJMCRUENcTmW3xUH%2B4kxuY5OT7d%2BpymGcFJ4uhyDV0I1USw3lSfqSJGycaGo0%2B3fO4oSqRLtaOns0hIs7AVlJXUwpFeyMPSwGCeVyjETpp1Ewl54tjqsGB5x2j3IV2JegLMGa%2BpcZviXFM791f3azwFILGUEW2vHyCkVL4XWc0E%2BcUmmKEox13R1cluMvtJ5t7KCTCtzwC0oMd5B28H4G00YgDJb832DdRtQ9LhAZp5bFgYPA7iYSG1gE%2BOqcE217Sc2GM5OKmQncGAM0BA2fB%2BWP41tMGfE9LAhEybGPZnYeJeco2VtG773sIt%2BYUUjmTB6IGG7brSrM5N7hXYp1sYNvFUJeKY9IrNKZkwqZuagBn%2BvhuVwWUNgSOMdqGFt3RyILsUMq8QoXFK%2BjrQuA1ZjoDqP2cYpxwpn2op94%2F743H%2B4CfCI7Lrqit3gEQnqIbRsn%2BKKYWRLZGMhFY01fLEBOaLIqAKIzQpuWIwhyfYoITHOcz4HRBpuIfgxTWL1cl6i6Y0yDpiLE2KBMvs0feI3cNpsug3STNyzVpu6rWYQuKOwSYLztBHiRrr30J9NgFee%2Ba7PVGsqDMO8EsYMzzVaHotjjeliB%2BWdwtgDdaiRvw9xWANZ%2FSfvHyUPXreGZ5%2FE2JrV%2FXrD9c%2Fduj8I%2FOg8jMKm12yF7dD%2F4PuR71swVJsV%2FEW1rkbJjJnJKtNi%2B8vQq001Od4m%2FR1zzKKx2TbzzM6ypZ3xdni8MOOf6c%2FbRPCOk3iHDK2pfXqj5CeEXtHGHyYJfOddEoL5v7QMc%2FjXAVVVI6Jd0%2BFuf%2BYCoVctomaDsHvZb9z%2B6I3L6c2Xz1l%2F0r4r2jdl2ZF3153O9FqdzT6i5W9d7BvLAgkAAA%3D%3D)

[Test bce.email/bceemail onwardtravel.com/mailtest](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIqSDWoC%2F%2B1VW2%2FaMBT%2BK5GlPpWkIQFKI01aN1qtm6i6lm6VWoQOjgGrxs5sA6OI%2F77jEO5tV%2B1pmvYUX875zuX7cjwjlg0zAZaRZEYyrcY8ZfoiJQnpUhawIXBBSquLSxiynSvD9JhTtnTZOd518LjsqpFMvaXdmGnDlSRJuUSE6qtbLdB%2BYG1mkqOjld9RDxBOycCM%2B%2BiVMkM1z2zuST4q2eP9kWZe4%2FLG04wqnRrPKG8dloJ0F4yPmQcYXquRZdvJeD2lPTvgxksV7mXgsgPNoStYYyveGMQInQ1aM%2B90CE9KejdnN4WfhyXxHqfgrD2rHpl8DtpMJf0gFH0kSQ%2BEYYuTq1H3C5s2ciuMtDDHuiWjNthqOxpfs5RjUXZlvmlQtIEk9zNip5ljoXXXwouBMhY3HcgTN8y4foIFPDvIKzvAA2uRhrgWhrj8aV2DBae2CZYOuOw3VerwToUg89IKvnm3Rn%2FvRKO4tKalcFs02jdDmwUj4zMw1i8HixRgYgKqhrnMuNLcTlEN4UYO8%2Fa8RNCQddZFtUtFcxBdyQno1GoYM1EgFWm4XliGyxLpI%2BVZhy%2BdM9AwNE70S5j7fZz2Euh%2BjdQuLfh3h9Cl5SjGFm5SnjNOXMq8L5VmHYNfsChPklg9QqKHI2F5BzDY6iilHcgyMcUKDd4i%2BC5tcvEnrWkLNoor%2BHslny1KOyl1lXP3z0a94169dhL7xywN%2FcpJN%2FS71Tjy426lEtcgjCjEGxNgbzS88P%2FvE8CMYdJyELlyJjA1ZL6rnqLI%2FcreKKCNGre19PdU3C6h%2FP6T%2B4%2BSi9PB4PhIO%2BDMozCq%2BWHVj8JWOUyqUVKtB%2BXoOI7qh2GYhKErCtEWbZjl63wkTbgdLCLOVk%2BQWWzyyfO6Fv5gLrqZOHdvhhs%2Bz7wZL%2Bsz2A0SbDNVUPzwSsoPhPxGKm8MUg69N0kJ35O5Y1rg24lU5Y1I1k3Hu82ZTRqH%2BvCK1SbXZ%2FJH63PzHC7ip7L%2Bfn4rymfjk9P6p4x%2Bg%2Bxr3zQr78j8F47Vo0pSCQAA)
