### PR TITLE
Add saleya.app custom-domain template

### DIFF
--- a/saleya.app.custom-domain.json
+++ b/saleya.app.custom-domain.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "saleya.app",
+  "providerName": "Saleya",
+  "serviceId": "custom-domain",
+  "serviceName": "Saleya Custom Domain",
+  "version": 1,
+  "logoUrl": "https://saleya.app/logo.png",
+  "description": "Connect your domain to your Saleya store",
+  "variableDescription": "",
+  "syncPubKeyDomain": "domainconnect.saleya.app",
+  "syncBlock": false,
+  "shared": false,
+  "warnPhishing": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "custom.saleya.app",
+      "ttl": 3600
+    }
+  ]
+}

--- a/saleya.app.custom-domain.json
+++ b/saleya.app.custom-domain.json
@@ -4,13 +4,12 @@
   "serviceId": "custom-domain",
   "serviceName": "Saleya Custom Domain",
   "version": 1,
-  "logoUrl": "https://saleya.app/logo.png",
+  "logoUrl": "https://saleya.app/apple-touch-icon.png",
   "description": "Connect your domain to your Saleya store",
   "variableDescription": "",
   "syncPubKeyDomain": "domainconnect.saleya.app",
   "syncBlock": false,
   "shared": false,
-  "warnPhishing": false,
   "hostRequired": true,
   "records": [
     {


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [+] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [+] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [+] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [+] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [+] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [+] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [+] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [+] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [+] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [+] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [+] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [+] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [+] `%host%` does not appear explicitly in any `host` attribute
- [+] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test saleya.app/custom-domain saleya.app/custom-domain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL2fFGoC%2F%2BVT7W7TMBR9lcp%2FadokXdo0EhJbi8RAbGgbA62qIte%2Bac0c29hOp1D13bGbfk%2FAA%2FAjsnw%2Fzj33%2BGSFLJSKYwsoWyGl5ZJR0NcUZchgDjXuYKVQe5%2B5waWrRPebnIsb0EtGYNNAKmNlGVBZYiYOuZOW1mhT1BrvipagDZMCZVEbcTmXXzV3xQtrlcm63QOHrvs4BFZWZBEwIkVHibnrp2CIZspuMNBICgHEtmpZ6VZDpGVlc90ScOM1%2BMFYMzzjMD4B8LRrQb5Us09Qb0lmqEEiDXjnRBhffcUleUZZgbkBF1lgDXR%2FXUhj7%2BBnxTZBqysX00CkpgZlkxWytfLyjG4uP79HTbm7vvOaSyaseZB7aU8nW%2BuU6vXDcD1dt9EvKSA%2F4E7bW9LnD7nFP3%2BruZaVytmuV2GNS%2BMtsUOZHMNMdziTMyDPhM2FUzg37sS2clpvly4rblmOX%2FAhREnun7V2xI3LOrzXgojGPueEKbb4X8K0UU6JX4J5e%2BKUJvFgFgVFFEfBRTyMglnaL4JhlPZINLggkKRHTn%2F9D%2FzN63%2BQFYwBYRn2nr7kL7g2aL2etp3E%2F8WizicGL4Hm2PfEYdwPwiSIk4domEVJFg47%2FUEySHtvwjALQ78RGNssvHJOOvYQeuo%2BR489DkVXGcrub%2Bc%2FyvGVItdF0hd8cHP39OFbMfoIj%2FA9fYvWvwEkIatK2AQAAA%3D%3D)