### PR TITLE
Add restorehub.net.widget-domain-verify template

### DIFF
--- a/restorehub.net.widget-domain-verify.json
+++ b/restorehub.net.widget-domain-verify.json
@@ -9,7 +9,6 @@
   "variableDescription": "Restore Hub will add a single TXT record at _restorehub-verify proving you own this domain.",
   "syncBlock": false,
   "syncPubKeyDomain": "restorehub.net",
-  "warnPhishing": true,
   "records": [
     {
       "type": "TXT",

--- a/restorehub.net.widget-domain-verify.json
+++ b/restorehub.net.widget-domain-verify.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "restorehub.net",
+  "providerName": "Restore Hub",
+  "serviceId": "widget-domain-verify",
+  "serviceName": "Restore Hub Widget Domain Verification",
+  "version": 1,
+  "logoUrl": "https://cdn.restorehub.net/static/cms/logos/logo-256.png",
+  "description": "Verifies your domain so the Restore Hub embeddable Discord verification widget can run on it.",
+  "variableDescription": "Restore Hub will add a single TXT record at _restorehub-verify proving you own this domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "restorehub.net",
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_restorehub-verify",
+      "data": "%token%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **Restore Hub** — `restorehub.net.widget-domain-verify`. The template adds a single TXT record at `_restorehub-verify` containing a server-issued verification token. Restore Hub uses this to prove dashboard users own the domain before allowing its embeddable Discord verification widget to run on it.

Filename: `restorehub.net.widget-domain-verify.json` (matches `<providerId>.<serviceId>.json`).

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://cdn.restorehub.net/static/cms/logos/logo-256.png returns 200 with `image/png`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `restorehub.net`; public RSA key is live at `_dc1.restorehub.net` (TXT, format `p=1,a=RS256,d=<base64 SPKI DER>`, verified via `dig TXT _dc1.restorehub.net @1.1.1.1`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — fixed in commit cc1993e per DCTL1028
- [x] `syncRedirectDomain` not needed — template doesn't use `redirect_uri` (Restore Hub builds its own return URL on the apply request, not in the template)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode: All` is set on the TXT record so prior `_restorehub-verify` records are replaced cleanly on re-apply
- [x] no bare variable used as full record value — record is `TXT _restorehub-verify %token%`, but token is server-signed and namespaced via the fixed `_restorehub-verify` host label; signature requirement prevents misuse
- [x] no bare variable used as full `host` label — host is the fixed `_restorehub-verify`
- [x] no variable used in `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` not applicable — single TXT, end users do not need to modify or remove it without invalidating verification

## Online Editor test results

**Editor test link(s):**

- [Test restorehub.net/widget-domain-verify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEzMFGoC%2F%2BVU30%2FbMBD%2BVyxLPK1p00A6GokHfkyCjQJisA1QFTn2pbVI7Mx2Wrqq%2F%2FvOCV3LYNPe95I4vvvuvvvuLkvqoKwK5oAmS1oZPZMCzJmgCTVgnTYwrbOuAkc7v6wXrERvet3ayWmdodGCmUkODXIuxQRcIHTJpApmYGS%2B2Li8hpOvDYCcNADyxQMkZ05qhTDEW39K%2Bh1a6Im%2BNQXCp85VNun1uFDdl0x71iGU93hpe96%2FfQZRPOhWaoIBBVhuZNWET2ibDSxZ6NqQljOxmrgpkG2OUGYgBMsKICfScm0EmW0RJW3RhDNFTK0I3kjX9fSZkR518iLrduS5LArChCCMWKkmmODm2w0x0ORgjqSb%2Bp7FJE0r1MRzJnqukKy0z9x9TrtQ%2FKjQ%2FJEmOSsstDdXdfYJFq3Ib%2FW3zWhp8rCkblH5JiERNEy1dfjxmocXkzmGth2nH0Ht4IVz2J7dMMTTkzvWKi8kdyPm%2BBQJj7TwYQ%2BLgq7Gqw79oRWkm7xjjLemB08MBxO6XJcbCniaGF1XqVz7V8yw0vrhXSMfXkDHa%2BwD9eeGpv94VcsBy3g%2F2qWelpwotKUW38zVBik7U6OKZV04mbI521wJnrKqKhZeHLRi6N%2FVU%2B28%2F029P5LZljMV3Jcp%2FYZBOByKaDcOhvleHOxl%2BX6Q5TAMwv5wEMf7bI%2FnfGtj397nf1jZjexgLSgnWdG0b84Wlq5W4w624H%2BqFyfIshmIlHm3KIwGQRjjr%2BUmipIoTvqDbj8cvt%2FvvwvDJAx9OUiiLXqJc7U9UZTlp9P779FV%2FsENytv70efL49m0d371UZyNzmOt7u4euTg6vr6AwwO6%2Bgl7nP4cqQUAAA%3D%3D) — apex test, domain `example.com`, host blank, token `restorehub-verify=abc123`
- [Test restorehub.net/widget-domain-verify example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKvMFGoC%2F%2BWUXW%2FaMBSG%2F4plaVcjEEJAa6RerOu%2BNHWqqnZrVyF0Ypvg1bEj24GmiP%2B%2B46QMGJ20%2B90ksY%2Ffc57z4aypF2WlwAuarWllzVJyYT9zmlErnDdWLOq8r4Wnvd%2FWr1DiaXrV2cmnOkejE3YpmWiVK8kL4SNuSpA6Wgor583uyLGcfG8F5LwVkG9BIBl4aTTKUO%2FCVzbsUWUKc2MVyhfeVy4bDBjX%2FUPSgfMoZQNWukE43z2jZDzpV7pAh1w4ZmXVus9oF0040pjako6ZOEP8QpB9RlHmgnPIlSDn0jFjOVnugZIuacJAE1trgjvS9wM%2BWBlU5wdR9z2vpFIEOCdAnNQFBri%2BvSZWtDHAk9kuv%2BdikrYVugjMxKw0wkr3zB5iukazM2XYA83moJzodi7r%2FItouiK%2F1N8uoqPZ%2FZr6pgpNQhA0LIzzuDjmCMUED2h75c2D0K9ww3tszyiO8evRvzN6riTzF%2BDZAoEvDA9u3ypFN9NNjz4ZLWa7uFP0t8UTj4CDKfrMlDsEqCpcFNbU1UxuJRVYKF2Y3634%2FkA93crvWz0uW9iwPsroFHI2TEY0wMlCo23m8A2%2BtgjubY21LGvl5QxWsNvibIauVRNKhFZ0%2FWcNdTf1xzXsdzk91%2FGvQPuFnXEWspXhruWTVIzSyTjKGYyj9A2wCJJ4FCXpJElYDnyYx3t39%2BWb%2FQ%2BX96ABwjmhvQTV9nIFjaObzbSHzfgP08Z5crAUfAbhZBInkyge4%2B%2FmOkmyZJKNh%2F00TYfpyes4zuIA5ZGjy3uNU7Y%2FX9T%2FKAfjJE3yp4s7sxpOrtK6sqq4OdM%2Fq9v55cnJhyZVdx8f9Pz9Kd38AohhG1G9BQAA) — subdomain test, domain `example.com`, host `app`, token `restorehub-verify=abc123`

---

## Signing details (reference)

- `syncPubKeyDomain`: `restorehub.net`
- Public key DNS record host: `_dc1.restorehub.net`
- Public key format: `p=1,a=RS256,d=<base64-encoded SPKI DER>`
- Signing algorithm: RSA-SHA256, base64url-encoded `sig` parameter, query string canonicalized per spec
- Public test: `dig TXT _dc1.restorehub.net @1.1.1.1`

## Contact

- Email: support@restorehub.net
- Docs: https://restorehub.net/docs