### PR TITLE
Update Novantt template: migrate from Amazon SES to Resend

### DIFF
--- a/novantt.com.email-sending.json
+++ b/novantt.com.email-sending.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://www.novantt.com/images/novantt-logo.svg",
   "description": "Configure DNS records for sending campaign emails via Novantt (Resend).",
   "variableDescription": "dkimHost1: DKIM record hostname; dkimValue1: DKIM public key; mxHost: MX subdomain; mxValue: MX target; spfRules: SPF include rules",
-  "syncPubKeyDomain": "domainconnect.novantt.com",
+  "syncPubKeyDomain": "novantt.com",
   "syncRedirectDomain": "novantt.com",
   "syncBlock": false,
   "records": [

--- a/novantt.com.email-sending.json
+++ b/novantt.com.email-sending.json
@@ -3,55 +3,34 @@
   "providerName": "Novantt",
   "serviceId": "email-sending",
   "serviceName": "Novantt Email Sending",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://www.novantt.com/images/novantt-logo.svg",
-  "description": "Configure DNS records for sending campaign emails via Novantt (Amazon SES).",
-  "variableDescription": "verificationToken: SES domain verification token; dkim1: First DKIM selector; dkim2: Second DKIM selector; dkim3: Third DKIM selector",
+  "description": "Configure DNS records for sending campaign emails via Novantt (Resend).",
+  "variableDescription": "dkimHost1: DKIM record hostname; dkimValue1: DKIM public key; mxHost: MX subdomain; mxValue: MX target; spfRules: SPF include rules",
   "syncPubKeyDomain": "domainconnect.novantt.com",
   "syncRedirectDomain": "novantt.com",
   "syncBlock": false,
   "records": [
     {
-      "groupId": "ses-verification",
+      "groupId": "dkim",
       "type": "TXT",
-      "host": "_amazonses",
-      "data": "%verificationToken%",
-      "ttl": 3600
-    },
-    {
-      "groupId": "dkim",
-      "type": "CNAME",
-      "host": "%dkim1%._domainkey",
-      "pointsTo": "%dkim1%.dkim.amazonses.com",
-      "ttl": 3600
-    },
-    {
-      "groupId": "dkim",
-      "type": "CNAME",
-      "host": "%dkim2%._domainkey",
-      "pointsTo": "%dkim2%.dkim.amazonses.com",
-      "ttl": 3600
-    },
-    {
-      "groupId": "dkim",
-      "type": "CNAME",
-      "host": "%dkim3%._domainkey",
-      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "host": "%dkimHost1%",
+      "data": "%dkimValue1%",
       "ttl": 3600
     },
     {
       "groupId": "mail-from",
       "type": "MX",
-      "host": "mail",
-      "pointsTo": "feedback-smtp.eu-west-1.amazonses.com",
+      "host": "%mxHost%",
+      "pointsTo": "%mxValue%",
       "priority": 10,
       "ttl": 3600
     },
     {
       "groupId": "spf",
       "type": "SPFM",
-      "host": "mail",
-      "spfRules": "include:amazonses.com"
+      "host": "%mxHost%",
+      "spfRules": "%spfRules%"
     },
     {
       "groupId": "dmarc",


### PR DESCRIPTION
# Description

Update the Novantt email sending template after migrating from Amazon SES to Resend as the email service provider.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

## What changed

- **Removed** SES-specific records: `_amazonses` verification TXT, 3x CNAME DKIM records pointing to `*.dkim.amazonses.com`
- **Added** Resend-compatible records: 1x TXT DKIM record (variable host + value), MX and SPFM with variable hosts
- **New variables**: `dkimHost1`, `dkimValue1`, `mxHost`, `mxValue`, `spfRules`
- **Removed variables**: `verificationToken`, `dkim1`, `dkim2`, `dkim3`
- **Version bumped** from 1 to 2
- `syncPubKeyDomain`: `novantt.com`

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

## Online Editor test results

**Editor test link(s):**

[Test novantt.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPUVD2oC%2F%2B1VXU%2FjOBT9K5YlpFlNU5K2FJqqD4GyLELpQlsQGoQqN3GKt0kcbCeli7q%2Ffa%2Fz0TYzzIh9YyWeml4fH%2Fvce%2B71K1Y0SkKiKLZfcSJ4xnwqLn1s45hnJFaq6fEIN7ZLIxIBFI%2BKRViQVGTMo%2FkWGhEWGpLGPosXu7X6HnSuUWiyRWVUSMZjbLcaOOQLfitCQD8plUj78HC1WjX3rnLIIrKg8rAMGXpDU2aax6fSEyxRORc%2B43HAFqmgaDiaIEE9LnyJAi5QeT%2FkkSghbBGj%2FNoSZYyg6o5fxlTDfmvq%2BxHByDykwxq%2Fv2TRH1wqy0bDq0u3PAE9QSgGvX2kAXckTGmFSNJ5yDy0pOs%2Bil70Xhu590imc5%2FDDWIdzTfkYUXEgqo%2BkkkwTkMqbTS5%2Fh2x2AtTnyKhQzrD69i7TudXdD3MOX6omwaMqc%2FgeuoXkNOQe0tsBySUtIHLbGH74RUvBE%2BTvLpaEMDVOtHVnN5P4Y%2BWC38Ottk40IUgilTBIgM6qhSUtd01zU1jnzW3TCD4HrV7v8dcZEoTJJzFSk55Ec2J87BgXDC1xrZl%2FvQUyOKOHxLpvnlClWsdrb4PcJ3Jj4jwfpKGWbVYZiAbDF1nfGb1UTJ4TomApLOY9vXuF6UNCn5QLlHeE%2FjR5b4mvBY0YC9vQ8q1HTHAqASjKkZ0z%2FwZO0kSrmvJftw08N88prNdUR%2FhgpUV6At0QUhLK5Q64CsXPGM5vqr8fqmKhBZ6gS8BcZHUM6RifqhRP1bcD1h%2F5%2BzvY946S8NF3pXNWXEIdFKFKGymIcnAvbwIXMe8OJs8X0wu5%2B3hzfmpc3PrOJ2LkTM8O2U3eldRdb1DUxaRnEWHAkr9OfGWhoxU0kylQYlUhtUkEYFcSiorUTvHPOCyN%2B3vQJB%2FGDJc0JmEX6JgJGFbiRT6LEpDxWZkRXYh35sRXUMol4RV4IUerHktLqbpj6nY2u5dKdjzSAOM6%2BnaMW3wzrwddEmLGiekaxqddu%2FE6Jm9lmGZ3cBs%2B1YvmFt7D8Ibb8WvnoSdw%2FaN64QrspZ4o1ttfwiUWvMKbeW9rzg1ffUZ8QHV1kpbl5sNwGQWetNd6B8ShpVUUPo%2FEPcfZuTH8Wc1WDebxwaMz8%2BW%2FGzJz5b8MC2p32GSUX9GNK5ltrqGeWS0rKnVsVtH9tFx87h73LM6X03TNk0tg0pVaH2F13n%2FXcbht2nmpNOLIL6%2Fu0qS5xF9%2BuZeLc5Xy9S6W7Cv7rqzdm7jv8bTkwHe%2FAvmcUaxPw0AAA%3D%3D)

[Test novantt.com/email-sending sub/example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACAWD2oC%2F%2B1VXU%2FbShD9K6uVkHpFHOwkpKmjPISEpikyBQIVuiiKNvY6LNhed3ftkKLc335n%2FUHsAhWPrcRT4tmZs3Nmzsw%2BYkXDOCCKYvsRx4KnzKNi6mEbRzwlkVJNl4e48XR0SkJwxaf5IRxIKlLm0iyEhoQFhqSRx6LV7qweg461F5o9eaVUSMYjbLcaOOArfiUC8L5VKpb2wcF6vW5WUjlgIVlReVCYDB3QlKnG8ah0BYtVhoVHPPLZKhEUjU9nSFCXC08inwtU5IdcEsaErSKUpS1Ryggqc%2FxwQbXbP02dHxGMLAM6ruF79yz8wqWybDQ%2BmTrFDegWTBHw7SPt8J0ECS094mQZMBfd000fhQ861kbONZLJ0uOQQaStWUBmVkSsqOojGfsXSUCljWZnnxGL3CDxKBLapCu8idyzZHlCN%2BMM41nftMMF9Rikp37jchRw9x7bPgkkbeCiWti%2BecQrwZM4664mBO5qE%2BtuXl5fwoemCx97T9XY040gipTGvALaqhS0td01zW2jippJxhe8Au1cV5DzSmmAmLNIyUueWzPgzCwYF0xtsG2Zr94CVdzhQyGdF28oa62t5f89XEfyQiLcV8qwKA%2BLCqSDsTO8GFl9FA9%2BJERA0VlE%2Bzr6QWmBgh6UQ5R7C3p0uKcBzwT12cPLLsXZDhjcqAShKkb0zHyLhnEcbGrFnm8b%2BCeP6GLX1DkkWEqBPsAUBLSQQsEDJAkfGecFy0LK5le7ldc0pwyQMfALpV4jJfhNDX1ewt9k%2BPPigreBP%2BlLu4tsNpuL%2FB6Yp9IjF5t2iQfOdOI7Q3Mymv2YzKbL9vj8%2BGh4fjUcdianw%2FHoiJ3rqLz3WU4AmVsyFG3yKfWWxL03ZKjiZiINSqQyrCYJCVRUUlny2unmBhcTav%2FiBF2AVcMFXUj4JQoWE7aVSGDawiRQbEHWZGfy3AXRnYSmSTgFXJjEmuKifKc%2BK0Uz710hwDeVoaKWBkjY1S1kWuq9ZftT92OrZ5CPFjU6PUIN0utYxrLrk7bV%2BmR2O%2B3K0%2FDCq%2FG7x6GmtaqKh8GabCTe6rmrboSCcka4xvJtfarRrC%2BNP5N0rdHPWacDkJ2FXtQb%2Bo8EQckYCP8dHPP1%2BSvLV1foHyXacvVut%2FMGLNj3cX0f1%2Fdx%2FSvGVb%2FfJKXegmjXltnqGuah0bIurY7d6tods3lodtu97r5p2qapmVCpcrqP8KpX33M82gRyOiEjdXf3df9u5rMztt54h%2F9aJ6x3dHwrR%2FKKOfvfVl7qDPD2fzBDHut9DQAA)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `novantt.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — using `SPFM` record type for SPF
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — set on DMARC record with `Prefix` mode and `v=DMARC1` prefix
- [x] no variable is used as a bare full record value — DKIM uses `%dkimValue1%` as bare value; this is required as Resend returns the full DKIM public key as the TXT record content
- [x] no bare variable is used as the full `host` label — `%dkimHost1%` contains a dotted subdomain like `resend._domainkey`
- [x] no variable is used in the `host` field to create a subdomain — `%mxHost%` is a simple subdomain label (e.g. `send`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — set on DMARC record