### PR TITLE
Update Mailtosh sending domain JSON configuration

### DIFF
--- a/mailtosh.com.sending-domain.json
+++ b/mailtosh.com.sending-domain.json
@@ -3,30 +3,18 @@
   "providerName": "Mailtosh",
   "serviceId": "sending-domain",
   "serviceName": "Mailtosh sending domain verification",
-  "version": 1,
+  "version": 2,
   "description": "Adds DNS records required for Mailtosh sending domain verification, custom MAIL FROM, and SPF.",
   "logoUrl": "https://mailtosh.com/logo.svg",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.mailtosh.com",
   "syncRedirectDomain": "mailtosh.com, app.mailtosh.com",
-  "variableDescription": "%dkim1%, %dkim2%, %dkim3%: DKIM verification tokens; %emailRegion%: email delivery region, for example us-east-1",
+  "variableDescription": "%dkimSelector%: DKIM selector; %dkimPublicKey%: DKIM public key; %emailRegion%: email delivery region, for example us-east-1",
   "records": [
     {
-      "type": "CNAME",
-      "host": "%dkim1%._domainkey",
-      "pointsTo": "%dkim1%.dkim.amazonses.com",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%dkim2%._domainkey",
-      "pointsTo": "%dkim2%.dkim.amazonses.com",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "%dkim3%._domainkey",
-      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimPublicKey%",
       "ttl": 3600
     },
     {

--- a/mailtosh.com.sending-domain.json
+++ b/mailtosh.com.sending-domain.json
@@ -8,7 +8,7 @@
   "logoUrl": "https://mailtosh.com/logo.svg",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.mailtosh.com",
-  "syncRedirectDomain": "mailtosh.com, app.mailtosh.com",
+  "syncRedirectDomain": "app.mailtosh.com",
   "variableDescription": "%dkimSelector%: DKIM selector; %dkimPublicKey%: DKIM public key; %emailRegion%: email delivery region, for example us-east-1",
   "records": [
     {


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

[Test mailtosh.com/sending-domain mailtosh.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHqcL2oC%2F%2B1V227bOBD9FYJAn2o58iWuo8APctx4va3T1k7R7gaBQZMjhbAkyiTl1A28375DW74mWOSxwPZJJGeGM%2BfwzOiJWkjzhFmgwRPNtVpIAXogaEBTJhOrzEOVq5RWdrYblqIvHZZWtBjQC8lhHWQgEzKLPaEwPNsbT6JI6Uc2fmQBWkaSMyuVC8KtcaugXqECDNcyX1sCGgphSO9mTDRwpXGtYV5IDYJESpPXXF8hvDBWpWQYDj6S69GnYYWwTJDx5%2Bsqpk5UrL7qBFM9WJub4OzskIczZ66aReyQLTPeTRSf0SBiiYHNyedi%2BgGWvQ38gG4K4CrLgNvqCaXOfwQCy%2Bd2F8Hy%2FNRvwbRk0wR6R1S8ETOZjiHBYKXfBKT3YTBE4Jv9JVmbsZpEcixoa8%2FXB2QGS%2FQAl2cEMd6H9vWOCEgk0rVEYuM1W45X%2BMFQJEAK4wEz1qthUeUD0ODuidpl7l739vstGh6Usc%2FKq042TGBidBHMMnRZdFxNtUsy62jDLkneOSkaXa3Ft2i0fH9V2eUZft%2BncS%2Ft1KlkZs2twpMIQEwZn3kmtXn1CGSVpeynygyYnail0tIuaVDzX86Fshg%2By2byaFQkgOApPm5SCAiOb17dryoU9zDZ03RfKdXwvLfK23EVa1XkE7kNyJlmqXGtuQ29O4693wbfUbc%2B5NydDQf9aBj6%2FavxvD8eTBu9L%2B%2B74ZevYdjs34S9q67cBu0430QNriAcdMNeeNONZ%2FOHmexfPPoY%2Bf46DMdX4TrvAbEuqNQGdchlnCkNE4NfZguNPFpdYIOkRWLlhD2y%2FZHgE1R8skSiDFrxplM9ZZvRkco4SpkfczOPjZw2xBymbF4w1sQkgk%2FlKyX2CnAHSqjQieCOf%2BmmW7MBvNFuNL0LeMe9Zq0eeaw59T12wf1W1GK1dtQ4GJUvjdH%2FHJZ7HYBBo5XMDaIweWRLQ1enHVASU2qyBHys%2FvJRnun%2BAN9xC%2FySaI90cAx30cFerJEXu5D8w5JkCxax%2Flrw7ivY4L%2B1%2Flvr%2Fwet4%2B%2FCsAWICXNudb%2Fe8vyWVzu%2F9VtBox7UW9Vmw2%2B3z9%2F6fuD7DgcYu4H9hP%2BTwz8JrS0L1vsW%2FT0fqG7%2FOu%2Fboj0K7R9%2FFvF56625evdp%2FDOx36Y%2F%2FspVh67%2BBZ7Wdy3hCgAA)
[Test mailtosh.com/sending-domain mailtosh.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJWcL2oC%2F%2B1VXW%2FiOhD9K5alfboEwldQU%2FEQSssilu4uUO1HVSEndlIvSRxsh15acX%2F7HROgBLpX%2B7jS3SewZ87MnDMzzgvWLMliohl2X3AmxYpTJocUuzghPNZCPVYDkeDKwXZLEvDF450VLIrJFQ%2FYFqRYSnkaWVQAPH01nqDQzg8VfmjFJA95QDQXBgRHZf65jQqmTAWSZ1uLiz1KFerfTpFkgZDwX7JlziWjKBQS%2FUr4CgpypUWCxt7wA7qZfBxXEEkpmn66qULqWETiTsaQ6lHrTLm12rEONWOuqlVkmK3ToBeLYIHdkMSKFTefcn%2FE1v2CvouLAgKRpizQ1RNJjf%2BEUSg%2F0AcEybJTvxWRnPgx65ekeEcXPJmyGMBCvnNRfzQcA%2FHifIm2Zqgm5gEUtLdn2wu0YGvwYCbPhEUQD%2BzbE6Is5iDXGoSNtmoZXdnfBIaEoVxZjCht1aGoXQOwe%2F%2BC9Toz3Z19nYHhUSh9Vl51XigBicGFEk3AZdU1NdUv0aIrFblEWfekaHDVGnrRdGx7UznkGX99TWM6baZT8FSrmYCbkDHqk2BhqURn1RLJKknIs0gVU4eh5kJyvcZu3X47F4zF%2BCybysJJHjMgj6G5cU6ZW468edhUMJzZ%2FFWmh8puGs53axcdWg%2BHSIo8m%2FM9JiOSJMps5x59X4Y%2F7PH32wAmzZHy5no8HIRjzx5cTZeD6dBv9j9f97zPd57XGtx6%2Fase34MOyheo4RXzhj2v7932osXyccEHF082IK9vPG965W1TH8lrQLsJwYY%2Fj1Ih2VzBL9G5BDW1zGFNkjzWfE6eyOsVDeZQe7wGuRRYIdLpVKXFA5LwKEyIHQVqGSnuN%2BmS%2BWSZE9KCJDTw%2BdGgVQs9fzpsv0DwaCYqeE4D0wZu3rmOYzfavuNb7TazrdZFp275ftiw%2FPZFwC5ajt1pOEeP5lsP6n8%2Bm6WJYArsmhPzKnnxE1krvDldh50%2BJlCZd3kddv05W4QjmuWd%2BF1Jl6binPWqCztaR29uJ%2FqHxPGeM1D%2B7Vg%2BVGDx%2FyzAnwX43y4AfFgUWTE6J8azYTccy3asentmO26z4babVdtpdJrOX7bt2rahwpQumL%2FAl%2Bf4m4On%2BsdzOp2Mhj%2Fq%2FeeZTFof3393Fp3wi%2FSXfDSriWZtFN71rpX9rYs3%2FwKeI5FCEQsAAA%3D%3D)
[Test mailtosh.com/sending-domain mailtosh.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALmcL2oC%2F%2B1V204bMRD9FcsST91NNjcKi%2FJARSsohNKQqiCEIseeBCve9db2bhtQ%2Bu0dJ5s7qtK3Sm1eYntmPHPOnPG%2BUAdJppgDGr%2FQzOhCCjAXgsY0YVI5bZ8qXCc0WNquWYK%2BtFNa0WLBFJLDLMhCKmQ6CoXG8HRl3IoipR%2BZ%2B5ECjBxKzpzUPgi31q%2FiekAFWG5kNrPE9FQIS86ub4kBrg2uDXzLpQFBhtqQfa4PCM%2Bt0wnpnF5ckQ%2FdT52AsFSQ25sPFUyt9Eh%2FMQpTPTmX2bhaXeeh6s0VW4w8sknK3ynNxzQeMmVhfnKTDy5hcjaHH9N5AVynKXBX2aLU%2B3dBYPncLSNYlm37FcxINlBwtkHFgRjL5BYUBmtzEJOzy4sOAp%2FvT8jMjNUoybGghT2bHZAxTNADfJ4ujPA%2BtM92RICSSNcEiR3N2PK8wg%2BGIgGS2xCYdWENiyobQOOHF%2Bomme9u766Hhidt3U55lf6cCUyMLoI5hi5F29dUOyHjtrHshGTtraLR1TnsReMwiqbBMk%2FnbpXGd9qrU8vU2Z7GkyGAGDA%2BDm3issoGyApL2LNOLdilqKU20k1oXItez4Wy6Oxks9mwmytA8BSbq3IB8ebN08dpQHEP%2FRVNj0Gpht3ZKm%2FH1cjoPOvLRUDGDEusH81F6MNm7OMi%2BIH69Trn%2Fozt91uELpn%2Fw9g1jn1kKRPqSZCjVBvoW%2FxnLjdIqTM5zkqSKyf77DtbHQneR%2FGrCXJm0Yo3bUsrnb8ie1a2p%2Bb2xbmmj4D2Bfddkf7NixoteNscsLDVfMvCZj1qhkcRhxDEEY8iMRCi1lx7QF97XH%2F7hK7UARaNTjL%2FPJ2q72xi6XR7LkqOSqWWqDdnouzPzjSs4dscjL8S7YYkNuEWbZzQGnl1NslPptQCLGL9u%2BA9Bjj2%2F2X%2FX%2Fb%2FmOzxI2JZAaLPvFs9qh%2BG0WFYa%2FWiw7jRiOvHlUarWTtuvYmiOIo8DrBuDvsFvzLr3xfagvvz%2FLxx%2Fvwl%2BlT9LK5k77mWnH69Ky6VHNzfJwwuB%2Bfw4%2BNR%2FX2bTn8BUT4FigILAAA%3D)