### PR TITLE
Add Resend domain verification template

### DIFF
--- a/resend.com.domain-verification.json
+++ b/resend.com.domain-verification.json
@@ -1,0 +1,21 @@
+{
+	"providerId": "resend.com",
+	"providerName": "Resend",
+	"serviceId": "domain-verification",
+  	"serviceName": "Domain Verification",
+	"version": 1,
+	"syncPubKeyDomain": "resend.com",
+	"syncRedirectDomain": "resend.com",
+	"description": "Verify domain ownership.",
+	"logoUrl": "https://cdn.resend.com/brand/resend-wordmark-black.svg",
+	"records": [
+		{
+			"type": "TXT",
+			"host": "@",
+			"ttl": 3600,
+			"data": "resend-domain-verification=%verificationToken%",
+			"txtConflictMatchingMode": "Prefix",
+			"txtConflictMatchingPrefix": "resend-domain-verification="
+		}
+	]
+}


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for Resend's domain ownership verification. The template provisions a single root TXT record (`resend-domain-verification=%verificationToken%`) so customers can prove they control a domain before sending mail through Resend.

This generalizes the existing `resend.com.sso.json` template, which is functionally identical (same TXT record). It was originally scoped to SSO, but domain verification is now also required for other features. Since `serviceName` can't be renamed, we're introducing this more generic proof-of-ownership template and will remove the `sso` template in a follow-up.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`resend.com.domain-verification.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `resend.com` (template does not use `redirect_uri`, so this is not strictly required, but it is present and valid)
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — set to `Prefix` with prefix `resend-domain-verification=`
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — value is prefixed: `resend-domain-verification=%verificationToken%`
- [x] no bare variable is used as the full `host` label — `host` is `@`
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — N/A: the single TXT record is the verification record itself and is not meant to be modified/removed by the end user

## Online Editor test results

**Editor test link(s):** 
<!-- TODO: run the template through https://domainconnect.paulonet.eu/dc/free/templateedit and paste the "Copy Markdown" link(s) here — at least one apex test and one subdomain (host set) test -->

[Test resend.com/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALMyF2oC%2F%2BVUW0%2FbMBT%2BK8gSTzRtmqQpjTRpiE0b4zIEHUNAFbnxaWqS2JHt3lb1v%2B84LbRANrTnPcU55zuX79yWxEBR5tQAiZakVHLKGagTRiKiQINgzUQWpPGsuaAFIslVpUO5BjXlCVQGTBaUC2cKio94Qg2XYovYGH6qMHs3LzFoou0raiN%2BIZLLyfAUFmvs60ys%2FgoYV5CYegQDnSheVr4jUoVa7K2T25MzgbHGvGwiMJep%2FKFyBI2NKXXUaiVMNLe%2BWkNFBWutBc5MKlZQlTnDnCZZU09TdIFZoFiT6H5JzKK0FPu3fVSMpTb48xGfxmAIP3RdTI0a%2BpyuU1OwD%2Fu7f32Zgdi3LubmWIpRzhNzTk0y5iI9l8xGu1Qw4vN6yEb313hkNVg1yC8pIN5yGTQ2zURbmFMcENjUdkMLX6mSkzLmT%2FiSKlpoO0RPlvcvTAdPtvfEvt%2BwtArvMStEnn07O%2FW9wMuzDM0wOZ4KqSDW%2BKVmopC1URNokGKSGx7TGd2KWBLTsswXyEWjFp2%2B7otYz6Hty%2FvNqEnoRTtjlljG3E5%2FL4Cw0ws9JxyB5wRuZ%2BjQUdhzWDsIkq7vd4fu4c4ivV2x91dpW3zQaGg4tbN7lM%2FoQpPVatDARvxPfHGONJ0Ci6mFea4XOm7H8br99mHkhlHgN71ur%2BMHB64bua6lAtqsq7Cs3tW80hLm9julitNhDpWwZj5JbXX%2BsCfVdtjNWNkbYWex5kZserNj2aw9Fw%2F%2F1rMHYpd6ZSuc45HE%2Bliu6KdiivLdVSI%2FJ5%2FT9jUbP57A7fFdK9BH4Yky12d3%2FZsD7n%2F%2F2km77MvN5YJnGo%2FFb7RO1R0wBgAA)

[Test resend.com/domain-verification example.com/newsletter](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANIyF2oC%2F%2BVVW2%2FaMBT%2BK5WlPY1ACLcSadKqbao22qrt2LVFkWMfwE1iR7a5FfHfdxygQJeum7Q97cnOuXw%2B37llSSxkeUotkHBJcq2mgoN%2Bz0lINBiQvMpURioPmguaoSW5LnQoN6CngkHhwFVGhfSmoMVQMGqFkjuLjePbwubo86ENuhh3C%2Btov5DschL3YLG2fRyJ018DFxqYLbfgYJgWeYEdkuKpxdE6uCM1k%2FjWWORVNEzVSH3SKRqNrc1NWKsxLqs7rFqsqeS1tcCbKc0zqhMvTilLqmY6QgiMAsWGhDdLYhe5o9j%2F2kfFWBmLH6%2Fxai0%2B0Wj7PoZGLX0I1ytJ2KsX%2B199lYB84SDm9o2Sw1Qwe04tGws5OlfcvXapYSjm5SYb3S%2FfI6vBqkLulYRox2VQ2RQTfWFOsUFgk9sNLQkzk4K1oFE20mqSR2LrmVNNM%2BPaaYtxcwAy2KLc7MMMii44ZO5Mgrskk2ny4azXCJpBmiQIgAGLkVQaIoMntRONmbB6AhWSTVIrIjqjOxFnEc3zdIH8DGoR9HGt5Lo3D0g9X6mSyA5qHXHmkiDcaNAub0GLBR5tMOY1Ka973W6n7QW0HR93WMw6DPam7Of5e37OyioDBiGsoK7FT9IZXRiyWg0qWKX%2FPAXYbYZOgUfUOQR%2B0Pb8lhd0%2BvXj0O%2BE9Wa12wyCVuOl74e%2B70iBset8LIt70d80h7k7p1QLGqdQCEu6mJTm6YkJK6bJTdLKbRfXsSXbZVOuPc9q6aK5%2FbPq3ZL1OjCTeBvdX2b35P74TcY7x%2Bq%2FIe%2FYQ4r%2FFmwOV2jE2WUDlfsrh5zMJc2%2F9dpn3fveu%2BDkavJdfrwbzi%2B7qbn3k8XodKx1z345O724wkX7AxX1ifNsBwAA)
