### PR TITLE
Update treadcommand.com template to v3: dual CNAME (www + apex)

### DIFF
--- a/treadcommand.com.custom-domain.json
+++ b/treadcommand.com.custom-domain.json
@@ -16,9 +16,15 @@
       "ttl": 3600
     },
     {
-      "type": "CNAME",
+      "type": "A",
       "host": "@",
-      "pointsTo": "customers.treadcommand.com",
+      "pointsTo": "104.26.12.191",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "104.26.13.191",
       "ttl": 3600
     }
   ]

--- a/treadcommand.com.custom-domain.json
+++ b/treadcommand.com.custom-domain.json
@@ -3,13 +3,18 @@
   "providerName": "TreadCommand",
   "serviceId": "custom-domain",
   "serviceName": "Custom Domain",
-  "version": 2,
+  "version": 3,
   "logoUrl": "https://www.treadcommand.com/logo.png",
   "description": "Connect your domain to your TreadCommand-powered tire shop storefront.",
   "syncPubKeyDomain": "treadcommand.com",
   "syncRedirectDomain": "www.treadcommand.com",
-  "hostRequired": true,
   "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "customers.treadcommand.com",
+      "ttl": 3600
+    },
     {
       "type": "CNAME",
       "host": "@",


### PR DESCRIPTION
# Description

Update `treadcommand.com.custom-domain` template from v2 to v3.

**What changed (v3)**:
- **Removed `hostRequired`** (defaults to `false`) — template now declares all records statically
- **Added explicit `www` CNAME record** → `customers.treadcommand.com`
- **Added two apex `A` records** → Cloudflare edge IPs (`104.26.12.191`, `104.26.13.191`)
- **Version bumped** from 2 to 3

**Why**: v2 only created one CNAME record per authorization (the `www` subdomain, with `host=www` passed at runtime via the query string). The bare/apex domain (`example.com` without `www`) was left untouched, causing stale registrar A records to serve wrong content after Domain Connect setup.

v3 declares all records explicitly so a single Domain Connect authorization creates:
- `www.example.com` CNAME → `customers.treadcommand.com`
- `example.com` A → `104.26.12.191`
- `example.com` A → `104.26.13.191`

**Why A records instead of CNAME for apex**: The initial v3 attempt (commit fc24519) used CNAME at `@` which failed DCTL1012 — standard DNS prohibits CNAME at apex. This fix follows the Leadpages pattern (`leadpages.net.custom-domain-apex-prod.json`): A records for apex, CNAME for www. The IPs are Cloudflare anycast addresses for our `treadcommand.com` zone; Cloudflare for SaaS routes traffic by SNI, so edge IPs are stable.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — N/A (no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record — N/A (no TXT records)
- [x] no variable is used as a bare full record value — N/A (no variables)
- [x] no bare variable is used as the full `host` label — N/A (no variables)
- [x] no variable is used in the `host` field to create a subdomain — N/A (no variables)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — N/A

## Online Editor test results

**Editor test link(s):**
[Test treadcommand.com/custom-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHYVG2oC%2F%2B1UXW%2FaMBT9K5Ffm4R8EUqkSUV0QtvUrutA1YRQZGID0RLbsx1SQPz33RAgtKXTtIdpk%2FqUj3vO9bnHx94gTXORYU1RtEFC8mVKqPxAUIS0pJgkPM8xIzY8kXms3%2BIc8GhYIfo1AqqKymWa0B05KZTmuUV4jlPW1PbE%2Fq5qXB%2BqSypVyhmKfBNlfM5HMgPUQmuholarLEv7uZhWBbMFmwObUJXIVOhdB9TnjNFEGyteSKNe39C8%2FjwVbAleUkmJoVNJDbXgwgBRks4kZ9quJK9YcldMP9HVXudZSyrUPSXQI9FH3DnFgAUMl0ShaLxBeiV2Ttz2bt5DacGVromVzTxlWg350Uew51w%2FrcEmP3ScrXls2GuaXT1t5TqB7YW269lu1%2F1jtv%2BCPdmaaM0ZjZvxJrApBy%2FoI4aA0b3kfXN4m0teiDg94AWWOFdVCA%2FM8RPq5MAdI1StmM4ZbFas4Il1IUG8lgU1UV5kOo1xiZtfJImxENkKBCqoQouX%2FrM6mLX%2FBGv8296bKCZJpTutco8pmQXdTmiRAGMr8Gcd6xK7ruU6nXYwdb2u3yYnB%2Bm1g%2Faro9RYSJWiTKe4Oiy9rMQrhbbPNnM%2F11Uz1asx%2BF8H8f%2F1QSYmBPwtcm%2BR%2B4uRg%2BtS4SUlMa5gnuOFltO2fGfohlHbjRzPDnwXdFw4TuQ41ShU6XrKDdyup%2FcqeujdXDy0pj%2BywUIth9%2F6607bv1%2BHA%2FfjaCpI%2BR1%2F%2Bfr58vF6MOr23qHtTxfdPCBSCAAA)
[Test treadcommand.com/custom-domain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPsVG2oC%2F%2B1Uy27bMBD8FYHXSjIl2mosoEADp4cgSNqm8ckwBFpkHDYSSZArK67hfy9p%2BRHnURS9FAFyIqSdWc7O7nKFgNe6osBRvkLaqIVg3JwzlCMwnLJS1TWVLHYnCvfxK1o7PLrxiFGHcFHLzUKUfEMuGwuqjpiqqZCH2JY42kSDs110wY0VSqKchKhSczU2lUPdAWib93pt28ZPxfQ8LNZy7tiM29IIDZsMaKSk5CUES9WYoLs%2FANV9PhYcadVyw1kAwvDA3ikdOFGG3xolIfaSl7L81swu%2BHKr80VLPOqaM5ejhD3uJcUO6zDKMIvyyQrBUm%2BcuDq9%2FOJCd8pCR%2FQ2KyHB3qi9j86el%2FIBOJtIhvE63Cc8PST7fJwqwf04zeIkjZNh8s9s8ow9XYfol5K8OJQ3dU3ZecEfqBswvpV8VOfcqEYXYkfR1NDa%2BjnckSdH7OmOPtnw%2Fb1iLl3LCutOCo1xJYBpeIjqpgJR0JYefrGyoFpXSyfTuqjL8rwLshtP375OIaNA%2F7oLISpY6eULvwEEz2hS9rOoP8vKqE%2BSWUTT2yxKyEl5kmI%2BxB%2Fxo5V6beX%2BtFRHZnJruQRB%2FeacVi1dWrR%2B0tlDeYfSXp2KN10NeQPVTEM39O8z%2BD6D%2F3MG3Ztq6YKzgnpkitMswoOI4JskywckTwbxMB32%2B%2FgDxjn2eoBb6Apduff38cuLRvNqQBZno%2FGP1jyQ8%2FHwvrr8jkfNycN9pgW9%2BFqT%2BU%2B4Ir10%2FAmtfwNIkIP6eggAAA%3D%3D)

### Context

- Provider: [TreadCommand](https://www.treadcommand.com) — multi-tenant tire shop SaaS platform
- v1 merged: PR #1113 (May 19, 2026)
- v2 merged: PR #1126 (May 21, 2026) — switched from variable to static CNAME target
- v3 initial attempt: commit fc24519 (May 22, 2026) — **failed** DCTL1012 (CNAME at apex)
- v3 fix: A records for apex following Leadpages/Framer pattern
