### PR TITLE
add Mailometer, Mailometer Email

### DIFF
--- a/mailometer.com.mail.json
+++ b/mailometer.com.mail.json
@@ -1,0 +1,75 @@
+{
+  "providerId": "mailometer.com",
+  "providerName": "Mailometer",
+  "serviceId": "mail",
+  "serviceName": "Mailometer Email",
+  "version": 2,
+  "logoUrl": "https://mail.mailometer.com/bimi/mailometer.com.svg",
+  "description": "Configures DNS to send and receive email through Mailometer: inbound MX to the Mailometer mail host, SPF, Mailu DKIM, DMARC at enforcement, the Resend (Amazon SES) sending subdomain, and mail-client autodiscovery (autoconfig/autodiscover).",
+  "variableDescription": "dkim: the Mailu DKIM public key (RSA, base64) for dkim._domainkey. resendDkim: the Resend DKIM public key value for resend._domainkey.",
+  "syncBlock": false,
+  "shared": false,
+  "multiInstance": false,
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mail.mailometer.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "mx include:amazonses.com"
+    },
+    {
+      "type": "TXT",
+      "host": "dkim._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DKIM1"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=reject; sp=reject; adkim=r; aspf=r; pct=100",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    },
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%resendDkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "p="
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig",
+      "pointsTo": "mail.mailometer.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "autodiscover",
+      "pointsTo": "mail.mailometer.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a Domain Connect template for **Mailometer** (`mailometer.com`) — a white-label transactional email platform (Mailu inbound + Resend / Amazon SES relay outbound). This lets Mailometer customers one-click-configure their mail DNS at their registrar.

`mailometer.com.mail.json` configures:
- **MX** `@` → `mail.mailometer.com` (inbound)
- **SPFM** `@` → `mx include:amazonses.com`
- **TXT** `dkim._domainkey` → Mailu DKIM (`v=DKIM1; k=rsa; p=%dkim%`)
- **TXT** `_dmarc` → DMARC at enforcement (`p=reject; sp=reject; pct=100`)
- **MX** `send` → `feedback-smtp.us-east-1.amazonses.com` + **SPFM** `send` (Resend/SES sending subdomain)
- **TXT** `resend._domainkey` → Resend DKIM (`p=%resendDkim%`)
- **CNAME** `autoconfig` / `autodiscover` → `mail.mailometer.com` (mail-client autodiscovery)

**Variables:** `%dkim%` (per-domain Mailu DKIM key), `%resendDkim%` (per-domain Resend DKIM key).

## Validation

JSON-validated and schema-matched against existing `*.mail.json` templates (e.g. `aiprospectscout.com.mail.json`). I was unable to run `dc-template-linter` locally (no Go toolchain on this machine) — please flag any lint findings and I'll address them promptly.