### PR TITLE
feat: add dmarcdrift.com DMARC monitoring template

### DIFF
--- a/dmarcdrift.com.dmarc.json
+++ b/dmarcdrift.com.dmarc.json
@@ -7,22 +7,8 @@
   "syncPubKeyDomain": "keys.dmarcdrift.com",
   "syncRedirectDomain": "api.dmarcdrift.com",
   "logoUrl": "https://dmarcdrift.com/icon-512.png",
-  "variables": [
-    {
-      "name": "policy",
-      "description": "DMARC enforcement policy",
-      "dataType": "ENUM",
-      "defaultValue": "none",
-      "options": ["none", "quarantine", "reject"],
-      "required": true
-    },
-    {
-      "name": "rua",
-      "description": "Aggregate report destination (pre-filled by dmarcdrift with your unique reporting address)",
-      "dataType": "STRING",
-      "required": true
-    }
-  ],
+  "description": "Sets DMARC aggregate reporting for your domain, routing reports to your dmarcdrift inbox.",
+  "variableDescription": "policy: DMARC enforcement policy (none, quarantine, or reject). rua: your unique dmarcdrift reporting address (pre-filled).",
   "records": [
     {
       "type": "TXT",

--- a/dmarcdrift.com.dmarc.json
+++ b/dmarcdrift.com.dmarc.json
@@ -5,7 +5,7 @@
   "serviceName": "DMARC Monitoring",
   "version": 1,
   "syncPubKeyDomain": "keys.dmarcdrift.com",
-  "syncRedirectDomain": "dmarcdrift.com",
+  "syncRedirectDomain": "api.dmarcdrift.com",
   "logoUrl": "https://dmarcdrift.com/icon-512.png",
   "variables": [
     {

--- a/dmarcdrift.com.dmarc.json
+++ b/dmarcdrift.com.dmarc.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "dmarcdrift.com",
+  "providerName": "dmarcdrift",
+  "serviceId": "dmarc",
+  "serviceName": "DMARC Monitoring",
+  "version": 1,
+  "syncPubKeyDomain": "keys.dmarcdrift.com",
+  "syncRedirectDomain": "dmarcdrift.com",
+  "logoUrl": "https://dmarcdrift.com/icon-512.png",
+  "variables": [
+    {
+      "name": "policy",
+      "description": "DMARC enforcement policy",
+      "dataType": "ENUM",
+      "defaultValue": "none",
+      "options": ["none", "quarantine", "reject"],
+      "required": true
+    },
+    {
+      "name": "rua",
+      "description": "Aggregate report destination (pre-filled by dmarcdrift with your unique reporting address)",
+      "dataType": "STRING",
+      "required": true
+    }
+  ],
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=%policy%; rua=mailto:%rua%",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "None"
+    }
+  ]
+}

--- a/dmarcdrift.com.dmarc.json
+++ b/dmarcdrift.com.dmarc.json
@@ -8,15 +8,16 @@
   "syncRedirectDomain": "api.dmarcdrift.com",
   "logoUrl": "https://dmarcdrift.com/icon-512.png",
   "description": "Sets DMARC aggregate reporting for your domain, routing reports to your dmarcdrift inbox.",
-  "variableDescription": "policy: DMARC enforcement policy (none, quarantine, or reject). rua: your unique dmarcdrift reporting address (pre-filled).",
+  "variableDescription": "dmarc_record: full DMARC TXT record value to set at _dmarc (e.g. 'v=DMARC1; p=none; rua=mailto:d-{id}@in.dmarcdrift.com'). Pre-filled by dmarcdrift.",
   "records": [
     {
       "type": "TXT",
       "host": "_dmarc",
-      "data": "v=DMARC1; p=%policy%; rua=mailto:%rua%",
+      "data": "%dmarc_record%",
       "ttl": 3600,
       "essential": "OnApply",
-      "txtConflictMatchingMode": "None"
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
     }
   ]
 }


### PR DESCRIPTION
# Description

Add DMARC monitoring template for [dmarcdrift.com](https://dmarcdrift.com) — a DMARC aggregate report monitoring service for indie builders and small teams. The template writes a single `_dmarc` TXT record with the full DMARC record value pre-filled by dmarcdrift (policy + unique aggregate report address for the user's domain).

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `keys.dmarcdrift.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `api.dmarcdrift.com`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`"Prefix"` with prefix `v=DMARC1` — replaces existing DMARC record only)
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

## Online Editor test results

**Editor test link(s):**

[Test dmarcdrift.com/dmarc example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEmOG2oC%2F%2BVU70%2FbMBD9VyxLE5toQpKSDoIqwWCTBuqAAhoaqiInvgSLNM5spzRU%2Fd937g%2FaQjVpn%2Fcpzt0733t%2BZ0%2BogWFVMAM0mtBKyZHgoL5zGlE%2BZCrlSmTGTeWQtl6zP9gQNvKY06BGIoVV4Sq2gJ%2F1TvqnpCdLYaQSZY6AESgtZEkjH8FNmV7VyQU0Z3LIBAbpEzTafcfCAvvAhYLUvEJZJd4jC5nLO1Vg%2BtGYSkd7e5uQPZHK0gn9wK1mdDjoVInKzCjRGzCazEmzPFeQ4xkRBZVUBtmTTCrSyFoRPuPQIkrWs8QcoomRi%2FxrTyLKRI5dK5wpwZICzjY6zpAx6pKKRySri2LR%2F%2Fb%2BlszDZMSKGuzeGgxhhsSzIvIR3NwlO6PurMA%2FIlW3lCUcEVWzLvIrjIy4MxF8eizKNye188klVwqcTBQFcJI0a5Qt2XlnTaOHCTVNZb1EQph4lNrgT7z0mzPD8P%2FDuo4PGDcGPWh3PK9FQWsojWDWlMvypKqKxgLG5lSWWSFS02MmfcRj7EluGyGvTIy3Qxa5iC5V0%2Blg2qIvqDtecR4gr%2BWUwJjhrMNiPBb0cZWjd1UslviKKTbU9j4sKx82SgfL2gdq1%2BtybeyvJuDyeGMvZCzyUiqINX6ZqRXqNqqGFh3WhRExe2arEE9jZg8N22nMYru3ppTz2%2FbWlH8itWFZzFN7FMLebD9I2tkhz5ywHXacfc4SJ0k6%2B46XJRw6BxCmweHaQ7H9Gdn2VKy82DYh0%2Bmghcb8J1JxpDQbAY%2BZxQVe0HG80Gn7t54fBZ2o3XY%2Fe34Y%2BLueF3meVQDazLVPcJrW54ie9%2FP%2B9VOnrtKrgL14u%2FcHX1Xv5ebnr%2Bvw4vx3%2BuxdepffzOjLXXLQpdM%2FbKL34w0GAAA%3D)

[Test dmarcdrift.com/dmarc example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGCOG2oC%2F%2BVU72%2FaMBD9VyxLVTeVhIQfgaVCatd%2BqSa2qmXStgpFTnwEq0kc2Q6FIf73nRMo0KJJ%2B7xP4Lt3uffunb2mBvIyYwZouKalkgvBQd1xGlKeM5VwJWbGTWROW6%2FZryyHozzmNKiFSGBfuI9t4bfj64cbMpaFMFKJIkXAApQWsqChj%2BBVkdxX8RdY3cqcCQzSZ1hp9x0LC3wALhQk5hXKSvEemclUflcZpufGlDpst48hbZHIwun7Hbes6XDQiRKlqSnRRzCaNKRZmipIcUZEQSmVQfZkJhVZyUoRXnNoESWrOtFANDFym3%2FtSUQRy6VrhTMlWJzB7VHHGhmhLql4SGZVlm37T35MSBMmC5ZVYL%2BtwRBmSFQXkQ%2Fgpi45X4zqAv%2BSlKNCFnBJVMVGyC8zMuTOWvDNlSjeTOr8o0vuFTgzkWXASbw6oGzJNp01DZ%2FW1KxK6yUSwsRcaoOHaOc3Z4bh%2BexQxxnGjUEPuoHntShoDYURzJryrbguy2xlAUtzI4tZJhIzZiaZ4xjHkttGyGsmlqch21xId6rpZrpp0d%2BoO9pzniKv3ZbAkuGuw3Y9tvR1FeMhRfvKSOxKSqZYru2V2BU%2FHVVPd%2BVPdb1tciDahv9qBf69Ovoc8hZpIRVEGn%2BZqRSqN6qCFs2rzIiIvbB9iCcRs6PDdhqz2O6tNUVz5xpr3Ebi1p5%2FInZkXsQTOxFh73i314tj6MdOMhjGTo8NE2foBb7TGQ66Qz%2BeeUO%2Ff%2FBknH5QTj0aR66cWpfNZtpCi%2F4vxbhgmi2AR8xCO14ncLy%2B0%2FUnnh92grAfuP7A9wfDC88LPc%2BKAG0a%2BWvcrcOtolo9Z9d3k%2FJO5XzgPf6Ci8nn%2B7n6VC3TwAwYvKTtyrz0Bj%2BD3ohu%2FgCEH0cXIQYAAA%3D%3D)