### PR TITLE
Update template: treadcommand.com / custom-domain v2 — Cloudflare for SaaS migration

### DIFF
--- a/treadcommand.com.custom-domain.json
+++ b/treadcommand.com.custom-domain.json
@@ -3,10 +3,9 @@
   "providerName": "TreadCommand",
   "serviceId": "custom-domain",
   "serviceName": "Custom Domain",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://www.treadcommand.com/logo.png",
   "description": "Connect your domain to your TreadCommand-powered tire shop storefront.",
-  "variableDescription": "`target` is the CNAME destination for your TreadCommand storefront (e.g., your-store.up.railway.app).",
   "syncPubKeyDomain": "treadcommand.com",
   "syncRedirectDomain": "www.treadcommand.com",
   "hostRequired": true,
@@ -14,7 +13,7 @@
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "%target%",
+      "pointsTo": "customers.treadcommand.com",
       "ttl": 3600
     }
   ]

--- a/treadcommand.com.custom-domain.json
+++ b/treadcommand.com.custom-domain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "treadcommand.com",
+  "providerName": "TreadCommand",
+  "serviceId": "custom-domain",
+  "serviceName": "Custom Domain",
+  "version": 1,
+  "logoUrl": "https://www.treadcommand.com/logo.png",
+  "description": "Connect your domain to your TreadCommand-powered tire shop storefront.",
+  "variableDescription": "`target` is the CNAME destination for your TreadCommand storefront (e.g., your-store.up.railway.app).",
+  "syncPubKeyDomain": "treadcommand.com",
+  "syncRedirectDomain": "www.treadcommand.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Update the TreadCommand custom domain template from v1 to v2.

**What changed:**
- `version`: 1 → 2
- `pointsTo`: changed from `%target%` (per-tenant variable) to `customers.treadcommand.com` (hardcoded Cloudflare for SaaS fallback origin)
- `variableDescription`: removed (no variables in v2)

**Why:** TreadCommand migrated from direct-to-origin CNAME (per-tenant Railway URLs) to Cloudflare for SaaS. All tenant domains now CNAME to a single fallback origin (`customers.treadcommand.com`), where Cloudflare handles SSL provisioning and routing via Custom Hostnames. This eliminates the need for a per-tenant `%target%` variable.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Note on N/A items:** This template contains no variables, no TXT records, and no DMARC records. The checklist items above are marked as passing because the conditions they guard against do not apply.

## Online Editor test results

**Editor test link:** [Online Editor Test Results](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACtDDmoC%2F91TYW%2FaMBD9K5G%2FjkAaQloiTVrFqm1CrSbENG0Vikx8gKXEdu0LWYr477sQUujGpn3eJ%2Bty7%2FnePb%2FsGEJhco7Akh0zVm%2BlAPtJsIShBS4yXRRciT6drPfSf%2BAF4dm8QUxaBHUd2K3M4EDOSoe68IUuuFSn3pE4OXS99113C9ZJrVgS9liu1%2FqLzQm1QTQuGQyqqur%2FKmbQwPpGrYktwGVWGjzcwCZaKcjQq3VpvXa%2Bh7otzwX7RldgQXgoLXhuo41HoiysrFbYbyTXKvtcLqdQH3VetKRBzUDQHRm%2B4C4pJuxGO5zBU0lg8ghtCT1GPG2FY8njjmFtDu483N7fHeFUvmuM11Khm%2BsXZ8mwSxMQybhhHAT7xb7HnrWC9DRgQVZ1CuEHp2eHM2GtbCrWVpcmlR3FcMsL16SjIz%2B%2BYi86%2BuOB38yVa0VGpo5OjqWFbteizFGmvOKnTyJLuTF5TTIddemW331QbWhadYIj%2F2cXeiwVWSNdNpm8FgHAKgL%2FWqy4H0F45Y%2Bv4ti%2FXsU3UbYci%2FGSn4X8Tz%2FB32L%2BykhwDhRK3mT5Nq947dh%2Bv%2BiRqf%2F7jpQJx7cgUt4gwyCM%2FWDkh8E8HCZhnAxH%2FZsoGkU3b4IgCYJmG3DYbr2j%2FJwnh4mncBBO%2Bex7rSM3Mlg9zeLZc7n5iMOv94WcjsP5h1u8m06yb2%2FZ%2FifeSh2O0AQAAA%3D%3D)
