### PR TITLE
FEATURE: add labels in PR review and new commits

### DIFF
--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -1,0 +1,48 @@
+name: Review Labels
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types: [synchronize]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  changes-requested:
+    # When a review with "changes requested" is submitted, add the
+    # "review issues" label.
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Add "review issues" label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "review issues" \
+            --remove-label "new review needed"
+
+  new-commits:
+    # When new commits are pushed to the PR, remove the "review issues"
+    # label and add "new review needed".
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Swap labels after new commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "review issues" \
+            --add-label "new review needed"


### PR DESCRIPTION
## Add review-labels workflow

Adds a GitHub Action that keeps PR review-status labels in sync automatically.

### Behavior

- When a reviewer submits a **"changes requested"** review → adds the `review issues` label (and clears any stale `new review needed`).
- When **new commits are pushed** to the PR (`synchronize`) → removes `review issues` and adds `new review needed`, signalling the reviewer to take another look.

### Implementation notes

- Single workflow `.github/workflows/review-labels.yml` with two jobs, each gated on the triggering event (`pull_request_review` vs `pull_request_target` / `synchronize`).
- Uses the `gh` CLI for label edits, matching the existing `template-labels.yml` convention.
- Scoped to PRs against `master` for the commit trigger; review events fire for all PRs (cannot be branch-filtered in `on:`).

### Prerequisites

- The labels `review issues` and `new review needed` must exist in the repository (created separately in repo settings).
