### PR TITLE
add-coldpost-ai-tracking

### DIFF
--- a/coldpost.ai.tracking.json
+++ b/coldpost.ai.tracking.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "coldpost.ai",
+  "providerName": "COLDPOST",
+  "serviceId": "tracking",
+  "serviceName": "Branded email tracking domain",
+  "version": 1,
+  "logoUrl": "https://coldpost.ai/logo.png",
+  "description": "Routes COLDPOST email open and click tracking through your own branded subdomain (e.g. track.yourdomain.com) instead of the shared COLDPOST host. Improves deliverability and keeps links on your brand.",
+  "variableDescription": "%token%: your COLDPOST domain-verification value (shown in COLDPOST > Senders). The tracking subdomain itself (e.g. track) is supplied via the Domain Connect host parameter, not a variable.",
+  "syncPubKeyDomain": "coldpost.ai",
+  "syncRedirectDomain": "api.coldpost.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "t.coldpost.io",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_coldpost-verify",
+      "data": "coldpost-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "coldpost-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **COLDPOST** (`providerId: coldpost.ai`), service `tracking`.

It lets a COLDPOST customer point a branded email open/click tracking subdomain
(e.g. `track.example.com`) at COLDPOST in one click. Two records, applied under the
Domain Connect `host` parameter (the subdomain):

- `CNAME @ -> t.coldpost.io` (routes the subdomain to the COLDPOST tracking edge)
- `TXT _coldpost-verify -> "coldpost-verify=%token%"` (one-time domain-ownership proof)

Signed synchronous flow only, with `syncPubKeyDomain` set. `hostRequired: true`
(subdomain-only; never applied at the apex). `%token%` is the customer's
verification value from the COLDPOST dashboard.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [[Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`coldpost.ai.tracking.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`coldpost.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (`api.coldpost.ai`)
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (`Prefix`, prefix `coldpost-verify=`)
- [x] no variable is used as a bare full record value — TXT data is scoped as `coldpost-verify=%token%`
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` `OnApply` — n/a; neither record is one the end user is expected to edit/delete independently

## Online Editor test results

<!-- Paste the "Copy Markdown" link from the Online Editor below. hostRequired=true,
     so only a subdomain (host set) test is required, not an apex test. -->

**Editor test link(s):** [[Test coldpost.ai/tracking acme.com/track](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABiGKWoC%2F%2B1U224TMRD9FcsSEhXJdnNpqFYCUQhCpVfSICFVVTSxJ4nJxl5sb9pQ9d8Z7yUbWvoOEk%2FJ2mdmzpk5nnvucZWl4JEn9zyzZq0k2mPJEy5MKjPjfASKt7ZX57AiKP9wcTq8vLga041Du1YCixhvQSyVnjfHFf69BS1RMlyBSlkNY9LQtyb0Gq1TRvOk0%2BKpmZuvNqWohfeZS%2Fb3d6jsh9soK0pIdMKqzBeBfGRyj47VzKpSJkPNqDYTqRLLprJfWJPPF2xjcsvMrWbTiqHLpyUr9hKjeVRGRAFWHkfCrPaY0s4jSGZmlAmZW4Cl2G3tRSDLjleha8RJYqpIIUxVqvymoLNEzBxLlV46ZnRJo6AQhW6AVTBNcfibwBfeLFG%2FSErwtlZJq0351UwJCGC2hjRH9tItgjKSsgW%2FZVdIMq3bi9iYiG%2F70chW3mE621VPch0BsixVJHKtoNA8LOEfjNYofCGZZWBp3h5ti2njGbBaSVDlNlpc5tMT3JShTzwWACOUylK%2BLQQyFf0OC5VG%2BCMnHHnO2xxbnEKMlY4n1%2Ffcb7LCoudHZx8rOH2%2BCyY2Sns3NsGpTVJl6Mp7MlxvEMcPrW2G8bdxEz%2Bp8WWnN8F%2F4GFHRHXxpprTblL6e%2BepUzMyoT8DLxbU8zMjQ5VLizN1x%2F8Iqe6e1uAPNw8t%2FtNonDTSb4jStm1ihcGqjYBilPQ5J%2BNnE1VHFCNz4fXXsddN8E0dfV2F00GhLpx0uj0eWKi5NhYnjn7B5xbrmazy1KsJ3EJzJMUEyEYbIu3olrI8nZcuN0ZNt2rys%2FNq8YkUgb4KC%2BhgIAaHcUe05UGv3%2B5PoduGfnzQft173Y2lBNGXvZ1t9odF98w6e9REdA61VxC21FF6CxvHH544p1Ly2DnRI2mPZxv6%2BncKvGmRY%2F5P7F%2BaGD1YB2uUEwjYbtwdtONBuxOPOwdJv5d042jQjQfdw1dxnMRxUIHOlzLv6W3vvmpueiff9Y%2BzI1RiDZ9OB0dfLj4Ptb749EWfXI3W3w6%2FL2CVDqejzjEtqF8fmIkfWwgAAA%3D%3D)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABiGKWoC%2F%2B1U224TMRD9FcsSEhXJdnNpqFYCUQhCpVfSICFVVTSxJ4nJxl5sb9pQ9d8Z7yUbWvoOEk%2FJ2mdmzpk5nnvucZWl4JEn9zyzZq0k2mPJEy5MKjPjfASKt7ZX57AiKP9wcTq8vLga041Du1YCixhvQSyVnjfHFf69BS1RMlyBSlkNY9LQtyb0Gq1TRvOk0%2BKpmZuvNqWohfeZS%2Fb3d6jsh9soK0pIdMKqzBeBfGRyj47VzKpSJkPNqDYTqRLLprJfWJPPF2xjcsvMrWbTiqHLpyUr9hKjeVRGRAFWHkfCrPaY0s4jSGZmlAmZW4Cl2G3tRSDLjleha8RJYqpIIUxVqvymoLNEzBxLlV46ZnRJo6AQhW6AVTBNcfibwBfeLFG%2FSErwtlZJq0351UwJCGC2hjRH9tItgjKSsgW%2FZVdIMq3bi9iYiG%2F70chW3mE621VPch0BsixVJHKtoNA8LOEfjNYofCGZZWBp3h5ti2njGbBaSVDlNlpc5tMT3JShTzwWACOUylK%2BLQQyFf0OC5VG%2BCMnHHnO2xxbnEKMlY4n1%2Ffcb7LCoudHZx8rOH2%2BCyY2Sns3NsGpTVJl6Mp7MlxvEMcPrW2G8bdxEz%2Bp8WWnN8F%2F4GFHRHXxpprTblL6e%2BepUzMyoT8DLxbU8zMjQ5VLizN1x%2F8Iqe6e1uAPNw8t%2FtNonDTSb4jStm1ihcGqjYBilPQ5J%2BNnE1VHFCNz4fXXsddN8E0dfV2F00GhLpx0uj0eWKi5NhYnjn7B5xbrmazy1KsJ3EJzJMUEyEYbIu3olrI8nZcuN0ZNt2rys%2FNq8YkUgb4KC%2BhgIAaHcUe05UGv3%2B5PoduGfnzQft173Y2lBNGXvZ1t9odF98w6e9REdA61VxC21FF6CxvHH544p1Ly2DnRI2mPZxv6%2BncKvGmRY%2F5P7F%2BaGD1YB2uUEwjYbtwdtONBuxOPOwdJv5d042jQjQfdw1dxnMRxUIHOlzLv6W3vvmpueiff9Y%2BzI1RiDZ9OB0dfLj4Ptb749EWfXI3W3w6%2FL2CVDqejzjEtqF8fmIkfWwgAAA%3D%3D)