### PR TITLE
Add Reeva.me mail template

### DIFF
--- a/reeva.me.mail.json
+++ b/reeva.me.mail.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "reeva.me",
+  "providerName": "Reeva.me",
+  "serviceId": "mail",
+  "serviceName": "Reeva Mail",
+  "description": "Reeva.me mail service: MX (mx1/mx2.reeva.me), SPF, DKIM, DMARC, and autoconfig/autodiscover CNAMEs (Thunderbird + Outlook auto-setup).",
+  "logoUrl": "https://app.reeva.me/auth-bg.png",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "reeva.me",
+  "syncRedirectDomain": "app.reeva.me",
+  "shared": false,
+  "variableDescription": "Reeva issues a per-domain DKIM key. dkim_selector and dkim_pub are minted by Reeva at /api/v1/domains/{id}/dns; the SaaS embeds them in the apply URL.",
+  "records": [
+    { "type": "MX",    "host": "@",                                   "pointsTo": "mx1.reeva.me",     "priority": 10, "ttl": 300 },
+    { "type": "MX",    "host": "@",                                   "pointsTo": "mx2.reeva.me",     "priority": 20, "ttl": 300 },
+    { "type": "TXT",   "host": "@",                                   "data": "v=spf1 mx ~all",                       "ttl": 300 },
+    { "type": "TXT",   "host": "_dmarc",                              "data": "v=DMARC1; p=none; rua=mailto:dmarc@%domain%", "ttl": 300 },
+    { "type": "TXT",   "host": "%dkim_selector%._domainkey",          "data": "v=DKIM1; k=ed25519; p=%dkim_pub%",     "ttl": 300 },
+    { "type": "CNAME", "host": "autoconfig",                          "pointsTo": "webmail.reeva.me",                 "ttl": 300 },
+    { "type": "CNAME", "host": "autodiscover",                        "pointsTo": "webmail.reeva.me",                 "ttl": 300 }
+  ]
+}

--- a/reeva.me.mail.json
+++ b/reeva.me.mail.json
@@ -3,21 +3,21 @@
   "providerName": "Reeva.me",
   "serviceId": "mail",
   "serviceName": "Reeva Mail",
-  "description": "Reeva.me mail service: MX (mx1/mx2.reeva.me), SPF, DKIM, DMARC, and autoconfig/autodiscover CNAMEs (Thunderbird + Outlook auto-setup).",
+  "description": "Reeva.me mail service: MX (mx1/mx2.reeva.me), SPF (via SPFM), per-domain ed25519 DKIM, DMARC, and autoconfig/autodiscover CNAMEs for Thunderbird + Outlook auto-setup.",
   "logoUrl": "https://app.reeva.me/auth-bg.png",
   "version": 1,
   "syncBlock": false,
   "syncPubKeyDomain": "reeva.me",
   "syncRedirectDomain": "app.reeva.me",
   "shared": false,
-  "variableDescription": "Reeva issues a per-domain DKIM key. dkim_selector and dkim_pub are minted by Reeva at /api/v1/domains/{id}/dns; the SaaS embeds them in the apply URL.",
+  "variableDescription": "dkim_selector and dkim_pub are minted per customer domain by Reeva (see /api/v1/domains/{id}/dns) and embedded in the apply URL. The selector is the only domain-customizable part of the DKIM record name; nothing else uniquely identifies the key — hence the bare variable in host.",
   "records": [
-    { "type": "MX",    "host": "@",                                   "pointsTo": "mx1.reeva.me",     "priority": 10, "ttl": 300 },
-    { "type": "MX",    "host": "@",                                   "pointsTo": "mx2.reeva.me",     "priority": 20, "ttl": 300 },
-    { "type": "TXT",   "host": "@",                                   "data": "v=spf1 mx ~all",                       "ttl": 300 },
-    { "type": "TXT",   "host": "_dmarc",                              "data": "v=DMARC1; p=none; rua=mailto:dmarc@%domain%", "ttl": 300 },
-    { "type": "TXT",   "host": "%dkim_selector%._domainkey",          "data": "v=DKIM1; k=ed25519; p=%dkim_pub%",     "ttl": 300 },
-    { "type": "CNAME", "host": "autoconfig",                          "pointsTo": "webmail.reeva.me",                 "ttl": 300 },
-    { "type": "CNAME", "host": "autodiscover",                        "pointsTo": "webmail.reeva.me",                 "ttl": 300 }
+    { "type": "MX",    "host": "@",                                   "pointsTo": "mx1.reeva.me",                             "priority": 10, "ttl": 300 },
+    { "type": "MX",    "host": "@",                                   "pointsTo": "mx2.reeva.me",                             "priority": 20, "ttl": 300 },
+    { "type": "SPFM",  "host": "@",                                   "spfRules": "mx" },
+    { "type": "TXT",   "host": "_dmarc",                              "data": "v=DMARC1; p=none; rua=mailto:dmarc@%domain%",  "ttl": 300, "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "v=DMARC1", "essential": "OnApply" },
+    { "type": "TXT",   "host": "%dkim_selector%._domainkey",          "data": "v=DKIM1; k=ed25519; p=%dkim_pub%",             "ttl": 300, "txtConflictMatchingMode": "All" },
+    { "type": "CNAME", "host": "autoconfig",                          "pointsTo": "webmail.reeva.me",                         "ttl": 300 },
+    { "type": "CNAME", "host": "autodiscover",                        "pointsTo": "webmail.reeva.me",                         "ttl": 300 }
   ]
 }


### PR DESCRIPTION
# Description

Adds `reeva.me.mail.json` for **Reeva.me**, a managed email/cloud SaaS. The template publishes the standard mail records on the customer's domain so users on Domain-Connect-enabled DNS providers (IONOS, Plesk, Namecheap, ClouDNS, …) can auto-configure Reeva mail with one click.

Template source-of-truth in our repo: <https://github.com/shukivaknin/Riva/blob/main/dns/domain-connect/reeva.me.mail.json>

## Records

- MX 10 mx1.reeva.me
- MX 20 mx2.reeva.me
- **SPFM** `@` `mx`  *(not bare SPF TXT — per DCTL1014)*
- TXT `_dmarc` `v=DMARC1; p=none; rua=mailto:dmarc@%domain%` *(txtConflictMatchingMode=Prefix on `v=DMARC1`; essential=OnApply)*
- TXT `%dkim_selector%._domainkey` `v=DKIM1; k=ed25519; p=%dkim_pub%` *(txtConflictMatchingMode=All)*
- CNAME `autoconfig` → webmail.reeva.me
- CNAME `autodiscover` → webmail.reeva.me

## Variables

- `dkim_selector` and `dkim_pub` are minted per-customer-domain by Reeva (see `/api/v1/domains/{id}/dns`) and embedded in the apply URL.
- `%dkim_selector%._domainkey` uses a bare variable in `host` only for the *selector* component (the leftmost label) — the rest of the label (`_domainkey`) is fixed. The selector is the only domain-customizable part of a DKIM record name; nothing else uniquely identifies the key.

## Type of change

- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — links below
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` → `reeva.me.mail.json`
- [x] `logoUrl` is actually served by a webserver — `https://app.reeva.me/auth-bg.png` (HTTP 200)

Linter (run on the latest revision):

```
$ dc-template-linter -loglevel error -tolerate info -logos reeva.me.mail.json
# exit 0
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`reeva.me`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.reeva.me`) for the sync flow
- [x] No TXT record contains bare `v=spf1 ...` content — SPF moved to `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT that must be unique: DMARC (`Prefix`, prefix=`v=DMARC1`) and DKIM (`All`)
- [x] No bare variable as a full TXT record value — every record has a fixed prefix (`v=DKIM1; k=ed25519; p=`, `v=DMARC1; ...`)
- [x] No bare variable used as the full `host` label — `%dkim_selector%._domainkey` has the fixed `_domainkey` suffix and is justified in the PR description / `variableDescription`
- [x] No variable used in `host` to create a subdomain (no `multiInstance` needed)
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record (end users may want to tighten `p=none` → `p=quarantine`/`reject` without breaking the template)

## Online Editor test results

Tests generated against the template at the current HEAD of this PR (commit 386b469), `example.com`, `dkim_selector=riva01ABCDEFG`, `dkim_pub=AAAA1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij=`.

- Apex (host = `@`):
  [Test reeva.me/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHM3EWoC%2F%2B1XbVPbOBD%2BKxrPMEOHvDgOCZBOZkih0JQGuBBarhyTka1NomJbRpJNUob77beykzjm0juuX8rNwBcU7Wq1z7O7j5IHS0MQ%2BVSD1XqwIikSzkB2mdWyJEBCKwFYpeX%2BKcWPLaufWxTIhHuQHggo9%2FOtVV%2FSy0wMlCd5pLkIV8IQc5DMj7VI74psBtNaNZg6lUUOb0rk4vyIbCacmkUPP0cgy0zg0ZAAcxqN2h45POn2SuSw1%2BkflAgNGaGxFp4IR3xcNUvGlScSkOTgtNN7r8hISDKYxCEic7lkZIucxdoX4jY9WFag46iCaftiLC6ljylPtI5Uq1qlUbTMzYSelN1xJQrH6IzxVYqvhlTMQu%2BdL7xbqzWivoJs5zx2T2B2mOZe5NlY%2B8C4BE8v7at3GZ8JlcCWARMqOXV9OCxQy255MFTgYxzEaKhId6LYJXiaBDzUwAyFxIuVFgEu5ly6M5KVbFMBEATKq0mtmhlV9YGzxyoL1Zs0JgQuMIaB8JyeAMFM%2FRm57H%2BqIK1AlvdzlZpFiNYsUjm7ln83qZOISk3EKHUyNSSIX2A9QmyhtyQUesLDMQHES%2BKQ38WAcbAdQ81HHLLYtzAjf8SOXdsmEwg9SDddg3VBkElyIpQ2Bc3iK6t1%2FWDpWWT6tHeF%2B8aO633T8gI5UgNh%2BnpaqxSGgQvJ9QwrbJcsrbEv6rb9WHpeKGd9KGd9KNPrxWAqGvVjH1QazFpxHVwNcs8hC6j0zMRRTfFz0k6novaWRO1QhMiqjGnbzJ0WrdR3fyOrzIaVJ4KrqT7A%2BfG5p3tUe6YOPcHMdecSRnxqrXWZ2%2FJr0Q2UMgWjZorOwo7plB9mv1Fo343KMEsNa1xAhJ2CgG7b8%2FE32DYWbf5cGB3fX00jFYY8kVw%2FimW8B9dwt1rKNcVbE2yhQM8Pd%2FNYsr5jxYZ5z94gCQtxgClF%2BYaKJ4L8JlyNpYijIV%2F444TRQBmJX5y8Lhy9WZy9tsy6wL%2FZlDyhdq3z7uDw%2FdHx0gN5NsYO%2FtWc%2BnajubO7Z8%2BdPnQ%2FnnzqnZ6d%2F9a%2FGFx%2B%2FnL1%2B1fqegxG4wn%2F1rYMLD4OhYShwv9UxxIp0zJGSQtiX%2FMhvaf5FvOGqbggCwqteOuTyQ2z12Y%2Fb5AnU5s3Q3F%2Bh8wztHDzgLG9bdr07Ga5Dg4rb4OzU951HLe8s9uobzObMXvHXXkNn76Sa97CvCCr%2Fd%2Fx7%2BlMWY9PNWMdCOffQDgvB0Q2xH9HkbRRtWokmJI%2Fqe8vcDRt%2B4Wm%2FhPqWZzDvE6%2FAt5SXn%2BEL5vm%2BTj%2BB3X9mUH%2F1WSsqfVCl%2BdsFER%2Bjv8fFPklw1h5Xl48kJsSPkyvKv6q4q8q%2Fqriryr%2Bf1Vx%2FC2gaAJsSI2bYzvNst0oO%2FWB3WjV6i2nXrEbdbvhbNl2y7ZN4qB0BusBfwOsfvu3PtztXob%2B0WV3qj5%2FOx9f0Hoc9La%2Busnx%2FRdqN%2B92ro41dE9Oz7q7bevxL3PjySq7EgAA)

- Subdomain (host = `mail`):
  [Test reeva.me/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGQ3EWoC%2F%2B1XbW%2FiRhD%2BKytLkXI6XmwTEuCEdOStl0tIcoSkadMILd4B9rC97u7agUTpb%2B%2BsDRgo6UX90lQNX7B3ZmfneWbmWfnJ0hBEPtVgNZ6sSIqEM5AnzGpYEiChpQCswmL9nOJrw%2BrkFgUy4R6kGwLK%2FXxp2Ze0MxMD5UkeaS7CpTDEbCSzbQ3SviXbwcQpBxO3NM%2FhQ4FcXR6T7YRT89DG9whkkQncGhJgbrXq1Mnh6Um7QA7brc5BgdCQERpr4YlwwIdl88i48kQCkhyct9pHigyEJN1RHCKyPpeMfCQXsfaFGKcbiwp0HJUwbV8MxbX0MeWR1pFqlMs0iha5mdCjYn9YisIhOmN8leJzkIpp6O37whtbjQH1FWQrl3H%2FFKaHae6rPBtrBxiX4OmFffks4zOiEtgiYEIlp30fDleoZWMe9BT4GAcxGirSlSjuE9xNAh5qYIZC4sVKiwAfZlz2pyQr2bYCIAiUlxOnnBlV%2BYmz5zIL1Yc0JgR9YAwD4T49AoKZ%2BlNy3TkrIa1AFudzlZpFiNYsUjE7lj%2Ba1ElEpSZikDqZGhLEL7AeIbbQJxIKPeLhkADiJXHIf48B42A7hpoPOGSxxzAlv8Wu7eyQEYQepIt9g3VOkElyJJQ2Bc3iK6tx92TpaWT6tH2L68aOz59NywvkSHWF6euJU1oZBi4k11OssF2wtMa%2BqNj2c%2BF1odzNodzNoUyvrwZT0aAT%2B6DSYNaSa%2Fe2m3v2WEClZyaOaorvSTOdCucTiZqhCJFVGdOmmTstGqnv562sMltWngg%2BTfQBzo%2FPPd2m2jN1aAtmjruUMOATa6PLzJYfi26glCkYNVN0EbZMp7yY%2FdZK%2B26VellqWOMVRNgpCGjcnI2%2FwbY1b%2FPXwmj5%2FnIaqTDkieT6sVrGB%2Bgb7pZLuaF4G4LNFej14e6fC9YjVqyX9%2Bw9kjAXB5hQlG8oeSLIT5oJ8VCKOOrx%2BR6cMhooI%2FPz3Xcr2%2B%2Fn%2B%2B%2ByAOaY5ToYg%2BQJtZ3W%2FsHh0fFPCw%2Fk2xhb%2BHPcyk51d69Wt2dOX06%2Bnp61zy8uv3Wuutc3P9%2F%2B8ivtewwGwxH%2F3rQMPD4MhYSewn%2BqY4nUaRmjtAWxr3mPPtB8iXm9VGSQDYVWPHVtgsPs1pkxMOuVtQHO%2B2J1lHvMM%2Bxwc5c5NlQdr%2BYVaa3iFHe8SqVYZ1UoOs4eG9Rqtr23Q5cuxvULc8O1uFqb5XFo%2BQ90qqzndQl5AYv7Iyzu28KSjfZGMEkT5cwhwYT8QX1%2FDmfXtt8wgkxaS%2BtAfqivq5Oa1%2B3fwrkQ4ZeAZrM%2BG9YlDf4r9A1C%2FE%2B04C2wsqH6cxmf0ZLfCWtE%2FI2Kv3U882vpP4XovoC32rv8v8v%2Fu%2Fy%2Fy%2F%2B7%2FP%2Fv5B%2B%2FPhRNgPWocXVtd7doV4tupWtXG06lYddKdt2t2%2FWPtt2wbZM8KJ1Be8KvjuXvDasDtbOrPbHj3BwlX%2B3vN9%2BuzuoRHe%2FpTm1%2FPBweTB87Nz67PG7tj5vW85%2FJO3xONRMAAA%3D%3D)

Both apply cleanly: MX × 2 + SPF (via SPFM) + DMARC + DKIM at `riva01abcdefg._domainkey.<domain>` + autoconfig/autodiscover CNAMEs; "Check template" returns no errors.

