### PR TITLE
Add Sendcorex email provider template

### DIFF
--- a/sendcorex.com.email.json
+++ b/sendcorex.com.email.json
@@ -1,0 +1,45 @@
+{
+  "providerId": "sendcorex.com",
+  "providerName": "Sendcorex",
+  "serviceId": "email",
+  "serviceName": "Sendcorex Email",
+  "version": 1,
+  "logoUrl": "https://sendcorex.com/logo.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "sendcorex.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "%spf_record%",
+      "ttl": 3600,
+      "conflictMatchingMode": "Replace"
+    },
+    {
+      "type": "TXT",
+      "host": "%dkim_selector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkim_public_key%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%bounce_prefix%",
+      "pointsTo": "bounce.emailsbit.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "bounce.emailsbit.com",
+      "priority": 0,
+      "ttl": 3600,
+      "essential": "OnlyOneRequired"
+    }
+  ]
+}

--- a/sendcorex.com.email.json
+++ b/sendcorex.com.email.json
@@ -31,7 +31,8 @@
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=none;",
-      "ttl": 3600
+      "ttl": 3600,
+       "conflictMatchingMode": "Skip"
     },
     {
       "type": "MX",

--- a/sendcorex.com.email.json
+++ b/sendcorex.com.email.json
@@ -12,8 +12,7 @@
       "type": "TXT",
       "host": "@",
       "data": "%spf_record%",
-      "ttl": 3600,
-      "conflictMatchingMode": "Replace"
+      "ttl": 3600
     },
     {
       "type": "TXT",
@@ -31,16 +30,14 @@
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=none;",
-      "ttl": 3600,
-       "conflictMatchingMode": "Skip"
+      "ttl": 3600
     },
     {
       "type": "MX",
       "host": "@",
       "pointsTo": "bounce.emailsbit.com",
       "priority": 0,
-      "ttl": 3600,
-      "essential": "OnlyOneRequired"
+      "ttl": 3600
     }
   ]
 }

--- a/sendcorex.com.email.json
+++ b/sendcorex.com.email.json
@@ -4,7 +4,7 @@
   "serviceId": "email",
   "serviceName": "Sendcorex Email",
   "version": 1,
-  "logoUrl": "https://sendcorex.com/logo.svg",
+  "logoUrl": "https://sendcorex.com/assets/logo/sendcorex-logo-dark.svg",
   "syncBlock": false,
   "syncPubKeyDomain": "sendcorex.com",
   "records": [


### PR DESCRIPTION
## Description
Adding Domain Connect template for Sendcorex (sendcorex.com), an email API provider. Template includes SPF, DKIM, Return Path (CNAME), DMARC, and optional MX records.

## Service Provider Information
- Provider ID: sendcorex.com
- Service ID: email
- Provider URL: https://sendcorex.com

## Records
- TXT `@` → SPF (dynamic variable)
- TXT `%dkim_selector%._domainkey` → DKIM public key
- CNAME `%bounce_prefix%` → bounce.emailsbit.com
- TXT `_dmarc` → DMARC policy
- MX `@` → bounce.emailsbit.com (priority 0)

## Test Links
https://github.com/marcossantosfl/Templates/blob/master/sendcorex.com.email.json