### PR TITLE
Add Destaff (destaff.ai) mailgun-sync template

### DIFF
--- a/destaff.ai.mailgun-sync.json
+++ b/destaff.ai.mailgun-sync.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "destaff.ai",
+  "providerName": "Destaff",
+  "serviceId": "mailgun-sync",
+  "serviceName": "Destaff Email (Mailgun sending subdomain)",
+  "version": 1,
+  "logoUrl": "https://destaff.ai/logo.svg",
+  "description": "Connects your sending subdomain (sync.<domain>) so Destaff can send and receive support email for you. Adds SPF, DKIM, MX and a tracking CNAME.",
+  "syncPubKeyDomain": "destaff.ai",
+  "syncRedirectDomain": "destaff.ai",
+  "warnPhishing": true,
+  "hostRequired": true,
+  "records": [
+    { "type": "SPFM", "host": "@", "spfRules": "%spf%", "ttl": 3600 },
+    { "type": "TXT", "host": "%dkimSelector%", "data": "%dkim%", "ttl": 3600 },
+    { "type": "MX", "host": "@", "pointsTo": "%mxa%", "priority": 10, "ttl": 3600 },
+    { "type": "MX", "host": "@", "pointsTo": "%mxb%", "priority": 20, "ttl": 3600 },
+    { "type": "CNAME", "host": "%trackingHost%", "pointsTo": "%tracking%", "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
Adds a Domain Connect template for **Destaff** (`destaff.ai`), service `mailgun-sync`.

Destaff is a support/helpdesk tool for online shops. This template configures a customer's email **sending subdomain** (`sync.<domain>`) for Mailgun:

- **SPFM** (SPF merge) — `include:mailgun.org`
- **DKIM TXT** — variable selector (`%dkimSelector%`)
- **2× MX** — `mxa`/`mxb.mailgun.org`
- **Tracking CNAME**

**Signed template:** `syncPubKeyDomain` is set to `destaff.ai`; the RS256 public key is published at `_dcpubkeyv1.destaff.ai` (TXT), and apply requests are signed (`sig`/`key`).

Notes:
- `hostRequired: true` — applied with `host=sync`, so `@` lands on `sync.<domain>`.
- Uses the spec record fields `spfRules` / `data` / `pointsTo`.

Marked as **draft** pending Online Editor validation; happy to address any linter/schema feedback.