### PR TITLE
Add review-status label automation

### DIFF
--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -1,0 +1,48 @@
+name: Review Labels
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types: [synchronize]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  changes-requested:
+    # When a review with "changes requested" is submitted, add the
+    # "review issues" label.
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Add "review issues" label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "review issues" \
+            --remove-label "new review needed"
+
+  new-commits:
+    # When new commits are pushed to the PR, remove the "review issues"
+    # label and add "new review needed".
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Swap labels after new commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "review issues" \
+            --add-label "new review needed"

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Download task artifact
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: label-task
           path: ./label-task

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -12,7 +12,12 @@ on:
 jobs:
   apply:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    # Only act on successful runs of the trigger workflow that were started
+    # by one of the events we expect. Anything else is ignored outright.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'pull_request_review' ||
+       github.event.workflow_run.event == 'pull_request_target')
     permissions:
       pull-requests: write
       issues: write
@@ -44,6 +49,34 @@ jobs:
 
           if [ -z "$pr_number" ] || [ -z "$action" ]; then
             echo "Incomplete task; nothing to do."
+            exit 0
+          fi
+
+          # --- Security hardening (workflow_run trust boundary) ---
+          # The artifact comes from a workflow that can be triggered by fork
+          # PRs. Validate everything before acting so a forged/malformed task
+          # cannot be used to mislabel an arbitrary PR or inject gh arguments.
+
+          # pr_number must be a plain positive integer.
+          if ! printf '%s' "$pr_number" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "Invalid pr_number: '$pr_number'; aborting."
+            exit 0
+          fi
+
+          # action must be one of the known values.
+          case "$action" in
+            changes_requested|new_commits) ;;
+            *) echo "Invalid action: '$action'; aborting."; exit 0 ;;
+          esac
+
+          # The artifact's PR must match the head SHA that the triggering
+          # workflow_run actually ran on. This binds the task to the run that
+          # produced it, so a fork run cannot hand off a different PR's number.
+          run_sha="${{ github.event.workflow_run.head_sha }}"
+          pr_sha=$(gh pr view "$pr_number" --repo "$repo" \
+            --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+          if [ -n "$run_sha" ] && [ "$pr_sha" != "$run_sha" ]; then
+            echo "PR #$pr_number head ($pr_sha) does not match triggering run ($run_sha); aborting."
             exit 0
           fi
 

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -39,10 +39,20 @@ jobs:
       issues: write
     steps:
       - name: Swap labels after new commits
+        # Only act when the PR already has "review issues" (i.e. a reviewer
+        # requested changes). Otherwise do nothing, so PRs that were never
+        # reviewed don't get "new review needed".
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
+          pr_number="${{ github.event.pull_request.number }}"
+          repo="${{ github.repository }}"
+          has_label=$(gh pr view "$pr_number" --repo "$repo" \
+            --json labels --jq '.labels[].name | select(. == "review issues")')
+          if [ -z "$has_label" ]; then
+            echo "PR does not have the \"review issues\" label; nothing to do."
+            exit 0
+          fi
+          gh pr edit "$pr_number" --repo "$repo" \
             --remove-label "review issues" \
             --add-label "new review needed"

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -1,58 +1,78 @@
-name: Review Labels
+name: Review Labels (apply)
+
+# Runs after "Review Labels (trigger)" completes. Because workflow_run runs
+# in the base-repo context, github.token is writable even for PRs from
+# forks -- so the actual label edits happen here.
 
 on:
-  pull_request_target:
-    branches:
-      - master
-    types: [synchronize]
-  pull_request_review:
-    types: [submitted]
+  workflow_run:
+    workflows: ["Review Labels (trigger)"]
+    types: [completed]
 
 jobs:
-  changes-requested:
-    # When a review with "changes requested" is submitted, add the
-    # "review issues" label.
-    if: >-
-      github.event_name == 'pull_request_review' &&
-      github.event.review.state == 'changes_requested'
+  apply:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     permissions:
       pull-requests: write
       issues: write
     steps:
-      - name: Add "review issues" label
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --add-label "review issues" \
-            --remove-label "new review needed"
+      - name: Download task artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: label-task
+          path: ./label-task
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true
 
-  new-commits:
-    # When new commits are pushed to the PR, remove the "review issues"
-    # label and add "new review needed".
-    if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Swap labels after new commits
-        # Only act when the PR already has "review issues" (i.e. a reviewer
-        # requested changes). Otherwise do nothing, so PRs that were never
-        # reviewed don't get "new review needed".
+      - name: Apply labels
+        if: steps.download.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          pr_number="${{ github.event.pull_request.number }}"
-          repo="${{ github.repository }}"
-          has_label=$(gh pr view "$pr_number" --repo "$repo" \
-            --json labels --jq '.labels[].name | select(. == "review issues")')
-          if [ -z "$has_label" ]; then
-            echo "PR does not have the \"review issues\" label; nothing to do."
+          task_file="./label-task/task.txt"
+          if [ ! -f "$task_file" ]; then
+            echo "No task artifact; nothing to do."
             exit 0
           fi
-          gh pr edit "$pr_number" --repo "$repo" \
-            --remove-label "review issues" \
-            --add-label "new review needed"
+
+          pr_number=$(grep '^pr_number=' "$task_file" | cut -d= -f2-)
+          action=$(grep '^action=' "$task_file" | cut -d= -f2-)
+          repo="${{ github.repository }}"
+
+          if [ -z "$pr_number" ] || [ -z "$action" ]; then
+            echo "Incomplete task; nothing to do."
+            exit 0
+          fi
+
+          echo "PR #$pr_number, action: $action"
+
+          case "$action" in
+            changes_requested)
+              # A reviewer requested changes -> flag the PR.
+              gh pr edit "$pr_number" --repo "$repo" \
+                --add-label "review issues"
+              gh pr edit "$pr_number" --repo "$repo" \
+                --remove-label "new review needed" 2>/dev/null || true
+              ;;
+            new_commits)
+              # New commits pushed -> only swap labels if the PR was
+              # previously flagged with "review issues". Otherwise PRs that
+              # were never reviewed would wrongly get "new review needed".
+              has_label=$(gh pr view "$pr_number" --repo "$repo" \
+                --json labels --jq '.labels[].name | select(. == "review issues")')
+              if [ -z "$has_label" ]; then
+                echo "PR does not have \"review issues\"; nothing to do."
+                exit 0
+              fi
+              gh pr edit "$pr_number" --repo "$repo" \
+                --add-label "new review needed"
+              gh pr edit "$pr_number" --repo "$repo" \
+                --remove-label "review issues" 2>/dev/null || true
+              ;;
+            *)
+              echo "Unknown action: $action"
+              ;;
+          esac

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload task artifact
         if: steps.detect.outputs.skip == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: label-task
           path: ./label-task/

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,0 +1,56 @@
+name: Review Labels (trigger)
+
+# This workflow only DETECTS what label change is needed and hands it off
+# to the "Review Labels (apply)" workflow via an artifact. It does NOT
+# write labels itself, because the pull_request_review event runs with a
+# read-only token for PRs from forks. The apply workflow runs on
+# workflow_run, which always has a writable token in the base-repo context.
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_target:
+    branches:
+      - master
+    types: [synchronize]
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine action
+        id: detect
+        run: |
+          pr_number=""
+          action=""
+
+          if [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            if [ "${{ github.event.review.state }}" = "changes_requested" ]; then
+              pr_number="${{ github.event.pull_request.number }}"
+              action="changes_requested"
+            fi
+          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            pr_number="${{ github.event.pull_request.number }}"
+            action="new_commits"
+          fi
+
+          if [ -z "$action" ]; then
+            echo "No relevant action; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mkdir -p ./label-task
+          {
+            echo "pr_number=$pr_number"
+            echo "action=$action"
+          } > ./label-task/task.txt
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Upload task artifact
+        if: steps.detect.outputs.skip == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: label-task
+          path: ./label-task/
+          retention-days: 1


### PR DESCRIPTION
## Add review-status label automation

Adds a GitHub Actions workflow that keeps PR review-status labels in sync automatically.

### Behavior

- When a reviewer submits a **"changes requested"** review → adds the `review issues` label (and clears `new review needed`).
- When **new commits are pushed** to the PR → if it currently has `review issues`, swaps it for `new review needed`. PRs that were never reviewed are left untouched (no false `new review needed`).

### Why two workflows

The `pull_request_review` event runs with a **read-only token for PRs from forks**, so it can't edit labels directly (this caused `Resource not accessible by integration` errors). The work is therefore split:

- **`review-trigger.yml`** — runs on `pull_request_review` and `pull_request_target`; only *detects* the needed action and hands it off as an artifact (no label writes).
- **`review-labels.yml`** — runs on `workflow_run` after the trigger completes, in the base-repo context with a writable token, and applies the labels.

### Security hardening (workflow_run trust boundary)

Since the trigger can be invoked by fork PRs, the apply workflow validates everything before acting:

- `apply` job gated on `workflow_run.conclusion == success` **and** an expected triggering event (`pull_request_review` / `pull_request_target`).
- `pr_number` must be a positive integer (blocks `gh` argument injection).
- `action` must be one of the known values.
- The PR's head SHA must match the triggering run's `head_sha`, binding the task to the run that produced it so a fork run can't hand off another PR's number.

### Notes

- Requires the labels `review issues` and `new review needed` to exist in the repo.
- The apply workflow only takes effect once merged to the default branch (how `workflow_run` triggers are evaluated).
- Uses `upload-artifact@v7` / `download-artifact@v8` (Node 24; resolves the Node 20 deprecation warning).
