### PR TITLE
Add crossly.net.storefront-subdomain template

### DIFF
--- a/crossly.net.storefront-subdomain.json
+++ b/crossly.net.storefront-subdomain.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "crossly.net",
+  "providerName": "Crossly",
+  "serviceId": "storefront-subdomain",
+  "serviceName": "Crossly Storefront",
+  "version": 1,
+  "logoUrl": "https://crossly.net/logo.svg",
+  "description": "Point your subdomain at your Crossly storefront for one-click setup with managed HTTPS.",
+  "variableDescription": "host: the subdomain label (e.g. 'shop'). verifyToken: ownership proof issued by Crossly during the connect flow.",
+  "syncPubKeyDomain": "crossly.net",
+  "syncRedirectDomain": "crossly.net,www.crossly.net",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "storefront",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "domains.crossly.net",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "_crossly-verify",
+      "data": "crossly-verify=%verifyToken%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template `crossly.net.storefront-subdomain` so Crossly sellers can attach a custom subdomain (`shop.theirbrand.com`) to their native storefront in one click instead of pasting a CNAME by hand.

Crossly is a multi-marketplace crossposting SaaS for resellers, with a native Crossly storefront feature; this template covers the subdomain-only flow (`hostRequired: true`). A future PR may add an apex flavor once we have the ALIAS / ANAME story sorted.

Live, verifiable template URL (identical content to the file in this PR):
https://crossly.net/api/public/domain-connect/templates/crossly.net/storefront-subdomain.json

Signing key published as `TXT _dck1.crossly.net` (`p=1,a=RS256,d=<spki-der-base64>`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver


# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `crossly.net`, with the public key published as TXT `_dck1.crossly.net` (`p=1,a=RS256,d=...`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — omitted intentionally
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — `crossly.net,www.crossly.net`
- [x] no TXT record contains SPF content — N/A, only a single namespaced verification TXT
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — N/A, the `_crossly-verify` label is service-namespaced and not shared with DMARC/SPF/etc.
- [x] no variable is used as a bare full record value — TXT uses prefix form `crossly-verify=%verifyToken%`, not bare `%verifyToken%`
- [x] no bare variable is used as the full `host` label — `_crossly-verify` is a fixed label
- [x] no variable is used in the `host` field to create a subdomain — the apply-time `host` query param drives the subdomain via `hostRequired: true`, records use literal `@` / `_crossly-verify`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — the CNAME is marked `essential: OnApply` so registrars warn before overwriting it

## Online Editor test results

**Editor test link(s):** [Test crossly.net/storefront-subdomain example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANcVTWoC%2F%2B1UeWvbMBT%2FKkZQulHbsXPXUFi6Frqry1oXSkswsq0korbkSXI8N%2BS778l2zgW2P8cYBIKld%2FyOp7dEiqRZghVB3hJlgi9oTMSHGHkoElzKpLQZUcjcXN3iFELR%2B%2FoSLiQRCxqRKkUqLshUcKYsmYcxTzFl25D9VON%2BEwwhCyIk5Qx5rokSPuMPIoHQuVKZ9FqtHSgtfWvLxQySYiIjQTNVJaIxp0wZJc%2BFsWlu4OZk3XSL0JhyYXBGrCih0Yshicozo6BqbqSY4RmJjRvfH9%2FbGhwWFIcJudrrN%2BdSeYaak223BIckMd4Qe2Ybp3LOs9O3tgHU6LT0%2BQthHi8YEJ3TzAA9%2BdSgUubQKSw3AONcUDbTZSPOGIkAZ8ILjUKWLBrn4SdSXtXCHlqkA%2B5ITAVkHQsxi6Kwf025THj0grwpTiQxK1Z35HsOVcBRJXI4g4JcxBJ5z0s0EzzPDsyGQqrMKm9vR1%2BuUV0FPt%2FpwdG2SJ%2FDZ62SPMCgFFjd6TuOiYiUhCmKtfdf2SjLYMJW5m7TSkwa4cqDTVv%2F0d82DZryVi28nhOs8FaK5vziZMeYk10cq8nKRK8wGsGW%2BMRs0EMd8gPDkyF2xNNtV%2B02fFVIA7rOybDAqdRPa539vJc%2BWec%2F1wUmJtpBpY8VkapBbOEwctsdpOHRGQP1Awn%2FWOWCrK1K80TRABd4exRHAdZKAhsJt1AUbDzwi9VPsyHR6PVbu4I40tRotS0GnUHYb3ctF7eJ1XXDjjXsDqdWvxN2hkPsRO2hu7NGjmyYP1gk%2B1ofnRY9LntT0VA7mAp7n%2BrBaBwR%2FW8lPkoKXErgPTFh4P47%2By86C1tB4gWJA6xD2067bzkD%2BPluz3N6Xu%2FcPnedXrd75jie42hCwLLmv4Rdsbsl0GUq5fX0aXA3vGV9%2F8wtX8c3n8%2BevqmHLn%2B8zgfpSEa9ll9%2BDOUFWv0E8ca66x8IAAA%3D)

Tested `crossly.net/storefront-subdomain` applied to `example.com` with host `shop` (subdomain case, `hostRequired: true`). Resolves to `CNAME shop -> domains.crossly.net` + `TXT _crossly-verify.shop -> crossly-verify=%verifyToken%`. Editor content matches the submitted template file exactly.

