### PR TITLE
add Daveloper, Daveloper Website

### DIFF
--- a/daveloper.ai.website.json
+++ b/daveloper.ai.website.json
@@ -4,7 +4,6 @@
   "serviceId": "website",
   "serviceName": "Daveloper Website",
   "version": 1,
-  "logoUrl": "https://daveloper.ai/daveloper-logo.png",
   "syncPubKeyDomain": "daveloper.ai",
   "syncRedirectDomain": "daveloper.ai",
   "description": "Connect your domain to the website you built on Daveloper.",

--- a/daveloper.ai.website.json
+++ b/daveloper.ai.website.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "daveloper.ai",
+  "providerName": "Daveloper",
+  "serviceId": "website",
+  "serviceName": "Daveloper Website",
+  "version": 1,
+  "syncPubKeyDomain": "daveloper.ai",
+  "syncRedirectDomain": "daveloper.ai",
+  "description": "Connect your domain to the website you built on Daveloper.",
+  "variableDescription": "`target` is the Daveloper hostname your site is served from (for example daveloper-xxxxxxxx.pages.dev), supplied by Daveloper.",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/daveloper.ai.website.json
+++ b/daveloper.ai.website.json
@@ -4,6 +4,7 @@
   "serviceId": "website",
   "serviceName": "Daveloper Website",
   "version": 1,
+  "logoUrl": "https://daveloper.ai/daveloper-logo.png",
   "syncPubKeyDomain": "daveloper.ai",
   "syncRedirectDomain": "daveloper.ai",
   "description": "Connect your domain to the website you built on Daveloper.",


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **Daveloper** (https://daveloper.ai), an AI website builder. Applying it points a customer's subdomain (e.g. `www`) at the hostname serving their Daveloper site with a single `CNAME` record. The template is subdomain-only (`hostRequired: true`) — it never writes a CNAME at the apex.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`daveloper.ai.website.json`)

No `logoUrl` is set in this template, so the "logoUrl is served" check is not applicable.

Also validated locally with `dc-template-linter -loglevel error -tolerate info -logos daveloper.ai.website.json` (exit 0).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`daveloper.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`daveloper.ai`) for the synchronous `redirect_uri` flow
- [x] no TXT record contains SPF content — N/A (no TXT records in this template)
- [x] `txtConflictMatchingMode` on unique TXT records — N/A (no TXT records)
- [ ] no variable used as a bare full record value — **`pointsTo: "%target%"` is a bare variable, and it is necessary here:** the CNAME target is a per-site dynamic hostname (e.g. `daveloper-<siteid>.pages.dev`) supplied by Daveloper at apply time, so it cannot be split into a fixed + variable part. This matches the already-merged `approximated.app.subdomaincname.json` template, which uses the same `CNAME @ -> %targetDomain%` pattern.
- [x] no bare variable used as the full `host` label — N/A (host is `@`)
- [x] no variable in `host` to create a subdomain — the subdomain comes from the `host` request parameter (`hostRequired: true`), not from a variable
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the CNAME record

## Online Editor test results

**Editor test link(s):**
- Subdomain (`www` of `test.com` → `CNAME daveloper-0d94ea58.pages.dev`): [Test daveloper.ai/website test.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADeMHWoC%2F91U%2FWvbMBD9V4SgsLHEOK6bJobBsn7A6PpBCSssBFe2LqmYLXmSnDQJ%2Bd97cuo4WTPWn2cCtnTvTvee7mVFLeRFxizQaEULrWaCg%2F7GaUQ5m0GmCtAeE7S1jd2wHLH0vI5iyICeiRSqrDkkRmC17e6fePKwRcxAG6EkjTqIXsj0rkyuYHGucibk2wYc4h640JDav2E4mFSLwlZV6ZmSEsFkoUpNeJVCrCL2Cchrmy5EklJklihJtj16rjmmBUsyON8r%2BWiZnoJ9JMJUdRpaT8pYiVw3p1XFEeNEAE4mWuXkw0RpAs8M9Qaybbz9%2FPp4BZuC8TjMPraIKYsiE5iZLPbbcsfcw%2B8SZUC5rS6hRVERpbmh0WhF7aJwcp%2FdDK4vXuG4%2FOIuUAlpzVDh8mjD4gh3rc1odNz1%2FRYFY0BawXCD3soBNrCg6%2FG6RZdKQtwcMkada%2F0tGOulKm%2BOms%2FnuJhqVRaxqPEF0yw3bsTqzFGTOq5zR1UyLjftuY1GJp%2F3Q2AnvUYm6noTU6k0xAbfzJYaak3yMrMiZnPWbPE0Zo4UUjEYxfJv9ZKbad2Q4Myy3Rk71MOegjFPHUfhjBBAvxekp6wNp51JO5wESTuBCbQT3ku64SnnfQ47tjpkucO%2B2tP54J2txy0U%2Fb8lhwNisBaPmYMGftBt%2B%2FjrDDvHURhEnROv5%2FfDsPvJ9yPfdyRw0jZ0V9V3NYjDevzwu%2FZ6FaiH71%2FSvM8Dbv7XzqJu5A5atLkVr67k7Sv%2FnqtCo66dqBn%2B4aE0rhKmbElibNcj9DKY3nV6ZxfDif11d7scPIjl9aX%2F%2FUFdXT%2FlYvl8%2FGMWfv2pBpdi%2BpmuXwDhxX%2BdJgYAAA%3D%3D)

(Apex test intentionally omitted — `hostRequired: true`, so the template is never applied at the bare apex.)
