### PR TITLE
add mrch.in, mrch.in Storefront

### DIFF
--- a/mrch.in.storefront.json
+++ b/mrch.in.storefront.json
@@ -1,0 +1,41 @@
+{
+    "providerId": "mrch.in",
+    "providerName": "mrch.in",
+    "serviceId": "storefront",
+    "serviceName": "mrch.in Storefront",
+    "version": 1,
+    "description": "Connects your domain to your mrch.in dropshipping storefront",
+    "variableDescription": "txtvalue is the per-store Cloudflare custom-hostname ownership token issued by mrch.in when the store owner saves their domain.",
+    "syncPubKeyDomain": "mrch.in",
+    "records": [
+        {
+            "type": "TXT",
+            "groupId": "verify",
+            "host": "_cf-custom-hostname",
+            "data": "%txtvalue%",
+            "ttl": 600,
+            "txtConflictMatchingMode": "All"
+        },
+        {
+            "type": "CNAME",
+            "groupId": "verify",
+            "host": "_acme-challenge",
+            "pointsTo": "%fqdn%.2a6776d49bfee91d.dcv.cloudflare.com",
+            "ttl": 600
+        },
+        {
+            "type": "A",
+            "groupId": "golive",
+            "host": "@",
+            "pointsTo": "104.21.27.109",
+            "ttl": 600
+        },
+        {
+            "type": "A",
+            "groupId": "golive",
+            "host": "@",
+            "pointsTo": "172.67.169.32",
+            "ttl": 600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **mrch.in**, a multi-tenant dropshipping storefront platform (Cloudflare for SaaS based). The template connects a seller's own domain to their storefront. Records are split into two groups so the service can drive them in the order Cloudflare's custom-hostname verification requires: `verify` (ownership TXT + delegated SSL DCV CNAME) first, then `golive` (two fixed A records at the platform's anycast IPs).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A, `logoUrl` is not set

Also validated with `dc-template-linter -loglevel error -tolerate info` (passes; one info-level note about the non-IANA `_cf-custom-hostname` underscore label, which is Cloudflare for SaaS's fixed ownership-verification convention).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A, `redirect_uri` not used yet
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — set to `All` on the ownership TXT (exactly one token may exist per hostname)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — **justification**: `%txtvalue%` is Cloudflare for SaaS's opaque per-hostname ownership token (a UUID issued by Cloudflare); Cloudflare matches the bare token value, so a service prefix cannot be added. The value is generated server-side by mrch.in and the apply URL is signed (`syncPubKeyDomain`), so the parameter cannot be tampered with. The pointing A records use fixed IPs, not variables.
- [x] no bare variable is used as the full `host` label — all `host` values are fixed (`@`, `_cf-custom-hostname`, `_acme-challenge`)
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A, all four records are required for the service to function

## Online Editor test results

**Editor test link(s):**
[Test mrch.in/storefront mystore.in/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJeVKmoC%2F%2B1WbU%2FbMBD%2BK5ElPq2JkjSkNNIkCp3QYKBJAwZCqHLtS2stsYPtpGQV%2F312StqUDbRJfGAS%2FpL4znfPc29xlkhDXmRYA0qWqJCiYhTkZ4oSlEsy9xhHvbX4DOewpVAgK0agOa60kJBKwfVGsW3gfOseqUAqJjhKgh6ioIhkhW726FBwDkQrpxaldKjIsbHVYrVtfVEpCjVnRcH4zNnCrrBkeJrBeMupvtcVzkpwmHL0HJwCpNuYOYeZKGmaYfNKSiPK3blQmhvqjlhww9KgGPgfwI2tKoE603pNYzE3Yutv5asxcBSuoEFhLX3P5qTm5Gs5PYF63Mi2MimBCEkVSm6WSNeFzdr51blRzKQoiybBJmEsrY3I0jP7CUndJ4SNkmKNjXKnjXfHyLTOUBL7fs9mwWQ3zRjRp1iTuUneqaAWbZRl6KG3Bj88G51%2BehkekxxcMsdZBnxmoQvBuFbnwsKnd5TveCGOB4OYRsNpCjAMqEdJ5ZF1vj0i8g69DvxoC3omMlbBBnp%2FGyzwIy8MvHDgBf7wNfwNQi82zuKh1w%2B7%2Fm4feuin4DDZVOvWZHxdzbppglVBH123uBPWHi%2BwxLmy09Ya3nQtb1vTG2Tf2zLaffC43NAst2%2BWG5nl7nYWshzZjBtvE2WeWJfSGGtZQg%2FlZabZBC%2FwRkTJBBdFVpuQlNEamKcNyFcz%2FGK3%2FRWzbh9OKLEZYLYa%2FRBCmlLfjdPdPTca%2BHsuDii4w4jgYR8wnTbGz3ybnv0EbQoASgHXDGdNmy9wrdDDH1q9DfS3vn4MclOkf%2BzrtxXuaBPqfqeCz8zQf8H9mXl9C9xve2bm30fqfaTeR%2BrVRspci%2FYPi06wPRb6Yez6sRsE50GQ%2BEES9b0wjIJB%2FMH3E9%2B37EHpVWBLczt270VUXhyW%2Bu74rL4oo%2FJ6diCOjq4vr6oxlSf3l1yPR3ffxwf4%2BPL4S%2FQRPfwCaBneci4LAAA%3D)
[Test mrch.in/storefront mystore.in/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALGVKmoC%2F%2B1WbWvbMBD%2BK0bQT42N7SYODgwW2myU9WWsWRktISiSnKi1JU%2BSnXql%2F30n580O7dhgjA6qL4nudPfcPXcn%2BREZluUpNgwNHlGuZMkpU6cUDVCmyMLjAnW24gucsZZCM1Vywurj2kjFEiWF2SnaBs5V80jJlOZSoEHQQZRponhu6j06lkIwYrRTyUI5VGYYbI1cbTe%2BqJK5XvA852LutLBLrDiepeyk5dQ8mBKnBXO4dsyCOTlTbm3mHKeyoEmK4S8pQJS5C6mNgNAduRQQJaAA%2FD0TYKsLRp1ZtQ1juQCx9bfyVRs4GpesRuGb8D3LSSXI52L2iVUntazFpGJEKqrR4PYRmSq3rI2%2FjUExV7LIa4KBMJ5UILLhwX5KEncvYFBSbDAoDzb5HoDMmBQNIt%2FvWBaA3STlxJxjQxZA3rmkFm2YpuipswU%2Fvhiej34Nj0nGXLLAacrE3ELnkgujx9LCJ9%2BpOPBCHPX7Ee3Gs4SxOKAeJaVHtnx7RGaN8Brwwxb0XKa8ZDvo922wwO96YeCFfS%2Fw47%2Fhrx96ETiLYu8obPqbPHXQDynYdFetCTC%2BrWZVN8GqoGvXeiHzDfaUb0xyrHCm7cRtjG%2Bb1pON%2Be3KftLZtq%2BVBevlhrDcI1huF5bbayxkY%2BVzAR6nGn6xKRQYG1WwDsqK1PApXuKdiJIpzvO0gtQ0aAFmvxHFapaf6TpvneS69X4rvGZTTimxVHBbmjCJaOD3u25EQ%2Bx2fZq4cS9mbnjUjWlC%2Bz3cjxs30t5F9eJ91K4G05oJw3Fa9%2F0SVxo9PdP7m4zbjb6Xrd15u9r9Ycu%2FvuSHu8T3yvrClP1PKbww2K8lhUkHLoe3uXubu7e5%2B7dzBw%2Bs%2FWajU2yPhn4YuX7kBsE4CAZ%2BOPBj4L7b9%2F1D3x%2F4vs2AabNK7hHe2eYLiy7w6P7h5uPy9PDs693NlzOdjMLrmF9flqEpPvCr2TUOL0%2FudG88eoeefgIqFw08gAsAAA%3D%3D)
