### PR TITLE
Add DirectIQ mail template

### DIFF
--- a/directiq.com.mail.json
+++ b/directiq.com.mail.json
@@ -35,7 +35,8 @@
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=none",
-      "ttl": 3600
+      "ttl": 3600,
+      "essential": "OnApply"
     }
   ]
 }

--- a/directiq.com.mail.json
+++ b/directiq.com.mail.json
@@ -1,0 +1,41 @@
+{
+  "providerId": "directiq.com",
+  "providerName": "DirectIQ",
+  "serviceId": "mail",
+  "serviceName": "Mail",
+  "version": 1,
+  "syncPubKeyDomain": "directiq.com",
+  "syncRedirectDomain": "directiq.com",
+  "description": "Configures DNS records for DirectIQ email signing",
+  "logoUrl": "https://directiq.com/directiq-logo.svg",
+  "records": [
+    {
+      "groupId": "outbound",
+      "type": "CNAME",
+      "host": "sender",
+      "pointsTo": "sender.directiq.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "outbound",
+      "type": "CNAME",
+      "host": "link",
+      "pointsTo": "clientlink.directiq.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "vip._domainkey",
+      "pointsTo": "vip._domainkey.sender.directiq.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test directiq.com/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADIeIGoC%2F%2B1V32%2FaMBD%2BVyK%2FNtCQrGRk6gOCtesq6MpAq1qhyLUNtZrYme2kY4j%2FfWdI%2BNEfWtEe1odKPOC77%2B67O98Xz5FhaZZgw1A0R5mSBadMnVEUIcoVI4b%2FrBOZInft6%2BMUsKi79J5dgkczVXDClkEp5snGVGJ7K2PBlOZSoKgBgJkg3%2FLbczbrSogRT%2FksYsBWxpcwlGmieGaWWVFHigmf5oppp9v%2F7gBSKqqdiVROVa3DbIGO5lPBxRQyJHIqRyqB6DtjMh0dHm5TrA81i6vrwoaUeVF0M0dTJfNs2bjMza3MBQWAmWW2606%2F3fsMxzupDRw1EzA9O0jJhdFDubbVH3VlDNQTND1v4e7FkHBxv5ufJJwJY%2B2v5KD3PH0xf8GzekyXV3HPZrtMu776Xo3RFCuyYR1eDTecceWk2GDLc9zttQedxicnOxZSsO2sLmIaiA3H9j4vRDvLkhlajBcu%2Bg3QeHNxY8hXrRT7hUEArCyxpIV%2Fy%2FpiXuEzrHCqrUiqyJud0HEVe4OQZYQNk4rFdtOwgZ1EkVE5c1GaJ4bH%2BAFvTJTE2JYKBWrwQgrYrEdXIFZKWi9ROY6%2FzNmF%2BRFbM7dzbra80KetoNbAflD70MJHNdykuOYHrYlHJswnQbgl9Oc%2BAs9IfTOx7em3kwc802hhb%2Fr5VsptLRt5xaa%2B5WaeSKNa171k8aY6XMmw7G8%2FGf6vLtaSX4xd0Oy7it5V9K6if1ERPGoaF4zG2OJ8z2%2FWPPgFw4Yf%2Ba0o%2BFj3jsJmGB54XuR5tnymzaq5ObyB268fuh0dhoPrs4Pr6QkhV72Ty9F17%2BsgGzXb5%2BL0y2lBOnc%2FTge9UCTkGC3%2BANWD3OyYCgAA)

[Test directiq.com/mail app.example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEceIGoC%2F%2B1VW2%2FaMBT%2BK5FfCWm4k0x9yEq3XgTtOipNq1BkYpd6JHZqOykM8d93DAnQm1a0h%2FWhEg%2F43L7zHZ8vXiBNkzTGmiJ%2FgVIpckaoPCXIR4RJGml270QiQfbGN8AJxKLeynv6DTyKypxFdJWUYBZvTUVsf23MqVRMcOTXIGDOo8tsfE7nPQE5%2FDmeibiia%2BNrMYSqSLJUr6qiI8Fv2SSTVFm9wXcLIoUkyroV0iq7tahp0FJswhmfQIVYTMS1jCH7TutU%2BQcHuxCbQ9XEOSo3KUVd5N8s0ESKLF0RF5kei4wTCNDz1LA%2BGgT9YzjeCaXhqCiH6ZlBCsa1GoqNzXnCSmvop9F23aW9F0LM%2BPRx%2FShmlGtjfyMGmbLk1fo5S52QrK5iSuePkR77nL2IkQTLaIs6%2FDHcYoalk2CNDc5hrx9cHdU%2BWekhF5zuVrURVQCsGTb3ecGDNI3naDla2ug3hIbbixtBvXKlcJo6dIZBBLRos4CGf6seQ1bmpFjiRBmhlNk3z9JHZf4NQgYZNk1IGpqNwxp2E%2FlaZtRGSRZrFuIHvDWRKMSmZWhUgRdKwIY9uQq%2BVtRmmYqx%2FGXeNswxMn0zM2%2FccZskatWqXTpuVJuddrfabXpRddxstzx626h3xvUdwb%2F0MXhB8tup7d5CED%2FguUJLc%2BMvUym2tiDyho19z2SeSaRc273k8a4YruVY8NtPjv%2BLxUb6y5ENuv1Q0YeKPlT0LyqCR03hnJIQm7i6W29XXfg1hrW6X%2Ff8lud4zXaj61Zc13dd0z5Vek1uAW%2Fg7uuHrr9Uzk4vW5Oz7pTgk5kYnM8q3q%2Bv%2BUknCH6OZ7lXSXh8TyvB5%2BNDtPwDeyWZT6AKAAA%3D)

[Test directiq.com/mail example.com/send](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKgsIGoC%2F%2B1VW2%2FaMBT%2BK5FfF2gCodBMfWCl0tqt9DI6TUMocmM3eCR2ZjsUivjvO04CBEa39mFaHyrl5dzPd8754gXSNEljrCnyFyiVYsoIlWcE%2BYgwSUPNftZDkSB7bevjBHxRL7eeXYNFUTllIc2DEszijar0vSiUUyoVExz5LjjMeXiV3X2i856AGP57PeNxQwvlUz6EqlCyVOdZ0Yng9yzKJFVWr%2F%2FFAk8hibLuhbRW3VrUNGgpFnHGI8gQi0jcyhiix1qnyj84qJZYCzXjV1dTE1LmRf5wgSIpsjQHLjJ9JzJOwEHPU4P6pN%2B9OAVxLJQGUVEO0zODFIxrNRBrXX0HldbQT%2FPQcZb2iyrEjE%2B284cxo1wb%2FTNrkAlLnsw%2FZWk9IPkqJnS%2BXWnbVn8RMJJgGW6qDr4NNjWDlZFgjU2d495F9%2BbEfW%2Blx1xwWs1qI6qgsGbY7POSd9M0nqPlaGmjR3ANNosbQb7VSdEZBgLQssXKskDKewzYKibFEifKEGUVPdwKH63ih0UCUxkuTUgamIvDGm4T%2BVpm1EZJFmsW4Ae8UZEwwKZlaFSBFdLAhe2sgheMKudbtlnO5i9Dt2GYoWme5UNvtZrtTuu%2BRjyP1jzvyKsduZ1GDbcd4rnEa4C%2Bwvp9f4Q9vN8eX3Ud3fgBzxVamtXvx5Sf6TaiZ9zva0e1hxiVa34Ra14d1IKpJdCCqbsA%2F0jX%2Fwln%2FXtYjmzg9hvT3pj2xrR%2FzTR4IBWeUhJg49twGoc1B77mwG36TddvOPV2x3HbrXeO4zuOgUCVLgAu4C2tvqKo94M7E301a%2BEP8Xjw8ZxGs%2FPb8dfx9%2FHgfDZ7PJ19vj697DsiOnw4RstfjMxp8egKAAA%3D)