### PR TITLE
Add Mailtosh email sending configuration

### DIFF
--- a/mailtosh.com.email-sending.json
+++ b/mailtosh.com.email-sending.json
@@ -1,0 +1,45 @@
+{
+  "providerId": "mailtosh.com",
+  "providerName": "Mailtosh",
+  "serviceId": "email-sending",
+  "serviceName": "Email Sending",
+  "version": 1,
+  "description": "Configure DNS records required for verified email sending with Mailtosh.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.mailtosh.com",
+  "syncRedirectDomain": "app.mailtosh.com",
+  "variableDescription": "%dkim1%: DKIM selector 1; %dkim2%: DKIM selector 2; %dkim3%: DKIM selector 3; %region%: sending region",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": "300"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": "300"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": "300"
+    },
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": "10",
+      "ttl": "300"
+    },
+    {
+      "type": "TXT",
+      "host": "send",
+      "data": "v=spf1 include:amazonses.com ~all",
+      "ttl": "300"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the Mailtosh Domain Connect template for configuring DNS records required for verified email sending.

## Template

- Provider ID: mailtosh.com
- Service ID: email-sending
- Template file: mailtosh.com.email-sending.json
- Sync public key domain: domainconnect.mailtosh.com
- Sync redirect domain: app.mailtosh.com

## Records

This template configures the DNS records required for Mailtosh email sending:

- DKIM CNAME records
- Custom MAIL FROM MX record
- Custom MAIL FROM SPF TXT record

Open and click tracking records are not included in this template.

## Public Key

The public key for the signed synchronous flow will be published under:

```text
domainconnect.mailtosh.com