### PR TITLE
Feature/add labels from pr review

### DIFF
--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -1,0 +1,48 @@
+name: Review Labels
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types: [synchronize]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  changes-requested:
+    # When a review with "changes requested" is submitted, add the
+    # "review issues" label.
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Add "review issues" label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "review issues" \
+            --remove-label "new review needed"
+
+  new-commits:
+    # When new commits are pushed to the PR, remove the "review issues"
+    # label and add "new review needed".
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Swap labels after new commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "review issues" \
+            --add-label "new review needed"

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -39,10 +39,20 @@ jobs:
       issues: write
     steps:
       - name: Swap labels after new commits
+        # Only act when the PR already has "review issues" (i.e. a reviewer
+        # requested changes). Otherwise do nothing, so PRs that were never
+        # reviewed don't get "new review needed".
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
+          pr_number="${{ github.event.pull_request.number }}"
+          repo="${{ github.repository }}"
+          has_label=$(gh pr view "$pr_number" --repo "$repo" \
+            --json labels --jq '.labels[].name | select(. == "review issues")')
+          if [ -z "$has_label" ]; then
+            echo "PR does not have the \"review issues\" label; nothing to do."
+            exit 0
+          fi
+          gh pr edit "$pr_number" --repo "$repo" \
             --remove-label "review issues" \
             --add-label "new review needed"


### PR DESCRIPTION
## Fix: don't add "new review needed" to unreviewed PRs

### Problem

The `new-commits` job added the `new review needed` label on **every** push to a PR — including PRs that had never received a "changes requested" review. The label is only meaningful after a reviewer requested changes, so it was being applied incorrectly.

### Fix

The job now checks whether the PR currently carries the `review issues` label before acting:

- **No `review issues` label** → logs and exits cleanly, leaving labels untouched.
- **Has `review issues`** → swaps it for `new review needed` as before.

This ensures `new review needed` is only added when a reviewer had previously requested changes.
