### PR TITLE
Add furlough.ai.custom-domain template

### DIFF
--- a/furlough.ai.custom-domain.json
+++ b/furlough.ai.custom-domain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "furlough.ai",
+  "providerName": "Furlough",
+  "serviceId": "custom-domain",
+  "serviceName": "Furlough Custom Domain",
+  "version": 1,
+  "logoUrl": "https://app.furlough.ai/logo.svg",
+  "description": "Point your branded sign-in domain at Furlough.",
+  "syncPubKeyDomain": "furlough.ai",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "proxy.furlough.ai",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `furlough.ai.custom-domain.json` — a new Domain Connect template for **Furlough**
(white-label sign-in for engineering-org analytics). It points a customer's chosen
sign-in subdomain at Furlough's Cloudflare-for-SaaS edge with a single CNAME
(`<host> CNAME proxy.furlough.ai`). Synchronous signed flow only.

providerId `furlough.ai` · serviceId `custom-domain`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — *link pending (see below); draft until added*
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://app.furlough.ai/logo.svg` returns `200` + `content-type: image/svg+xml`

Also validated locally with [`dc-template-linter`](https://github.com/Domain-Connect/dc-template-linter): default run and `-merge-or-fail` both exit `0`. The two `-cloudflare` notes (DCTL5006 `hostRequired not supported`, DCTL5007 CNAME-flattening) are info-level and expected for a subdomain CNAME.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`furlough.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` set whenever `redirect_uri` is used — N/A, template uses no `redirect_uri` (synchronous signed flow only)
- [x] no TXT record contains SPF content — N/A, no TXT records
- [x] `txtConflictMatchingMode` set on unique TXT records — N/A, no TXT records
- [x] no variable used as a bare full record value — N/A, template has no variables
- [x] no bare variable used as the full `host` label — N/A, no variables
- [x] no variable used in `host` to create a subdomain — correct; the subdomain comes from the `host` request parameter (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute — correct; `host` is `@`
- [x] `essential` set to `OnApply` where the user may modify/remove a record — N/A; the single CNAME is the service itself (removing it disconnects the domain)

## Online Editor test results

> With `hostRequired: true`, the apex test is exempt per the template note — a single subdomain (host-set) test suffices.

**Editor test link(s):**
<!-- paste the "Copy Markdown" link from the Online Editor here (domain e.g. z8ch.com, host e.g. testing) -->
