### PR TITLE
Add Permanu app-domain template

### DIFF
--- a/permanu.com.app-domain.json
+++ b/permanu.com.app-domain.json
@@ -1,0 +1,49 @@
+{
+  "providerId": "permanu.com",
+  "providerName": "Deploy by Permanu",
+  "serviceId": "app-domain",
+  "serviceName": "Permanu App Domain",
+  "version": 2,
+  "description": "Connect a domain or subdomain to an application deployed on Permanu.",
+  "variableDescription": "ip is the IPv4 address of the Permanu server. apex-verification is the ownership verification token for apex domains. subdomain-verification is the ownership verification token for subdomains. Subdomain mappings use the standard Domain Connect host apply parameter.",
+  "syncPubKeyDomain": "domainconnect.permanu.com",
+  "syncRedirectDomain": "permanu.com",
+  "syncBlock": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "groupId": "apex",
+      "essential": "OnApply",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 600
+    },
+    {
+      "type": "A",
+      "groupId": "subdomain",
+      "essential": "OnApply",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 600
+    },
+    {
+      "type": "TXT",
+      "groupId": "apex-verification",
+      "essential": "OnApply",
+      "host": "_deploy-verification",
+      "data": "%apex-verification%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 600
+    },
+    {
+      "type": "TXT",
+      "groupId": "subdomain-verification",
+      "essential": "OnApply",
+      "host": "_deploy-verification",
+      "data": "%subdomain-verification%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Permanu app-domain Domain Connect template for connecting apex domains and subdomains to applications deployed on Permanu.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A: this template does not include `logoUrl`)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — bare A `pointsTo` `%ip%` is required because Permanu signs the target app server IPv4 at apply time; bare TXT verification tokens are required because the current Permanu root-domain verifier checks the exact token at `_deploy-verification.<domain>`.
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Test permanu.com/app-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACHnDmoC%2F%2B1V227bOBD9FYJAn2IrkixfImCBpk0vQdE2aNOi2CAwKHIUs5FJlaQcu0H%2BvUNJtuI62d3u7kNb5EnUXM%2FMnCGvqYN5WTAHNL2mpdELKcAcC5rSEsycqSrgek57G9UbNkdTegRloVckW5GTxgxNLJiF5FA7s7LsCz1nUnWK1rV1IIdlSY7WJgswVmpF07hHBVhuZOnqf%2FpUKwXcEUaaeEQbYqus%2FXGaMEUwWyE58x5E1MhAEDy3qQKfgBnJsgKOtoLLkkhL3AzI8ckiIUwIA9YSndeyNVKPH0yAaWDZx5PM18laZ32lEP8Mo21pnb4ERXIE7D1b%2FDbo4P%2B7YBt3DPV%2B04k5NkGqC0sqC3Uc65gSzIi2yWTdyJm2ru7YipTM4Ewc1uantFL8pMpewaqdSkqb0LxxDLYJ4c3fgZAGVRuHXZMnheaXNM1ZYaFHfe538KVCL7ERYgRthKXp2TV1q9Jz5BC9L4yuypZMsEQBTgaUk6xA0Vt16CugTUgUPPYc1VI5e6rx95EsH6HEOTQeheFN757Qm17%2Bb%2FFPP53ugN%2Ba899lmjYM%2Ft5HMMd84p14NY6lw%2FHmuATuNXN8hkR4rUVdblH8M5x3k%2FI%2Fgr076A8hPr%2Fp0a9awbSjyXmvZSZaw5Lh%2FQUt41pU68Kmcm1fM936O45bk0%2FrZUIN5ZMoTkYH2SAfDEexGMdZIsYw5EOWRVGShCLnB5EYZvRWzrOtpOfrrGfUn2XpT3E4CMIgigZBFHrpLgnQqP5f9WtdAwgt7xlDZ44Ga2vsjLxQ2sDU4pe5ymD%2FnKlwp%2BZV4eSUXbFOJPi03npspEUthtzeN9Vcz4%2B78W1V0Y2kh1PnvpXS8yYewWgwyYb9OBlCP8lF0p%2BMB6wPB0M%2BiJMxT2K49X7c8bTc%2B25007yLgzffLfWvjL9ZxraCv96pXdb8ZpV1BP8JCzvv4W3ysDcPe%2FOwNz%2B2N%2F5pYwsQU%2BZqhsWjfohAotMoSsNRGh4Ek2QyGI%2F2wjANa9aBdU2B1%2FjO3X7haB59fiVmNt7ff1E9f7v34upltDzam3x0l89OsupDtXe8%2BLPU%2B5dZnPxBb74BUa%2BwKeMMAAA%3D)
- [Test permanu.com/app-domain example.com/store](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADjnDmoC%2F%2B1VbW%2FbNhD%2BKwSBfqol6NWpBQxoFm9YOyQN2hQZEBgGJZ4SIjKpkJQTL8h%2F35GS7Th20O7lwwbsk83j3XPP3T1HPVILi7ZhFmjxSFutloKD%2FsBpQVvQCya7sFILOtpcnbEFutIptI1akXJFzns3dDGgl6ICH8zaNuBqwYTcXgyhQwA5blsyXbssQRuhJC2SEeVgKi1a68%2F0REkJlSWM9HhEaWK6cjhYRZgkmK0RFXMRhHtmwAn%2BH1KFLgHTgpUNTHfARUuEIfYGyIfzZUYY5xqMIar2tjVTxx90iGngIcB%2Fol4nG4LVvUT%2BN4i2c2vVLUhSI2EXOfA34Zb%2BXwPbhCPUl00nFtgEIa8N6Qx4HGOZ5Ezzoclk3cgbZazv2Iq0TONMLNbmprSS1XlX%2FgqrYSoF7aGrPjDcFYRz%2FwxcaLzaBOy7%2FNio6pYWNWsMjKjL%2FRnuOoziGyMiKM0NLa4eqV21TiPHGH2tVdcOYoIHNOBkQFrBGjR9kseuAtpDouG906gS0poLhcc3on2DFmvReRxFT6NXoDe9%2FMfwL3672CO%2FM%2BdvZZr3Cn4Zw5llLvEenufxYHG8NS6BPWW2ukEhnCruy22a7%2BN5WJR%2Fk%2Bxh0D%2FFePY0or8rCfOtTGajQZnoDQ8M3y8YFDewMlZpWFc3Fz5oZ9SvFIvAfiWMewwro%2Bu53zoXXb2Lk2w8KdM6zccJP0rKjB9BXuWsjOMsi3hdTWKel%2FQZuasddrM1vauB32wg%2BP3khPdNojSMwjhOwzhy1n2FoZM%2FrwJ%2F1xcxexV5644Oa29su7iWyHNu8JfZDhkXVne4sIuusWLO7tnWxKu5f1JwSgZvEXJ3mWX%2F9q8HM%2Bhjp5LtzEcoq8qNQDhhvsvzfJLwPIh4lAQZz6KAxRyCdMLKkk3qKptMnn2gDny7Xv0wvZDLIaU%2F7a3MUMoh5Ycv6tvr6r%2B1xtkIl%2Br%2Fif2XJubWmS2Bz5n1c0nGQZQHSXwRx0U0LtIknETxUZq%2BjaIi8rMCY%2FsqH3G3n281lV8%2Fffn5LJleniRwdAmnd23z8eQ8Y19Xt9Pjt5c%2Ffczv736ZpvX9mfqBPv0BI8REvjQKAAA%3D)
