### PR TITLE
Update syncPubKeyDomain to achene.app

### DIFF
--- a/achene.app.customdomain.json
+++ b/achene.app.customdomain.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://achene.app/favicon-light.svg",
   "description": "Connect a subdomain to your Achene teaching academy",
   "syncBlock": false,
-  "syncPubKeyDomain": "domainconnect.achene.app",
+  "syncPubKeyDomain": "achene.app",
   "syncRedirectDomain": "achene.app",
   "hostRequired": true,
   "records": [

--- a/achene.app.customdomain.json
+++ b/achene.app.customdomain.json
@@ -4,7 +4,7 @@
   "serviceId": "customdomain",
   "serviceName": "Achene Custom Domain",
   "version": 2,
-  "logoUrl": "https://achene.app/favicon-light.svg",
+  "logoUrl": "https://achene.app/achene-logo.png",
   "description": "Connect a subdomain to your Achene teaching academy",
   "syncBlock": false,
   "syncPubKeyDomain": "achene.app",

--- a/achene.app.customdomain.json
+++ b/achene.app.customdomain.json
@@ -3,7 +3,7 @@
   "providerName": "Achene",
   "serviceId": "customdomain",
   "serviceName": "Achene Custom Domain",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://achene.app/favicon-light.svg",
   "description": "Connect a subdomain to your Achene teaching academy",
   "syncBlock": false,


### PR DESCRIPTION
# Description

Corrects `syncPubKeyDomain` from `domainconnect.achene.app` to `achene.app`.
Update logo URL.

Background: Cloudflare builds the public-key TXT lookup as `{key}.{syncPubKeyDomain}`. The `key` URL parameter carries the sub-label prefix (`domainconnect`), so the full lookup domain must be `domainconnect.achene.app`. The previous value (`domainconnect.achene.app`) caused Cloudflare to query `domainconnect.achene.app.domainconnect.achene.app`, which does not exist. The JWT returned had `perms: []` and the flow failed silently.

No DNS records were changed — only the `syncPubKeyDomain` metadata field and the logo URL.

## Type of change

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — `achene.app.customdomain.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://achene.app/favicon-light.svg`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `achene.app`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `achene.app` (used in the synchronous redirect flow)
- [x] no TXT record contains SPF content — no TXT records in this template
- [x] `txtConflictMatchingMode` — not applicable, no TXT records
- [x] no variable is used as a bare full record value — no variables used in this template
- [x] no bare variable is used as the full `host` label — no variables used
- [x] no variable is used in the `host` field to create a subdomain — `host` parameter is used via `hostRequired: true`
- [x] `%host%` does not appear explicitly in any `host` attribute — `host` is `"@"` (expands to the provided host parameter)
- [x] `essential` — not applicable, no records the end user would need to modify independently

## Online Editor test results

> `hostRequired: true` so apex test is not required — only subdomain test needed.

**Editor test link(s):**

[Test achene.app/customdomain tinkr.co.uk/learn](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN7XDWoC%2F91S0W7aMBT9lcivJWkaIJBIlcqg27qtZUJUaoVQ5Nh3YJHYnu3QpYh%2Fnw2klHba3vcUx%2Ffcc889PhtkoJQFNoDSDZJKrBkFdUNRijBZAocAS4laL5U7XFokGuxq9l6DWjMCuwZSaSNKKkrM%2BLF00uENdxhv1IDWoDQTHKVRCxViIe5VYcFLY6ROz8%2BPEg5H32ECyRe2lYImikmza0dDwTkQ42FPV%2Fleg2eEV4tKeYfZBiwJ4wsPE0yhrJ3GmpMPhSArlP7AhYb9zfcq%2Fwr1QeMbI1x9ApQpO%2BzPiKXQZgI%2FKwuxrhhVWVaLFopqlM42yNTSGTK8G9xeH%2BD298qZLBg3eipevAxOiI2x3rTjMNzOty30LDhkR965NaSRYxhfqYCIoFodBxSAlXN8oUQlM9Y0Saxwqd3jN%2B2zk%2F55QzA7MLjZbMGFgkzbLzaVgmbNsioMy%2FATPl5Rkln1RW2lalu1PO8t4PuINAopNvhfFrRQRolTzVzykgTii05O%2FDxPEr%2BThz0ft2PqJzSCXhhD1IP2qxC%2Fj%2FdfYvzGPtAauGHYxXRQPOFao%2B123rJW%2Fo972dfXeA00ww4bhVHsh10%2FCqcX3bTTTztxkHQ7%2FSQ%2BC8M0DN0ioM1%2Bz43NyeuEoBszjQePZ%2BNxfs2%2BjfCD%2FCwfuyrujx9%2BQXVPRn3ZX02%2BrJ4%2Ffby9RNvfr6i5yJkEAAA%3D)