### PR TITLE
Add StoryPages site-subdomain-root template (subdomain + root redirect)

### DIFF
--- a/storypages.ai.site-subdomain-root.json
+++ b/storypages.ai.site-subdomain-root.json
@@ -1,0 +1,27 @@
+{
+	"providerId": "storypages.ai",
+	"providerName": "StoryPages",
+	"version": 1,
+	"logoUrl": "https://platform.storypages.ai/_next/static/media/storypages-logo.2dfb6f9c.png",
+	"syncPubKeyDomain": "storypages.ai",
+	"syncRedirectDomain": "storypages.ai,api.storypages.ai,platform.storypages.ai",
+	"syncBlock": false,
+	"serviceId": "site-subdomain-root",
+	"serviceName": "StoryPages Website (subdomain + root redirect)",
+	"description": "Points a user-chosen subdomain (CNAME) to a StoryPages site hosted on Vercel, and adds an A record at the root for redirect to the subdomain.",
+	"variableDescription": "%vercelSubdomainHost%: subdomain label; %vercelCnameTarget%: Vercel CNAME target; %vercelApexTarget%: Vercel A-record IP for root redirect",
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "%vercelSubdomainHost%",
+			"pointsTo": "%vercelCnameTarget%",
+			"ttl": 3600
+		},
+		{
+			"type": "A",
+			"host": "@",
+			"pointsTo": "%vercelApexTarget%",
+			"ttl": 3600
+		}
+	]
+}


### PR DESCRIPTION
## Type of change
- [x] New template
## Summary
1 additional template for StoryPages (storypages.ai) -- subdomain site with root redirect. This complements the 4 templates merged in PR #[PR1_NUMBER].
- **site-subdomain-root** -- subdomain CNAME + root A record for redirect
The `host` query parameter cannot be used here because the template creates records at two different DNS levels (subdomain CNAME + root A record). The `%vercelSubdomainHost%` variable is the only way to achieve this.
# How Has This Been Tested?
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
# Checklist of common problems
- [x] `syncPubKeyDomain` is set — set to `storypages.ai`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` — set to `storypages.ai,api.storypages.ai,platform.storypages.ai`. The list covers the root domain plus the actual callback hosts (`api.storypages.ai` for the api-gateway callback endpoint and `platform.storypages.ai` for the storypages-next user-facing callback page). While signed requests are technically exempt per spec Section 4.1.2, we include it defensively per Quality Guideline Rule 3
- [x] no TXT record contains SPF content — no TXT records
- [x] `txtConflictMatchingMode` — no TXT records
- [x] no variable is used as a bare full record value — only `pointsTo` fields use variables
- [x] no bare variable is used as the full `host` label — **Justified exception:** `%vercelSubdomainHost%` is the user-chosen subdomain. The `host` query parameter cannot be used because the template has records at two DNS levels (subdomain CNAME + root A). Using `host=blog` would incorrectly scope the A record to `blog.example.com`.
- [x] no variable is used in the `host` field to create a subdomain — **Justified exception:** same as above. The variable is constrained to valid hostnames from the StoryPages API.
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — not applicable; all records are integral to the service
## Online Editor test results
**Editor test link(s):**

###site-subdomain-root

<!-- without host --> 
(https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG4%2BFGoC%2F%2B1U%2FWvbMBD9V4Sg0FLbcZyvxmPQrOm2UlrCkrawEoJsX1KttuVJStok5H%2Ffyfmw02bs1w0GBtu6d%2B%2FePem0pBqSLGYaqL%2BkmRQzHoG8iqhPlRZynrEJKIdxau2CtyxBMO2bcM%2BEMTYDqbhIqV%2B1aCwm4k7GCHnSOlN%2BpWL4x0Imzh5lZZTCq64ozTQPKwlEnFUKgG1oHC8aB81xO3SydIJl1DwNe9PgGuZdkTCeHlBpIN%2BQS0KoD4MslvF9JdZhgRu2T7EIn6k%2FZrECXAE54yGsHeIabDUNoryOLYXQdId4ZxN5gMBkkONdCjklJonIjeATTI9AhZJnOreT9gRPtSKMTJHWDp%2BEgpQU%2BccXt52byxOiBUJKpfI6CNYQEZGSe5AhxBZhaURYFCFfSjpYNRQSFzTRT7AWgibsxBhSE9hVc8xGM8lZEEN3T%2BXRLC%2FQ3yK%2FYuUjv6QzZgHEH8gGd5GiNwMmJ2BQa3Ek74TofHWH7GTw%2BhbYsTfCr3prvWUHUeI6qqj%2FuKR6nplNyLkxZBz5nVxzwnOzB6KAlJUiQGs81rWm666sHXen4D0%2FyFHqYY9iuLLoQqQwKgQPcfu3ZxZeGQ4mOKFIigr4NZFimo34Fp8xyRJlhneb%2BbiXOtzmPlLzfaBzEwpw2opwqWsTDM2vsw7ZUaq2vG%2FbM9hW08HHq%2BJDTYN8kgoJI4VvpqcSDdNyimOUTGPNR%2ByFFUtROGJZFs%2FRD4VRZHu%2Fgel6qHK5mME0w7%2BD%2BkpOW3QUhcYhboa25rVb9XoQ2dWWC3Z9fBbabReadoMBa3ltCIA1S7fdwavwz5dAsV%2BgcGQ1Z%2BZC7MQvbK7o6s3x2XR1XrRUtvHv7mRo4Sn8v1H%2FwEbhxCo2g2jEDMxzvabtNmyvMah6frXtN84cr16t12qnruu7rukGlF63ucRJLs8wHfQXotVVavx90fpy%2F%2FPu8jN0F3et5nWt1X6IZ%2Fe1Qdz%2FMasnk5vnj3T1C0LOPIZlCAAA)

<!-- with host --> 
(https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMA%2BFGoC%2F%2B1UbW%2FaMBD%2BK5alSq2ahBAoL5kmjbXTirZ10NL2Q4UiJzHUWmKntqFliP%2B%2BcwIkvEz7vGkSEuB77rnnnvN5iTVNs4Roiv0lzqSYs5jKfox9rLSQi4xMqXIIw9Y2eENSAOM7Ex6YMMTmVComOPbrFk7EVNzLBCDPWmfKr9UM%2F0TI1NmhrAWcvuma0kSzqJbSmJFaCbANjePFk7A16UZOxqdQRi14NJiFX%2BjiSqSE8SMqDeQWuCSN9HGQRTK2q8Q6LnDN9jER0Q%2FsT0iiKJxQOWcRLRximtpqFsZ5HVsKofEWcWATeqShyUCn2xR0jkwSkmvBZ5AeUxVJluncTjwQjGuFCJoBrR09C0U5KvNPL2963z6dIS0AUimV1wGwpjESHD1QGdHEQoTHiMQx8HHUg6qRkHCgkX6mhRAwYSvGkJrAtppjBk0kI2FCr3ZUnszzAncb5DVUPvErOhMS0uQdWuMuOXgzInJKDaoQh%2FJOkM5Pt8heRt%2F2gT17Lbw%2FKPRWHQSJRVRh%2F2mJ9SIzQ8i5IWQc%2BZ1cc8Nzs0eihFSVAkBruNaNluuurC13r%2BT9cJSj0sMOxXhl4Z%2BC06AUPIbxb%2B4sfSOwmNSJRFpW0FTp%2FKeFp1LMsoBt8jIiSarMEm8YnnYoxhuOp5JknC%2FuvhMGEsL2leGKCyYYmb9OEbJjrjb8%2B%2B0abLvlwMerwwebhtmUC0kDBd9EzyQYqOUM1iqdJZoF5JWUR3EUkCxLFuCPgiiwHQ6UF0tm5DoVb2KiCRwfFVoZgYWDODKWMbPNpN6cdLxO1663othuNsK23a1HLbvT6ISEtptN4jYqz%2BDRN%2FLPr8PhIKmCndaMmBezl7yShcKrvfu1bvOww6q9f0djYwtu6%2F9B%2FgODhI1XZE7jgBi453ot272wvYtR3fO9uu%2B5Trvd7Lrtc9f1Xdd0BYxFu0t4CapvAH656g%2BZN%2Fx6%2F3DbHZ3z3vXnQf%2FzY%2B1%2BOOQv3sOrV5v2v1%2FfJe6t6L%2FHq1%2BMpjHhtQgAAA%3D%3D)