### PR TITLE
Add drin.run email template (DKIM + MAIL FROM + DMARC)

### DIFF
--- a/drin.run.email.json
+++ b/drin.run.email.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "drin.run",
+  "providerName": "Drin",
+  "serviceId": "email",
+  "serviceName": "Drin email sending",
+  "version": 1,
+  "logoUrl": "https://app.drin.run/icon.png",
+  "description": "Add the DKIM, MAIL FROM and DMARC records that let Drin send email from this domain. We never read or write any other records.",
+  "variableDescription": "dkim_value: the complete DKIM record value Drin supplies for this domain at apply time. MAIL FROM (SPF) and DMARC are fixed.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "drin.run",
+  "syncRedirectDomain": "app.drin.run",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "drin._domainkey",
+      "data": "%dkim_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "CNAME",
+      "host": "bounces",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "bounces",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@drin.run",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/drin.run.email.json
+++ b/drin.run.email.json
@@ -4,7 +4,7 @@
   "serviceId": "email",
   "serviceName": "Drin email sending",
   "version": 1,
-  "logoUrl": "https://app.drin.run/icon.png",
+  "logoUrl": "https://app.drin.run/icon.svg",
   "description": "Add the DKIM, MAIL FROM and DMARC records that let Drin send email from this domain. We never read or write any other records.",
   "variableDescription": "dkim_value: the complete DKIM record value Drin supplies for this domain at apply time. MAIL FROM (SPF) and DMARC are fixed.",
   "syncBlock": false,

--- a/drin.run.email.json
+++ b/drin.run.email.json
@@ -21,9 +21,10 @@
     },
     {
       "groupId": "mailfrom",
-      "type": "CNAME",
+      "type": "MX",
       "host": "bounces",
       "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "priority": 10,
       "ttl": 3600
     },
     {

--- a/drin.run.email.json
+++ b/drin.run.email.json
@@ -22,7 +22,7 @@
     {
       "groupId": "mailfrom",
       "type": "MX",
-      "host": "bounces",
+      "host": "send",
       "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
       "priority": 10,
       "ttl": 3600
@@ -30,7 +30,7 @@
     {
       "groupId": "mailfrom",
       "type": "SPFM",
-      "host": "bounces",
+      "host": "send",
       "spfRules": "include:amazonses.com",
       "ttl": 3600
     },
@@ -38,7 +38,7 @@
       "groupId": "dmarc",
       "type": "TXT",
       "host": "_dmarc",
-      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@drin.run",
+      "data": "v=DMARC1; p=none;",
       "ttl": 3600,
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "v=DMARC1",


### PR DESCRIPTION
# Description

New Domain Connect template for **drin.run** (service `email`). It publishes the DNS records that let Drin send authenticated email from a customer's domain: DKIM (TXT), custom MAIL FROM (MX + SPFM) and DMARC (TXT). No other records are read or written. File: `drin.run.email.json`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — checked, and apply tested for both apex and subdomain (links below)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`drin.run.email.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://app.drin.run/icon.svg` → 200, image/svg+xml)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `drin.run` (RS256 public key published at `_dck1.drin.run`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `app.drin.run`
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on TXT records that must be unique — DMARC (`Prefix`/`v=DMARC1`) and DKIM (`All`)
- [ ] no variable used as a bare full record value — **exception:** the DKIM record uses `%dkim_value%` as the full `data` because Drin supplies the complete, ready-to-publish DKIM record string per domain at apply time; the selector host (`drin._domainkey`) is fixed, so misuse is limited.
- [x] no bare variable used as the full `host` label
- [x] no variable used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

## Online Editor test results

Both pass with no errors (DKIM TXT, MAIL FROM MX + expanded SPF TXT, DMARC TXT):

- [Test drin.run/email example.com/@ (apex)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABsvGWoC%2F%2B1W328aORD%2BVyxLlXo6IAsNv7bKwwJJS5MNCUd10UURMmsDPrz2nu0lkIj72ztelrD0ErX3cpeHPGXjGc9838w3Yx6xZXEiiGXYf8SJVktOme5T7GOquazoVOLS0%2FklicEP98ACp4bpJY9Y5sxiwsX%2BrOCIMhMyTFIuZ%2BCyZNpwJbFfLWGhZuqrFuA6tzYx%2FtERSZLKLvMRj5SsmKW7RZmJNE9sdhMHlCI7Z6h33g9LKAz6F%2BhsOAgRkRT1wmDYRZpFSlMDXsQiwSzKsDgUOaCpVjFYuUFUwYGsoN8ZkgzQwV1CkdLoXnPLIOYaKUimdzErjgTRnEwE6x3Aogsej5dEpMzP4EUKasvsFmd%2BHWX2HE6aJIIzg6aQrYAFAWYohFgjy2NWKRB8%2F9vV2S8FmkQzNOUrRh0os5ZRR6hogf0pEYZtT67SyTlb97LAh2111iGjHIDZJ3uxAeCTc8b%2B7SOeaZUmW20AUTDadeLaPLoZwT9zZewu%2FnjLY8HWrnXEEjC821fnnbtroe0fGp4HnyvbVXIqeGRDYqM56CRU1EUOhMCbUjGz651r3T57eLNP7vrr9Kq4tGak4GTKGJ2QaFE2sU0qqSkzYmy5WiExeVDSMFOJsmCJ5gravQZZegVwP0oO7Qj%2Fkd4k02EqGBQNcxmJlDL%2F%2B3QvJKAx0dELhR3vjHk9lyeZBKofUXIilWQff7aoV5qBZPCzLrltHx3cmAFelhM3pgMZOF3izd2mhIERG%2B8FcgfQdipiK%2BKkn7PNGcBXRnXMM%2F%2BdigpV3VKEQAnRJDZuJ%2B1C3h7EvNsFvcXuOwv7g5B7%2BTlH4AczCcVbnGhDXA3Dfr%2FT%2FzO47MwWf80X%2FFP73usE16dnQTDoBtetwNm7s3P4Pg0sMxbE7VVrH47rjWarHXS6vdOzHKGSYn05GMEaEdf9XnAddLArF59JpdnYwF9iUw0wrE5hSONUWD4m92R%2FRKNxNv9QXQNWAAzjdyAKud2wL07bf8zvQHpjGrnOcadoEjWPPc9rllvVllc%2Bbk9b5UnUrJcbk1pzSkm9OqnTwgvz%2Fcvz3BuzV1NRmYG4J2uDN26gipshL1Q%2Bmnl1fnYrFEgdLojXQvFADIcclyewh6ro2Q2E%2FiZCvM6mHTD6lzvvf%2BHwtBI3dyXYgW%2BD%2Bjaob4P6ygcVfg4YsmR0TJxfzas1yl69XGuPvIZfrfv1eqVRq7cbzV89z%2Fc8hx3mbEvtEV7y4huOiTc7DsX88%2FqL6fyxOv20urkYng%2Fk18VVah%2Baswb9fKEGycPoSzc6wZtvoKpqTXENAAA%3D)
- [Test drin.run/email example.com/mail (subdomain)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGkvGWoC%2F%2B1WbW%2FiRhD%2BK6uVTmpVcAwkvPjEBwMhogkhUKpGjRBavGvYY%2B11d9ckNKK%2FvbPGBJPL9e5Te6ryCbMzO%2FM8M8%2BM%2FYwNixJBDMPeM06U3HDK1IBiD1PFY0elMS69nN%2BSCPxwDyxwqpna8IBlziwiXBzPCo4oMyHNYsrjJbhsmNJcxtirlLCQS%2FmrEuC6MibR3tkZSRLnkPmMBzJ29MbeokwHiicmu4l9SpFZMdS7HgxLaOgPblB%2FMhoiElPUG%2FqTLlIskIpq8CIGCWZQhsWiyAGFSkZg5RpRCQexg35jKGaADu4SiqRCj4obBjG3SEIydYjpWBJEcbIQrHcCi655NN8QkTIvgxdIqC0ze5z5dZTZczhpkgjONAohWwELAsxQCLFFhkfMKRD84Ze7%2Fo8FmkQxFPInRi0ovY2DjpDBGnshEZrtT%2B7SxTXb9rLAp2211gmjHICZF3uxAeCTc8bewzNeKpkme20AUTCabWLbPL2fwp%2BV1OYQf77nsWZb2zpiCBg%2BHKvzwd410PZa3XXh8cl0ZRwKHpghMcEKdDKU1Eb2hcC7UjGz7Z1t3TH78P6Y3PbX6lXy2OiphJOQMbogwbqsI5M4qS4zok254pCI%2FCljzbQTZMESxSW0ewuydAvgvpYc2jH8LL1OwkkqGBQN8zgQKWXe63RfSEAjooIvFHZ%2BMOb13LQzCVQ%2BoqQdy5h9%2FNai3ikGksFvuuS2Y3RwYxp4GU7smI5i3%2BoS72a7EgZGbH4UyAygHVTEnoiVfs42Z5DviIzunGd3DkoqVHZPE4IlRJFI2710CPtwEnd2CPywjzzLQ38l7FGG1hF4wmxCEddtpYmt5XAw6Aw%2B%2Bbed5fqP1ZpftR7djj%2B%2B7Pv%2BqOuPm761d5fX8HzpG6YNiNytVGvnF%2FVGs%2BV3ur3Lfo5SxmJ7O5rCOhHjQc8f%2Bx1sy8aXsVRsruGXmFQBDKNSGNYoFYbPySM5HtFgnu0BqLIGKwCGMTwRR7zftK%2BmzslLfZTKv0nyRIdzGtgWcivvRe1iUa2fk3IYNCrl81alXl6c1xrlZo3UW7TRCps1WnjdvH4NvfXCOZVWUaq%2BeCRbjXd2woqrIq%2BYndVXZfrWXVFgd7o2vieuJ%2FJ4g%2BymDWuqgt5cUOgvIsT328YTavu1%2BLng%2F2k3%2FmdkXtbnblaCffk%2BzO%2FD%2FD7M%2F4Nhhs8KTTaMzon1rbrVetm9KFdbU7fuVRpepea4tWrjovmT63qua%2FHDGO7pPcMXQfFbANfH4urnp5vJ%2BIrfw1DW5RW9YUkDbvwe9qvLy7N0ehWOeotP3UEb7%2F4Gppr5BMENAAA%3D)

