### PR TITLE
Add peloran.com.email template

### DIFF
--- a/peloran.com.email.json
+++ b/peloran.com.email.json
@@ -1,0 +1,42 @@
+{
+  "providerId": "peloran.com",
+  "providerName": "Peloran",
+  "serviceId": "email",
+  "serviceName": "Email",
+  "version": 1,
+  "syncPubKeyDomain": "peloran.com",
+  "syncRedirectDomain": "app.peloran.com",
+  "description": "Configure DKIM, SPF, MX, and optional click-tracking CNAME for transactional email.",
+  "logoUrl": "https://www.peloran.com/peloran-logo3b.svg",
+  "records": [
+    {
+      "groupId": "outbound",
+      "type": "MX",
+      "host": "%spfDomain%",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "groupId": "outbound",
+      "type": "SPFM",
+      "host": "%spfDomain%",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "ttl": 3600,
+      "data": "p=%domainKey%"
+    },
+    {
+      "groupId": "click-tracking",
+      "type": "CNAME",
+      "host": "%clickTrackingSubdomain%",
+      "pointsTo": "%clickTrackingCnameTarget%.resend-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Service provider: **Peloran** (`peloran.com`)
- Service: **email** — merchant transactional email DNS (MX, SPFM, DKIM, click-tracking CNAME)
- Based on `resend.com.mail.json` (same SES/Resend record shape)
- `syncPubKeyDomain`: peloran.com
- `syncRedirectDomain`: app.peloran.com
- Synchronous signed flow (RSA-SHA256)

## Public key DNS
`_dcpubkeyv1.peloran.com` TXT (published on peloran.com before provider onboarding)

## Onboarding
After merge: Cloudflare (`domain-connect@cloudflare.com`) and GoDaddy (`domainconnect@godaddy.com`).