### PR TITLE
Add DeepCurrent Mailgun outreach template

### DIFF
--- a/deepcurrent.app.mailgun-outreach.json
+++ b/deepcurrent.app.mailgun-outreach.json
@@ -1,0 +1,59 @@
+{
+  "providerId": "deepcurrent.app",
+  "providerName": "DeepCurrent",
+  "serviceId": "mailgun-outreach",
+  "serviceName": "DeepCurrent Managed Email",
+  "version": 1,
+  "logoUrl": "https://deepcurrent.app/assets/images/deep-logo.png",
+  "description": "Automatically configures DNS records so your selected sending subdomain can send outbound email through DeepCurrent managed email infrastructure.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.deepcurrent.app",
+  "syncRedirectDomain": "deepcurrent.app",
+  "variableDescription": "%mailgunDkimDomain%: Mailgun PDK target suffix returned by Mailgun, for example b04a44.dkim1.us.mgsend.org. Apply this template with the Domain Connect host parameter set to the selected sending subdomain, for example outreach-test.",
+  "records": [
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:mailgun.org",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim-pdk",
+      "type": "CNAME",
+      "host": "pdk1._domainkey",
+      "pointsTo": "pdk1._domainkey.%mailgunDkimDomain%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim-pdk",
+      "type": "CNAME",
+      "host": "pdk2._domainkey",
+      "pointsTo": "pdk2._domainkey.%mailgunDkimDomain%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "tracking",
+      "type": "CNAME",
+      "host": "email",
+      "pointsTo": "mailgun.org",
+      "ttl": 3600
+    },
+    {
+      "groupId": "receiving-mx",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mxa.mailgun.org",
+      "ttl": 3600,
+      "priority": "10"
+    },
+    {
+      "groupId": "receiving-mx",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mxb.mailgun.org",
+      "ttl": 3600,
+      "priority": "10"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the DeepCurrent managed email Domain Connect template.

This template configures a selected sending subdomain for outbound email through DeepCurrent's managed Mailgun/Smartlead infrastructure.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality attempted using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit); editor redirected to provisioned OIDC login and returned a server error, so no signed editor token link is available yet
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC); no TXT records requiring unique conflict matching are included
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC); no such end-user-modified records are included

## Online Editor test results

**Editor test link(s):**

No signed Online Editor token link is available yet.

The editor redirected to provisioned OIDC login and returned a server error from this validation session. No forged editor link is included.

## Template

- Provider ID: `deepcurrent.app`
- Service ID: `mailgun-outreach`
- File: `deepcurrent.app.mailgun-outreach.json`

## DNS Records

- SPFM for Mailgun sending
- Mailgun Automatic Sender Security PDK CNAME records
- Mailgun tracking CNAME
- Mailgun MX records scoped to the selected sending subdomain

The template uses the standard Domain Connect `host` apply parameter for selected sending subdomains. It does not use a custom host variable.

## Signing

- `syncPubKeyDomain`: `domainconnect.deepcurrent.app`
- Key label for testing: `_dcpubkeyv1`

## Validation

- Online Editor signed token result: unavailable due provisioned editor login / server error
- [x] `dc-template-linter -cloudflare -logos`: passed

Linter note: `DCTL5003 syncRedirectDomain is not supported`. Cloudflare documents this as ignored for its implementation.

## Live DNS / Mailgun Test

The template values were manually applied to an isolated test domain, `outreach-test.deepcurrent.app`, without touching existing production outreach domains or Smartlead campaigns.

Mailgun verification result:

- Domain state: `active`
- SPF: `valid`
- PDK1 CNAME: `valid`
- PDK2 CNAME: `valid`
- Tracking CNAME: `valid`
- MX records: `valid`

## Notes

Human replies are handled by the configured reply-to mailbox in DeepCurrent/Smartlead. The Mailgun MX records are scoped to the sending subdomain and match the current production Mailgun setup pattern.
