### PR TITLE
Add HiBubo proxy template (hibubo.ai.proxy)

### DIFF
--- a/hibubo.ai.proxy.json
+++ b/hibubo.ai.proxy.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "hibubo.ai",
+  "providerName": "HiBubo",
+  "serviceId": "proxy",
+  "serviceName": "HiBubo AI Visibility Proxy",
+  "version": 1,
+  "logoUrl": "https://hibubo.ai/favicon.png",
+  "description": "Connects your domain to the HiBubo rendering proxy so AI crawlers (ChatGPT, Perplexity, Claude, Gemini) receive fully rendered pages. Adds a single CNAME record pointing to proxy.hibubo.ai.",
+  "syncRedirectDomain": "hibubo.ai,hibubo-dashboard.vercel.app",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "proxy.hibubo.ai",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## New template: hibubo.ai.proxy

HiBubo (https://hibubo.ai) is an AI-visibility platform that serves fully rendered pages to AI crawlers (ChatGPT, Perplexity, Claude, Gemini) through a CDN proxy. Customers currently add a single CNAME record manually; this template enables one-click setup via Domain Connect.

- **providerId:** hibubo.ai
- **serviceId:** proxy
- **Records:** one CNAME on `@` (or the host the user selects) pointing to `proxy.hibubo.ai`, TTL 3600
- **Flow:** sync flow, unsigned (no `syncPubKeyDomain` in v1)
- **syncRedirectDomain:** hibubo.ai, hibubo-dashboard.vercel.app

### Online editor test results
Draft PR — editor test-result link will be added before marking ready for review.

Made with [Cursor](https://cursor.com)