### PR TITLE
Add Cavuno templates (cavuno.com: boards, boardsapex)

### DIFF
--- a/cavuno.com.boards.json
+++ b/cavuno.com.boards.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "cavuno.com",
+  "providerName": "Cavuno",
+  "serviceId": "boards",
+  "serviceName": "Cavuno Job Board (subdomain)",
+  "version": 1,
+  "logoUrl": "https://cavuno.com/images/favicon/android-chrome-192x192.png",
+  "description": "Connects a subdomain (e.g. jobs.example.com) to your Cavuno job board.",
+  "variableDescription": "txt is the domain-ownership verification value issued by Cavuno.",
+  "syncPubKeyDomain": "cavuno.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "edge.cavuno.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_cavuno",
+      "data": "%txt%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/cavuno.com.boards.json
+++ b/cavuno.com.boards.json
@@ -8,6 +8,7 @@
   "description": "Connects a subdomain (e.g. jobs.example.com) to your Cavuno job board.",
   "variableDescription": "txt is the domain-ownership verification value issued by Cavuno.",
   "syncPubKeyDomain": "cavuno.com",
+  "syncRedirectDomain": "cavuno.com",
   "hostRequired": true,
   "records": [
     {
@@ -20,7 +21,8 @@
       "type": "TXT",
       "host": "_cavuno",
       "data": "%txt%",
-      "ttl": 3600
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
     }
   ]
 }

--- a/cavuno.com.boardsapex.json
+++ b/cavuno.com.boardsapex.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "cavuno.com",
+  "providerName": "Cavuno",
+  "serviceId": "boardsapex",
+  "serviceName": "Cavuno Job Board (apex)",
+  "version": 1,
+  "logoUrl": "https://cavuno.com/images/favicon/android-chrome-192x192.png",
+  "description": "Connects your domain to your Cavuno job board, served at the www host with the bare domain redirecting to it.",
+  "variableDescription": "ip is Cavuno's origin address for the apex redirect; txt is the domain-ownership verification value issued by Cavuno.",
+  "syncPubKeyDomain": "cavuno.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "edge.cavuno.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_cavuno",
+      "data": "%txt%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/cavuno.com.boardsapex.json
+++ b/cavuno.com.boardsapex.json
@@ -8,6 +8,7 @@
   "description": "Connects your domain to your Cavuno job board, served at the www host with the bare domain redirecting to it.",
   "variableDescription": "ip is Cavuno's origin address for the apex redirect; txt is the domain-ownership verification value issued by Cavuno.",
   "syncPubKeyDomain": "cavuno.com",
+  "syncRedirectDomain": "cavuno.com",
   "records": [
     {
       "type": "A",
@@ -25,7 +26,8 @@
       "type": "TXT",
       "host": "_cavuno",
       "data": "%txt%",
-      "ttl": 3600
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
     }
   ]
 }


### PR DESCRIPTION
# Description

Two new templates for Cavuno (https://cavuno.com), a job-board platform. Customers connect custom domains to their hosted job board:

- `cavuno.com.boards.json` — connects a subdomain (`hostRequired`): CNAME to Cavuno's edge target plus a `_cavuno` domain-ownership verification TXT.
- `cavuno.com.boardsapex.json` — connects an apex domain: A record at the apex (Cavuno serves a permanent redirect to the www host there), CNAME at `www` to the edge target, plus the `_cavuno` verification TXT.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (`All` on the `_cavuno` TXT — the label is exclusively Cavuno's verification slot, and a re-apply must replace a stale token rather than accumulate)
- [x] no variable is used as a bare full record value — **one justified exception**: the `_cavuno` TXT data is `%txt%` (a randomly generated ownership token). The host label `_cavuno` is provider-specific rather than a shared label, so the bare value cannot collide with or spoof other services; prefixing would diverge from the value format Cavuno's manual setup instructions and verifier already use.
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not needed — all records are required for the service; none are user-tunable extras

## Online Editor test results

**Editor test link(s):**

- [Test cavuno.com/boards example.com/jobs](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKwpKWoC%2F%2B1Ta2vbMBT9K0IwaJntOI%2BlaWCwvhhrlzJKRsdKCLJ046i1JU%2BSk3gh%2F31XTtIka9nnfhjEBEnnHt1zju6SOsiLjDmg%2FSUtjJ5JAeaLoH3K2axUOuI6p8HzyS3LEUkv6jPct2BmkkNdkGhmhN1tHmDJtU7IuUeQI1smQudMqmMEz8BYqRXtNwOa6VR%2FNxkWTZ0rbL%2FR2DXRkDlLwTYmDLm1ajAljJYi5FOjcwibp60FflGhUiQVYLmRhauJ6YVWCrizhJHnq8kRRGlEHnViI1gw9AD8LcfEaVLp0pBN2wggtbDI98qMZEkGlwf0buGItMRNgay5Qz1XqGoqC4Lq5ERy5qFkxrISEGpLECSpNld4Ylsp%2Fq1MbqC6rBn%2Btt%2Bf34GQBmW8jphq6%2B7gV4kQzMKZEgKKaO0T6T8sqauKOozbs8HVBo7LTz5aLZWzQ41LECm6sE%2FrHKbR7sbxKnjmGP4Y7hjGfPsUBHMMN96hHe%2F2KwNvEEYwySR3A%2Bb4VKp0oIWnOssyuhqtAvpbKxjv%2Bh0h3VbmXjq7a31uuEqNLoux3NYUzLDc%2Bpe8rX44KB9t6x%2FWBKO6N790gNu%2BEZkqbWBs8Z%2B50sDWy7zMnByzOdttCT5mRZFV2LfFU6R56bNaz8Cm3Y1F%2F7A5oGPBvQDpJyrudFqTpkhC3u4lYafTbYW9uNUOe5y329DrfGifiL3hfDm2r47noYVgLSgnWVbHMWeVpasXYW9kbMKODuXU3r09DaMAn8T%2FRN5SIjhvls1AjJmHtuJWN4y7YTMexqd9%2F4ujXhNv77yPY1x4BShkrWmJs7k%2FlfTx%2Fn7w1AM3MdfV58vbG5G1L06yr%2FOk1V0UT5apy%2BH5z0Tf99Krj3T1B897BJfoBgAA)
- [Test cavuno.com/boardsapex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKgpKWoC%2F%2B1VbW%2FaMBD%2BK5alaptKILx2YZrU10nb1BZNTG1XIXSJDbgEO7UdQob47zuHUErb7dM%2B9EM%2FRHF8d889d%2FfYWVLLZ0kMltPukiZazQXj%2BiujXRrBPJWqGqkZrTxYLmCGnvSksOG%2B4XouIl4EhAo0M5Dwxdaw40%2B%2BqZAcOy%2Fy3rl9QL8510YoSbv1Co3VWP3UMfpPrE1Mt1bbcqiJGYy5qY0AYZWsgWRaCeZFE61m3KsHjQU%2B1USOEZRxE2mR2AKYnigpeWQNyVWqCVMzEJJYtf4smd0hs4J%2FhTjmnBGwxE44ybKMTJSxJBN2UuyEoPkGRXMmNGILOXaIwlZdSaAFhDE%2F3WEhEiJMme6dIUqLMQIAY5obQ0ZKF%2BCuLQ%2Bon4hdWBflLOuMnsokdmyCaNg5MRIROHwyhzjl6GpSpB7mZR7HxuQy6qXhd56fFghPJ%2BvsP8qEL3ugReFgafd2SW2euHke4bbrCi4PnTqUkNb0FX7uiWQPd6zFMTY7vr%2BqPASdXBydn20DsbO7oZyNeXUn80so%2Fev%2BFmMYbYTIwIJLjx3byY%2FLhUUFjGIR2XOw0QRnda5YUUUc09VgVaG%2FleTDbZkDhNt0gi8AzwcvCZVpcTXWKk2GYuOfgIaZcWdoE3m7EzrYxN5StxaJWznBPnqcAck6S66o4yXGUmk%2BNPgGm2rkbHXKK3SWxlYMIYPtFouGkCRxjmUYtCLI7rTk%2BiAeblv1NPtO04YscsUId64D3mkF9XrgRX676bWCFveCCAKv0wyhcQDtZovBoyvi%2BeXx10ti2048A1xaAXExlgxyQ1cvSKesYi2dso5%2FyObV1bEWb1nFM%2FHm6hWSH1RQ329aetPS%2F9AS3nAG8O86BOfW8Bsdz%2B94db%2FvB13%2FY7fdqfpBo3XQ3vf9ru%2B7Crix64qWeB8%2BvgnppZ1f7YfT3vG0E19Op%2FdNVW%2Fe9H61wxt7fSmOegdXX07u7%2BQ0U2ef6eoPlAxt1OkIAAA%3D)
- [Test cavuno.com/boardsapex example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKYqKWoC%2F%2B1VbW%2FTMBD%2BK5alCRBNm%2FSNJgiJsTFpg21sdIIxVZEbu41RYme20zRU%2Fe%2Bc03RdxuAb0j7sQ5TYd%2FfcPXePnRU2LM0SYhgOVjhTcsEpU8cUBzgii1zIdiRT3LqznJEUPPFBZYN9zdSCR6wKmEqiqCYZW%2B4MDX90Iqfog%2FVCL63bK%2FBbMKW5FDjwWjiRc3mlEvCPjcl00OnsaujwlMyZ7swIwErRIYIqyakTxUqmzPH87hKedibmAEqZjhTPTAWMD6QQLDIalTJXiMqUcIGM3Czryn5CZVX9LWQrZxQRg0zMUFEUKJbaoIKbuNqZEsW2KIpRrgCbi7lF5KZtKRHFyTRhh40qeIa4rtO90EgqPgcAQqliWqOZVBW4bcsd6ltklsZGWcsmoyMLAR2LAQ06x2c8IhYfLUiSM3DVOZQ%2BLes8thpdiuhLPv3EysMK4eFkrf2yTvi4B1gkDBYHNytsyszOcx%2B2bVfg871Vh%2BTC6LGE5R7P9mDHGBhjb%2Bi669Zd0MHZ%2FunHXSB0thnK6Jy1G5kfQxl%2FH%2B8wwmgrREoMsemhY4388Lk0oIBZwiNzSkwUw6xOJa1YJAleT9Yt%2FEsKFu5oTgBu2wm2JHA%2BWF1QnVbHMoPVXMk8C%2Fk2JiOKpNqeo230TSN8so2%2F2QDAmmd2ZYV777EGKNpaSoltfXwupGKhhjcxuYLajcpZC6d5YnhICrLbolFIsiwpgY4GK4A0pyY2B7JmUHftYQGN%2FoU0spy4PeJ9v%2Bv3RjPf8cmbmdMf%2Bq7jj3o9xx2M2IgMut3I69%2B7Lf68R%2F56XzQ7C0eCCcNJUk2pIKXG60eUVJMBJbWbhP4hpSdJaCPqmk4t6geUSvlEWUxaIP5nkT2L7L%2BKDO5ETeC%2FHBLr2nW7Q8cdOp47dv3A6wWe2%2FZGo8Fg%2BNp1A9e1LJg2G1YruEHv3534Os8vvx2dLxfn4ro4k8mtubg8orE8co99z%2F%2Fcv%2FUu2MnM9L7%2BuHqH178BtEnGRiMJAAA%3D)


