### PR TITLE
Add draft2live.ai.blog template

### DIFF
--- a/draft2live.ai.blog.json
+++ b/draft2live.ai.blog.json
@@ -1,7 +1,6 @@
 {
   "providerId": "draft2live.ai",
   "providerName": "Draft2Live",
-  "providerShortName": "Draft2Live",
   "serviceId": "blog",
   "serviceName": "Draft2Live Hosted Blog",
   "description": "Connect a custom domain to a Draft2Live hosted blog so visitors reach it as https://example.com instead of https://your-blog.draft2blog.com. Records: one CNAME pointing the apex at the tenant's Draft2Live edge plus one TXT for ownership verification.",
@@ -10,6 +9,7 @@
   "syncBlock": false,
   "syncPubKeyDomain": "_dc.draft2live.ai",
   "syncRedirectDomain": "draft2live.ai",
+  "hostRequired": true,
   "variableDescription": "slug = the tenant's draft2blog.com subdomain; token = the per-attempt verification token Draft2Live generated for this domain.",
   "records": [
     {

--- a/draft2live.ai.blog.json
+++ b/draft2live.ai.blog.json
@@ -7,7 +7,7 @@
   "version": 1,
   "logoUrl": "https://draft2live.ai/logo-domain-connect.svg",
   "syncBlock": false,
-  "syncPubKeyDomain": "_dc.draft2live.ai",
+  "syncPubKeyDomain": "domainconnect.draft2live.ai",
   "syncRedirectDomain": "draft2live.ai",
   "hostRequired": true,
   "variableDescription": "slug = the tenant's draft2blog.com subdomain; token = the per-attempt verification token Draft2Live generated for this domain.",

--- a/draft2live.ai.blog.json
+++ b/draft2live.ai.blog.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "draft2live.ai",
+  "providerName": "Draft2Live",
+  "providerShortName": "Draft2Live",
+  "serviceId": "blog",
+  "serviceName": "Draft2Live Hosted Blog",
+  "description": "Connect a custom domain to a Draft2Live hosted blog so visitors reach it as https://example.com instead of https://your-blog.draft2blog.com. Records: one CNAME pointing the apex at the tenant's Draft2Live edge plus one TXT for ownership verification.",
+  "version": 1,
+  "logoUrl": "https://draft2live.ai/logo-domain-connect.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "_dc.draft2live.ai",
+  "syncRedirectDomain": "draft2live.ai",
+  "variableDescription": "slug = the tenant's draft2blog.com subdomain; token = the per-attempt verification token Draft2Live generated for this domain.",
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "blog",
+      "host": "@",
+      "pointsTo": "%slug%.draft2blog.com",
+      "ttl": 1800
+    },
+    {
+      "type": "TXT",
+      "groupId": "blog",
+      "host": "_draft2live-verify",
+      "data": "draft2live-verify=%token%",
+      "ttl": 1800,
+      "txtConflictMatchingMode": "All",
+      "txtConflictMatchingPrefix": "draft2live-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Service Provider template for **Draft2Live**, a multi-tenant hosted blogs platform (similar in shape to Webflow / Vercel for AI-generated blogs). Users publish their blog at `{slug}.draft2blog.com` and can attach their own custom apex domain. This template handles that custom-domain attachment via the synchronous Domain Connect sync flow.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`draft2live.ai.blog.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver

We've also smoke-tested the end-to-end signed-URL flow against real Cloudflare-hosted zones (`knowrix.app`), confirming DoH TXT discovery → `/v2/{apex}/settings` → signed apply URL round-trips against the published public key.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `domainconnect.draft2live.ai`, public key live as split TXT at `_dck1.domainconnect.draft2live.ai` (verifiable via `dig +short TXT _dck1.domainconnect.draft2live.ai @1.1.1.1`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`draft2live.ai`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the TXT verification record (`All` + matching prefix `draft2live-verify=` so repeat connect attempts replace cleanly)
- [x] no variable used as bare full record value — TXT data is `draft2live-verify=%token%`, not bare `%token%`
- [x] no bare variable used as full `host` label — both records have fixed `host` strings (`@` and `_draft2live-verify`)
- [x] no variable in `host` field to create a subdomain — `hostRequired: true` is set instead so the host configuration is supplied at apply time
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` not set — neither record is user-editable post-connect (the CNAME IS the connection; the TXT is for ownership verification and can be removed once we mark the domain verified, but we hold onto it for re-verification on transfer)

## Online Editor test results

**Editor test link(s):**

[Test draft2live.ai/blog example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGGHM2oC%2F%2B1VbW%2FbNhD%2BK4SAYBtmKbLsOLaHAuvsrivWFEGatsuywKDJk8yFFhWSUuIG%2Be87Un6R7KDDvnVAP0nkvfDueZ4jHwMLy0JSC8H4MSi0qgQH%2FYYH44BrmtpEigoiKoLO1viOLtE5mHrzWzSjzYCuBAMfN5cq220deJPflLHAyS%2B1GwfDtCisUDm6TVSeA7OEElYaq5aEqyUVObEKtxo5FnUOdxQxilTCCKu0IRooWxCBCQxZWFuY8fExPFDsECKG6USOcZQTlW7NK1Xq0CWK6ob9L%2FpG5AKY0tyMicqBTN69PHtFCiVyK%2FKM2EVdBKHW%2F1vIaW6%2FM80igWfQ8cGXf1ySVGmi7nPQZiEKUoEWqWDU9d0hNOeNQ5wnLbF7tDLy%2Fv1bwkDb2h2IMKakOQNsmpKJVCVPJdVAppOPhIOEzOeMEFo8w3hYk06ATakPWiLEm75b9B47e1iDHbKahMhUnsdVzpArdhuMUyoN1Dvn5fx3WE19gNOK%2F9kE7ivHBVwAFxqNu5A9J4fmBdyV6IUqsrrEkyqqBZ1LmLZEYmSZkRdt2NvcEVPO65J%2BQuncQr52L0CH1DrF2xYDa6cGdxkgU9RpzLFhF8KQTcL0jm%2FypaWUXgY5qtzv1LIFjTSRNRxOLt9DlEVerlFTjpi6ufTEF%2FDwA%2FmrTOJun5QGC0Dtz0shuc%2FfZrkhGCeRrTYc%2B7pWbzC%2BfgzsqnBD6L3RlGlVFs1ZdS3g6mc35U7h5lLh8sgBfbQ3FuhiLeqoO4zjp842NSr8C4lnO7JDj%2FvKTT61tKWDtenFkWfjqHkS%2Fj5YvBxSKZg9o5YtENUzxd3RL6UMnrWfa0jFw7NHBI3S%2Fw2VGWVLCNmCSgl5BnsYOTUcRTDq8W7aP5lDyvvxMI44qyK2Hc4mcD3E7eapE3zGgZ%2FtSLrprIcIkzY0sStjXZSvciY2MQXVdGnc3b2Jvm6F32zir%2BsEuHasuvVyhZcmuB2Pt9uq0QnpnHWTXuCqFFmuNMwMfqktNWwmc1lKK2b0nu62OJvRopArbMqgFfMdKi%2BvX4N1L2sF1IV8QWcdFBBzPQrHzgjmvW4vHoSQJCdhfzg4DeloNApTepp2oTuc9yFpPFfPvmXPvFdtmMEYwJueSi%2Bwe7oywdOB3NfdHKo7ajd4qL820F91q3vU7U3DXqf7N9x%2FHIyvpfubDs7WN%2FV%2BU%2B%2F%2FU73ukqcV8Bl1rkmcDEKsozu8jE%2FGJ91xMor6yelwNPgxjsdx7DoAY2sMHvHOb972QXplr%2BTfH69OJ%2BnZp18%2FV4Py1TTO7m7vyvjNn9Ikrwe98%2F7ofnixyvBV%2FQeb%2BZznTwwAAA%3D%3D)

## Records (2)

- `CNAME @ → %slug%.draft2blog.com` — CNAME-flattening at apex; works natively on Cloudflare per their Domain Connect docs
- `TXT _draft2live-verify → draft2live-verify=%token%` — ownership verification, `txtConflictMatchingMode: All` + matching prefix so repeat connect attempts replace cleanly

## Cloudflare onboarding email

Going out separately to `domain-connect@cloudflare.com` per their published process at https://developers.cloudflare.com/dns/reference/domain-connect

