### PR TITLE
Add GroceryIO storefront template

### DIFF
--- a/groceryio.com.storefront.json
+++ b/groceryio.com.storefront.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "groceryio.com",
+  "providerName": "GroceryIO",
+  "serviceId": "storefront",
+  "serviceName": "GroceryIO Storefront",
+  "version": 1,
+  "description": "Connects a custom domain or subdomain to a GroceryIO storefront.",
+  "variableDescription": "",
+  "syncBlock": false,
+  "syncPubKeyDomain": "groceryio.com",
+  "syncRedirectDomain": "groceryio.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "store.groceryio.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for GroceryIO storefront custom domains. The template connects a customer-owned host to the GroceryIO storefront SaaS target with a CNAME to `store.groceryio.com`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver. N/A: this template does not include `logoUrl`.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC). N/A: no TXT records.
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC). N/A: the single CNAME is the storefront routing record.

## Online Editor test results

**Editor test link(s):**

[Test groceryio.com/storefront example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABKaJWoC%2F91S72%2FaMBD9VyJ%2FLbCElB%2BJNGktTFtXhVW0nbQhFDn2tbWW2JntQAPif98ZyICu1b5PihSd793zu%2Be3JhaKMqcWSLwmpVYLwUFfcRKTR60Y6FqoDlMFaf1pTmiBYPJp1776ii0DeiEYbMeMVRoetJL20Hg54t0egxagjVCSxEGLcDBMi9JuazJSUgKzxqMeq5C48LgqqJCe0p6psn1hFfYP3AcBHUdOtaBZDuMTYietluwyV%2BwniR9obmB3clNl11CPt8SveOAgU%2BBCo6o3QU%2FK2Cn8qhCFhlhdITcOKM0NiWdrYuvSuTGaXCQf93AsPziLlZDW3KnGxs5LamtzEod939%2FMNy2yUhLSA%2FMc7Ws0wTPFZ4UjRY7zSZVYIWlVpqKZKammhXHP30zPTsbnzfxsR%2BBuFo8S5aUG%2F9RWGpo1iyq3IqVLejjiLKVlmdco1GAXaf62QO7ysdfHqaX%2FdqBFUs6cauFSF4XhAKJo2KZ8MGyfM7%2FXHkLWbXezKGNB1IdgEB1l%2BNWAv5niU%2FvAGJBWUNRBLvIlrQ3ZbOYttPK%2FXAyf39AF8JQ6aNfv9ts%2BfoO7oB8HURz6nfNeL%2FCjM9%2BPfd8tAsbuNl1jUo4zQs7GiU3uIybreppMbvRq%2Be02WYU9e%2FkjH0ajJPx%2B9eXd55rx6%2Fv3ZPMb0ZBLfJwEAAA%3D)

## Additional validation

The repository checks passed JSON schema and linter validation. I also ran the official Domain Connect linter in Cloudflare mode locally via Docker; it exited successfully.
