### PR TITLE
Add Storix storefront domain templates

### DIFF
--- a/storix-ai.com.storefront-apex.json
+++ b/storix-ai.com.storefront-apex.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "storix-ai.com",
+  "providerName": "Storix",
+  "serviceId": "storefront-apex",
+  "serviceName": "Storix storefront apex custom domain",
+  "version": 1,
+  "logoUrl": "https://storix-ai.com/branding/storix-default-logo.png",
+  "description": "Connect an apex/root domain to a Storix merchant storefront.",
+  "variableDescription": "%storixVerificationToken% is the Storix ownership token used in the verification TXT value. %storixAValue% is the Storix IPv4 ingress target for the storefront apex.",
+  "syncPubKeyDomain": "domainconnect-keys.storix-ai.com",
+  "syncRedirectDomain": "storix-ai.com",
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "_storix-verify",
+      "data": "storix-verify=%storixVerificationToken%",
+      "ttl": "600",
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "storefront",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%storixAValue%",
+      "ttl": "600"
+    }
+  ]
+}

--- a/storix-ai.com.storefront.json
+++ b/storix-ai.com.storefront.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "storix-ai.com",
+  "providerName": "Storix",
+  "serviceId": "storefront",
+  "serviceName": "Storix storefront custom domain",
+  "version": 1,
+  "logoUrl": "https://storix-ai.com/branding/storix-default-logo.png",
+  "description": "Connect a subdomain to a Storix merchant storefront.",
+  "variableDescription": "Set Domain Connect host to the merchant storefront label, for example www for www.example.com or shop for shop.example.com. %storixVerificationToken% is the Storix ownership token used in the verification TXT value. %storixCnameTarget% is the Storix storefront CNAME target.",
+  "syncPubKeyDomain": "domainconnect-keys.storix-ai.com",
+  "syncRedirectDomain": "storix-ai.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "storefront",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%storixCnameTarget%",
+      "ttl": "600"
+    },
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "_storix-verify",
+      "data": "storix-verify=%storixVerificationToken%",
+      "ttl": "600",
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two Storix storefront custom-domain templates:

- `storix-ai.com.storefront.json` connects a merchant subdomain by creating a CNAME at the Domain Connect `host` and a Storix ownership TXT record.
- `storix-ai.com.storefront-apex.json` connects an apex/root domain by creating an A record at the apex and a Storix ownership TXT record.

Both templates use `syncPubKeyDomain` for signed synchronous apply flows and `syncRedirectDomain` for redirects back to Storix after provider authorization.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set - **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` - the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) - use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary - prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description. The Storix verification TXT uses the fixed prefix `storix-verify=%storixVerificationToken%`.
- [x] no bare variable is used as the full `host` label - the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain - use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC). Not applicable here: all records in these templates are required for Storix verification or storefront routing.

## Online Editor test results

**Editor test link(s):**
- [Test storix-ai.com/storefront example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOSVJ2oC%2F%2B1UbU%2FbMBD%2BK5YlPi0p6csCVEIaAqaxDcagICSEKje%2BNB6pndlOS4f633dO0iYpoH2dpkmRkvPdPb577sk9UwuzLGUW6PCZZlrNBQd9xumQGqu0ePKZ6ERqRr2N84LNMJheF248N6DnIoJNDsRaSVs7WvGkjiBRjsaMcDVjQmL8HLQRStJh16OpmqobnWJeYm1mhru7rXJ2J5pJLuR0fcwhZnlqfZfXyeQU4TiYSIvMFpD0WEkJkSWMmHxSXkmsQrOqawY6ShhWVRfYcTUxLdgkhZMW2DVYclJirHETZawDtAm8hkVSNoHUI7HSBJ4YUg5ksVgUNr471ZnrjeCRSVRW%2BNxH09khO2XHt6BFLCLmKhqpR5A7RJji9qohtZDIZyIyrArdJDfAiWsaQ%2BaNZDK6G5E5S3PYYB9LHNmI6SnYbdRGR8cXR%2BenxBZhjiqzlNFlPvkCy5Ia5KnkOSop8h9haTrbqnJZV8CFxohN3naQI%2FcKfuYYhSqzOgePYoLS3NDh%2FTOdapVnLwVol5lTXlFohYLmB6dlJaQ1I4XmKz27VOu0FwYBXXlN%2FCZz9Q1IYY0%2FrqovQpdOiMyyuqny%2BPDNMbYux%2B8nixKLUxHZc2ajBDV%2Frri79ChN6eph5dFfSsK4puPBq3jHmIZy6gKdptAqmhqLdU7GNJsZtwXW2fet9Id1%2Fn0JgPYL5pyz%2FKv9EqQ572I0ddqLzl0yj3wLxvqbf5S6BsVUYurY4JvZHEEqCczwjxdjtmD1EY%2FGLMvSJfJh0IuYKI8tHchyIVU0VNP5Q9nVUHAmHh3zyNEknB72gv4gjvvc709C7g%2B6XfAnMev6wONgMAj3%2Bd77fmN3vrpY31yg7XmBMSCtYGkx%2BwVbGrpy4mxpsOqtrcFOu9W2EF9S%2Frf2%2BuChTv%2BP858Zp1sFbA58zFxoL%2BiFfoDPwSgYDHvhsNvrHHT7Ydh7FwTDchdiY2XTz7gVmvuAfvwcJd8Wg%2BRsFF7Ix6z31fxIz%2Favk9PjT%2Byye3fbuw3lHb%2B5OlXfD%2BnqN6lgQ%2F72CAAA)
- [Test storix-ai.com/storefront-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOaVJ2oC%2F%2B1UbWvbMBD%2BK0bQT4sdx3WSxlBoWBh0o6O0WdhagrnIiiNqS66kvDXkv%2B8UO3ES1rGPGwyCI9099%2FbcnTbEsLzIwDASbUih5IInTN0mJCLaSMVXLnCPypw0DsqvkCOYPO7UKNdMLThlBxs2VVIYFwp2pD0xcmqYY2EOnaMkdxKZAxdotGBKcylI1GqQTKbym8rQeGZMoaNm8ySx5kSBSLhI9%2BKETWGeGdfaeYVI0V3CNFW8MDuX5KMUglGMLHbBm0pKU4V2jHTAqZLMmaIzwBTrbD2bGygOk4wNTpxelNFHTPEpp2ClQ%2FnCxIXDtWNmbO9ULgXWNuMFhkK1M9cscWxghCyOjJ3h96GzgGzOPKfy3R%2FZ67nD2%2FtFiA5SxTTKQaXMOFOpdpAzmm32ei3o%2FXzyha0HJdkRKUunJSvuC1tr77z11uqBJVwh4mB3DkKlVIkm0fOGpErOi91EHBeFILMu7BxgdXiZSW3wEleedtC17RcYqAOU4ut3GbZejZ2Pju%2Fb88pgh6cZp%2BYODJ0hN3cysUH7WUa2jePkaoLq1Pp1Yjd26iUXRg9l3eOqDydht%2BNtg7xJweKahXGjohYxbAW4ZaxiqnKPp10qMd%2FjC1CQa7uJe8vnE9Px3vaZ2PM7jFh1Ql3DdLWFB2iZutW3wrYXhC2v1e543Tax6fNUIBuxxn8wc4Uwo%2BasQXLcJh7DEmpRQmMoimyN1WrUokPs%2BUlrRbnvf9bak2QrWpHVBokTasngtlfhJVAIuj03nLR8%2FMCVe0XDiZv0aO8yDIJJ0IKjV%2BqXT9jvn6q6LbhLTBgO2W5qlrDWZGsn52hEqgJv6prOKP1r6xg3cNT%2B9%2Bvf6ZddX1iwJAYLC%2Fyg4%2Fr46w39MAo6USv0Ou2u32l%2F8P2ofAKxOWWRG9zr440mo1V6XwySJ390KbMn06d3n99%2BPARsuXyEV1i8vnY%2BdbqvdPDytLwm259L27DnHggAAA%3D%3D)
- [Test storix-ai.com/storefront-apex example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOiVJ2oC%2F%2B1UbWvbMBD%2BK0awT7Udx83LYigstIy1JaNd07JRQpAtxdFiS54kO81C%2FvtOthPHWbvPGwwCjk7Pcy%2FP3WmLNE2zBGuKgi3KpCgYofKaoAApLSR7cTBzI5Ei%2B3D5GacARg%2FlNdgVlQWL6IFDF1Jw7eCMHt22SFYDswzMinKwpBYRKWYcSAWVigmOgq6NEhGLR5kAeal1poJOp5VYJ5SYE8bjvZnQBc4T7Riem%2FEY3BGqIskyXbpEl4JzGkFkXgbvSCF0HdrSwsJWnWRKZbTEkGKTrWtyw5LhMKFXLafvquhPVLIFi7CxTsWK8ncWU5Ze0r1TseZQ25JlEAqurVxRYpnAACmOyNb069QqcJJT16p9j5%2FM8dTh9V3RAwexpArsWMZUWwshS8iJzCZ7teHRXR7e0s1VJXaAqtKjShVnRTfKPW29YX2hhElAHHinILgUkigUPG9RLEWelRNxXBSA9CYzcwDVwWEplIbDvPZUQjemX1jjJkBlvnhTYeNVm%2FkYeJ75%2F6Khw4uERXqCdbQEbSaCmKDjJEE7%2Bzi5RqAmtXGT2Acz9YJxraai6XHdh1bY3Wxno5%2BC03mjwsyupQUMfcGwZbRWqnavliKDU5nOnO05GZY4VWYb9%2BznFn225z9XDuD8hjIGQiJHU1Vto1PyDviqDgPq9vqu3%2Bu63f7AHfaRqYXFHKSZK%2FhinUuAaZlTG6WwWmyO17gxkWiOsyzZQOkKbsEhDECrz7xa%2Fnaf3br8V5v9e9q12iC2jeYkMvow08JzQnxvEXrOeeh5Ts%2F3B877YXjujBajcOR1%2FWHodY8er1dftj%2B%2FYO1uwZpRrhlOyoFa441COzNUR9NTl9uu70Tjv7qcmQ2D%2BL%2BJ%2F3gTzaLjgpI5NlDfgyw8%2BI2mXi%2FwB0F34Pb8%2FsAbnnleUL2c0Kyq0C28AMe7jyYsxo%2BrMbnht99vJvHH7pX%2FqROvCjm6fPrG8rP1fRHSh%2BsfitxfoN0vugUIbVUIAAA%3D)