### PR TITLE
Add emajl.io email template

### DIFF
--- a/emajl.io.email.json
+++ b/emajl.io.email.json
@@ -1,0 +1,41 @@
+{
+	"providerId": "emajl.io",
+	"providerName": "emajl",
+	"serviceId": "email",
+	"serviceName": "emajl — email sending and receiving",
+	"version": 1,
+	"description": "Sets up emajl to send and receive email for your domain: inbound MX at the apex, DKIM, and SPF/Return-Path at the send subdomain. No nameserver change.",
+	"syncBlock": false,
+	"syncPubKeyDomain": "emajl.io",
+	"syncRedirectDomain": "emajl.io",
+	"records": [
+		{
+			"type": "MX",
+			"host": "@",
+			"pointsTo": "inbound-smtp.eu-west-1.amazonaws.com",
+			"priority": 10,
+			"ttl": 3600,
+			"essential": "OnApply"
+		},
+		{
+			"type": "TXT",
+			"host": "resend._domainkey",
+			"data": "%dkimvalue%",
+			"ttl": 3600,
+			"essential": "OnApply",
+			"txtConflictMatchingMode": "All"
+		},
+		{
+			"type": "MX",
+			"host": "send",
+			"pointsTo": "feedback-smtp.eu-west-1.amazonses.com",
+			"priority": 10,
+			"ttl": 3600
+		},
+		{
+			"type": "SPFM",
+			"host": "send",
+			"spfRules": "include:amazonses.com"
+		}
+	]
+}


### PR DESCRIPTION
# Description

New template for **emajl** (emajl.io) — an email service that sets up sending + receiving for a customer-owned domain: inbound MX at the apex, DKIM TXT, and SPF/Return-Path at the `send` subdomain. No nameserver change.

## Type of change

- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — links below (apex + subdomain)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] `logoUrl` — not used (N/A)

Also validated with the official `dc-template-linter` (exit 0, no findings).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`emajl.io`; public key published and resolving at `_dcpubkey._domainconnect.emajl.io`)
- [x] `warnPhishing` is **not** set
- [x] `syncRedirectDomain` is set (`emajl.io`)
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode: All` is set on the DKIM TXT
- [x] bare variable as full record value: the DKIM TXT data is `%dkimvalue%` — **justified**: RFC 6376 dictates the DKIM key record content verbatim (`p=…`, the per-domain public key issued by our email provider); it cannot carry a fixed prefix
- [x] no bare variable as the full `host` label — DKIM host is the fixed label `resend._domainkey`
- [x] no variable in `host` to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential: OnApply` set on the apex MX and the DKIM TXT (records the user may need to manage)

## Online Editor test results

**Editor test link(s):**
- Apex: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB6nIWoC%2F%2B1VbU%2FbOhT%2BK5alfaLpklICi4S0lDJWsTAKXMS9XFS58UnrixNnttPSIfbbd9wXmm69d9P9sn1AihT7vPo5zzn2I7WQl5JZoNEjLbWaCA66x2lEIWf%2FyKZQtPEsP2M5rDQoNqAnIoWVtajJ6pbk76rlB20yNyEGCi6KEWEFJxpSEBPcoeMEtBGqoFHQoBxMqkVp53t6CdaQqiSLYFbNQ9T8YRk5U5rMVKUJV7gvIiKKoarQLLkhzBI7BsJKeGiQ7mkvacwDXJ6%2Fe30BttKFd87seGU2T2Cq4SJQk5wpUiAghw00ScesGEHTgZ0VaUeq9J5GGZMGFpLzangKs%2B7cd7OOTnsBXOC57TY9ypXmhka3j9TOSlfB5AblY2Usrt86KpQorLlSuF3C80xuyyZU3hSM9YImy9lnVbCpaaYqn5MnlBZ2hpX1G9RaSaPd0MclGMRpBUMB%2FVjEZSln9KnxnPnq5mqdWoOrSXOwqMg9zFDFmWWoesXvRT5hsoJX9Ifx0eDBHqkikyK1CbPpGNlPFHcJYynr%2BevIXfJN8BkAH7L0fjt6Az9AX8uDPZB8l8mU2UUlwczLnMqKQ7QZ%2BenuqUFxD4M1aXdYky2sLiPjaqRVVQ7EyrhkmuXGDd7K7Xbtd7dyvKVu%2FVxkJygPk95JlsT%2BydHlp5PL3nC32z%2FuxP0%2F4rh9chZ3jzqif9oZ9bvwwHC6oR93qDuvGBVKw8Dgn2HTYyyrK%2BzavJJWDNiUrUU8HTDHGMIzqMWs3%2FRksZjwt%2BtG%2BMl%2BrHXIJjkDnrpaCHedBG%2BGrXS4d%2BC1ADKvHcCB9yY8OPD2eMCzgIXMZ2ntYvr2wtp2M61p2Nr433X%2BEuB%2FdP7%2FoWED%2F2%2BDuM7ocgKWGH92zn4vVmM5ZTPz76RuYpwc4rgHZOugky9MyhU%2BhPfLEd018Op4mcWXWXyZxV8%2Fi%2FgwGzYBPmDOrOW3Qs%2FHr30VhFErjPyw2fbD%2Fb32ju9Hvu%2BOjowtkD7ie1x%2Fien71oMc74yTqcmv%2F%2BqM%2FxS93f3O3qgDx%2B2Pr7l9%2F%2Bk4Sz68C%2BPrvH1In74CxuSQDbkLAAA%3D
- Subdomain (host set): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFenIWoC%2F%2B1VbW%2FiOBD%2BK5al%2FXSETYDSNlKlC2WvYiu6UFqpp26FTDwB0yTO2Q40V%2FV%2B%2B41Ds022rHa1n%2FqhEhKZ8bz4mWdm%2FEgNJFnMDFD%2FkWZKbgQHNeLUp5CwddwWkra%2B6S9YAtUJqjWojQihshY1Xd2SfM07rtcjpQnRkHKRLglLOVEQgtighI4bUFrIlPpei3LQoRKZKWU6A6NJnpFdMCPLEDV%2FeI4cSUUKmSvCJcqpT0S6kDmajW8IM8SsgLAMHlpkeD4at8oAs8lfHy%2FB5Cp1JsysKrMygc4Xu0BtciFJioAsNlAkXLF0CW0LtkjDQSzDe%2BpHLNaw00zyxTkUw9K3WUd7eglc4L3NvnPUS8U19W8fqSkyW8HxDepXUhv8%2FtNSIUVq9JVE8RmeoxOTtSF3tqCN47VZwv6VKdvqdiiTkjwhlTAFVtZtUWNi6nf7Ln6CRpxGMFTQL2mQZXFBn1rfMl%2FdXL2kVmBr0p7vKnIPBR5xZhgefeD3ItmwOIcP9Kfx0eDBnMo0ikVoxsyEK2R%2FLLlNGMRxPX8duU3eBB8B8AUL7%2Fej1%2FAT9LU82APjV5l0Fl3mMeiyzGGcc%2FCbkZ%2FunloUZZi%2FkHaHNdnDahU5X6CwVDLP5qKyz5hiibazV3nevrjeVb63pbMNX5Xa6rKT8egsGgfu2ensn7PZaNEdTj8Ngul1EPTOLoLh6UBMzwfL6RAeGM44TIMBtbcWy1QqmGv8Z9j6GMuoHHs3yWMj5mzLXlQ8nDPLG4LUeIpZv%2BvMdDfnO2zPDfGLfVnrlCZJcx7aggi7ViLuHQCLjh1%2BdHDs9Ba86xx50HFY2It4P3Q9dtitLajvF9e%2BDdWgY%2B8MvBqCZ5SvhqDdwP07fDTK8JaAN9i1qBtQf3X63hzHQbxlhf4xxa%2Bhbk5wF3hk7xYg%2F7E4rmAiyrcA7K6Fe%2BV9St%2Bn9H1K3%2FKU4mOu2Qb4nFnLjtvpOy7%2Belde3%2B8c%2Bm633T86dI%2B8P1zXd117e%2BRuB%2FYR3%2FD6602vt9HhF%2FW5l%2FSvC8iXur%2B%2BWV%2BPRp%2F%2FPph2J7NhsD4Wk9l6BJtOcEKf%2FgcI2ohL8wsAAA%3D%3D