### PR TITLE
MigrationTool auto DNS apply

### DIFF
--- a/migrationtool.fr.point-to-server.json
+++ b/migrationtool.fr.point-to-server.json
@@ -1,0 +1,16 @@
+  {
+    "providerId": "migrationtool.fr",
+    "providerName": "MigrationTOOL",
+    "serviceId": "point-to-server",
+    "serviceName": "Pointer le domaine vers le serveur migre",
+    "version": 1,
+    "logoUrl": "https://migrationtool.fr/icon.png",
+    "description": "Configure les enregistrements A du domaine (racine + www) pour pointer vers le serveur de destination apres une migration MigrationTOOL.",
+    "variableDescription": "adresse IPv4 du serveur de destination",
+    "syncPubKeyDomain": "migrationtool.fr",
+    "syncRedirectDomain": "migrationtool.fr",
+    "records": [
+      { "type": "A", "host": "@", "pointsTo": "%ip%", "ttl": 300 },
+      { "type": "A", "host": "www", "pointsTo": "%ip%", "ttl": 300 }
+    ]
+  }

--- a/migrationtool.fr.point-to-server.json
+++ b/migrationtool.fr.point-to-server.json
@@ -4,7 +4,7 @@
     "serviceId": "point-to-server",
     "serviceName": "Pointer le domaine vers le serveur migre",
     "version": 1,
-    "logoUrl": "https://migrationtool.fr/icon.png",
+    "logoUrl": "https://migrationtool.fr/favicon.ico",
     "description": "Configure les enregistrements A du domaine (racine + www) pour pointer vers le serveur de destination apres une migration MigrationTOOL.",
     "variableDescription": "adresse IPv4 du serveur de destination",
     "syncPubKeyDomain": "migrationtool.fr",


### PR DESCRIPTION
# Description

  New Domain Connect template for MigrationTOOL (website migration service). After a migration it points the customer's domain to the new server by setting the apex and `www` A records to the destination server's IPv4 (single variable `%ip%`). Synchronous flow, signed via `syncPubKeyDomain`.

## Type of change
  - [x] New template
  - [ ] Bug fix (non-breaking change which fixes an issue in the template)
  - [ ] New feature (non-breaking change which adds functionality to the template)
  - [ ] Breaking change

# How Has This Been Tested?
  - [x] Template functionality checked using Online Editor
  - [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
  - [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems
  - [x] `syncPubKeyDomain` is set
  - [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
  - [x] `syncRedirectDomain` is set (template uses `redirect_uri` in the synchronous flow)
  - [x] no TXT record contains SPF content (no TXT records in this template)
  - [x] `txtConflictMatchingMode` — N/A, no TXT records
  - [x] no variable used as a bare full record value (`%ip%` is the A record value, its intended use)
  - [x] no bare variable used as the full `host` label (hosts are fixed `@` and `www`)
  - [x] no variable used in `host` to create a subdomain
  - [x] `%host%` does not appear in any `host` attribute
  - [x] `essential` — the two A records are the sole purpose of the template and must remain (default `Always`); no user-removable records

## Online Editor test results
  **Editor test link(s):**
  - Apex: [Test migrationtool.fr/point-to-server example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHPVKmoC%2F%2B1UbWvbMBD%2BK0ZQ2Kjt2PXLgmGw0FLoy9qwdexDCUaxLq6GLQlJjpuG%2FPed3KZpStfPG%2ByLfb675%2B65N6%2BJhVY11AIp1kRpueQM9BkjBWl5ranlUlgpm3Chif9sv6It%2BpOvW4%2Bb6%2BtLNBvQS17BgFaSCxtYGTgl6J31CTt1dtBeAx6TLeUCPHQz7ntAdNpzBACBTo9JSBH7pJG1%2FKEbDHBnrTLFaPSa5mhBMY0UIT4QzMBUmis7BCDHUix43WnAPMYDoaHmxmpoQVjjTTzWPbP5oGnl3ode3%2FcfPSWRkXoi%2FZopwyLAWC4GIh5VGqN3CH4m5%2B31KnRVUc3pvIGTPYKUIdSAdzZdpo7N2xlcN1eimnbzC1idDITfHpjz%2BgaMa6jse35ol5oZUtyuiV0pN6AJqu%2BksSh%2BcaN3pZsbiZ8HXB2gxlocQxJFG%2F8tDDbtfdRs45MHKaDc5Z7huLYk4Z7iXkJYyXYXFKVay06VfOuvqKatcbu7Rd7uQWdb7C1xMldOOoqSMArjOAnjiDgevBZSQ2nwTS1uByms7sAnbddYXtKe7lSsKqlSzQppG7RiuP2Wicf1di1j1FIU97LtGuCTklWOOHfnMoZsnuTzKkjycRqkWZoEdJxlQb6Yz9OcLVKajl8c4J8O9P0L3HXR7ZiwnLpDmjQ9XRmyeTXHp0Ie5%2FivlTLzcTn%2BD%2BYvHAweoaFLYCW1A%2B%2BjPIjyII5v4qxI0iKOwzSJ8jQ%2BjKIiGmrB395jlWu81Jc3Si6vLlLdH57fn5%2B1ss5Gp6bt2u%2F5VBx%2Fmhz9HF2oPvl1Oc5O02zymWx%2BAw9lh1DrBgAA)
  - Subdomain (host set): [Test migrationtool.fr/point-to-server example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIzVKmoC%2F%2B1UbU%2FbMBD%2BK5ElpE0kwWnSrkSaNDRgoA2oRpmmoSpyk0vxltjGdlpK1f%2B%2Bc6CUVozPm7QvSe7luXvuLQtioVYVs0DSBVFaTnkB%2BrQgKan5RDPLpbBSVmGpif9kP2c1%2BpOzlcfw4uILmg3oKc%2BhRSvJhQ2sDJwS9Nr6iB04O2ivAq%2BQNeMCPHQzTm4RjfYcAUCg02MSkkY%2BqeREXukKA9xYq0y6t7dNc69kmEaKEB8ILsDkmivbBiAfpSj5pNGAeYwHQsOEG6uhBmGNd%2BAVzRObN5rl7r3rzWazt56SyEg9kt5mWmARYCwXLRGPKY3RGwQ%2FkfM2ehW6qpjmbFzB4QZBViDUgHc6mCaOzcsZXDfnIh80488wP2wJvzww5%2FUVCq4ht6%2F5oV3qwpD0ekHsXLkBHaD6RhqLnx%2Fc6F3pZihR3OFqBzXW4hhiSpf%2BSxhs2uuo0dIn91JAts49wnGtSMIdw72EMJf1dtCJlo3K%2BAqimGa1ceu7Al9voEcr%2BHWLR5ErJ3RoHNIwiuIwosSx4RMhNWQG38zijpDU6gZ8UjeV5RmbsbWqyDOmVDVH8gatGG6zceJhyR%2F4FswyFDbyrRvhk6zIHXvuzoZ2k3y%2Fl5dBEsdJkHTelUG%2F6HeD8T6NE9rpj6Nu9OwQ%2F3Sor1%2FiRjfdugnLmbupg2rG5oYst0a6rib8Zysa%2Bbgr%2F4f0lw8Jj9OwKRQZsy31Ti%2BgvSCKhlE3jZM07oVJ0tmnnV1KU9qWgz%2FFh0IXeMHPb5cMftyen3w6O4qGd4M%2BT%2BblJfw8LunR%2FekR%2F0W%2FnX0%2FPmkEvTy86iXvyfI3X4aG0gkHAAA%3D)