### PR TITLE
Create theelevateagent.com.agentsite.json

### DIFF
--- a/theelevateagent.com.agentsite.json
+++ b/theelevateagent.com.agentsite.json
@@ -1,16 +1,17 @@
 {
-    "providerId": "theelevateagent.com",
-    "providerName": "Coldwell Banker Elevate",
-    "serviceId": "agentsite",
-    "name": "Elevate Agent Website",
-    "description": "Connects your domain to your Coldwell Banker Elevate agent website.",
-    "logoUrl": "https://theelevateagent.com/email-logo.png",
-    "version": 1,
-    "syncPubKeyDomain": "theelevateagent.com",
-    "syncRedirectDomain": "theelevateagent.com",
-    "shared": false,
-    "records": [
-      { "type": "CNAME", "host": "www", "pointsTo": "agents.the-elevate-team.com", "ttl": 3600
-  }
-    ]
-  }
+  "providerId": "theelevateagent.com",
+  "providerName": "Coldwell Banker Elevate",
+  "serviceId": "agentsite",
+  "serviceName": "Elevate Agent Website",
+  "version": 2,
+  "logoUrl": "https://theelevateagent.com/email-logo.png",
+  "description": "Connects your domain to your Coldwell Banker Elevate agent website.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "theelevateagent.com",
+  "syncRedirectDomain": "theelevateagent.com",
+  "hostRequired": true,
+  "warnPhishing": true,
+  "records": [
+    { "type": "CNAME", "host": "www", "pointsTo": "agents.the-elevate-team.com", "ttl": 3600 }
+  ]
+}

--- a/theelevateagent.com.agentsite.json
+++ b/theelevateagent.com.agentsite.json
@@ -6,9 +6,9 @@
     "description": "Connects your domain to your Coldwell Banker Elevate agent website.",
     "logoUrl": "https://theelevateagent.com/email-logo.png",
     "version": 1,
-    "syncBlock": false,
-    "warnPhishing": true,
-    "shared": false,  
+    "syncPubKeyDomain": "theelevateagent.com",
+    "syncRedirectDomain": "theelevateagent.com",
+    "shared": false,
     "records": [
       { "type": "CNAME", "host": "www", "pointsTo": "agents.the-elevate-team.com", "ttl": 3600
   }

--- a/theelevateagent.com.agentsite.json
+++ b/theelevateagent.com.agentsite.json
@@ -1,0 +1,16 @@
+{
+    "providerId": "theelevateagent.com",
+    "providerName": "Coldwell Banker Elevate",
+    "serviceId": "agentsite",
+    "name": "Elevate Agent Website",
+    "description": "Connects your domain to your Coldwell Banker Elevate agent website.",
+    "logoUrl": "https://theelevateagent.com/email-logo.png",
+    "version": 1,
+    "syncBlock": false,
+    "warnPhishing": true,
+    "shared": false,  
+    "records": [
+      { "type": "CNAME", "host": "www", "pointsTo": "agents.the-elevate-team.com", "ttl": 3600
+  }
+    ]
+  }

--- a/theelevateagent.com.agentsite.json
+++ b/theelevateagent.com.agentsite.json
@@ -9,8 +9,6 @@
   "syncBlock": false,
   "syncPubKeyDomain": "theelevateagent.com",
   "syncRedirectDomain": "theelevateagent.com",
-  "hostRequired": true,
-  "warnPhishing": true,
   "records": [
     { "type": "CNAME", "host": "www", "pointsTo": "agents.the-elevate-team.com", "ttl": 3600 }
   ]


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [ ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [ ] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [ ] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [ ] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
