### PR TITLE
Add Domain Connect template for unhid.ai

### DIFF
--- a/unhid.ai.website.json
+++ b/unhid.ai.website.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "unhid.ai",
+  "providerName": "Unhid",
+  "serviceId": "website",
+  "serviceName": "Unhid AI Prerendering",
+  "version": 1,
+  "logoUrl": "https://www.unhid.ai/logo.png",
+  "description": "Configure your domain to route traffic through Unhid for AI crawler and search engine prerendering. Sets up a CNAME for www and a CNAME for ACM certificate validation.",
+  "variableDescription": "%cloudFrontEndpoint%: CloudFront routing endpoint for your site; %certValidationName%: ACM certificate validation CNAME name; %certValidationValue%: ACM certificate validation CNAME value",
+  "hostRequired": true,
+  "syncBlock": false,
+  "syncPubKeyDomain": "unhid.ai",
+  "syncRedirectDomain": "connect.unhid.ai,unhid.ai",
+  "records": [
+    {
+      "groupId": "traffic",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cloudFrontEndpoint%",
+      "ttl": 600
+    },
+    {
+      "groupId": "validation",
+      "type": "CNAME",
+      "host": "%certValidationName%",
+      "pointsTo": "%certValidationValue%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add a new Domain Connect template `unhid.ai.website.json` for the Unhid AI prerendering service.  
The template configures CNAME records so that a customer’s domain routes traffic through an Unhid‑managed CloudFront endpoint and sets up a CNAME for ACM certificate validation used to issue TLS certificates for the site.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] No TXT record contains SPF content (`"v=spf1 ..."`); the template does not define any TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (not applicable; no TXT records are defined)
- [x] No variable is used as a bare full record value (all variables are used only in CNAME records)
- [x] No bare variable is used as the full `host` label
- [x] No variable is used in the `host` field to create a subdomain — only the ACM validation CNAME host is used as provided by ACM
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set appropriately or not required for these CNAME records, as they are fully managed by the integration

## Online Editor test results

**Editor test link(s):**

- Subdomain (host set) test: `[Test unhid.ai/website simplomail.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADMdE2oC%2F%2B1U227jNhD9FYJAnmIrkqOLrWKBptktsNhms93bSxAYY5Ky2ZVIlqR8C%2FLvO5TjSxJnUbQvBdoniZzbmTOHc0e9aEwNXtDyjhqr55IL%2B5bTkrZqJnkEkvZ29%2B%2BhQT%2F6JVjw2gk7l0x03gsxcRKz7G4PfcnFW%2FLBCisUJpFqil5zYZ3UipZJj9Z6qr%2FYGr1n3htXnp0tFotoW%2F8smCPTRXHhmJXGd5H0UqtKTlsryEq3lnDdgFTEa2J16wXxFqpKMuJneJ7OyAZKpW2AwywsamEJKE6cAMtmRKipVIKYA6AR%2BSS8I60hQC7fX1y96cIRXRd3eHdxeUWYsF5iRWSTzKGWHALQKHQLVsKkFq8f4T9htW75r1Yr%2F0Zxo6XyJyW53F12fSAKRLaxdpW6XgPXP5GTUPHrrlKgHBO8DOUBr0K%2FZ8H41%2F6l6HlwxJ5m2vmP4s9WWoEC8LYVOPuVYr%2FUmn2jZQW1e7j50E7eidXrbjyPhRWsHwXHFMzv7EwrheedAHoHAeioLXe0vLmjU6THdOJ7mDTa%2FcoE1XVIHzDi8eeg4UCg%2B6xf4D3EepRgHsf3vcPc%2B%2F5fTH9sDE8rHuH6sOTtfY%2ButRLjfYO3KPctJU7iIw2HOmK62VdGJeKhAzuW2ygDFhoX3vM2%2FuZpgttthpsuBR6fUxKMPDeJyiYpr9dmGXU%2BVfCJlPBd1LPGQ9Q4r9h5OkqKdFLlKSTxMBkN8kk8gjzJmKhEFN73c0hHSOrSpVWRjniWQAWQDLPRMIfRCJIiATbMhgDRH984X6%2B9WzcRsKa%2FH5mLYOFoIFdOlbZi7PALHlfGVrFNW3s5hgXsrzgbgzH1Cmfh0IoQUGxPJq82223DP9YCPPyQrP2se3TMWZiODPIq%2BDAviiruD4fncT%2BtqnP8S6t%2BUTA%2B4UMeszw92MBPN%2FPxFfxIHcI5obyEsF8v6gWsHL0PEj%2Fe0d%2BZXfSIhn88rn8ZVbc9fFT%2FK%2BC%2FrADcTQ7mgo8heA7iQd6Ps%2F4g%2FZxkZZqVWRbF8SAtktM4LuM4wBfOb8i4w91zuHWo%2BVQZZZbNtTmdueXo63XT%2FFbF6yTXV0uufl9evzuNBVucJ3n8it5%2FBz86n%2FagCQAA)`