### PR TITLE
Add dmarcdkim.com domain connect template

### DIFF
--- a/dmarcdkim.com.dmarc-dashboard.json
+++ b/dmarcdkim.com.dmarc-dashboard.json
@@ -7,6 +7,7 @@
   "logoUrl": "https://dmarcdkim.com/dmarcdkim-logo.svg",
   "syncPubKeyDomain": "domainconnect.dmarcdkim.com",
   "syncRedirectDomain": "app.dmarcdkim.com",
+  "multiInstance": true,
   "records": [
     {
       "type": "TXT",

--- a/dmarcdkim.com.dmarc-dashboard.json
+++ b/dmarcdkim.com.dmarc-dashboard.json
@@ -1,0 +1,64 @@
+{
+  "providerId": "dmarcdkim.com",
+  "providerName": "DmarcDkim.com",
+  "serviceId": "dmarc-dashboard",
+  "serviceName": "DMARC Dashboard",
+  "version": 1,
+  "logoUrl": "https://dmarcdkim.com/dmarcdkim-logo.svg",
+  "syncPubKeyDomain": "domainconnect.dmarcdkim.com",
+  "syncRedirectDomain": "app.dmarcdkim.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "dmarcdkim-verification=%dmarcdkim_token%",
+      "ttl": 3600,
+      "groupId": "verify",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarc_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "groupId": "dmarc",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "%spf_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=spf1",
+      "groupId": "spf",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "mta-sts",
+      "pointsTo": "%mta_sts_host%.mta-sts.dmarcdkim.io",
+      "ttl": 3600,
+      "groupId": "mta-sts",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "_mta-sts",
+      "pointsTo": "%mta_sts_host%._mta-sts.dmarcdkim.io",
+      "ttl": 3600,
+      "groupId": "mta-sts",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_smtp._tls",
+      "data": "%tlsrpt_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "groupId": "tls-rpt",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

DmarcDkim.com is an email security solution for enterprises, MSPs, and SMBs. We offer an opinionated yet flexible setup:
1. our system forces SPF/DMARC/TLS-RPT records merge, which is why we have to use bare full record values for them.
2. `dmarcdkim-verification` could be added multiple times, so there is no txtConflictMatchingMode

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

apex: [Test dmarcdkim.com/dmarc-dashboard example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFtFJ2oC%2F%2B1YbU%2FjOBD%2BK5UlPtGUJH1hGxSJbuGk1V1ZBD0dJ7ay3MQtXpI4st1AF%2FHfd9wmTVL6BqeTqFQJCcczYz%2Fz4mc0fUGKhnFAFEXOC4oFT5hPxTcfOcgPifD8RxbWPB6i6kJ4RUJQRhdafJGLJRUJ82huavhEPgw5EX4uzWx7nZtu5aIgT6iQjEfIsaoo4GP%2BtwhA70GpWDonJyUo%2BZehNWsyGesLppF3PRn%2BSacXPCQs0ihmC49HEfVUbdkdbXBDfSZAuDAhcfxGMZwEin2LpCKRB%2BCVmNAqAisufImc%2BxekprF2qn%2FXB%2B0HLhV8nMPSJ4oU42iAk2zEPKLAU%2FdosY8Vf6TREVgoBV7XW6ZZRWPBJ%2FEsmDOrKUiplDRSjOjIfI86cRxM0Wt19f14dnoOYn4bTkgwoUs3qWfV5dEoYJ7qEeU9sGjc474%2BsRMEqIgkO%2FM9QAqBOJLx6J0IrgUdsWe0UiWVQYBcONgqIYWN7Ti7V53eZY40VMSQSupK5yxSss81ZtjFsIu10lEt1SnUCOPr8paf9z4ceBcg%2BH9BUi4hGaq4hlUgCymELxGr%2F1hHcIgBp6zDM3itol88ojh%2FZINq%2BppBjz4TYCyavs4UbHY%2BZpl%2BTAQJpWa1zPK%2BZDrIbO%2BRXi%2B9Rr1Nhp5l1xfCudNakLgzArPOKrEr6E8gkLOKmBAXrgkUd0oEcg6CUpK06mid6mhJleiVK2EBFe0KsGWujvZZZcRdy%2FEdqeEt3tUcnH4NFYNA0EFWLBstLrMbKBQzOrfv%2F3V7c91PrA1OgVG58nTO2DjigmIJ%2F4maiAVXzggUkyeSb%2FkeJjrZkGIJUrh3mUejeafYzqNplkqliH1PJ57pYms3SMukpy1j6DXaRqNx6htt8ws1mha1Wl7z1KNtu9DdVra%2Bzb0tL8GV5fzmfaWuLVP0p6qq%2FQvneTGS%2BRPYC0eyDpC6kvP1cunre3doQnviJ97iKN5fT8svfUUn%2FRjNfmLfB1XougcWP7D4gcUPLH5g8X1lcT1OkIT6mGg927Rbhgl%2FX%2Fq27TRsp96s1e261Wwem6ZjmtoVKtU8Gi%2Bz9XzkykDpj4QIRoYBLUuyOQstqL80ZX02Ii3MWEvMVJ6w3uSjPF99uGLWjL%2BzoVcPvK%2F6Nyk9S634TSot4IJlrVyDaTX%2F2NydfyC0uQvWdrjhM6V1g0M7ebKogvJBq%2FvA9uDs0B%2B2s%2FB7r8Hb7lnDgbvl%2BgO1rmM5ABIGIgugOoCJNKsUcQM6VPyVAXW%2F%2Bu0%2Fvj42LjtB92fPi4IeCZ%2BC4W1r1A3u%2FnkS%2Fe%2FHd%2FH08vjO%2FtdFr78Bwyv9ifMWAAA%3D)
subdomain: [Test dmarcdkim.com/dmarc-dashboard example.com/billing](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIRFJ2oC%2F%2B1Ya2vjOBT9K0HQT40zthvcxsUwodlZ2p10OpnsMtAJQrGVVFvb8kqKp5nS%2F75XiZ95Ne2y0EKgUNv3de5D56I8IkWjJCSKIvcRJYKnLKDiMkAuCiIi%2FOCeRS2fR6hZCK9JBMqop8W9UiypSJlPS1MjIPJuzIkISmlu2%2B8OLhq9ijylQjIeI9dqopBP%2BZ8iBL07pRLpfvhQg1K%2BGVqzJdOpDjCP%2FZvZ%2BA867%2FGIsFijWDz4PI6pr1qr6WiDAQ2YAGFhQpJkTTGahYpdxlKR2AfwSsxoE4EVF4FE7u0jUvNEJzX8PgTtOy4VvHyEx4AoUq2jAUmyCfOJgky9o%2BI7VvyexkdgoRRkfeKYZhNNBZ8li2IurOYgpVLSWDGiK%2FMl7iZJOEdPzc3x8cJ7CWIZDacknNGVSOpBXfB4EjJf9Yny71g87fNAe%2ByGIaoiyX2%2BBEilEEcymbwQwY2gE%2FaANqpkMiiQB46tGlL48DzOi%2Btu%2F7cSaaSIIZXUk85ZrOSQa8zwFcNXrJWOWplOZUYY39a30t%2FLcOB9gOD%2FBUl9hGSkkhZWoay0EN5Eov7jHIETA7xswzN6aqJfPKa4PGSjZnaaQY8%2BEGAsmp3ODOyYhSEEzMNglpslRJBIanLLHdzWPIxyF7eFDx2sfja1lIx9yz4phMsSaEHqLejMOm8knqB%2FA52cN8SMeBAtVNyt0clHENRaplUn21QnK6pEP3kSHmC%2BPQG2zNO1P29MuGe5gSs1vOKULcHps9EwCLQAZNUh0uI614FCtb9L%2B%2BHnb4ObYWrtSAqM6nOoO8imMRcUS%2FhP1EwUzLmgU0x%2BkvJT4GOiWw8NlyCFuKusGi%2F3Rtnl3dya9ao2njjw9RQwPYBnfscy26RtnJ2eOEa7Y5sGccxTwwlMp93uBHanbVY23sZ1uHvfrY3lxklfO3pZnkv2bq2l%2B6ZG7d1Wd0NZy0PynrLKF0eWV74Stp8SDWOPHfa%2B0sZ75o3ffeJ1jijW8yaeeA1rv%2F1SjJqw0g%2B74bAbDrvhsBsOu%2BGwG6q7QV99SEoDTLS6bdqOYcLf2dC23faJazkt57RjWfaxabqmxqSoVMuiPC6el7fEHJt%2BSYlgZBzSuiS%2FE6JildRuhG%2BNiSv3wRU2q98G19pSvwu%2BenC2XNwX93R9R3%2FSv6bpe9%2BGX9Oyea5YtuqjmA31j93b%2FgdCz6zTPSK8pbbuSGivTIopqDvasjSedbnHEtmDo18YBj8XZxsl7lWhV8y6ruUIOBn4LITpACbSrFLFDehQ9RcR9PXn4Or%2B%2B7fhbMCuo%2BjTlUmvIib7pHc5%2FHKc%2FP7Z%2F6t7fRz%2F43yyv3ro6V%2BgFC5MrRcAAA%3D%3D)