### PR TITLE
Update byteseats.com.storefront: add Cloudflare ownership TXT record

### DIFF
--- a/byteseats.com.storefront.json
+++ b/byteseats.com.storefront.json
@@ -21,6 +21,7 @@
       "type": "TXT",
       "host": "_cf-custom-hostname",
       "data": "%ownership%",
+      "txtConflictMatchingMode": "All",
       "ttl": 300
     }
   ]

--- a/byteseats.com.storefront.json
+++ b/byteseats.com.storefront.json
@@ -3,7 +3,7 @@
   "providerName": "Bytes",
   "serviceId": "storefront",
   "serviceName": "Bytes AI Storefront",
-  "version": 2,
+  "version": 3,
   "logoUrl": "https://static.trybytes.ai/bytes-new-logo.png",
   "description": "Point your domain at your Bytes online-ordering storefront.",
   "syncBlock": false,
@@ -16,6 +16,12 @@
       "host": "@",
       "pointsTo": "%target%",
       "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "ttl": 300
     }
   ]
 }


### PR DESCRIPTION
# Description

Updates the previously-merged `byteseats.com.storefront` template (#1168) to add the **Cloudflare hostname-ownership verification TXT** record alongside the existing CNAME.

Bytes serves customer storefronts through **Cloudflare for SaaS** custom hostnames, which require two DNS records to go live: the routing **CNAME** (already in the template) and the **`_cf-custom-hostname` ownership TXT** (a per-hostname token that keeps ownership pre-validation on — the mitigation against dangling-CNAME subdomain takeover). With only the CNAME in the template, the one-click apply left customers to add the ownership TXT by hand; this change lets a single apply write both records.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key is published at `_dcpubkeyv1.byteseats.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set
- [x] no TXT record contains SPF content — the only TXT is the Cloudflare ownership token at `_cf-custom-hostname.<host>`
- [x] `txtConflictMatchingMode` is set on the TXT record that must be unique — set to `All` so a re-apply / hostname rotation replaces the ownership token rather than stacking a duplicate
- [x] no variable is used as a bare full record value — the CNAME's `pointsTo` and the TXT's `data` are full values (`%target%` / `%ownership%`); the request is RSA-signed (Cloudflare requires signing), preventing tampering
- [x] no bare variable is used as the full `host` label — CNAME host is `@`; TXT host is the literal prefix `_cf-custom-hostname` combined with the apply `host` parameter
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — N/A; both records are core service records that must not be removed without breaking the storefront

## Online Editor test results

Subdomain test (apex test not required since `hostRequired: true`). Applying with `domain=bytesai.dev`, `host=order`, `target=qa.web.byteseats.com`, `ownership=<cf-token>` produces:

- `CNAME order → qa.web.byteseats.com`
- `TXT _cf-custom-hostname.order → <cf-token>`

**Editor test link:**
[Test byteseats.com/storefront on bytesai.dev/order](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKFIHmoC%2F%2B1Ua2vbMBT9K0HQT41d187DNgyWdmUrpY916R6UYGT5OhFzJE%2BSk7kh%2F31XzrNtBvs4xiDg6Orcq3vOudKCGJiWBTVA4gUplZzxDNRlRmKS1gY0UKNdJqekvd28oVMEkzO7jWENasYZNCnaSAW5ksLsNvbhrcFl69M%2BZgZKcylIHLRJIcfyQRWInRhT6vjkRBtqOHONqpteXMpPmj%2BOgLlj4W4pxlglA80UL01TidxJLkyrlpVqZXJKuWjR9XLVgxQFF%2BBIhVy4GLd2Tbu261qws0Ky7yTOaaFhFbmr0iuo3zXlDkhjIfeQcQXMbEEZ1ZNUUpXtE0DwRGpzDz8qRKNmRlV4BiZiP5rEjwti6tIKdn4zuL5Yw3H51jpgmemhxOWRoWoM5gijxqBmQc%2Fzlu1t8vDrcJeasNxhFdKcOjYirCEoGjXUFpJzgSZMeNnU%2BmnOpcgLzsw1NWyC%2BlzLzFYcFMX2LDxqtGyTJykg2XU%2BwprPBKLczWC266NRHJdjJasy4Zukkio61Xb8NumPz%2FJHmwKP6woYWLG3oR%2FUnUPqPncEEVtaFtT30rQf%2BrkT9iBzOv0ocsLIA4d2u2EOwJgfdImlxMcChyHR%2BKWmUrDxZ1oVhid0TnehjCW0LIsaFdC4i8e89k6sZn9DfC35wZb3fGyTJGNWD27vVM6ygPbz0OlCN3A6QQpOlHZ9p9MDP%2FKyzulpEO3dzoNX97d39IUzoDUIw2nRGD6ntSbLV1O1JnVgqtwXRP9I9t1Q%2FWW8R22czv%2Be%2Flue4sug6QyyhFqs7%2Fk9x8OfP%2FSC2OvFXuQG3dPQ8489L%2FY8SwS0WVFf4Puw%2FzIQNRh%2BuA0eOvyWX1xFc3GhQhY%2Bva8%2FS66iKPqWXw6%2FhFl1HIQf35DlL13ZdixqBwAA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
