### PR TITLE
Add new redirect domains for inbound email service

### DIFF
--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -3,7 +3,7 @@
   "providerName": "Novu",
   "serviceId": "inbound-email",
   "serviceName": "Inbound Email",
-  "version": 2,
+  "version": 3,
   "syncPubKeyDomain": "domainconnect.novu.co",
   "syncRedirectDomain": "dashboard.novu.co,eu.dashboard.novu.co,dashboard.novu-staging.co,connect.novu.co",
   "syncBlock": false,

--- a/novu.co.inbound-email.json
+++ b/novu.co.inbound-email.json
@@ -5,7 +5,7 @@
   "serviceName": "Inbound Email",
   "version": 2,
   "syncPubKeyDomain": "domainconnect.novu.co",
-  "syncRedirectDomain": "dashboard.novu.co,eu.dashboard.novu.co",
+  "syncRedirectDomain": "dashboard.novu.co,eu.dashboard.novu.co,dashboard.novu-staging.co,connect.novu.co",
   "syncBlock": false,
   "logoUrl": "https://dashboard.novu.co/images/novu-logo-dark.svg",
   "description": "Configure MX records so Novu can receive inbound email for this domain.",


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

[Test novu.co/inbound-email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPbMDWoC%2F91T226bQBD9FbRSngwY41uCVKltekmUm5WLlCay0MKO8Sqwi3YXXGr53zuL7ZI4VT%2BgTwxnrufM7JoYKMqcGiDRmpRK1pyBOmckIkLWlZ9K4v6Br2mBYeQaHYhqUDVPoY3lIpGVYB4UlOedb5dwvvU6X3feGpTmUpBoiJGNSGdVcgHNF4luBAlrjVQKAanxuzFs6C0wrhDugqleJpIqtg90ofLfg28RTxuacZFZz9%2F7fM5l%2BkKiBc01uCSXmXxQObZbGlPqqN9%2F16HPC5qB7rflbbzHqHrxdZ1hRQY6Vbw0LWlyKsWCZ5UC5%2BrRQTJSMe1o6VhdnZQKiwGvwdmp6rSqOgupHLPk2tnq42PdXTKJntfENKXV%2BuoR8aXUBu2PdneSC6PvJf4e2TJ3uBlQW%2FmO2t1yqbhpSDQIXGIMkhwGwWa%2BcckvKSDuWszd3WawFPykeDWAvIuuHVqZklUZ8318SRUttL2sfebzm9T5PveZWPtwPovvNPCtb5uDk%2FFMSAWxxi81KCSJjKpwT0WVGx7TFe0glsa0LPMGiWj0YskDrcT2Rq1WjBraHXPXstPlUK%2BYpZYdt28gDBZsmCQn3nCcTL0RhYFHB9OJNw1hTEeDcXI8Gb16TAdv7F%2BvqdMXtAZhOLWn%2BClf0UaTzWbuotb%2FHys8CE1rYDE17RzhxAvGXhjcD8ZREEaDkX9yPJ6GYS8IoiCwdECbLdk13sjr6yAPs8tv01Utk7NZ0j9b3k6qm%2FvTu97Nqv4RTJ6eerOLVe%2Bm%2BN4U%2FdUHsvkN4oUCrhUFAAA%3D)

[Test novu.co/inbound-email example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABHNDWoC%2F91Ta2%2BbMBT9K8hSPw2I82yKNGl9SY2mttPWTZWqCDn4QryCzWxDS6P8910HMtp02g%2FYJ8w59%2BFz7vWGWCjKnFkg0YaUWtWCg15wEhGp6ipMFPH%2FwDeswDBygwSiBnQtEtjFCrlSleQBFEzkPdclLFrWu%2BzYGrQRSpJojJGNTL5Uq8%2FQXCikESR8d0iUlJDYsL%2BGC%2F0KXGiE%2B2Bm1ivFNN8H%2BlCF78G3SGAsy4TMHPP3Pme5Sh5JlLLcgE9ylanvOsd2a2tLEw0G7zoMRMEyMINdeRcfcKYfQ1NnWJGDSbQo7U40OVcyFVmlwbu%2B91CM0tx4RnnOVy9h0mEgavA6V72dq16qtGfXwnitPyHW7ZJJ9LAhtimd19f3iK%2BVsXj%2B5GanhLTmTuHvkSvzDScDurXvaDdbobSwDYmG1CfWosgxpdvl1icvSkLct1j63WSwFDwz3BpA3UXfzgJ%2BfJJpVZWx2OeUTLPCuO3aZz%2B8SV%2Fu8x%2FaAvh%2FeE%2FHdV6Ejmvz8IYik0pDbPDLLBpKIqsrnFdR5VbE7In1EE9iVpZ5g4IMsljywDPZ7mongjPL%2Br3uu%2FYWHVoX88SJFO45TGbH6Zymx0FCh5NgAtMkWA3no2A2SWhKV7BK0%2FGrd3Xw3P71sN5aDcaAtIK5zTzNn1hjyHa79NH2%2F1YcrodhNfCYudARHc0COg1G9G44jegomgzDk9F0TmcfKI0odZKwWit4gxvzelfIT%2BAXZd3M6OJ%2BfDU4Pj9Rql7MxEt9ecErffWLXt%2Be%2FXieX76sTz%2BS7W8KtuMvKwUAAA%3D%3D)

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
