### PR TITLE
add ImprovMX, Email Forwarding

### DIFF
--- a/improvmx.com.email-forwarding.json
+++ b/improvmx.com.email-forwarding.json
@@ -1,0 +1,50 @@
+{
+    "providerId": "improvmx.com",
+    "providerName": "ImprovMX",
+    "serviceId": "email-forwarding",
+    "serviceName": "Email Forwarding",
+    "version": 1,
+    "logoUrl": "https://improvmx-public-assets.s3.eu-west-3.amazonaws.com/improvmx_logo.svg",
+    "description": "Set up the DNS records needed to forward emails for your domain with ImprovMX: MX records for inbound mail, SPF for forwarding, and DKIM for sending through ImprovMX SMTP.",
+    "syncBlock": false,
+    "hostRequired": false,
+    "syncPubKeyDomain": "improvmx.com",
+    "records": [
+        {
+            "groupId": "mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mx1.improvmx.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mx2.improvmx.com",
+            "priority": 20,
+            "ttl": 3600
+        },
+        {
+            "groupId": "spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:spf.improvmx.com"
+        },
+        {
+            "groupId": "dkim",
+            "type": "CNAME",
+            "host": "dkimprovmx1._domainkey",
+            "pointsTo": "dkimprovmx1.improvmx.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "dkim",
+            "type": "CNAME",
+            "host": "dkimprovmx2._domainkey",
+            "pointsTo": "dkimprovmx2.improvmx.com",
+            "ttl": 3600
+        }
+    ]
+}

--- a/improvmx.com.email.json
+++ b/improvmx.com.email.json
@@ -1,7 +1,7 @@
 {
     "providerId": "improvmx.com",
     "providerName": "ImprovMX",
-    "serviceId": "email-forwarding",
+    "serviceId": "email",
     "serviceName": "Email Forwarding",
     "version": 1,
     "logoUrl": "https://improvmx-public-assets.s3.eu-west-3.amazonaws.com/improvmx_logo.svg",
@@ -9,6 +9,7 @@
     "syncBlock": false,
     "hostRequired": false,
     "syncPubKeyDomain": "improvmx.com",
+    "syncRedirectDomain": "improvmx.com, app.improvmx.com",
     "records": [
         {
             "groupId": "mx",

--- a/improvmx.com.email.json
+++ b/improvmx.com.email.json
@@ -9,7 +9,7 @@
     "syncBlock": false,
     "hostRequired": false,
     "syncPubKeyDomain": "improvmx.com",
-    "syncRedirectDomain": "improvmx.com, app.improvmx.com",
+    "syncRedirectDomain": "improvmx.com,app.improvmx.com",
     "records": [
         {
             "groupId": "mx",


### PR DESCRIPTION
# Description

New template for [ImprovMX](https://improvmx.com), an email forwarding service. The template sets up the records needed to forward emails for a domain (or subdomain) with ImprovMX:

- `mx` group: two MX records (`mx1.improvmx.com` prio 10, `mx2.improvmx.com` prio 20)
- `spf` group: SPFM record merging `include:spf.improvmx.com`
- `dkim` group: two fixed-selector DKIM CNAME records (`dkimprovmx1/2._domainkey`) used when sending through ImprovMX SMTP

Groups allow applying MX+SPF only for forwarding-only domains, with DKIM added for domains that also send through ImprovMX SMTP.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes: the template has no variables and no TXT records (SPF uses `SPFM`), so the TXT/variable rules are satisfied trivially.

## Online Editor test results

**Editor test link(s):**

- Apex (all groups): [Test improvmx.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALTBKGoC%2F%2B1XbU%2FbMBD%2BK5a%2FLglpWkoVCWl0wASsFSrdxIRQ5MbX1iKJg%2B30ZRX77TunbxRa0e0Tk%2FjU5F6eu8d3fpTOqIE0T5gBGs5oruRIcFAXnIZUpPY1nXixTKmz8rVZirH0ovS2btGjQY1EDGUSpEwka9si%2BMxayblUY6a4yAYYMAKlhcxoWHFoIgfyu0owcGhMrsODg2VtNy96iYhdpjUY7emqB4U7Bm3cqsdS9ktmbKxtg6uMyIJ5emRrcNCxErkp69AbMKTIiRkCOW3fEAWxVFyTDIADJ0aS%2Frw%2FUnLQ9pVMZaEIl2jIyFiYIVnSDknrdgVhI0XWk0XGic11yM31eWntryg7hKH39OqiVTo0ZNaK3ShZDNa45KbVvfbsAU6zuJnI%2BIGGfZZocOhQatOBx0Io4CujDbsuelcwPS27fD03G9EBjlmx2RrjsDz3XiQtmNHwbkYH2GFeDjedoMtMczvScvK2JXz%2BbNdDiszorizDKt6r5RFSCTPFcfsIYXDW1brvPzn%2FBB%2Fshg92w%2Bu8v8bHAbU2K6C7UySg7elkcVJwCNG0WWkTkD%2BIdI34pX3SOltDWuc8s%2BJF8w16gOkmk%2BcxLxjt4LBnyWCPksHukvdPDsWrBdF6De7xNi2XByYMJQMWaYvi%2BFS2GYkyfj7M%2BZGXTSNAzhRLtdWZJdTdBtb9EuyO2ucSbisUticGmVQQafxlplB4GkYVeB%2FSIjEiYnjpViYeR7jhyRTZaPQiIi718zXL5iJll4Azw7Zv8Op0Xi5zxGNLSdjx1CFmrMrqbp9XK26tfwRug%2Fl197De61Wgd1RrHPaeSek2md0mpusjBtTBzAhmtfIkGbOppk92Q96iE%2BxFJ3hndLq33a18Rse4DRWy65qS3yxJlhyR4jtjtby1C147hWJBdh%2BR%2BE8IBm8QDN41wXsHVfBDOj6k40M6PqTjL6UDP2c0GwGPmA0L%2FKDuYtGK3%2FUrYe0wDGperREE9cYn3w9937aP%2F3HmJGf4tfP8O4fWNIOmf%2FH19NvPSxHrRj6Y6DbLm%2Bzgsdlo%2F1C12O8Ma9nBp0t9TJ%2F%2BAGQv8z%2FhDQAA)
- Subdomain, host=sub (all groups): [Test improvmx.com/email example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM7BKGoC%2F%2B1XbU%2FbMBD%2BK5a%2FLknTUFoaCWlsgAaoFSud6ISqyI2vxZDEme20dIj99p3TNwqtVk37wCQ%2BtbmX5%2B7xnR8lj9RAmifMAA0faa7kWHBQZ5yGVKT2MX3wYplSZ%2BlrsxRj6VnpbfXQo0GNRQxlEqRMJCvbPPjEWsmpVBOmuMhGGDAGpYXMaFh1aCJH8ptKMPDWmFyHlcqitpsXg0TELtMajPb0ngeFOwFt3D2PpeynzNhE2waXGZEF8%2FTY1uCgYyVyU9ahV2BIkRNzC%2BS4fUUUxFJxTTIADpwYSYaz%2FkjJQdtHMpWFIlyiISMTYW7JgnZIWr0lhI0U2UAWGSc21yFXl6eldbik7BCG3uOLs1bp0JBZK3ajZDFa4ZKrVvfSswc4zeJPiYzvaThkiQaH3kptOvCjEAr40mjDLovBBUyPyy5fz81GdIBjVmw2xjgsz70XSXNmNLx5pCPsMC%2BHmz6gy0xzO9Jy8rYl%2FP%2FRrocUmdFdWYZVvVfLI6QSZorj9hHC4Kz36r7%2F5PwVfLAdPtgOr%2FPhCh8H1FqvgO5OkYC2p5PFScEhRNN6pXVAfi%2FSFeLn9lHrZAVpnbPMqhfNNugeputMnse8YLSFw44lgx1KBttL9p8cilcLotUa9PE2LZYHHhhKBszT5sV1McCHstNIlCmzec5OvewbMXKmWKqt1CzQbtbg%2Bgu8mxKwP0fciIZNilEmFUQaf5kpFJ6JUQXeirRIjIgYXr2liccR7nkyRU4avYiIq%2F182bKZVM14cGbY5k1entLLpY54bHkJO6ZGs15vHvCaWwNourUgZi4bNGN32Ggwjr7BsArPJHWT3G4S1bWjBpTEzAhmZfMombCppk92Wf7MKdiJU%2FD2OHV73S2kxoe4GVWy7eKSXyxJFkSR59ujtrjKc3Kb1cNb47yLevw%2FPIMdeAZvnWffQaF815V3XXnXlXdd%2BZe6gi9Cmo2BR8xGBn5Qd%2F26W%2FW7fjWs7Yf7vlc%2F2D9o7n3w%2FdD3LQP8RprxfMT3pOdvSPT8tHH9dXDf%2FH5%2BF7RZs3pa6V0Pu7r35aIW%2B%2Bd%2B96TBeieVTmX%2FrnZIn34D9JW6cSEOAAA%3D)
