### PR TITLE
Add cloudcat.me.connect-site template

### DIFF
--- a/cloudcat.me.connect-site.json
+++ b/cloudcat.me.connect-site.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "cloudcat.me",
+  "providerName": "Cloudcat",
+  "serviceId": "connect-site",
+  "serviceName": "Connect your domain to your Cloudcat site",
+  "version": 1,
+  "syncPubKeyDomain": "cloudcat.me",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "sites.cloudcat.me.",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%dcvtarget%.dcv.cloudflare.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/cloudcat.me.connect-site.json
+++ b/cloudcat.me.connect-site.json
@@ -1,8 +1,8 @@
 {
   "providerId": "cloudcat.me",
-  "providerName": "Cloudcat",
+  "providerName": "CloudCat",
   "serviceId": "connect-site",
-  "serviceName": "Connect your domain to your Cloudcat site",
+  "serviceName": "Connect your domain to your CloudCat site",
   "version": 1,
   "syncPubKeyDomain": "cloudcat.me",
   "hostRequired": true,


### PR DESCRIPTION
# Description

Adds `cloudcat.me.connect-site.json` — the [CloudCat](https://cloudcat.works) Domain Connect template that connects a customer's custom domain to their CloudCat site. It writes two records:

- a routing **CNAME** at the applied host (`@`) → `sites.cloudcat.me.` (Cloudflare-for-SaaS hostname routing), and
- a delegated **DCV CNAME** at `_acme-challenge` → `%dcvtarget%.dcv.cloudflare.com` (Cloudflare delegated certificate validation).

The template uses the built-in `host` parameter with relative record hosts (`hostRequired: true`), and the synchronous signed flow (`syncPubKeyDomain: cloudcat.me`, RS256). It has been reviewed with Cloudflare's Domain Connect team, who will onboard it DNS-only.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) <!-- link pending below; will be checked before marking ready -->
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver <!-- N/A: no logoUrl set -->

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected <!-- set to cloudcat.me; pubkey TXT published at _dck1.cloudcat.me -->
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [ ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow <!-- Intentionally omitted. Cloudflare is the target provider and does NOT support syncRedirectDomain (dc-template-linter --cloudflare flags DCTL5003); their reviewer explicitly asked us to remove it. The template JSON itself declares no redirect_uri. -->
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead <!-- N/A: no TXT records -->
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) <!-- N/A: no TXT records -->
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description <!-- %dcvtarget% is anchored by the fixed suffix .dcv.cloudflare.com -->
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description <!-- hosts are the constants @ and _acme-challenge -->
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead <!-- subdomain handled via the built-in host parameter -->
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) <!-- N/A: both records (routing CNAME + DCV CNAME) are required infrastructure that must not be modified/removed -->

## Online Editor test results

<!--
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**
[Test cloudcat.me/connect-site example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC3WJmoC%2F%2B1UXYvbMBD8K0FwT2e7cj4c21Boeu1DKZeWcKEPIRhF2vjU2pIjyU59If%2B9chw3Se%2FavJZSMNjr0ezu7A7aIQN5kREDKN6hQsmKM1AfGIoRzWTJKDFeDsj5CU2JDWN014B3xFhEg6o4hZYjhQBqXM0NnKCO04K9Wpaqx2ROuOgZ2YZdvt6RWYHSXAoU%2BzZLLejncvUR6ncH0rPeHqU2M9iUXIFtwqgSHKSASsU0ihc7ZOriUH86uX9%2FPG7DN40qyYXRD9KGTWHtnSX2LG5MhuJBgPHe%2BV2ahNAcXPpIsgxECpdJbxitDFEpmBvPfrbp1xlR4FGZXxRY7h30JAUkp86XDmKdYvhO7J462rH2dru1QapkWSS8oxREkVw36%2BzIiwv2sqMvDvymSNfk8Z93dtyjUTQO2Lg%2FGJFBPxyHqGmUp0IqSLR9E1Mq6Kael5nhCdmS0y9GE1IUWW11aYvaEs83IlqDtHIYMeTqPhyUMNpo5I3tQryiaz8cuoxi5g4Zpe4qWK9c1h%2F4QRBFmAyGZx5%2Bwd5%2FMPHFrEFrEIYT2waaZFtSa7R%2FwRtHQb94w7sQeG3QVwzzV01g6Vjn%2Fd%2Frv7dXeztoUgFLSHOyj%2FuBi%2B0TPvjDeBjG%2FsALw1EwHt1iHGPc6ABt2kHs7D1xfkMgPsvX96KYS38%2BSc3b8svq63xWl%2BHtt9SPompTTV%2FVm80nFeT4Ndr%2FANhtsEGaBgAA)
