### PR TITLE
Fix: add GH_TOKEN to trigger workflow detect step

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -17,9 +17,13 @@ on:
 jobs:
   detect:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Determine action
         id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           pr_number=""
           action=""


### PR DESCRIPTION
## Fix: GH_TOKEN missing in trigger workflow

### Problem

The `detect` step in `review-trigger.yml` calls `gh api` to check whether a
push is an "Update branch" merge commit, but `GH_TOKEN` was not set in the
step's environment. This caused the workflow to exit with code 4:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

### Fix

Added `GH_TOKEN: ${{ github.token }}` to the `detect` step's `env` and
`permissions: contents: read` at the job level (required for the commits API).
