### PR TITLE
Specific, 2 templates

### DIFF
--- a/specific.dev.custom-domain-apex.json
+++ b/specific.dev.custom-domain-apex.json
@@ -1,0 +1,41 @@
+{
+  "providerId": "specific.dev",
+  "providerName": "Specific",
+  "serviceId": "custom-domain-apex",
+  "serviceName": "Custom domain (apex)",
+  "version": 1,
+  "description": "Point a root (apex) domain at your Specific service.",
+  "variableDescription": "apex-a group: ip1/ip2/ip3 are the Specific ingress IPv4 addresses (A records). apex-cname group: target is the Specific ingress hostname, applied as an APEXCNAME for providers that support apex CNAME flattening.",
+  "logoUrl": "https://specific.dev/icon.svg",
+  "syncPubKeyDomain": "specific.dev",
+  "records": [
+    {
+      "type": "A",
+      "groupId": "apex-a",
+      "host": "@",
+      "pointsTo": "%ip1%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "groupId": "apex-a",
+      "host": "@",
+      "pointsTo": "%ip2%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "groupId": "apex-a",
+      "host": "@",
+      "pointsTo": "%ip3%",
+      "ttl": 3600
+    },
+    {
+      "type": "APEXCNAME",
+      "groupId": "apex-cname",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/specific.dev.custom-domain-cname.json
+++ b/specific.dev.custom-domain-cname.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "specific.dev",
+  "providerName": "Specific",
+  "serviceId": "custom-domain-cname",
+  "serviceName": "Custom domain (subdomain)",
+  "version": 1,
+  "description": "Point a subdomain at your Specific service.",
+  "variableDescription": "target is the Specific ingress hostname to CNAME the subdomain to.",
+  "logoUrl": "https://specific.dev/icon.svg",
+  "syncPubKeyDomain": "specific.dev",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two Domain Connect templates for **Specific** (`specific.dev`), used to point a
custom domain at a Specific service:

- `custom-domain-cname` — CNAME a subdomain to the Specific ingress (`hostRequired`).
- `custom-domain-apex` — point a root/apex domain at the Specific ingress, with two
  `groupId` variants the caller selects between:
  - `apex-a`: one `A` record per ingress IP (`%ip1%/%ip2%/%ip3%`) — universal.
  - `apex-cname`: a single `APEXCNAME` to `%target%`, for providers that support
    apex CNAME flattening.

Synchronous-flow requests are signed; `syncPubKeyDomain` is `specific.dev` and the
public key is published at `_dck1.specific.dev`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://specific.dev/icon.svg` (200, `image/svg+xml`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `specific.dev` on both templates; sync requests are signed
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — N/A, `redirect_uri` not used
- [x] no TXT record contains SPF content — N/A, no TXT records
- [x] `txtConflictMatchingMode` is set on every unique TXT record — N/A, no TXT records
- [x] no variable used as a bare full record value — the bare variables are `%ip1/2/3%` (A-record `pointsTo`) and `%target%` (CNAME / APEXCNAME `pointsTo`), each inherent to its record type (cf. `approximated.app.arecord`, `saaskevin.com.widget-custom-domain-apex` for A; `monpetitbistro.com.website`, `moodiycloud.com.lms-apex-cname` for APEXCNAME `%target%`)
- [x] no bare variable is used as the full `host` label — host is `@` on every record
- [x] no variable is used in the `host` field to create a subdomain — placement uses the `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` set to `OnApply` where needed — N/A, no records the user must independently modify

Note: `custom-domain-apex` carries two mutually-exclusive apex groups (`apex-a` /
`apex-cname`), so each is tested with its group selected (applying both at once
intentionally conflicts — the same structure as `vercel.com.website`). The linter
emits info-only `DCTL1038` for the APEXCNAME record ("not widely supported"), which
is why `apex-cname` is offered only to providers known to support it.

## Online Editor test results

**Editor test link(s):**
- [Test specific.dev/custom-domain-cname example.com/api](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGlrIGoC%2F91Uf2vbMBD9KkIw2FjsqqmdpobBSjtYV1rSrWWwEoxiXRJ1tuVI57Rp8HefZMf5sabb%2Fh4E4rPund57d%2BclRciKlCPQaEkLreZSgL4QNKKmgESOZeILmNPO%2BuyaZzaXflud2hMDei4TqEFJaVBlnlAZl7mX5C55nbGCntU5pMkhb005ah7f2cw5aCNVTqPDDhVgEi0LrGM6UDJHwsk6nXAkC1Vq0lIhq2t8V4dryUcpnO%2FUQK4ngEQaglPY4GQ%2B0WAMmSqDjjFBRc6uT68%2B1WmbC1G50qmaqDud2nJTxMJEBwfbTh3IROW%2BmU%2Bc7EWeDMrRJSzO6wIvTXU3foVZKTVY91CX0KEaEqWFodH9kuKiqB1zZFbpNvzo2uHsMLfKhm8aWW%2FsW0TL66jHWDWsOvRZ5RBvyg2tpS0PeOK27eAnKtvU5YW0wUSrsohlCym45plx09GC73fQwxZ%2BX%2BNt2NBxL1bG%2BjuqHTM5yZWG2Nh%2FjqWGVntWpihj%2Fsg3r0QS86JIF1aIsae27Etf8mawGv6CI7fB3ru3HOrQWCROlnRzy8Yh67PgyBOj7okX8CD0%2BqPjrieCftAT4zGEfbG1BPsW5O9rsGOz5QY5Su4G6TR95AtDq2rYsZb%2Fz%2FrseBg%2BBxFzl9ll3Z7H7O%2Fo9vA4Ck8iFvrBYe%2BE9d4zFjHm9IDBRvGyfq4ncZuZv4eL%2F2Dcvi%2FXn4Ea1c7la9b983K4xajcorqB3Luom4b5W8X83f78qZF2fytneQoJWrec8t868rpuC9zeLKpmP68GD5ejwZSb2Sw8vghuZvj8%2Beau%2Bx1L%2FuP2Mi%2FG5dPz%2BZfw5gOtfgHff5DxEgYAAA%3D%3D)
- [Test specific.dev/custom-domain-apex example.com/@ (apex-a)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPtrIGoC%2F%2B1WDU%2FbMBD9K5alSSDaNF%2F9INIkKigCTYNKA7QNVZVJ3OItjTPbKXRV%2F%2FvOTkKbtYwxQGISUqs25%2FOL33vns%2BdY0UkaE0VxMMep4FMWUXEc4QDLlIZsxEIrolNcuxs7IRPIxZ%2BKURiRVExZSM2kMJOKT%2BoRnxCW1ElKb5cJxcx9k4LyFLSlc7YhaUqFZDzBgVPDEZWhYKkyz7jPWaIQQYJzVeSXs4lCM54JVK4GFa%2ByNCARjFzF9KACpqfXCRoLnqUBYqnTYKkLXw8RQZG6pksslowFlRId96c%2BIlGkH6hEW10kaMhFJLctZODCBJiVkIqIMVWIyc1g11wqnV6DqWnMaISIRCRB3X7v8%2F5J92MPjbhApdgaBDjKLE25UOZtqMgCzxRNAFZzjfmYn4sY%2BF0rlcqg0Vh1r8FCnlhyOtZezJKwn119oLMDI%2BG60QU5HFzOsZql2rIuhA0943EuIYQ0F3je09WhPZJnHB7fgajvIKQUrMdr2fai9s9A7nMBefcClbqvAxpb7wfNja7iDhY1%2FJMndLgUcQDlXCpNbwlsNmqFfFLFNW8eMjOhZAMTUyLIROqdWUJcVjAGJcgloAwKmCoEmKEDnuW4tuX48Lvr53FXx1sQ6LhWu205bSePezrudCCxaXVg2DP5OVs9VFSyVSkbTZyNEy7oUMIvUZkAdZXIaA1PslixIbkhy1AUDnX5z0AnCaMAWy22JG8VWpqIKAJ%2FqwRWNK%2FhYRRqiZjpP47XjlrNUd1zKKn7xPbruyPq1v2Wd9WMOi3H2W2tNLNNje7Bdrbim%2B4IiWJE77xufENmEi9%2Bq9J1KlXN%2F2sq1TJ51VQGNdiKb1X2VmUvW2XQKiWZ0mhIdJ5ru626DR%2FvzOkEthN4juU33V3X3rHtwLY1GSpVznNu%2Fpt2v7osq7oQcypZ36S%2BzczvLjlmVtmjN7foh84hkjK8PEJ0Q8%2Bbc%2BUmUB6VhUkwx1oBs6rmFPZtXI05Kv9AU%2Bu9maU50dZ2qjnP1orenGbr9fPyOnUfqVGVzuYd8VdAVQWeAFQV7Z4bUwH4hBIobiqvzeQ9vOE29aDVz2Lzs1j8WHsHC70daUxDBb1L96HltRpGVi91uN8UZ0cXh17mHVwdnZ53bg%2Ft5Gvk70%2Fpj9744vT7zpd20oj9HdI7f48XvwBjMb%2BBYg4AAA%3D%3D)
- [Test specific.dev/custom-domain-apex example.com/@ (apex-cname)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGRtIGoC%2F91WDWvbMBD9K0IwaKnj%2BCOfhkFDW1gZKynNxlgIQbHVVFtiuZKcNAv57zvJdhOnSUvXMMogIdbp7sn33t0pS6zoNJkQRXGwxIngMxZRcRnhAMuEhuyWhXZEZ9h63LsiU%2FDFN%2Fku7EgqZiykJihMpeLTSsSnhMUVktCHtUMeeWZcUOaCjrTPMTjNqJCMxzhwLRxRGQqWKLPGXc5ihQgSnKvcv4gmCi14KlDxNig%2FytaARDAymtDzEpgOrxA0FjxNAsQSt8oSD74%2BIoIidUfXWCweCyoluuzOaohEkV5QiY46SNCQi0ge28jAhTFkVkAqIsZUISZ3g91xqbS7BaHJhNEIEYlIjDrdi%2B9nV50vF%2BiWC1SQrUEgR5kmCRfKnIZyL9BM0Rhgda4TPuZfxQTyu1MqkUG1uqlelYU8tuVsrLVYxGE3HX2mi3ND4VOh8%2BRw0F9itUi0ZB0wm%2FSMxhmFYNK5wPpUV4fWSPY4LD8AqR%2FApBS8j99wnJX110DeoYD8vUAF708Bjaz7QTOhy7iDlYV%2F85gO1yQOoJwLpukDgWajdsinZVxz8pCZgM3DITghgkyl7s4Cpl%2FCGRRAfUAa5FBPYUAUbfRt13Nstwa%2F7Vpm97S9AYaWZzebttt0M7uv7W4LHOt2C7Z9459lrbfyirZL5aMJYOOYCzqU8EtUKoBlJVJq4Wk6UWxI5mRtisKhboMF8CVhF2D7O5WJs9GhqYqIIvC48%2FQNKSw8jELNGtN6Op5LRo1Ro0KcZlSpNdq1SsuN2pU2uSVh1KrV6j7dmHG75t%2BLU25DTj0oYsWIbsjOZE4WEq9WAwtq4T9OD4pDkhmNhkT7eY7XqDjw8XtuK3Cage9BFbXrDffEcQLH0clQqbJ0l%2BbZFPnma9nlFzG1bP%2BUeo4vH8e7iSqqch9vz3cgSRheN44u4awcSzNwSyuIsTfA7LI4z6lohsQzaWq%2Bd2dpenirhfMO3mrgvH%2B32tf6Fzx1XslROZ2tEf8aoDIDbwAqk7bnrsgB31AC%2BaX13kQ%2Bxdt3CMEvS30QmQ8i8WvlfZQiuyrfvxz5lb5HkgOWqB5TdEJDBTNdz%2Bfy%2FyLY3bzi8fX1vbw6aTL3l193WePb%2FNM9T2aj%2BY%2Bx2zs7D3vVefWGd056F83WR7z6A2wvL2d4DAAA)
- [Test specific.dev/custom-domain-apex example.com/api (apex-a subdomain)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANttIGoC%2F%2B1XDW%2FbNhD9KwSBAi1qyfqyYwsYUKMpmmBol27NPhAYBi3RDgdZ1EjKjWP4v%2B%2BOkmJrtpdlzYp0KGDD0fH4xHvveHdZU8MXRcYMp%2FGaFkouRcrVeUpjqgueiJlI3JQvaedu7T1bgC%2F9qV6FFc3VUiTcbkpKbeTCSeWCidxhBb%2FZOtQ7X1sXUrmQ5%2BjzApyWXGkhcxr7HZpynShRGPtML6TIDWFESWlq%2F2Y3M2QlS0Wa05D6VS4CMiXYNOOnLTDc7jAyV7IsYiIKvyuKAL4hYYoTc823WCKfK641Ob9YRoSlKT5wTZ6PiOKJVKl%2B4RILl%2BQQWQNpmJpzQ4Q%2BDHYttUH3DmwtMsFTwjRhORldvPn19fvRuzdkJhVpyEYQiFGXRSGVsW8jtRdoZngOsBhrJufyUmUQ37UxhY673V31uiKRuauXc9RilScX5fR7vjq1FO4LXQdH46s1NasCJRuB2YZnNa4oBBPGAs%2BvMDtQI%2F1RwuMzIPUZmIyB84R9z9t0%2FjVQ8FhA4VGghvd9QCvrcdBK6DbueNOhtzLnky2JY0jnhml%2Bw%2BCycTeRiy0uK0Tz7omwW5p4YGvBFFtovJsNyFULZdzAXFmccQ3UBgFB0BC6fuC5fgS%2Fw6iyB2jvg2EQuCcnrn%2FiV%2FYQ7f4AHHvuAJZD619FjEt1Nrut1MHgxTyXik80%2FDJTKmDYqJJ36KLMjJiwT2xrSpMJXoEVcKVhFWDbCZdX5aKiJ2WGwUM7hB3mO3SSJkiTQPmCWTKdRVHf6U2joRP5%2FsCZJtHASQfhcMims3DQ7%2B2UtEPl7t6i1lIPK0NuBMMbOMo%2BsZWmm79k66Fw2sx%2F9eG0E%2BaJhzPuwNX8lnHfMu7LZRyUUM2WPJ0w9Ay8oO948Ak%2F%2BoPYG8ah73q9MOr3X3pe7HkYDteminRt%2F7aNYPdgbvsotmO5v2ucdNZ3A5Dd1dTuw6X7AT0KW9oGpwQs2q0poWmjW6HcHTC3LU8t4MHT2Db6N2Ei44ejtJ1u787aPreX%2BrbL7WfQf8%2FT6IEctcM5eivuB2oz8BlAbdKOTFM14GekQD3BPDWRX9EDU9a9Uj%2BKzI8i8UPlvZOiGoifvhzVOY9J8qgpal%2Fl6HLanPFJF6QvTg%2F7yqj5Jxf5%2F1GzxxvssTzjiYGBBIcLBNqRC5Z3%2F42jt95l78z78Mvt6I%2FLRbd8F94Uwx9%2FWJ2ds7dvz4OfT3%2BLMh5cfjjrvpTf0c2f1tFcUVgSAAA%3D)
