### PR TITLE
Add Mailtosh sending-domain template

### DIFF
--- a/mailtosh.com.sending-domain.json
+++ b/mailtosh.com.sending-domain.json
@@ -1,0 +1,45 @@
+{
+  "providerId": "mailtosh.com",
+  "providerName": "Mailtosh",
+  "serviceId": "sending-domain",
+  "serviceName": "Mailtosh sending domain verification",
+  "version": 1,
+  "description": "Adds DNS records required for Mailtosh sending domain verification, custom MAIL FROM, and SPF.",
+  "logoUrl": "https://mailtosh.com/logo.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.mailtosh.com",
+  "syncRedirectDomain": "mailtosh.com, app.mailtosh.com",
+  "variableDescription": "%dkim1%, %dkim2%, %dkim3%: DKIM verification tokens; %emailRegion%: email delivery region, for example us-east-1",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.%emailRegion%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new Mailtosh Domain Connect template for sending domain verification. The template creates DKIM CNAME records, a custom MAIL FROM MX record, and SPF configuration using the `SPFM` record type.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test mailtosh.com/sending-domain example.com/app.mailtosh.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABIAFWoC%2F%2B1WXW%2FTMBT9K5alPZFkabJ1JWgPhW1oQAvaumkwTZUb33amSZzZTkeZym%2Fnuk3XT7ohXgD1Kc79OL733JujPFADaZ4wAzR6oLmSA8FBnXIa0ZSJxEh968Uypc6jr8lSjKWN0oseDWogYhgnaci4yHoul5iezZxLWaSMI5M4MgAluiJmRkibhK%2FanqKKQznoWIl87IlonXNNjprnREEsFZ4V3BVCASddqchz4B0SF9rIlDTqpx%2FIydnHhkNYxsn5pxMPr05kT16oBK%2B6NSbX0e7uPA%2B71u3pQc92Nszi14mM%2BzTqskTDxPKp6LyH4dGk%2FYhOCohllkFsvCVKbfwZcCw%2FNo8Z8zFYWZ4vZw2YEqyTwNECMTu8L9LKjkPGh2B6CHcicvT%2BtLFAATGyD5l%2BRXbAYp9BD40YOH4jHBKB0UOktjfmyzIL3xiuCZBCu8C0cStYSDkCGl0%2FUDPM7XzfNOuNY3TdSm1mRXntCQ19GNpFkiIzuiXn%2FPbhsZR9l5kGXfZpDE4hrPr%2ByNmIHzyBH%2FwhfvgEfvgb%2BI2rGbjd0UW4LgDvsLjv6tTk3sJwVtBzJaQSZojfiL%2F%2BLlzoxsptOu%2BeFQng0CiuZVJwiBaRRzcjh%2BI7tGfjvXHKPcaschHKKkrwNVvaU7LI22KanzPFUm01Zop0vQB1M8W6XgWz19s9sc57zvTUEIyjNQ%2BmhrA0hNYwx541l4tLbXuil0kFbY1PZgqFZBlV4PebFokRbXbPZiYet7GeZIhsaPQi0uqyZxNts6XNbYq3hhTODJtGbt4Zh7Z5bOkSVlXDTrVbO6gF7ssO%2BO4eCzruywO25x7shxDvV%2F0ar3bmJHqdfG8U6V%2BPETQGG8GsINaTezbUdLTmeykpsMN4HgXjyP%2BUgvDZFIT%2FBwVjVSv7t6gbml6UuPKj3ETAos79E3S0rlrP5mNwiIpcIWu1mPxgSTJlA8n4u%2Fu%2FcVDnt%2BK4FcetOG7FcSuOS%2BKIP6SaDYC3mU0L%2FKDq%2BvtuUG35QeRXcXxeEOwHtYMXvh%2F5vu0LtJnQ8IB%2FrPP%2FqvSq8u6c38XF21az%2F%2Fq48u5y7%2BSLX28eJ7pzd1G7rxaDy5O7rxefT3uNQzr6CSF0G%2B3iDwAA)

[Test mailtosh.com/sending-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALUCFWoC%2F%2B1WbW%2FTMBD%2BK5alfSLp0nR9WRAfNsamaeuArkClaarc%2BNKZJnGwnW6hKr%2Bdc5vSZisDhIQA7VPO9%2BZ77s6PMqMGkixmBmgwo5mSU8FBnXIa0ISJ2Eh9UwtlQp1vtguWoC%2Ftlla0aFBTEcIiSEPKRTp2ucTwdG28F0VKP7L0I1NQIhIhM0LaIDxqKwV1h3LQoRLZwhLQA841Obq4JApCqVBW8CkXCjiJpCI%2Fk94hYa6NTEj34PScHPdedx3CUk4u3xzX8OpYjuU7FeNVN8ZkOtjd3ezDrjXX9HRskRVpeBjLcEKDiMUalpo3%2BegMiqMl%2FIAuCwhlmkJoavdaav17wLH80HyL2PTByrLsftSUKcFGMRxVGrPDJyKp7zhkIfgrobETkKOz026lBcTICaT6OdkBm7sHY1Si4%2BJEOMQCvQts7XjRL9tZuGO4JkBy7QLTxq1jIeUIaHA1o6bI7HxfXhx0X6HpRmqzLqo2XLZhAoVdJClSo%2Ftyw24%2FNZawzzLVoEucxuAUGi3PmzuP5vd%2FkN%2F%2FzfyNH%2BRv%2FEL%2B7mCd3O5oNV0EwEcsnLg6MVmtMpwH2TMlpBKmwDfibb8LF7r74DadRb08BhwaxbWMcw5BNfP8eu5QPMNwPd5rp9xjjCoXoayiTI7SWMk8G4qVf8YUS7TllFXkVSX0ehV7Ra282AN7uOVMrxS%2BVTDN%2FZWiUSoaVrHRHasuF5Pa8sU4lQqGGr%2FM5AqbYVSO7zPJYyOG7JatVTwc4hOLC0Sr0YqZHi5zuuQuW1p1EzgzbGV4fAUcOuSh7YawJOnttZr1dhvctg%2BRu8ejkdvpdPbdvSiEDtuv%2B0022mDcbWz8KOeupwIajUYwy2cH8S0rNJ1vWfcSoe31VoQLw3%2BCsPE9hI1%2FE%2BGCUkp45SMvMVXppHwgj%2BGrcspfibY%2F6H8P7vQFkludbKU18oXF8QosYv274F07SJlPvPPEO0%2B888Q7f5J38DdKsynwIbNuvue3XK%2Fp%2Bq2%2B5wf1duA3a%2FudZqvlPfO8wPMsDtBmCXuG%2F1mbf1jUnJxkHz4KzqL%2Bq6g4vDz0m%2B1B%2FLaf65v23d3uoHd%2B0X1%2FZ9L09t0LOv8KJXWTXngOAAA%3D)