### PR TITLE
add Minimo, Email

### DIFF
--- a/minimo.it.mail.json
+++ b/minimo.it.mail.json
@@ -4,7 +4,6 @@
   "serviceId": "mail",
   "serviceName": "Email",
   "version": 1,
-  "logoUrl": "https://www.minimo.it/logo-black.svg",
   "description": "Configure email sending for your domain through Minimo (SES domain verification, DKIM and DMARC).",
   "variableDescription": "dnsToken: Minimo domain-ownership verification token (always mn- prefixed). dkim1/dkim2/dkim3: the three Amazon SES easy-DKIM selectors.",
   "syncPubKeyDomain": "minimo.it",

--- a/minimo.it.mail.json
+++ b/minimo.it.mail.json
@@ -4,6 +4,7 @@
   "serviceId": "mail",
   "serviceName": "Email",
   "version": 1,
+  "logoUrl": "https://www.minimo.it/logo-black.svg",
   "description": "Configure email sending for your domain through Minimo (SES domain verification, DKIM and DMARC).",
   "variableDescription": "dnsToken: Minimo domain-ownership verification token (always mn- prefixed). dkim1/dkim2/dkim3: the three Amazon SES easy-DKIM selectors.",
   "syncPubKeyDomain": "minimo.it",

--- a/minimo.it.mail.json
+++ b/minimo.it.mail.json
@@ -1,0 +1,50 @@
+{
+  "providerId": "minimo.it",
+  "providerName": "Minimo",
+  "serviceId": "mail",
+  "serviceName": "Email",
+  "version": 1,
+  "description": "Configure email sending for your domain through Minimo (SES domain verification, DKIM and DMARC).",
+  "variableDescription": "dnsToken: Minimo domain-ownership verification token (always mn- prefixed). dkim1/dkim2/dkim3: the three Amazon SES easy-DKIM selectors.",
+  "syncPubKeyDomain": "minimo.it",
+  "syncRedirectDomain": "minimo.it",
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "%dnsToken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "mn-"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Minimo** (https://minimo.it) — `minimo.it.mail.json`. It configures a user's domain for sending email through Minimo: domain-ownership TXT, three Amazon SES easy-DKIM CNAMEs, and a DMARC TXT. Synchronous signed flow (`syncPubKeyDomain` set; public key published at `_dcpubkeyv1.minimo.it`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A, `logoUrl` omitted from the template (the logo https://www.minimo.it/logo-black.svg is provided to Cloudflare during onboarding instead)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — none present (SES easy-DKIM uses CNAMEs)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — apex token (`Prefix` `mn-`) and DMARC (`Prefix` `v=DMARC1`)
- [x] no variable is used as a bare full record value unless necessary — **justification:** the apex `TXT %dnsToken%` is Minimo's ownership token, which our verifier matches **verbatim**; the token already carries a fixed `mn-` provider prefix (covered by `txtConflictMatchingPrefix`), so a service-prefixed form would break verification. Bare value is required here.
- [x] no bare variable is used as the full `host` label — DKIM hosts are `%dkimN%._domainkey` (fixed `._domainkey` suffix)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — DMARC

## Online Editor test results

**Editor test link(s):**

- [Test minimo.it/mail example.com/@ (apex)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAIXMWoC%2F%2B1W%2F2vbOBT%2FV4Sg0LE459ip03oULmsyVkrW0QZ2RylGsV4SEVsykpLWLfnf9%2BTETbLrFsodbDvqH2zpvY%2Be3tcPfqQW8iJjFmj8SAutFoKDPuc0prmQIldNYWnjSfGJ5Qikg0qFcgN6IVJY4ZnINqI1sr%2BWLkAboSSNWw3KwaRaFLba0zMlx2Iy10DAYYkByYWckLHSpFRzTbhCuSR2qtV8MiWru8nhdf%2B6VqFxMRYpcxYbpHdxPiBMctIbdK%2FO3jTd7UwLNsqgt3Mzl2aoZiDj2ubKnKfuJHo7FcWOYWIdlhyy7I6VhuTSI4WGsbgH%2FqZJ%2BEzkrT%2FcO6jeYYwOg3MagHRz9oAGnMfATOlVHhrIILVKG%2BegKWX6eT66gLJX%2BfBN%2Bp36CrjQeOK7gPeZSmc0HrPMAEqmTAN%2F2uJJpbmh8c0jtWXhSjP8a4gnp8pY3PyJS84sw%2BVBnZcDlFmb0TiMfB%2BX99bVKhOpHTCbTrFIA8Wdpc9VHuizkLUO3ZUeXTaebj%2F71B30N%2FcfVAk8aCarGsygdF2nhLToy5befZqsyqcB00xVvu3kHvvBHvvBv7Qf7rEfvsD%2BTnUSnjOdbkq0OK16u%2FWOFKdSSXj3n1aqto4wMDiOVjA0TS9ltyiyki5vlw2K%2FkOyaapbdK3uS7hnyCiwjm0dAa4mOL9FImp8wTTLjWOd%2BuTNztHb%2BuwNdeu6Kd0eW8mCsa0gbB9FneMTn41SDuMK5trEYVCE%2BrXBlhNX8%2BtXT6uGBnuhQQ0N90JD6jIjJlJpSAx%2BmUVao7HVc5zAfJ5ZkbA7thHxNGEupZhIg1q84NvplCsW3ZrO78W%2B0wAJT11ihaPlzqjNo6jDvKN0DF47iELvGB%2BPH0VwHI14eNw%2B2mL4f1D%2FMxS%2Fqel2f3QrYqTLZ4ZkHcaPa7I7O%2Btw9xz58Tj9nokIXp6I4H%2BZiPDliQh%2Fm0TszPcL%2Bf2nxPBE%2F8vbBvL3K1O9MtUrU70y1a%2FNVPjvZtgCeMIcLvCDyPMjrxUN%2FZM46MSh32x1giAK3vp%2B7PvOd2SsVWiP%2BC%2B3%2FRdHw%2Bnf511rT0JIhV8OH9iXj4uLdNzP2HUaXX74eNm7fv%2FFzNr9y7tTuvwK4T3lzlkPAAA%3D)
- [Test minimo.it/mail example.com/mail (subdomain)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFMXMWoC%2F%2B1WW2vbMBT%2BK0JQ2Fic%2BZI6iUdhWdOHMrJLF9igFKNaJ4moLXmSkjYr%2Be87cuwm6bqFXWBsNA%2BOfS6fzvWzb6mFosyZBZrc0lKrheCgTzlNaCGkKFRbWNq6U7xhBRrSUaVCuQG9EBms7ZnIN6La8qSWLkAboSRNghblYDItSls902MlJ2I610DA2RIDkgs5JROlyVLNNeEK5ZLYmVbz6YyszyZPPpx8aFQILiYiYw6xRYavT0eESU6Go8HZ8dO2O51pwS5zGO6czKUZqyuQSYO5hvPUtcRoZ6LcASbW2ZInLL9mS0MK6ZFSw0TcAH%2FaJvxKFMFzdw2ra5RgwOCCBiCDgn1BABcxMLP0qggN5JBZpY0L0Cxl9m5%2B%2BRqWwyqGe%2BV36jPgQqPHdw1e5Sq7osmE5QZQMmMa%2BN0jeirNDU3Ob6ldlq41409j9JwpY%2FHhJd5yZhneHjR1OUCZtTlNotj38fbGul7lIrMjZrMZNmmkuEN6V9WBPmhS6zBc6dFV6%2B704zeD0cnm%2FIOqgAftdN2DK1i6qVNCWoxlS%2B%2F%2B2qyqpwHTzlSxHeQe%2FHAPfvib%2BNEe%2FOgn8He6k%2FKC6WzTosVRNdvBC1IeSSXhxR%2FtVIOOZmBwHa1gCE3fykFZ5ku6uli1KMYP6WaoLjC0Zi7hhiGjQJ1bnUFNA1Pc4TIVjU%2FJNCuMY57G%2B3zH%2FaLxP18DuGPq4axk0rNgbBBGncO42%2Bv77DLjMKnM3Lg4GxShvgYNnLjaY7%2F6BY1puNc0bEyjvaYRdRUSU6k0pAb%2FmUV6o4nVc9zEYp5bkbJrthHxLGWutFhQg1o84P6WyjWb1lWsp%2BB76e%2FMQsozV1%2FhGDrkQTfs9iZe1u%2BEXqfv970eiydeN4CgC4fdGFi8RfbfvAUeYPvd9m6Py6DiSbp6YGfqbH7cmq1Vau%2Fmvcfvxyv271Yk%2FMWKhP9tRaJfrEj0T1VkhwHWb4J7ye55Hfy1ZO7eGKuLFtL9I6k9ktojqT2S2n9DavhFaNgCeMqcbeiHsefHXhCP%2FX4S9pLDoH0Y93tR95nvJ77v4kdmW6d3i1%2BI29%2BGlPnD93YQPR%2FH0Wf96rTTe8b6n4bv1cfi81SpRTEPLoe23zlZnJ0e0dVXX9spQ7cPAAA%3D)

