### PR TITLE
Create godrivv.com.routing.json

### DIFF
--- a/godrivv.com.routing.json
+++ b/godrivv.com.routing.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "godrivv.com",
+  "serviceId": "routing",
+  "providerName": "GoDrivv",
+  "serviceName": "Domain Routing",
+  "version": 1,
+  "logoUrl": "https://godrivv.com/logo.png",
+  "syncRedirectDomain": "godrivv.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/godrivv.com.routing.json
+++ b/godrivv.com.routing.json
@@ -6,6 +6,7 @@
   "version": 1,
   "logoUrl": "https://godrivv.com/logo.png",
   "syncRedirectDomain": "godrivv.com",
+  "syncPubKeyDomain": "godrivv.com",
   "records": [
     {
       "type": "A",


### PR DESCRIPTION
# Description

This Pull Request adds the domain connect template configuration for **godrivv.com**. It contains static A and CNAME records to automatically route custom domains to our Vercel hosting platform.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Note on N/A items:** This template has no variables, no TXT records, and no DMARC records. All checks are passed.

## Online Editor test results

**Editor test link(s):**

[Test godrivv.com.routing.json][token=H4sIAAAAAAAACnWPQUvDQBSE%2F4rMOW6aCinsyWJFRCxS9CQe4u4jXUj2hbfbDaH0v0tqSRTx%2Bma%2BeTNHdMLJWZJHC42arbiUlOEWGQJJcobOivAhOl8jm4Bt1RI0HngzIrP9ct9wWzl%2FtZu4RBIce%2BgiQ8M1v0kDjX2MXdB5%2FuNzPqqqO0Nh8GZH1gmZ%2BJ34t%2BXgzcvh84mGfwxChsUG6Pcj4tCN5dbIsOcQoXE7TmLnY3hlaKxKtSrVslDLAhlibKBvysXilE3s3Xb9fD%2Fzfd%2F%2FTjC%2BakklEkPNtfXh0mKO%2Bjh9AZb65pd2AQAA)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEe%2FFGoC%2F%2B1T227bMAz9lYGvsxPf4iYGBixri3VYL0PQGxYEhmJpjjZbciXZRhrk30c1SZ1gLbbHPgwQYJnkoQ55yBUYVlYFMQySFVRKNpwy9YVCArmkijdNL5MlOKCZanjGnjxK1oaLHK07wCUpMQF8licW0oVv7SeyJFy8mzzjGqY0lwIS34FC5vJGFRi2MKbSSb%2B%2F93LfenvVE0gvRTZhlCuWmU3GP1liyLd6%2FpUtXwlArFRUQzJdgVlWltwYzQupDV4%2F2pIkF0ZfS%2Fw9int4Ah8POoxBjmHseWvnGXt8Ob447fBt2x5myAQ2oIfVZqxwqdBbFl2q2dqBRylY2hGbOUBfJr99BW85SlClfBdfEUVKbRXcIacH0NkOOwWwL%2FJcSMVSjV9iaoWVGFUzB8q6MDwlLelMNEtJVRVLJKjRiykOOyc2CtvOUWLI611zIKWZpcjtCIVs%2BIPGcehGQTh0ozDw3Tn1I3cURcOAkCiaj0Z78%2FXPA9m1iGnNhOHEDta4aMlSw%2FoF5bb8N8ptK%2Fibam%2BilJmDyv%2FX4m1ogQumScNoSmxY4AWx6w3cYHAd%2BEkwSqKwN4jDoyB%2B73mJ51n%2BTJtNhSvcx%2F1NhPP8gc0bSR4fvAsxEZP7s1t19Sta%2BD%2Fvw%2B%2Bfirq9y87O9fHp6Cb%2FAOvf1FoB5MEFAAA%3D)

