### PR TITLE
add Bytes, Bytes AI Storefront

### DIFF
--- a/byteseats.com.storefront.json
+++ b/byteseats.com.storefront.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "byteseats.com",
+  "providerName": "Bytes",
+  "serviceId": "storefront",
+  "serviceName": "Bytes AI Storefront",
+  "version": 2,
+  "logoUrl": "https://static.trybytes.ai/bytes-new-logo.png",
+  "description": "Point your domain at your Bytes online-ordering storefront.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "byteseats.com",
+  "syncRedirectDomain": "dashboard.trybytes.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **Bytes** (`byteseats.com` / `storefront`). It points a customer's host at their Bytes online-ordering storefront via a single CNAME to our Cloudflare-for-SaaS fallback origin. Synchronous, signed flow.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key is published at `_dcpubkeyv1.byteseats.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set
- [x] no TXT record contains SPF content — N/A (no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A (no TXT records)
- [x] no variable is used as a bare full record value — the single CNAME's `pointsTo` must be a full hostname (our per-environment Cloudflare-for-SaaS fallback origin), so `%target%` is used as the full value. The request is RSA-signed (Cloudflare requires signing), which prevents tampering with the target.
- [x] no bare variable is used as the full `host` label — `host` is `@`
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — N/A; the single CNAME is the core service record and must not be removed/modified without breaking the storefront

## Online Editor test results

Subdomain test (apex test not required since `hostRequired: true`):

**Editor test link(s):**
[Test byteseats.com/storefront bytesai.dev/order](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA1lHGoC%2F91T7W6bQBB8Feuk%2FKrB2CROglSpdltVSZUoX22lRhZa3y3kVODI3YJFLL979%2Bw4dtr0BfoLdm92bmZYloKwrAsgFMlS1Na0WqE9UyIR847QIZALpSlF%2F%2BXwEkoGi6k%2F5rZD22qJ6xFHxmJmTUW7g314b3LWu93HtGidNpVIRn1RmNx8swVjH4hqlwwGjoC0DMl2ay0h6MH6JahwEXh4WFc5syh00uqa1kziyuiKep1pbE%2BZEnTVg%2Bdyo8FUha4wMJa96Crv7USHXnVXyWlh5C%2BRZFA43HSumvlX7D6t6d6IxkNuUGmLkl5ACtzD3IBV%2BwYY%2FGAc3eBjw2jOjGzDd%2FAg63EiuV8K6mof2MfLycXnZziXH%2FwX8M7cneHygMDmSAfcJeLM4nEUrWarvngyFaY7uhmn80o16FBhu%2BNdx8Blbk1Tp3o7VIOF0vmd2I7fv5qfbQnunxm4sZHkW48QLnAevo7Jq9N5xWGnjp9AjcWt%2F7IpSKewgF1LyRTquujYjONTpv07m2qzW1sPCgi4fPP2vZz6IlXSW9N%2BZ09OM5WBmgfDeCSDw%2BgIg%2FnxaRbE45M4kuMhZBDvbf%2Bbv8Y%2F%2F4E%2FQkbnsCINfsknxQI6J1arWZ8D%2F1%2B98Vo4aFGl4LGjaDQOoqMgHt4Nx8nhKDmKw%2BOIZR%2B%2Bi6IkirwTdLTxuuR92d8UcaXPiCRdT9Wkndof13dfZHH7c9DK7%2BfHOi4uyvNpVoxcl%2BX5e7H6DQ1YHjjaBAAA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
