### PR TITLE
Add Ivy's Studio Website custom-domain template

### DIFF
--- a/studio.ivy-s.de.custom-domain.json
+++ b/studio.ivy-s.de.custom-domain.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "studio.ivy-s.de",
+  "providerName": "Ivy's Studio",
+  "serviceId": "custom-domain",
+  "serviceName": "Website",
+  "version": 1,
+  "logoUrl": "https://studio.ivy-s.de/static/brand-logo-256.png",
+  "description": "Points your domain at your Ivy's Studio website.",
+  "syncPubKeyDomain": "dcsig.studio.ivy-s.de",
+  "syncRedirectDomain": "studio.ivy-s.de",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Ivy's Studio Website service. Adds the DNS records needed to point an operator's custom domain at their Ivy's Studio website (a marketing site for short-term rental accommodations).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`dcsig.studio.ivy-s.de`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`studio.ivy-s.de`) — the service's apply flow uses `redirect_uri` to return to the operator's session in our app after the registrar writes records
- [x] no TXT record contains SPF content (template has no TXT records)
- [x] `txtConflictMatchingMode` — not applicable (no TXT records)
- [x] no variable is used as a bare full record value, **EXCEPT** the A record's `pointsTo: "%IP%"`. Justification: an A record's value is a literal IP address by definition; there is no non-bare formulation. Same pattern as accepted templates like `treadcommand.com.custom-domain.json` (`pointsTo: "%target%"`).
- [x] no bare variable is used as the full `host` label (all hosts are literals: `@` and `www`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is intentionally not set on either record — both are required for the service to function (removing either breaks the website serving)

## Online Editor test results

**Editor test link(s):**

- Apex attach (`example.com`, no host): [Test studio.ivy-s.de/custom-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADFSDWoC%2F%2B1T24rbMBD9lSBY%2BlDbsZ04F0NhQ7spbmg2NHuBDcHIksgKbMtIY6dOyL9XinPttn3eh76NNOeMzswcbRGwrEgxMBRuUSFFxSmTEUUhUlBSLhxe1bZyKEPWKT3FmYajqKo%2FqNZ8D9NZxWTFCdtzSalAZDYVGeb5OXcgPrNEcTAVKyYVFzkKPQulYiUeZarzrwCFCtvt3xToMwZO2onEObUN3PaDnlPkK12JMkUkL2BfDc0Ez0G1alHKViOihaE5XqpurRsljpFY52RWJhNWf2lUh4gSxVfO2zkY6A9GuWQETuC3MJ0WkioULrYI6sJ0PtLXr0KBDm%2FNQPcyH4Q%2B3kSzG30DoAfQ6bnuzjqRPk9H3%2B%2FOxPV6fU29veItdxbaiJzF5%2BeXejxHmewn1vtmDhHZuaSOVlKURcyP%2BAJLnCnjiSNzcUVdHrkLZOJoZqL%2BwOn2HG%2FQd7xgiIwQvsqFZLEeY46hlLobkCWzUFamwGO8xucrSmJcFGmtdSud1fWux5Y33jHNUgxYh9fPXczAQjElRjs3XgwSv%2BdSRux%2BQKjdTYKBjZOOb2PfD%2Fpk4A2ToXth7r94%2F1%2FuPk%2BRKcVy4Ni4eJSuca3Q7g%2BbPPTSbPLQzfVi3msvS0u74%2F9i3uFi9C9UuGI0xgbmu37PdgPbdx%2FcXugNQj9wgkF36HsfXTd0jRZgCpoWt%2FqnXv5R9ORFAI9ZJ3kKvlXTajMfT9KvYznd3MuXeymTzvP8bly%2BRBMcfUK7X3BkeJZEBgAA)
- Subdomain attach (`example.com`, host=`blog`): [Test studio.ivy-s.de/custom-domain example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMIYEGoC%2F%2B1TbW%2BUQBD%2BK5dNGj8IFDi4FxKTVtukZ5Vc9IwxzYUs7Eq3ArvZXaB4uf%2Fu7NF7waqfNfEbz848wzPPzGyQpqUosKYo2iAhecMIlQuCIqR0TRh3WNPZyiEUWYdwjEtIR4ume6FGH3dpEFVUNiyjO25WK81Lm%2FASs%2BoYeyJ%2Bpqli2lRsqFSMVyjyLFTwnH%2BSBcTvtRYqOj%2F%2FSQFgrFl2nkpcEduk2344cUSVQyVCVSaZ0LtqaMlZpdWo47Uc9SJGWPfwVPWo7ZU4RmJXZcs6vaXdVa86QiRTLHee%2B2BSP1DCJM30Ifl5GoS5JApFdxukO2E6v4Tne640fF4YQ3cyVxzg2WJ5Bi9agwHjieturQPpTXz5%2FvpIbNt2SL0Y8NZbC33nFU2Ov1%2BDPXuZ9BHDvKmT8fJYMgUzAeWS1yJhe47AEpfK7MWefTegr%2Ff8u74A4MXSoOnMCSaON5s6XjhHRhDLKy5pAnZWWNcSutKyphYq60KzBLf4%2BESyBAtRdKBfQRTqDe2r%2Bh16kkywxoCGfzyxw0IJyUwLzKyll4YpCYKvdjbO5nbghYGNKfZs35%2BTkKQphPDJnv%2FmDP606ENDqVK00gybpb4sWtwptP3FYJ9agsE6w7YMcoYT%2B5s7W1uwNv%2Bn9a9MC%2B5V4YaSBJtU3%2FUnthuChpU7i0I38lxn7M%2FC%2Bfyl60aua7qhSve9buCmT68ZydfxVIr8%2BiGQX%2BK3V%2BN3%2BMG7EZrEjzfFMm%2FiWXwrAl9NV%2BLbK7T9AcHXU052BgAA)
