### PR TITLE
add Convee website template

### DIFF
--- a/convee.app.website.json
+++ b/convee.app.website.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "convee.app",
+  "providerName": "Convee",
+  "serviceId": "website",
+  "serviceName": "Funnels",
+  "version": 1,
+  "logoUrl": "https://convee.app/favicon.svg",
+  "description": "Enables a custom domain to work with Convee Funnels",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.convee.app",
+  "syncRedirectDomain": "portal.convee.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "funnels.convee.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Convee website template.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**  
- [Test convee.app/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACT4MWoC%2F91SXYvbMBD8K0avlw%2FZ59g5Q6Fpcwel7bWkKRRCMIq8TkRkyZXkuG7If%2B86Ti4JV%2Bh7n8TuzuzOrmZPHBSlZA5Isiel0TuRgfmQkYRwrXYAA1aWpPdSeWYFIsn7Yw3zFsxOcDgSalhZ4a6yJ%2FBTpRRIi%2FkdGCu0IonfI1Kv9Xcjsb5xrrTJcHgZOMwZ8rUa2N0aaRlYbkTpjlTyqNhKgvWYxyvrdOFlumBCeU57tTZbrxZu43UCvcto2yj%2BTmq%2BJUnOpIUu87VafYRmemyArbtOOFgBd4ObA7ToGWTCYOUFX2rjmLwFbrR1M%2FhZIRKP4kyFo5CkTWZJstgT15THCz5PPj%2Be4Bi%2BbW%2BshXJ2rjHMO923nZ3Da91HlB6Whx75rRWkl8bL3kk9suEXwz8FZBeXCXVdY7A2uipTcaaUzLDCtl9%2FJi9u2MszfXHkt3PFWmkDqcWXucrAeceikk6krGaXVMZTVC4blGmxil1e7686j3TqMubYP7fvkTTjrWTRmi4fxXnMw6zP4sDvhw9h3H%2FwadAfZYzGwRjGMYRX%2Fn3t7L87%2BOZoYC0oJ1hr1omsWWPJ4bDs4QH%2Fp33wry3bQZayFhnQIOrTqO%2FHc%2BonwTih4cAPRyMa3FGaUNpuANZ1G%2B7RF9eOIHeNBT7buimN1HQVfXF8Vd0PnzY5DSfRExRyJOffZpMf%2FBN%2FQw5%2FALodkx6FBAAA)