### PR TITLE
Sitesplaced Template

### DIFF
--- a/sitesplaced.com.hosting.json
+++ b/sitesplaced.com.hosting.json
@@ -26,7 +26,8 @@
     {
       "type": "TXT",
       "host": "_sitesplaced-verify",
-      "data": "%verifytoken%",
+      "data": "sitesplaced-%verifytoken%",
+      "txtConflictMatchingMode": "All",
       "ttl": 600
     }
   ]

--- a/sitesplaced.com.hosting.json
+++ b/sitesplaced.com.hosting.json
@@ -1,0 +1,33 @@
+{
+  "providerId": "sitesplaced.com",
+  "providerName": "SitesPlaced",
+  "serviceId": "hosting",
+  "serviceName": "SitesPlaced Website & Store",
+  "version": 1,
+  "logoUrl": "https://sitesplaced.com/logo.png",
+  "description": "Connects your domain to your SitesPlaced website or online store.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "sitesplaced.com",
+  "syncRedirectDomain": "sitesplaced.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%aip%",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%cnametarget%",
+      "ttl": 600
+    },
+    {
+      "type": "TXT",
+      "host": "_sitesplaced-verify",
+      "data": "%verifytoken%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **SitesPlaced** (https://sitesplaced.com), a website and
e-commerce store builder. The template connects a customer's domain to their
SitesPlaced site:

- `A @` — routes the apex domain to our hosting infrastructure
- `CNAME www` — routes the www subdomain
- `TXT _sitesplaced-verify` — domain ownership verification for our platform

**Justification for variables in `pointsTo` (`%aip%`, `%cnametarget%`):**
our hosting platform (Vercel) assigns per-project targets — established
projects use `76.76.21.21` while newer ones are assigned `216.198.79.1`, and
CNAME targets may be project-scoped (e.g. `cname.vercel-dns-017.com`). The
values are generated server-side from the hosting API and every request is
signed (`syncPubKeyDomain` is set), so the variables cannot be tampered with
by end users.

The verification TXT uses a fixed prefix in the template
(`sitesplaced-%verifytoken%`) on a dedicated label, with
`txtConflictMatchingMode: All` so re-applying replaces a stale token instead
of accumulating records.

`syncRedirectDomain` is set to `sitesplaced.com` — the synchronous flow
returns users to `https://sitesplaced.com/domain-connect/callback`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) 
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published at `_dck1.sitesplaced.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label (`All` on `_sitesplaced-verify`)
- [x] no variable is used as a bare full record value — TXT data uses the fixed prefix `sitesplaced-%verifytoken%`; A/CNAME `pointsTo` variables are justified in the description above
- [x] no bare variable is used as the full `host` label — all hosts are fixed (`@`, `www`, `_sitesplaced-verify`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not needed — all records are core to the service and safe to manage via the template

# Online Editor test results
Editor test link(s):

[Test sitesplaced.com/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKsxKWoC%2F%2B1UW0%2FbMBT%2BK5El9rKmJL030iQYTLupHYKObaCqcu3TYpHawXZaQtX%2FvuP0ksDKtKeJByQ%2F2Of%2BfeccL4mFWRJTCyRakkSrueCgP3MSESMsGFQx4FWmZqSyU%2FfpDM3JhTM4yw1QaUDPBYPc9UYZK%2BS0kP7p4f2AscvgvfEurNKAtnPQRihJorBCYjVV33XsYlmbmOjw8Ek5h86imuRJOBimRWJzZ3KipARmjZepVHtczaiQnlXrZ7mCxaYCpT0lYyHBM66Sqis7k%2Bx9rNgtiSY0NrCWnKXjr5Cd5hH3EuSMzoELjfn%2FYuboOYe7FO34LgH6KM0Nia6XxGaJo%2Bt4Y4vXI0e%2FEtKagcLnARXJAYqsRYpaQbCq7JxO%2Bse9D4XjYrF44sokNsNSPQX7TIjBz0ERYFSq38cWiUnmKKeWPsbmH6yVVt2CzAPfW2zFJBbM9qhlNzgQPcVzXHFcTjxcVciDkjAqKBhihi1%2FcE9xQqHEHQrxNtUqTUZia59QTWfGTfHW8%2FqR63Dre03cHQl013ariqcW4nHSEjdOmz%2BriItB7HNptoFKSJ0ZHYc1xusN4pCIqcQhQtamktoUBzuyOsX%2BztLYihFd0ELE2YgmSZwhcINaDPW493K9NUcF3%2BVyCwYrZMSZQy7c8tUCBrXJpOtDF0K%2F0aR1n3Zox%2B%2BGQaMRBs02p5PSMj%2Bz6%2FvXuWAfjAFpBY3zfi5oZshqzxRuIKyncANiL6svGs16ITZY%2FnkhdmPxArENK7gzr9P2Om3%2FZ9rwzzR0DnxEbV5JreUHLT8MBkE3atSjoF1t1uqdsPk2CKIgcBDA2DXIJf6p5d%2BUHGdjc0NVXSXym%2BxcKsi%2BNMf1eav%2F6%2FLq4ePdJ4jbjat5V5%2BGvXdk9RubDjBF4QgAAA%3D%3D) [Test sitesplaced.com/hosting example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABYyKWoC%2F%2B1UW2vbMBT%2BK0bQvSx2nNh1EsNgXTbWMVJKm7FCCUaRFFetI7mSHDcN%2Be87snNxunSv60PBDz73833nHK2QYfM8w4aheIVyJRecMvWDohhpbpgGE2HUI3KOWjvzBZ6DO7q2DpeVAxg1UwtOWBV6J7XhIt1r%2F45wfrOpreB8cK6NVAx8F0xpLgWKOy2UyVT%2BUpnNZUyu43b7RTtt6%2BHlVRHKNFE8N1UwGkohGDHaWcpCOVTOMReOkbXY7KDcdCCVI0XGBXO07cSzbS8F%2BZJJ8oDiGc40qzWXxfQnW36tMh4lyDpdMcoV1P%2BHm6Xnij0W4Ed3BSBGKqpRfLtCZplbus42vvD72dIvuTB6LEE8wTw%2FAZUxQFHk%2B%2BvWLmh4cTb6tg8sy%2FJFKBEwDINVyswrKcY3432CpNG%2FCyPis6WlHBt8iM09qY1GPjBRJX4yMIpZxokZYUPuYCFGkla4sqxZeLJuoWcpWLKnYAIVtvyxJwwbyhrcgXIK4wcpVbLIE76NybHCc203eRt9exA%2B2cbf1glABiKt2Is8%2BLod%2BKy2wZG1VqIH%2BAjLXCr0NlkDsXXD006X0CBEFhFPBSwTsJcKbApY8NioAuY8LzLDE1zivYqSBOd5tgQCNFgh1eEOiPp6Npg31Dc73pPZQgkllgBu79AfsNNZ1AvdADpzw7AXuNMomrr9Ph6QkASY4qBx16%2Bc%2FfHLPhwE05oJw3FWjbfES43WR5ZygwSW0jtEc5ThNw%2BrPpQNqCOH8gJk02G3K28U5KQFB%2FW%2Bhu9r%2BJ%2FXEF5ZjReMJti6dv1u5PqR2%2FHH%2FiAOw%2Fg09Ab96LQXfvT92PctDKZNDXQFr3Dz%2FYXnmpfnZ%2FeiL4fXz%2FKhHfQv82B49%2BPctJ%2B7j0be3Kcj2hHfC9%2F%2FhNZ%2FAJCzk%2FAbCQAA)