### PR TITLE
Add BeeRanked content template

### DIFF
--- a/beeranked.online.content.json
+++ b/beeranked.online.content.json
@@ -1,0 +1,15 @@
+{
+  "providerId": "beeranked.online",
+  "providerName": "BeeRanked",
+  "serviceId": "content",
+  "serviceName": "BeeRanked Content",
+  "version": 1,
+  "logoUrl": "https://beeranked.online/android-chrome-512.png",
+  "description": "Serve your BeeRanked content on a subdomain of your site, with an automatic HTTPS certificate on BeeRanked's edge.",
+  "syncPubKeyDomain": "beeranked.online",
+  "hostRequired": true,
+  "syncBlock": false,
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "connect.beeranked.online", "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
  # Description

  New Domain Connect template for BeeRanked. Connects a customer's subdomain (e.g. content.theirsite.com) to BeeRanked's
  hosted content with one click , a single CNAME → connect.beeranked.online. BeeRanked issues the HTTPS certificate on
  its edge (Cloudflare for SaaS).

  ## Type of change
  - [x] New template
  - [ ] Bug fix (non-breaking change which fixes an issue in the template)
  - [ ] New feature (non-breaking change which adds functionality to the template)
  - [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

  # How Has This Been Tested?
  - [x] Template functionality checked using Online Editor
  - [x] Template file name follows the pattern <providerId>.<serviceId>.json (beeranked.online.content.json)
  - [x] resource URL provided with logoUrl is actually served by a webserver
  (https://beeranked.online/android-chrome-512.png , image/png, HTTP 200)

  # Checklist of common problems
  - [x] syncPubKeyDomain is set (beeranked.online; public key published at _dck1.beeranked.online, valid 2048-bit RS256)
  - [x] warnPhishing is not set alongside syncPubKeyDomain
  - [x] syncRedirectDomain is set whenever the template uses redirect_uri — N/A: the apply request does not use
  redirect_uri
  - [x] no TXT record contains SPF content — N/A: no TXT records (single CNAME)
  - [x] txtConflictMatchingMode is set on unique TXT records — N/A: no TXT records
  - [x] no variable used as a bare full record value — N/A: no variables (pointsTo is fixed)
  - [x] no bare variable used as the full host label — N/A: no variables
  - [x] no variable used in the host field to create a subdomain — correct: the subdomain comes from the host parameter
  (hostRequired: true), not a variable
  - [x] %host% does not appear explicitly in any host attribute — correct (host is @)
  - [x] essential is set to OnApply on records the user may need to modify/remove — N/A: the single CNAME is the fixed
  service binding; removing it disconnects the service, so it isn't a record the user modifies independently (unlike
  e.g. DMARC)

  ## Online Editor test results
  Editor test link(s):
  [Test beeranked.online/content example.com/content](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHUpL2oC%2F91Ty27bMBD8FYGXHmI5kiLbsYACzaNIH4kbJC5QNDCENbmWGUukSlJ%2Bwv9e0o6sNEmBnnvSanc4y50dbojBoszBIEk2pFRyzhmqz4wkZIyoQMyQtaXIuUDSOtQHUFg8OUe82yFsSaOac4q7k1QKg8I02Zd47%2BKAmKPSXAqShC2Sy0x%2BV7lFTo0pdXJ8%2FPIOxyCYkpz5dKpkgX4njNqlyCwPQ00VL82Oi9zbvuitZKW8punTtTwpPPB0NWayAC48OdkDNTfY8hbcTD2wiMrYsuHU%2BzQc3t57FJXhE06tUo7gwPpOe8gybLthV4LeVuOvuLrcMb%2Bt4VRqc4e%2FKq6sbolRFe5PnueSzkgygVzbjEIqFdMkedgQsyqdeheDs5uPTwT294Pbh%2BTC6KHcay6QmvYbHY2xkp50g2A72rbIWgpMG%2FqRla6%2BLS7BegHbVBZNn2aZmZJVmfL6WAkKCu1sUxM8%2FMEwqikeDhw2Be7fBXYBdUiF9UeNdQmzPITF8pAEleFT3s7BMyEVptp%2BwVQKay2LKjc8hQU0KUZTKMt8ZcfWtmopXqsq9hZtpmVg4B91bZGUUScE37mfTsa9sN%2Fx%2B50e82OEvn%2Fa6aIfhixEBsEp9vrP3tLf3trbD%2BrVUlBrG3Bwr%2BYsX8BKk%2B121LIL%2Bt9ndB6CObIUHDoKoq4fdP0wHkZREoVJHLb7J3HYi46CIAkCNwtqs594Y%2F3z3DlkdlpdL68uB1%2Fuj37G60V%2F3H28GN7i%2BvJk%2FahuxOJbFufj2fTHVRa%2FJ9vflO5MUjUFAAA%3D)