### PR TITLE
Add shiply.now.cname template

### DIFF
--- a/shiply.now.cname.json
+++ b/shiply.now.cname.json
@@ -1,0 +1,14 @@
+{
+    "providerId": "shiply.now",
+    "providerName": "Shiply",
+    "serviceId": "cname",
+    "serviceName": "Shiply Custom Domain",
+    "version": 1,
+    "logoUrl": "https://shiply.now/icon.svg",
+    "description": "Point a subdomain at your Shiply site.",
+    "syncBlock": false,
+    "syncRedirectDomain": "shiply.now",
+    "records": [
+          { "type": "CNAME", "host": "%host%", "pointsTo": "cname.shiply.now", "ttl": 1800 }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect CNAME template for Shiply (shiply.now), a SaaS hosting platform.
The template creates a single CNAME record pointing a user's chosen subdomain to cname.shiply.now.

## Template editor test results

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIsqLmoC%2F91SXY%2FaMBD8K5GlezoSTC58ReoDpa3UqodOlOoqIRQttgHTxE5tB5oi%2FnvX4TiOXqW%2B98ny7s7uzO4ciBNFmYMTJD2Q0uid5MJ85CQldiPLvI6U3pPWc2YCBVaSL00O41aYnWSiATDlk8%2Bxq9JgXFmni%2BCdLkAqLNoJY6VWJO20SK7X%2BqvJsXjjXGnTdvsyuy2ZVpHdrRHDhWVGlq7BkQctlQsgsNWSN10DcEGtKxM8jbTSicjzqRV7m2v2naQryK04RaaCSyOYe2L0h17MaMMtSecH4urSCxlPRvfvMbXR1uH3xr83fjWeh53p8waiq0bOoa7OgNLj4tgiv7QS2aX3AjWdx4ufgIcQEdPFZQiUJX7WRldlJs%2BQEgwU1t%2FrDJ5foRdn%2BLzB%2B7lyrbQRmcUXXGVQjjMVLqKocicz2MMlxFmGqLxGmhaz2OX1CtTptFgXnRhycPAP%2FS2SceZJS%2B%2BVlVgO6GCwDPvQ52HSoxBCf5iElEEyjLsr0aHshe1eG%2FJvxrtamrBWKCfB22qU76G25HhctHCB%2F5MevLWFneAZ%2BMqYxr2Q9sJOMqNJ2klSehcl3bhH724pTSn1%2FIV1J3UH9MVLR5D%2Balo7LX7cDkeTaeLkh228VfD58aEqlvfq23gW591Pw9nycbt%2FQ46%2FAcIrJ8k6BAAA

## Type of change

- [x] New template
## Checklist

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] - [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] - [x] resource URL provided with `logoUrl` is actually served by a webserver (https://shiply.now/icon.svg)