### PR TITLE
Add Drin inbound email template

### DIFF
--- a/drin.run.inbound-email.json
+++ b/drin.run.inbound-email.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "drin.run",
+  "providerName": "Drin",
+  "serviceId": "inbound-email",
+  "serviceName": "Drin inbound email",
+  "version": 1,
+  "logoUrl": "https://app.drin.run/icon.svg",
+  "description": "Enable Drin to receive inbound email for this domain by adding the apex MX record. Only apply this after enabling receiving in Drin; changing apex MX can route inbound mail away from an existing provider.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "drin.run",
+  "syncRedirectDomain": "app.drin.run",
+  "records": [
+    {
+      "groupId": "inbound",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound.drin.run",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a separate `drin.run / inbound-email` Domain Connect template for opt-in inbound receiving. It writes one MX record at the applied host, pointing to `inbound.drin.run`, and is intentionally separate from the existing `drin.run / email` sending template so send setup never changes a customer's inbound mail routing.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- Apex test (example.com): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACiTJWoC%2F91T7WrbMBR9FaG%2FTVwnddPUY7CMpjC6Ll1JWWkJRpGuE622ZCTZSxry7rty5toZZQ8wMPb1%2FTw652pHHeRFxhzQeEcLoyspwHwRNKbCSBWYUtHem%2F8byzGPXmEEvRZMJTnUyVItdalEH3ImszbWKSB%2FUkiTUoGxUisaD3o00yv9YDJMXTtX2Pj0lBVF0CA4lVyrwFYrrBJguZGFqyvpVLFlBqTu7zQxwEFWcDyKpNoQt5aWCI3%2Fiiy3hAkh1Qq9QFgBG3L76Gu1EQGZqQzjRYHvuoilDgwBP8iXHEZ4Czv5uR8IXzO18p6mFWeKGF26FkiNg%2F1iW5IanROMw0Za54sabgPP2lbxz5nmLzROWWbh4LkrlzewvarBH%2Bvio%2FcgJIJyb%2FEuc5hzOJel8fOOrhBV0dUL425beIluH9Fea%2BvQ%2FuQl11I5O9dtbnC0EFIb6bYoXogtHCp3NgrRBGtBOcm8lDM18TTS%2FWLfo69aQdJiWaCSDWDYMFxBCLjOWwxo1WgT2eQXzLDc%2BjVtKp%2BPShdN7TOlfqJcKW0gsfhlrjR4SGdKpDQvMycTFKN1CZ7UiiNAi1FsgWR1iVGHPfbECObY%2B6R0aDjmJxHcw5b1rRqLdMDGUZ9FIupHPOX9S8FF%2F3IYhuNoBCNIo86N%2B%2Fsm%2FuvOtcy9q8J%2B0UMa%2F8uDofSWVSAS5vOG4XDUD%2FG5mA%2FO4%2FMwDsNgGF1E49FJ6H%2F8icC6w3l3uCndHaH3c7OszvTs9WU6C22pVPlVTiePuX06ufu%2BMdc31z%2FmPycP86dN9JHufwPZ7AMhQAUAAA%3D%3D
- Host test (inbox.example.com): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACmTJWoC%2F91T7WrbMBR9FaG%2FS1wnbuLGY7CVdqOUrKV0kFGCUazrRK0taZKcxg159105deOUsgcYBEe6n%2Beec7WlDkpdMAc02VJt1FpwMFecJpQbIQNTSdp7s%2F9kJcbRC%2FSg1YJZiwyaYCEXqpK8DyUTxcHXSSCvIaQNWYOxQkmaDHq0UEv1yxQYunJO2%2BTkhGkdtAhORKZkYNdLzOJgMyO0azLppWSLAkhT3yliIAOxhuNWJFeGuJWwhCu8S7KoCeNcyCVagTANGzKd%2BVxleEBuZIF%2BrfHbJLHcgSHgG%2FmUfQt%2Fwkq%2B72eSrZhcektbKmOSGFW5A5AGB3tmNcmNKgn6YSOs80ktt4FnrZbZeaGyJ5rkrLCwt9xWi2uoLxrwx7p47x1wgaDcm7%2FLHMbs57I0edjSJaLSXb3Q72rtJZrO8LxS1uH5q5dcCensvTrEBkcLIZQRrkbxQizhULloHOIRrAXpBPNS3shvnka6m%2B969EVJSA9Y5qhkCxg2DFcQgkyVBwy%2B6QavDeRUtEmaGVZav6tt%2BsNR%2Frwt8PBawfcWS6kMpBb%2FmasMjutMheSWVeFEirIcTDxLG%2B0RqkUv1kHauhTJ%2FUa38Dhz7GOKOqQcs5XyzOMXXoZ4tDiNRtGkHw2Go%2F5pBOP%2BZDzM%2BpOcx0M4zfOcxZ339%2F5d%2FusFvuPxQ2F28x6S%2Bn9PiBth2Rp4ynzwMByO%2ByH%2B4vvBKBmFSTgI4rPobBh%2FCvES%2BrHAuv3QW9yd7tbQ%2B9q4lz8%2Ffl9OH8PVaBYXYfQ0uL67PVMXk9XscVx%2Bd%2Frq8byYsOkXuvsLU1ZAeFwFAAA%3D
