### PR TITLE
Add linklyhq.com.cname-cloudflare (Cloudflare for SaaS CNAME)

### DIFF
--- a/linklyhq.com.cname-cloudflare.json
+++ b/linklyhq.com.cname-cloudflare.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "linklyhq.com",
+  "providerName": "Linkly",
+  "serviceId": "cname-cloudflare",
+  "serviceName": "Linkly link shortener custom domain (Cloudflare CNAME)",
+  "version": 1,
+  "logoUrl": "https://linklyhq.com/img/linkly-logo.svg",
+  "description": "Adds a CNAME record to point your subdomain to Linkly (Cloudflare) for short link management.",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "linklyhq.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "domains.linklydomains.com.",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `linklyhq.com.cname-cloudflare`, a CNAME template for Linkly custom domains served via **Cloudflare for SaaS**. It mirrors the existing, already-merged `linklyhq.com.cname` template, repointed from `domains.linklyhq.com.` to our Cloudflare-for-SaaS CNAME target `domains.linklydomains.com.`. Subdomains move to Cloudflare; the existing `cname` and `a-record` templates are unchanged.

> ⚠️ **Draft:** opened ahead of the mandatory Online Editor test — see "Online Editor test results" below.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`linklyhq.com.cname-cloudflare.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (same asset as the merged `linklyhq.com.cname` template)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`linklyhq.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` — N/A; the template contains no `redirect_uri` (consistent with the merged `linklyhq.com.cname` / `linklyhq.com.a-record` templates)
- [x] no TXT record contains SPF content — N/A (CNAME-only template)
- [x] `txtConflictMatchingMode` — N/A (no TXT records)
- [x] no variable used as a bare full record value — N/A (no variables)
- [x] no bare variable used as the full `host` label — `host` is `@`
- [x] no variable used in the `host` field to create a subdomain — uses the `host` parameter, identical to the merged `linklyhq.com.cname` template
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential`/`OnApply` — N/A (single CNAME record)

## Online Editor test results

**Editor test link(s):** [Test linklyhq.com/cname-cloudflare example.com/links](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPAdIGoC%2F%2BVTa2vbMBT9K0KfVmanip0ljWGwrN2j9EFX2n0pwSjWjSMqW64kp3FD%2FvuuYqdN18H2fRAw93XuuSdHa%2BqgqBR3QJM1rYxeSgHmVNCEKlneq2bx0Mt0QYPn2iUvsJeeb6uYt2CWMoPtSFZiMcyUrsVccQMv5VdTxEMTu9DGQQmGZLV1uiBCF1yW5N3x8zw5vpxcfDlAmCUYK3VJk35Alc71rVEIt3Cussnh4T7VQ1nkXSL0nT27zBFAgM2MrNwWhE6EsIS38MRApo0gTpNKy9KRRteG2HrW8cF8R3uP2QGZa9Oe0F5T8JLnUEDpev7qpsw%2BK53d02TOlYWALrR11%2FBQSwOolDM1tF1X9ewMmpPtqreit9QsTe7W1DWVl3DLmbaAGH7yf42nbW80hi1n22txdhGCeVbOoWjxkLHNdBPQJ11C%2BrJgGnTDiAIrjqaAjkS3yUNaDHOj6yqVu6GKG15Y757d%2BN2r%2BekO4K5D8LtlXmoDqcUvdzUapVOkqJWTKX%2FkLymRpbyqVINULVYR560WZeuuHUPBHf9nLQKaiszTl97BH3ifz0azKJwP4n44GA%2BH4VE2EmHEWH88ggGH4WDvMfzpofzlQfymJliLnpHc23miHnlj6WYzDVDZ%2F%2BBM9IblSxAp970Ri4Yhw19804%2BS6CiJo954zOJB%2Fz1jCWP%2BHLCuPXuNLtr3D12qm9XZVxN%2FO7%2B9nVWXo1iz61lztaoWubqezKOTnz%2B%2BT47n7EmcfqSbX80b5Ff4BAAA)

Test: subdomain (`host=links`, `domain=example.com`). Result: `links.example.com. CNAME 3600 domains.linklydomains.com.` ✅


