### PR TITLE
add Track Link, Custom tracking domain

### DIFF
--- a/gettrack.link.tracking-domain.json
+++ b/gettrack.link.tracking-domain.json
@@ -1,0 +1,14 @@
+{
+  "providerId": "gettrack.link",
+  "providerName": "Track Link",
+  "serviceId": "tracking-domain",
+  "serviceName": "Custom tracking domain",
+  "version": 2,
+  "logoUrl": "https://gettrack.link/logo-lt.webp",
+  "description": "Connect your subdomain to Track Link for branded short links over HTTPS.",
+  "syncRedirectDomain": "gettrack.link",
+  "hostRequired": true,
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "cname.gettrack.link", "ttl": 3600 }
+  ]
+}

--- a/gettrack.link.tracking-domain.json
+++ b/gettrack.link.tracking-domain.json
@@ -6,6 +6,7 @@
   "version": 2,
   "logoUrl": "https://gettrack.link/logo-lt.webp",
   "description": "Connect your subdomain to Track Link for branded short links over HTTPS.",
+  "syncPubKeyDomain": "gettrack.link",
   "syncRedirectDomain": "gettrack.link",
   "hostRequired": true,
   "records": [


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **Track Link** (https://gettrack.link), a link-tracking / branded short-link SaaS. The template lets a Track Link customer one-click-add the CNAME that points their subdomain (e.g. `go.brand.com`) at Track Link, which then serves their branded short links over HTTPS (Cloudflare for SaaS custom hostnames).

Single routing record: `CNAME <host> -> cname.gettrack.link`. No variables.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
- [x] Passes `dc-template-linter -loglevel error -tolerate info -logos` (exit 0)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published as TXT at `_dcpubkeyv1.gettrack.link`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (sync flow uses `redirect_uri`)
- [x] no TXT record contains SPF content — N/A (no TXT records)
- [x] `txtConflictMatchingMode` set where needed — N/A (no TXT records)
- [x] no variable used as a bare full record value — N/A (no variables)
- [x] no bare variable used as the full `host` label — N/A (no variables)
- [x] no variable used in `host` to create a subdomain — N/A (uses the `host` parameter)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — N/A; the single CNAME is the required routing record

## Online Editor test results

**Editor test link(s):**
[Test gettrack.link/tracking-domain example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGmDGmoC%2F91SXW%2FaMBT9K5ZfS8B8l0iTVjHUVeuqiqabJoQiJ74Eq4lvajvQFPHfZ0MpdN3H%2B54S%2B55z77nHZ0MtFGXOLdBwQ0uNKylAXwka0gys1Tx9aOZSPdDGa%2FGGFw5MI18j1%2FuaAb2SKex4O5JUWSCw4FIdqy%2FEcWUsFuQAI6%2BwFWgjUdGw06A5ZnivcwdfWluasNV6I6fl60Fum2tISkcVYFItS7uj0zEqBaklNVaamCrZTyAWyVE0WaAmieZKgCBmidoS39gQdDLI5yi6vWt66bVKb6vkC9Sf9jLf%2B%2BIhUxBSu5F%2FBC3R2Ck8Vg7lPLK6ggZ1BNTC0HC2obYud97cXHydvMDd8aO3HaWyJkJ3TJVzsPlra2udTd0BY9v5tkGfUUF87Dx33hw0wRN3Tw3NFIvjiAzdf6axKmN5YJRc88L4QBy4szfk%2BYE983Q%2FVWYKNcTGfbmtNBxWLKrcypiv%2BfFKpDEvy7x2Io2ruibv11f7pOy0CW75v3dv0FikXrH0EWQpnPc440FvwFnQa%2FeTgI%2F67WAI%2FaQjRglbJOwk0b%2BN%2B98jfeoeGAPKSu7TepGveW3odjtvOCf%2Fz83c8xu%2BAhFzD%2BywziBg%2FaDLIjYIO8Ow322OemzYZWeMhcyrsWDsftmNy8ppSuh0et5anuF3jbX6ob89ttllggM2jq7grrqHyc3ldbEePi%2BqSfaBbn8CEfLtC64EAAA%3D)

Tested with `domain=example.com`, `host=go` -> output record `CNAME go.example.com -> cname.gettrack.link`, matching what Track Link's backend expects for that subdomain.
