### PR TITLE
Create zblocks.app.website.json

### DIFF
--- a/zblocks.app.website.json
+++ b/zblocks.app.website.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "zblocks.app",
+    "providerName": "zblocks",
+    "serviceId": "website",
+    "serviceName": "zblocks Website Hosting",
+    "version": 1,
+    "logoUrl": "https://zblocks.app/logo.png",
+    "description": "Connect your domain to your zblocks website",
+    "syncPubKeyDomain": "domainconnect.zblocks.app",
+    "syncRedirectDomain": "zblocks.app",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "groupId": "cname",
+            "host": "@",
+            "pointsTo": "sites.zblocks.app",
+            "ttl": "3600"
+        }
+    ]
+}


### PR DESCRIPTION
# Description
New Domain Connect template for zblocks custom domains. Users connect a domain to their zblocks site by applying a single CNAME pointing the connected host at `sites.zblocks.app`, the zblocks Cloudflare-for-SaaS routing endpoint. TLS is issued automatically at the edge via HTTP DCV once traffic routes through us, so no verification TXT record is required.

`pointsTo` is the fixed value `sites.zblocks.app` rather than a variable because the routing target is shared infrastructure — identical for every domain, with the specific site resolved from the Host header — not a per-user value, so there is nothing for the user to supply.

`hostRequired` is set so the record applies at the host the user is connecting (e.g. `www`) rather than defaulting to the apex.

## Type of change
Please mark options that are relevant.
- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?
Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems
Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.
- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead _(N/A — this template has no TXT records)_
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) _(N/A — no TXT records)_
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description _(N/A — `pointsTo` is the fixed literal `sites.zblocks.app`, no variables)_
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description _(N/A — `host` is `@`, no variables)_
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead _(uses `hostRequired` + the `host` parameter)_
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) _(N/A — the single CNAME is the essential routing record; there are no optional records)_

## Online Editor test results
**Editor test link(s):** 
[Test zblocks.app/website corelith.io/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIduIGoC%2F91S7Y7aMBB8FeS%2FDZCQg7uLVKmIa3XXD6hOtFcVocixt8FqsHO2QwiId%2B86afhoq3uASpEie2d2Z8a7JxbWeUYtkGhPcq02goN%2B4CQiuyRT7Kfp0Twn3rE0pWs4FbFgQG8Eg5pSQmIEtjreXqI7T029c6%2BMFTJF3Aa0EUqSKPBIplL1RWeIX1mbm6jfP5PQd9VeXpM4GKZFbmsimSgpgdlOpQrd4WpNhexY1RzbwWfCKsk%2BF8kHqO5qKDZoOKxp07u07eCPwIXG0pFwCVmhmUd4LhCDGVhdgEcQrjQ3JFrsia1yl8FkOv70FuGpVkVep8WkS6dpgMc3LmUlpDVzhUen1%2FyhxlqXTjjyfXJYHjyyUxLi06yl99uLa640ZMKuekKdRpRl2SqIRUvJqaZr456%2FJS8u2MuWvqj5bq5IJQJig39qCw2t7XWRWRHTkp6uOItRe1ahTINV7PJ3JLLZkkYdp5a%2BZN%2B590jMmVMsXI4%2B%2FEiCEHiXB8Ob7hWEvJsEbNiFEU3C4TDk1wj2Xlruf%2B%2FwRWhgDEgrqHuAcVbSypDDYelhgP%2BTH3xrQzfAY%2BqQA38w6vr4hfPgJgoG0SDs3QZX18Hwle9HuIRoAYxtHO5xL843gpSD0cf7yXZWhvNq%2B3A3ffbZOxO8346vd34%2Bu%2F32lNDq6%2Fd0NgnS1%2BTwC7pzCj%2BJBAAA)