### PR TITLE
Add appnest.ing.appnest template (AppNest custom domains)

### DIFF
--- a/appnest.ing.appnest.json
+++ b/appnest.ing.appnest.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "appnest.ing",
+  "providerName": "AppNest",
+  "serviceId": "appnest",
+  "serviceName": "AppNest app",
+  "version": 1,
+  "logoUrl": "https://appnest.ing/favicon.svg",
+  "description": "Serves an app built on AppNest (appnest.ing) at the user's subdomain. One CNAME to AppNest's Cloudflare-for-SaaS fallback origin; the TLS certificate is issued automatically via HTTP domain-control validation once the record resolves. Removing the CNAME detaches the subdomain from AppNest.",
+  "variableDescription": "This template uses no custom variables. The standard domain and host parameters select the subdomain the CNAME is written for.",
+  "syncPubKeyDomain": "appnest.ing",
+  "syncRedirectDomain": "dashboard.appnest.ing",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.appnest.ing",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **AppNest** (appnest.ing) — a platform where people build small web apps by describing them to an AI assistant, and AppNest hosts them. This template lets a user serve their app on a subdomain they control: a single CNAME to AppNest's Cloudflare-for-SaaS fallback origin (`cname.appnest.ing`). The TLS certificate is issued automatically via HTTP domain-control validation once the record resolves; removing the CNAME detaches the subdomain from AppNest.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated locally with [dc-template-linter](https://github.com/Domain-Connect/dc-template-linter) — no findings.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the synchronous flow uses `redirect_uri`)
- [x] no TXT record contains SPF content — the template has no TXT records
- [x] `txtConflictMatchingMode` — N/A, no TXT records
- [x] no variable is used as a bare full record value — the template has no custom variables
- [x] no bare variable is used as the full `host` label — N/A, no custom variables
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter selects the subdomain (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is intentionally left at its default: the single CNAME *is* the service — a user removing it is the supported way to detach the subdomain from AppNest, so `OnApply` semantics (record removable without affecting the service) do not apply here

## Online Editor test results

**Editor test link(s):**
[Test appnest.ing/appnest example.com/portal](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGz1KmoC%2F91U70%2FbMBD9Vyx%2F2aY1JSkBRKdJYzAxtI0hKGMTQtXFvqQWjh1sp6xD%2Fd93bgktP6R9nxQpsu%2Fu3XvPZ9%2FxgHWjISAf3vHG2amS6I4kH3JoGoM%2B9JWpeO8hdAw1pfK9pjmmIAU8uqkSuF6y2n2czShOsSk6r6zhw6zHta3sudOUMwmh8cONjbW2GyUQiDV9P40UJHrhVBMWtfyMOqBnYCIqK1qlA7OGda1er%2BG8YRBYmCBridYrz3xbSFuDMn323SDbP9779okF29VSxr62rSw1OExK65IzgDNWgtYFiGtmnaqUebdAHH09YwJdUKUSZCJTnj7fomTQBuoRaFvrGZsqYJ9HoxO2bJyQquCsZlPQSkKUROQFLjAdCusk%2FbzVJLHPTrEm8021iC7ZSgwgJqQ%2Fbj3oYaWzdSejH60Gp6DQePDIutGEaHbnHk3xzFgmWk%2BMWVdCfUcRO4CRQHTuO9CKTSwZ3ICjww10lsyjRhGeUFlxpWa3ToWAxM%2B6SMvPjDhpiy84O1gkP5u2mHCKUpEV4SFFgp8Ulrj0HydHOqd401I2DWFwLfb40kPPh5d3PMyaOIQLMvfptPwQh9oqE%2FzI0lIYUvMEOAQazM3tNJ1fzXv8jzU4XuFe0UB2zPA3kJnYF7ZeNWisC6BpXTnbNmPVVS2M8%2FG6dfWXjwCuOoTLDiJ2V5WxDsee%2FhBah53QutVBjeEWVltSjEmHnhFZT1ECem6CWV7MB440g%2FAvF3p8LEXkreJdL7JBLvKtQbJdbookx508KQblVgIS82wnxXIgYO3deOFJefnleOoeeo8mKIhvxJ6%2BhZnn8%2FlVj5z8%2F1TR0XuYohxDTB6kg%2B0k3U6ybJTtDLdSotvPs93dPHubpsM0jSoIfSnyjmZkfTp49ePioroWdnaxf7L7sbmuZufF6eSnzkeHrlT10Y08%2FOXqrGmO8vd8%2FheYTYZoCAYAAA%3D%3D)

`hostRequired` is `true`, so per the instructions the apex test is not required; the subdomain test (`portal.example.com`) is linked above.
