### PR TITLE
Add hostaria.cloud wordpress-hostaria template

### DIFF
--- a/hostaria.cloud.wordpress-hostaria.json
+++ b/hostaria.cloud.wordpress-hostaria.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "hostaria.cloud",
+  "providerName": "Hostaria",
+  "serviceId": "wordpress-hostaria",
+  "serviceName": "WordPress managed",
+  "version": 1,
+  "logoUrl": "https://hostaria.cloud/logo.svg",
+  "description": "Point your domain to Hostaria managed WordPress hosting.",
+  "variableDescription": "%IP%: Hostaria proxy server IP address.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "hostaria.cloud",
+  "syncRedirectDomain": "hostaria.cloud",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "%IP%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **Hostaria** managed WordPress hosting (`hostaria.cloud` / `wordpress-hostaria`).

Creates two A records on the customer domain apex and `www`, both pointing to the Hostaria reverse-proxy IP supplied via the `%IP%` variable at apply time. Used for custom-domain WordPress sites ordered through Hostaria.

Public signing key is published at `_dcpubkeyv1.hostaria.cloud` (TXT).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Validated locally with [dc-template-linter](https://github.com/Domain-Connect/dc-template-linter) (default + `-cloudflare` flags, exit 0).

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **hostaria.cloud**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — **hostaria.cloud**
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] N/A — no TXT records in this template
- [x] no variable is used as a bare full record value — `%IP%` is used only in A record `pointsTo` (IPv4 address; no fixed prefix possible)
- [x] no bare variable is used as the full `host` label — hosts are fixed `@` and `www`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] N/A — no user-editable optional records requiring `essential`

## Online Editor test results

Validated with the Online Editor (Check template passed). Apply tested on apex and subdomain:

- Apex (example.com): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJSOHWoC%2F%2B1T72vbMBD9V4ygn5o4duxmrWGw%2FhgsK9280tGUEszFUl01tuVKclI35H%2FfXZPMzZZtXzcYGCx0753evbtbMCuKKgcrWLRglVYzyYUechaxe2UsaAlumquas8736CcoEM0%2BrOMYMULPZCpeaHOleaWFMd37nwBr5jVCYoI4BZSQCUo%2BE9pIVbLI77BcZeqrzkmDtZWJer1tLT0CuGaWIY8Lk2pZ2Rcui5UsrdOoWjtcFSBLxypnI3TzmtO%2BT3llmbkkgCCTXJxtJdwbxntRmwEteGocqkZoZxg7wDnlIb5pyvQkV%2BmURXeQG7G6ievJuWjOXrTs8pQwl4JLLVL7axRGUbJh0e2C2aYiD4%2FxmnB4fEe9ocLNlVpLxhtr0cDA85adXZz5fP571njZYc%2BqFEn79hjd3kgUT4BjI9xUFW1SPGVa1VUiN%2FgKNBSGRmvDvN2ijjfcW0bnYUynQ8%2F1fdc%2FCt1Dn5EOmZVKi8TgH2ytsRSrazS4qHMrE5hDe8XTBKoqb1C2wSim27asXE0gWcbBAh63XmsN6LCEpyRc0lAfAffhTZh2eRAMuqF3JLqHg8mgexCC3w%2FDCeeQvtqQ3fvzxy1pbcSAKK0E2oHjfA6NYcsfGrmuZNXIf66WcQfH439r%2FsrW4CIamAmeAMH6Xn%2FQ9fDzr%2FwgOuhHfc8N%2B8HAO9j3vMjzqBhh7KrMBW7r6z1ld1%2BmJ6N81NzUpjp%2Ffuztn44qfZqNyotmGn98CB5usovHy%2Bvz4PP7t2z5DWU6ygWOBgAA

- Subdomain (www.example.com, host=www): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJSOHWoC%2F%2B1TbW%2FTMBD%2BK5GlfVqa5qUZWSQkOoagGhoRagesqiLXdlOLJI5sp2mo%2Bt8594Uuo8BXkJAqpfY9z91zj%2B82SLOiyrFmKN6gSooVp0yOKIrRUiiNJccOyUVNkf0jeo8LQKN3hzhEFJMrTtiO1ghJK8mU6i1%2FAhyYnwCSGIhV4BJnzCRfMam4KFHs2SgXmZjI3GjQulJxv9%2FV0jcAR60y4FGmiOSV3nFRIniprVbU0qKiwLy0tLCOQo%2FVrFN9k5eXmWMEGMg8Z7edhBej5CI%2BZQAL1q1lumHSGiUWptTkMXzVluQmF%2BQrihc4V2x%2Fk9TzO9be7rSc89RgPjLKJSP61yiIgmSF4ukG6bYyHg7h2uDg7yvzNqZxNRYHyXCjNRgYuO7WPsdpmub3rNnWRt9EydJT7Rm4fZTI1hjGhjlEFM%2BTZlLUVcqPlApLXCgzXUfytMOeHenTHR%2BOo8QcItfxPMe7HjiRh4wanpVCslTBF%2BtaQkNa1mBzUeeap7jBpytKUlxVeQviFUQhXde4cj%2BHe70UawyHTr2TETZKKTHquRluN%2FQWCz%2BMeov5tdcbkBekF0U06nlXfkRIQAYLEjzZlPN79Mdt6dgJMVZqjs06DPMGtwptn73pqR3n321pZsO0%2FH%2Bmv%2F6ZYEEVXjGaYoP0Xf%2Bq58LPG3tBHPqx7zrRlRcM%2FEvXjV3X9MOU3ne6gS1%2Bur9ouJTvw7vggw5ff3lw83x92TxMPofN2yHuh4%2BhHt8ssuiRJpPszUu0%2FQ6aLKiLrAYAAA%3D%3D

**Editor test link(s):**
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJSOHWoC%2F%2B1T72vbMBD9V4ygn5o4duxmrWGw%2FhgsK9280tGUEszFUl01tuVKclI35H%2FfXZPMzZZtXzcYGCx0753evbtbMCuKKgcrWLRglVYzyYUechaxe2UsaAlumquas8736CcoEM0%2BrOMYMULPZCpeaHOleaWFMd37nwBr5jVCYoI4BZSQCUo%2BE9pIVbLI77BcZeqrzkmDtZWJer1tLT0CuGaWIY8Lk2pZ2Rcui5UsrdOoWjtcFSBLxypnI3TzmtO%2BT3llmbkkgCCTXJxtJdwbxntRmwEteGocqkZoZxg7wDnlIb5pyvQkV%2BmURXeQG7G6ievJuWjOXrTs8pQwl4JLLVL7axRGUbJh0e2C2aYiD4%2FxmnB4fEe9ocLNlVpLxhtr0cDA85adXZz5fP571njZYc%2BqFEn79hjd3kgUT4BjI9xUFW1SPGVa1VUiN%2FgKNBSGRmvDvN2ijjfcW0bnYUynQ8%2F1fdc%2FCt1Dn5EOmZVKi8TgH2ytsRSrazS4qHMrE5hDe8XTBKoqb1C2wSim27asXE0gWcbBAh63XmsN6LCEpyRc0lAfAffhTZh2eRAMuqF3JLqHg8mgexCC3w%2FDCeeQvtqQ3fvzxy1pbcSAKK0E2oHjfA6NYcsfGrmuZNXIf66WcQfH439r%2FsrW4CIamAmeAMH6Xn%2FQ9fDzr%2FwgOuhHfc8N%2B8HAO9j3vMjzqBhh7KrMBW7r6z1ld1%2BmJ6N81NzUpjp%2Ffuztn44qfZqNyotmGn98CB5usovHy%2Bvz4PP7t2z5DWU6ygWOBgAA
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJSOHWoC%2F%2B1TbW%2FTMBD%2BK5GlfVqa5qUZWSQkOoagGhoRagesqiLXdlOLJI5sp2mo%2Bt8594Uuo8BXkJAqpfY9z91zj%2B82SLOiyrFmKN6gSooVp0yOKIrRUiiNJccOyUVNkf0jeo8LQKN3hzhEFJMrTtiO1ghJK8mU6i1%2FAhyYnwCSGIhV4BJnzCRfMam4KFHs2SgXmZjI3GjQulJxv9%2FV0jcAR60y4FGmiOSV3nFRIniprVbU0qKiwLy0tLCOQo%2FVrFN9k5eXmWMEGMg8Z7edhBej5CI%2BZQAL1q1lumHSGiUWptTkMXzVluQmF%2BQrihc4V2x%2Fk9TzO9be7rSc89RgPjLKJSP61yiIgmSF4ukG6bYyHg7h2uDg7yvzNqZxNRYHyXCjNRgYuO7WPsdpmub3rNnWRt9EydJT7Rm4fZTI1hjGhjlEFM%2BTZlLUVcqPlApLXCgzXUfytMOeHenTHR%2BOo8QcItfxPMe7HjiRh4wanpVCslTBF%2BtaQkNa1mBzUeeap7jBpytKUlxVeQviFUQhXde4cj%2BHe70UawyHTr2TETZKKTHquRluN%2FQWCz%2BMeov5tdcbkBekF0U06nlXfkRIQAYLEjzZlPN79Mdt6dgJMVZqjs06DPMGtwptn73pqR3n321pZsO0%2FH%2Bmv%2F6ZYEEVXjGaYoP0Xf%2Bq58LPG3tBHPqx7zrRlRcM%2FEvXjV3X9MOU3ne6gS1%2Bur9ouJTvw7vggw5ff3lw83x92TxMPofN2yHuh4%2BhHt8ssuiRJpPszUu0%2FQ6aLKiLrAYAAA%3D%3D