### PR TITLE
Update keplars.com/email: v2, syncRedirectDomain=dash.keplars.com

### DIFF
--- a/keplars.com.email.json
+++ b/keplars.com.email.json
@@ -3,12 +3,12 @@
   "providerName": "Keplars",
   "serviceId": "email",
   "serviceName": "Email",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://cdn.keplersmail.com/keplars-logo-main.svg",
   "description": "Configures your domain to send email through Keplars Mail Service. Sets up SPF, DKIM, DMARC, and bounce handling automatically.",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.keplars.net",
-  "syncRedirectDomain": "keplars.com",
+  "syncRedirectDomain": "dash.keplars.com",
   "variableDescription": "%dkimSelector%: DKIM selector name; %dkimPublicKey%: Full DKIM TXT record value; %region%: AWS SES region code (e.g. us-east-1)",
   "records": [
     {


### PR DESCRIPTION
## Type of change

- [x] Update to existing template

## What changed

- `version`: `1` → `2`
- `syncRedirectDomain`: `keplars.com` → `dash.keplars.com`

The Keplars dashboard is at `dash.keplars.com`. The previous value (`keplars.com`) caused Cloudflare's apply endpoint to reject the `redirect_uri` with "URL is not verified" because the redirect URI host did not match the registered domain exactly.

No records, variables, or other fields were changed.

## How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

## Online Editor test results

**Editor test link(s):**

[Test keplars.com/email keplars.net/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFdmMWoC%2F%2B1WbW%2FiOBD%2BK5alle5UEhK6vAUhlW53pV6P3V7paXuqKmScIViYOGs7bLmq99tvTAKBLny4T92T%2BgUczzPvM0%2FyRC0sMsks0OiJZlotRQz6MqYRnQPea%2BNztaC1regzWyCUXhVCFBjQS8FhrQILJmR1V2I%2FlrdL0EaolEaNGpUqUX9qidKZtZmJ6nUep75ziSCHd27rZQieQ3t4m%2FpmmaClGAzXIrNra%2FSDSqciyTUYslK5JrFyUGIVMZDGZB0UsTOt8mRGysDJ0F2Oijh9PFhD8oyMrj%2FVyMXV5RB%2Fh4ObDzXC0MJE5SkHMsOzFGlCWG7RhRWcSbnyXb6rlJ9Lxec0mjJpoLi5zidXsLpYR4NhFmFxlabArb%2Bpbgq2NHADsdAoqhSYmfn7XVgyLdhEwsVeAd7Fc7EYgURlpd9F6wQw9%2BKZpNiFHlljMCIpOAaFoE%2B5lAXy9u6WoGOlY7JkMndgDQmaRtTg64iMPo5IcUG4ioH8An7ik9x4wIz1wl8xrkLd0Oj%2BidpV5rqOpRyiZKaMxaczl2Q2vcklIIpiHWQeQ1Rmt2k4gqzFoThtBcFzbWsKA6wsjeMF09wNAbMMn5f9dafCHsn633KmWWpFijnonPWdXauitYanIVPamrMXPlGP234YBD3CXI36Gg8Yal%2FvRoPHR%2BsGDetnh8zyGQ7CEKuBEVxrmIpHehBSyqowEQYG59IK5qb%2FSzrIMrmix7Ldb60%2FLoZoDquqAC86e6SGw7vKaDHPbqmVSK25VXg3BYgnjM89s7CZvxkAny3Y3yo1UNGAUFrYFY3C4LCj%2Fb5vXf3H5j881yg6hnE1WQ%2B1coV2uKnYntIXnhJc8mwsNvgMx2FhHLNtNO%2F3VB82uvfUnXdrvQPdiLY1djLsJ%2B5O2Jv3tWG9rD%2B8vPR930GL0jlMuSLUJSOSVGkYG%2FxnFrmKRlbnSBSLXFoxZt9ZdRXzMXNDgbkblKKl%2BxfDkRbEera7BVjgkBwpLfkHmWp%2FnMcxd3URjrYZ67bCuBl67LTZ9t43Oh1vMpk0vG4MvNNtNMP3Db7zCjjwdjj0Eqi6sjvwA%2FmdrQx9%2FmHgy5xea71fqx5bAjhWkI3hQ6t%2FZAh%2F1kavOahMa0sMZSr7%2FFNuzg%2F0s5PXPhP9rOP8Ms3%2F354%2B1JBJ3wjojYDeCOiNgF6FgPCbyrAlxGPmYI2g0fKClhe2bsNmFDSjZtdvdxrdoH0SBFEQuOjB2CLdJ%2Fzy2v3movVzkSenv50MTurL%2BV%2F15tUjY3ej3792TzvneZu1h9P6l7qAzwr%2B6NPnfwF6AkWyHg8AAA%3D%3D)

[Test keplars.com/email keplars.net/keplars.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEdmMWoC%2F%2B1WbW%2FbNhD%2BKwSBAhtmKbIdq7ECA02aFsgCZ1nsdQWCwKApyiZMkSpJuVWC9LfvKMmWldoD9mVYsHyxKd77c3eP9IgtSzNBLMPRI860WvOY6csYR3jF4F4bn6oUd7aia5KCKr6qhCAwTK85ZaUJSwkXzV2t%2B6G%2BXTNtuJI46nWwUAv1hxYgXVqbmejoiMbSdyFByem7sEd1Cp7T9uBW%2Bma9AE8xM1TzzJbe8HslE77INTOoULlGsXKqyCpkmIxRmRSyS63yxRLViaOxu5xUefpwsAblGZrcfOygi6vLMfyOz27fdxABD3OVS8rQEs6CywUiuYUQllMiROG7egtJz4WiKxwlRBhW3dzk8ytWXJTZQJpVWlRJyaj1N%2BhKZmsHtyzmGkSNATFLv92FNdGczAW7aAHwJl7xdMIEGCv9JioLgNqrZyShC6eo1IGMBKeQFCh9zIWoNKefpwgCKx2jNRG5U9ZsAa5B6%2BzPCZp8mKDqAlEVM%2FQT8xc%2Byo3HiLFe92fIqzI3OLp7xLbIXNcByjFIlspYeHrnisyS21ww0MKAg8hjFtXVbRoOStbCUPTDIHjqbF1Bgo2nWZwSTd0QEEvgeT0qO9U9RdnoS040kZZLqEHnZOT8WhWVFp5mmdLWvHsWE%2ByoHXWD4BQRh9FIwwFSHendbOD4zbpBA%2FzsmFi6hEEYAxqQwY1mCf%2BG96rUsiZNUGMG5tJy4qb%2FN3mWZaLAh6ptt9afVUO0YkUDwLPOHsBw%2FLlxWs2zW2rFpTVTBXcJY%2FGc0JVnUpv5mwHwSUoelDSsoQGuNLcFjrrB%2FkDtvm9D%2FcPm3z91MARms2ay7jv1Cu1wU7U9daz2qixg37MZ35hmMBmpcSS3cXLX8nK%2FcXPX8uOC7nRgR7wRbZF3MugybFT3dDXShpxmo%2FHlpe%2F7TrUC1OnUi4NdiXwhlWYzA%2F%2FEAoPhyOoc6CPNheUz8pU0VzGdETcqgIgBKXi6ezYysqLbNgzbLYEGdNEB6NF3YLL2uM9i6sDicUlE7HjIwmMvCfuJdzzszb3hSZh4g4QOh2HSj7uD4c4rYs%2FbY99LYm%2FXdnfjTHwlhcFPP%2BxGXWjFBP6Bev8dVvgPwLSlkEM4bUwb8jiI2b7hfQFjUZJbXW3FOPsrbJNcvYg%2FcNxOuW26ewE78XfVv2gOuO8Ai78y3ivjvTLeK%2BP9PxgPvhoNWbN4RpxFL%2BiFXhB63XDaHUTBIDru%2Byf9QT8MfwmCKAhcIczYqvJH%2BLbc%2FarE5z2WFak1%2BcNYDo6ur3vZ%2Bae3n5Jfz%2BmUP6yEJcPl78HtVHy5ORnhp78Ag4pSRBYQAAA%3D)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `domainconnect.keplars.net`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — updated to `dash.keplars.com`
- [x] no TXT record contains SPF content — `SPFM` record type used for both `@` and `bounce`
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`Prefix` / `v=DMARC1`)
- [x] bare variable `%dkimPublicKey%` used as full TXT value — justified: BYODKIM requires the complete DKIM public key TXT record value as a variable since it is unique per workspace and has no fixed prefix
- [x] `%dkimSelector%._domainkey` host contains a fixed non-variable suffix `._domainkey` — not a bare variable host
- [x] no variable used in `host` to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential: OnApply` set on the DMARC TXT record