### PR TITLE
Fix formatting in variableDescription and add hostRequired

### DIFF
--- a/godaddy.com.ans-registration.json
+++ b/godaddy.com.ans-registration.json
@@ -6,8 +6,9 @@
   "version": 1,
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
   "description": "Provisions DNS records required for Agent Name Service (ANS) registration.",
-  "variableDescription": "%acmeChallenge%: ACME challenge value for domain validation. %ansData%: Complete ANS registration data.\n%ansBadgeData%: Complete ANS badge data.",
+  "variableDescription": "%acmeChallenge%: ACME challenge value for domain validation. %ansData%: Complete ANS registration data. %ansBadgeData%: Complete ANS badge data.",
   "syncPubKeyDomain": "domain-attach.api.godaddy.com",
+  "hostRequired": true,
   "records": [
     {
       "groupId": "acme",

--- a/godaddy.com.ans-registration.json
+++ b/godaddy.com.ans-registration.json
@@ -3,7 +3,7 @@
   "providerName": "GoDaddy",
   "serviceId": "ans-registration",
   "serviceName": "Agent Name Service Registration",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
   "description": "Provisions DNS records required for Agent Name Service (ANS) registration.",
   "variableDescription": "%acmeChallenge%: ACME challenge value for domain validation. %ansData%: Complete ANS registration data. %ansBadgeData%: Complete ANS badge data.",


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [ ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test godaddy.com/ans-registration example.com/myagent](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPSvEGoC%2F%2B1WW2%2FbNhT%2BKwSBABtqXeyktqPAD569DsOQrI3TbkBgCIx4LHORSJWk7GhB%2FvsOJfnWOBs2dEAf8mRJ5%2Fqd7zukH6mFvMiYBRo90kKrleCgf%2BY0oqnijPPKT1ROO1vTFcvRlf6kps6IBgN6JRKoQ5g0noZUGKuZFUruzG3YOAVpiXshs8ZArg%2F9V6CNe4p6HZqpVH3UGcYtrS1MFATr9drnKmdCJkpKSKyvdBqsCw9fLaYOyiJTjJugF%2FbCIOwFLYjYpYolrP1CpliFg0m0KOqaEX3vsLmqhkyvZkRDojQ3%2BPu5FBo4WShNjnT%2B3fhq9j3Zx%2Bs7AEwLdpfB9KDECUtymCxZloFM4SQi48nljyTZfCArlpVQF2rguQ%2BCN0nJCc51yizDsIlCtsACGdeN7koTdGaN6w%2BMp3DM%2F84ZGkfHTCWT9%2BXdL1BN65LYZVPbY9ayZOmzQviHIlgqY6%2FbqdDI6hI6tJ0WjW4faapVWTRKQLgYYKvC0X7z%2B00bjS%2Bxs3lb6I4N7Oj5jFy4RfJP%2B2HYoWAMEiCYU8OvclwUWUWfOvslsY2XS0pzmG5bsp2ssz7YiZKLTCT2ktlkKWR6qTjU%2BoCFeDju0toiuhphru7Fv2vKqyl5sbUdk1%2Bpv6ae63L%2B1KF%2FKgnxjr95pxUAesMDc8LZ4x0%2F5hVzW4AfaoCxqMM2XNdQMUfBNMuNO0422W4P0s03%2BW63CedtxiPZDjTh7EblkCmZovARXu3ScOiMLQmkPUVGq64f%2BuEFKUZ5UlyQHOc14qjexF6QUmejzbnSNuLv9RlgRJt9S8O2xGaOzwrtJ8XNlAanATKpfHz0LRjr7W1UsOoGdV0TOFReWQpOHTEilQg%2FNvjLbImDaHctLzMrYrZmu088iZlbBuTRoBU7xD08kJtsjt4v1s7fkdkK7ovBHmgy5okjVDhJL2ABw3DIPDjjC%2B8MwoV3ft7l3mnYH7JFfzDoDtjehXHkLvmHK%2BOZ2o7uvtuz4zhx0s%2FAfW1hfKPTGWdrVpm%2FH06j3RdG9D8K%2B1sf2byDJ%2BDr8rwuz%2Bvy%2FIflwZvSsBXwmDlv%2FPvd98K3Xq930z2PTt9G3b5%2FOhyEw9M3YRiFocODsJvhPeKNt3%2FX0T8mvSD7VPxW9j5ANZHX7z53iw9vqlm5LM2n%2Fv3g%2Br6cDIb3785mH0f06S%2BWZHyqwwwAAA%3D%3D)