### PR TITLE
Create godrivv.com.routing.json

### DIFF
--- a/godrivv.com.routing.json
+++ b/godrivv.com.routing.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "godrivv.com",
+  "serviceId": "routing",
+  "providerName": "GoDrivv",
+  "serviceName": "Domain Routing",
+  "version": 1,
+  "logoUrl": "https://godrivv.com/logo.png",
+  "syncRedirectDomain": "godrivv.com",
+  "syncPubKeyDomain": "godrivv.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This Pull Request adds the domain connect template configuration for **godrivv.com**. It contains static A and CNAME records to automatically route custom domains to our Vercel hosting platform.

## Type of change

- [x] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Note on N/A items:** This template has no variables, no TXT records, and no DMARC records. All checks are passed.

## Online Editor test results

**Editor test link(s):**

- [Test without host (godrivv.com)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJLCFGoC%2F%2B1TUYvaQBD%2BK2VfL9EYY6KBQqVKseVsEUtpRcK6O%2BQWkt2wu4m14n%2Fv7BkvSu9oH%2B%2BhsJDNzHyz38w3cyQWyqqgFkh6JJVWjeCgF5ykJFdci6bpMVUSjxjQjWDw6NGqtkLmaL0AlrTEBOSDmjlIF97aZ6qkQr5ZPeEa0EYoSdKBRwqVq6%2B6wLAHayuT9vtXL%2Fedt1c9gsxBshVwoYHZc8Y%2FWWLIl3r3CQ4vBCBWaW5IujkSe6gcuSmaH5SxeH3nSlJCWrNW%2BJvEPTzhAA86rEWOwzgITt4T9v1yej%2Fv8Pv9%2FjYDk9iAHlbLoPC5NC2LLtX25JFfSkLWEdt6hD9Pvn0FbzlKUGXiEl9RTUvjFLwgNzfQ7QW7IcS9KHKpNGQGv9TWGiuxugaPlHVhRUb3tDNxltGqKg5I0KAXU9x2Tp4Vdp3j1NKXu%2BaRjDNHUbgRovEIksl4549jNvIjCoE%2FHkDiM5hAlAzZjkfJ1Xz980B2LQJjQFpB3WBNiz09GHJ6RrmW%2F1m5toK%2FqfYqStl6qPx%2FLV6HFrhghjbAM%2BrCwiCM%2FWDkh6N1OEijYRrFvVE8DgfJXRCkQeD4g7HnCo%2B4j9ebSJYLOVmo4EdVVx%2FXkZmv7Ozupx1raMLIfJ995v2czWn%2BTcD9W3L6DUw0727BBQAA)
- [Test with host (www.godrivv.com)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIDHFGoC%2F%2B1TXWvbMBT9K0Ovsx35I05jGCxps4%2BuK6UkWyEEo0haIrAlIyk2ach%2F31XS1DFr2R77MDDYvveeq3Puudohy8uqIJajbIcqrWrBuP7KUIZWimlR1wFVJfKQ4boWlB8yWm2skCuIngC3pIQG6LO6cpC2%2FCl%2BpUoi5Lv7Z1zNtRFKoiz0UKFWaqYLKFtbW5ms1zs7ueeyQXUAma2k95wJzak9dvyTJZTcbZbf%2BPaVAsAqzQzK5jtkt5UjN4LwWhkLnx%2BdJCWkNVMFv4M0gCcK4YGEtcAxTjHee8%2FYy9vR90mLb5qm24FKGEAAaikvfCbNE4u21WLvoUcled4SW3iIvUy%2Bc8oKXKhycYJURJPSOBNP4HkHvTjB5we8O1espNI8N%2FAmdqNBj9Ub7qFyU1iRk4a0IUZzUlXFFmgayEKX7vzk0ecjM0YseX16HsoZdTyFWyXMOOEhpj6Oo76fLOOhvxzQof8rjtKUkiTkfHi2Z%2F%2B8mJ1RcWO4tIK4HRsVDdkatH%2FBxFZE0BHyNxPfiqKFB4vw35e35wvcPUNqznLiKiMcpT7u%2B1F%2FGkUZTrLkIkjiJLkI32OcYewkcGOPIndwT89vKHoMw%2Bly%2BuM6LYcPX65nn8Zs3dzEzWDyMKovw7ohP%2B8mdibGYzn6gPa%2FAStIMPffBQAA)



