### PR TITLE
Update Drin email template DKIM host

### DIFF
--- a/drin.run.email.json
+++ b/drin.run.email.json
@@ -3,10 +3,10 @@
   "providerName": "Drin",
   "serviceId": "email",
   "serviceName": "Drin email sending",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://app.drin.run/icon.svg",
   "description": "Add the DKIM, MAIL FROM and DMARC records that let Drin send email from this domain. We never read or write any other records.",
-  "variableDescription": "dkim_value: the complete DKIM record value Drin supplies for this domain at apply time. MAIL FROM (SPF) and DMARC are fixed.",
+  "variableDescription": "dkim_value: the complete DKIM record value Drin supplies for this domain at apply time. dkimhost: the DKIM record host relative to the zone apex (e.g. 'drin._domainkey' or a unique 'drin-<id>._domainkey'), so a recycled domain's old key can't collide. MAIL FROM (SPF) and DMARC are fixed.",
   "syncBlock": false,
   "syncPubKeyDomain": "drin.run",
   "syncRedirectDomain": "app.drin.run",
@@ -14,7 +14,7 @@
     {
       "groupId": "dkim",
       "type": "TXT",
-      "host": "drin._domainkey",
+      "host": "%dkimhost%",
       "data": "%dkim_value%",
       "ttl": 3600,
       "txtConflictMatchingMode": "All"

--- a/drin.run.email.json
+++ b/drin.run.email.json
@@ -6,7 +6,7 @@
   "version": 2,
   "logoUrl": "https://app.drin.run/icon.svg",
   "description": "Add the DKIM, MAIL FROM and DMARC records that let Drin send email from this domain. We never read or write any other records.",
-  "variableDescription": "dkim_value: the complete DKIM record value Drin supplies for this domain at apply time. dkimhost: the DKIM record host relative to the zone apex (e.g. 'drin._domainkey' or a unique 'drin-<id>._domainkey'), so a recycled domain's old key can't collide. MAIL FROM (SPF) and DMARC are fixed.",
+  "variableDescription": "dkim_value: the complete DKIM record value Drin supplies for this domain at apply time. dkim_selector: the DKIM selector (e.g. 'drin' or a unique 'drin-<id>'), so a recycled domain's old key can't collide. MAIL FROM (SPF) and DMARC are fixed.",
   "syncBlock": false,
   "syncPubKeyDomain": "drin.run",
   "syncRedirectDomain": "app.drin.run",
@@ -14,7 +14,7 @@
     {
       "groupId": "dkim",
       "type": "TXT",
-      "host": "%dkimhost%",
+      "host": "%dkim_selector%._domainkey",
       "data": "%dkim_value%",
       "ttl": 3600,
       "txtConflictMatchingMode": "All"


### PR DESCRIPTION
# Description

Update the Drin email template so its DKIM TXT record uses a signed selector variable while keeping the security-sensitive `._domainkey` suffix fixed in the template.

This fixes domain recycling: Drin creates per-identity selectors such as `drin-<id>`, so an old key left at a previous selector cannot collide with the new identity. The DKIM TXT value remains `dkim_value`; `dkim_selector` contains only `drin` or the unique `drin-<id>` selector.

This template is version-bumped to 2. The matching Drin dashboard change is [ATOM00blue/drin#116](https://github.com/ATOM00blue/drin/pull/116). During rollout, Drin sends both the new selector and the legacy full-host parameter so the currently gated template continues to work until Cloudflare refreshes it.

## Type of change

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern <providerId>.<serviceId>.json
- [x] resource URL provided with logoUrl is actually served by a webserver

# Checklist of common problems

- [x] syncPubKeyDomain is set — this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] warnPhishing is not set alongside syncPubKeyDomain — the two must not appear together
- [x] syncRedirectDomain is set whenever the template uses redirect_uri in the synchronous flow
- [x] no TXT record contains SPF content ("v=spf1 ...") — use the SPFM record type instead
- [x] txtConflictMatchingMode is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. @ TXT "%foo%") unless necessary — `dkim_value` must contain Drin's complete per-domain DKIM public key
- [x] no bare variable is used as the full host label — `dkim_selector` is scoped by the fixed `._domainkey` suffix
- [x] no variable is used in the host field to create a subdomain — the selector is provider-generated, signed, and limited to the DKIM namespace
- [x] %host% does not appear explicitly in any host attribute
- [x] essential is set to OnApply on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- Apex test: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMg%2FJmoC%2F%2B1Vf2%2FbNhD9KgSBIC1qK%2FKvJFOXAUrcBF7mxs3StVsQGDR5djhTokpSTrzA%2B%2Bw7yrIttynaAQOWPwIYsHR3unv3%2BO74QB0kmWIOaPRAM6NnUoDpCRpRYWQamDyltbX9LUswjnbRg1YLZiY5FMGQMKk2tkogKVzEQipkOsGQGRgrdUqjZo0qPdHvjcLQW%2BcyG%2B3tsSwLVpX3JNdpYGf%2BKwGWG5m54ksaC0HcLZDuea9fI%2F249ws5vbzoE5YK0u3HlyfEANdGWIxijihwpMDiUZSAxkYn6JWWCI2GNCAfgKSA6PBbJog25M5IB5hzTjQWM6ucgW%2BCGclGCrpbsMRUJsMZUzlEBTyukVtwS5zl56Twl3DyLFMSLBljtQoWgpiRCDUnTiYQkCKvBQXcaROtOycrE3kBwSQgu564XY%2BckTyVn7BMYar%2FKMVPuy9rxGr0IIw5VyDKWruWaCXIFOaEs3TXIWil8LCDCq0vfh2cvqyQywyQsbwH4amw85QfK82nNBozZWFpGeSjc5h3ixLbYvLeSxAScbi1v3rsGFMyTaPrBzoxOs%2BWikQa0OnmmRfX1ccrfLnV1uHLzhZFO8Fw2Rx25bXDHFvHFPTv%2BDQOddfaD0N8vHcnOh0ryV2fOX6LQu1r4YvEStFFrQrCi8drZwOk%2F3GDwwvMD4yWqbNXGi1jADFifFq3icuC3NaBWVdvBCxhf%2BnUgg14kSwzUqPe5jRqhBVw3yqOJ9P%2ForzNxpe5AuSPypSrXED0ebmvFBAJM%2FwrHA9XzpLP2VGhhsZrkh2lOoXX30vqwACqhz4aUvo22TEMLPblJPN74iKN%2FWDQxc2iRrEjGG60coPQVoKCe%2BZnr%2By27ACfilaHsohfCarC6rJFTJQxwxLrl%2BIq5fVWzptV0mvqn4u030i5JdEi1s8ma4yavCXa0Bnvr6MKkfoQZAEHHSmeHhnLPNP9Xu%2B492f89ngy%2FXQ7lWc%2F3IXH8bs3p3F8cRK%2FO4y9%2F2Ryjs9vYgfW%2BRHwXMlJqg0MLf4zlxvM7kyOw5rkyskhu2Mbk%2BDDYvsgtRa9iAPHcEsR6XK%2Ff9HAo3P33%2FSwpa2h4P5opJfsqB22mm3RrjM%2Bbtbbzca4zgCgHsJBp3NwyDudUbNyh31%2Btz12i23kUpVerO7Y3NKFn5jq6JdklLNXNv29Y19pansDPJUWtw58u8fZES6aBnl0xZC%2FmVJP89C2OvqXS%2B1%2F6WG98xY3NVxyz8P4PIzPw%2FgEhhFva8tmIIbMxzXD5n49xN%2FhVdiOwv2o1QzCw2az03gVhlEYeuw4PsvWHvBGrt7F9OffDt4baLQuEjg5e3UwOkvDPxqjV73B1YfBvWaD7rzdv%2Be%2Ftw77%2FIgu%2FgEitMZwtw0AAA%3D%3D
- Subdomain host test: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN0%2FJmoC%2F%2B1VYW%2FbNhD9KwSBIC1mK7Idp4m6DJCTpvMSJ2mWogWCwKDFs8OaElWSsqMG3m%2FfUZZtKU3XfhiwDghgwPbd8e7d47vjA7UQp5JZoMEDTbWaCQ66z2lAuRaJp7OENtb2cxZjHD1GD1oN6JmIoAiGmAm5sVUCSeEiBhIukgmGzEAboRIatBtUqol6ryWG3lmbmmBnh6Wpt6q8IyKVeGbmTnEwkRapLU7SkHNi74Acn%2FYHDTII%2B2fk5OpiQFjCyfEgvDoiGiKlucEoZokESwosDkUJaKxVjF5hCFdoSDzyAUgCiA7PMk6UJnMtLGDOnCgsplc5PdcE04KNJBzXYPGpiIczJjMICniRQm7BLnGWx0nhL%2BFkaSoFGDLGahUsBDEjETInVsTgkSKvAQmRVTpYd05WJvICvIlHth1x2w45I1kiPmOZwtT8VfDftl82iFHoQRh5JIGXtbYNUZKTKeQkYsm2RdBS4mV7FVpf%2FHl58rJCLtNAxuIeuKPC5EnUkyqa0mDMpIGl5TIbnUJ%2BXJSoi8l5r4ALxGHX%2Fuq1Y0zJNA1uHuhEqyxdKhJpQKfNUyeu64%2FX%2BOdOGYt%2FtmoUbXnDZXPYldMOs2wdU9C%2F5dJY1F1nz%2Ffx5709UslYisgOmI3uUKgDxV2RUEq6aFRBOPE47WyADD5ucDiBuYFRIrHmWqFlDMBHLJo2TWxTLzNNYMY2Wx6L2ReVGDBeVCRLtVCot5wGLb8C7nvF8WYGX5U36fgqk4D8UZFEMuMQPC73jQI8Zjr6BsfDlbPkc3ZYqKH1mqSHiUrg9Y%2BSeqkB1UOfDCl9m%2BwYBgb7soK5PXGRhG4w6OJ20aDYEQw3WrlFaCtBwT1zs1d2W3ZQLqmi3aEozqxEVWF22SYmS5lmsXGLcZX2ppb3dpX4Zpn5tkz9nbQ1qRaxbkZZa9SOOnwXuuO9dVQhVheCbODAI9XTQ22YY3zQ7%2Ff6n8Lz3mT6%2BW4q3h7M%2FV747s1JGF4che%2F2Q%2Bc%2Fmpzi7zehBWPdKDjOxCRRGoYGv5nNNGa3OsOhjTNpxZDN2cbEo2GxhZBig17EgeNYU0ay3PNfNVCZP68kfSOaf6GRmtCGPHJ3JJx%2BWbTfHUe7frMzao%2Bbu5y1myPe9pusw%2FZG7VH3FR%2B%2Fqjxojx%2B6p560unaqWgzlnOWGLtwIVXdByYobxkfd%2F%2BgyqHRX3ws%2FU681CTzR7OwQ91CLPLmByF9Myp%2F3GmutLffe1zr%2Bp%2BX3nzWz3o%2BL2wYuxOeBfR7Y54H9nwwsvvqGzYAPmYtt%2B%2B29po%2Bf%2FWt%2FN%2FD3gm7Ha3U7B63uL74f%2BL7Dj9O1bO8BX%2Fbqm0677JP%2BvZvPp2dRb%2F5%2BJ98%2FO%2B8f%2FMFaB1%2Bms15fnp9efeBZR%2B%2FsTueHdPE3dPgr6gcOAAA%3D
