### PR TITLE
Update Convee website target host to connect.convee-dns.com

### DIFF
--- a/convee.app.website.json
+++ b/convee.app.website.json
@@ -3,7 +3,7 @@
   "providerName": "Convee",
   "serviceId": "website",
   "serviceName": "Funnels",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://convee.app/favicon.svg",
   "description": "Enables a custom domain to work with Convee Funnels",
   "syncBlock": false,

--- a/convee.app.website.json
+++ b/convee.app.website.json
@@ -14,7 +14,7 @@
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "funnels.convee.app",
+      "pointsTo": "connect.convee-dns.com",
       "ttl": 3600
     }
   ]

--- a/convee.app.website.json
+++ b/convee.app.website.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "convee.app",
+  "providerName": "Convee",
+  "serviceId": "website",
+  "serviceName": "Funnels",
+  "version": 1,
+  "logoUrl": "https://convee.app/favicon.svg",
+  "description": "Enables a custom domain to work with Convee Funnels",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.convee.app",
+  "syncRedirectDomain": "portal.convee.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "funnels.convee.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Update the Convee website template target host from `funnels.convee.app` to `connect.convee-dns.com`.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- [Test convee.app/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANkyM2oC%2F91S247aMBD9lcivEDZcQthIlUpbtmrRXoqWShVCkYkHcEns1OMkSxH%2F3gmBBbR96HOfEs%2BcM5czZ8cspFnCLbBwxzKjCynAfBEsZLFWBUCLZxlrvmYeeEpI9vGQoziCKWQMB0IJC5T2InoE3%2BVKQYIUL8Cg1IqFnSZL9EpPTUL5tbUZhjc354Y3S058rVpYrIgmAGMjM3ugspHiiwTQ4U6co9WpI3TKpXKsdkptNk4p7dqpB3TOrXGr4g%2BJjjcsXPIEoY485YsxbD8dClDpuhI1VhDb1pUAFXoCQhrKvOIzbSxProFrjXYCv3JCkijW5NSKSNoIZOFsx%2Bw2Oyj4MLwfHeH0fF9prKWy%2BKxr7S9GcIVC%2Bk0JYy0p1u173n6%2Bb7LfWkF0Lj5vHjegCvDC6a5wpB27lGVJj5XReRbJEyXjhqdYnf9Enl2x5yf67MCv%2BsqV0gYipC%2B3uYHTnmmeWBnxkp9DIo5Il2RLYyJlqcpbDVTtk3o6wS3%2FJwWaLBJxNbaszHfbjoPOMgAX%2BsHC7QWDtjvwBwPX92Hhd0WfD7zlhY%2FfOvzvTr4SDhBBWckr0w6Tkm%2BR7ffzJon4v%2B1EN0degIh4hex4nb7r9d128Nzphr4X9m5bnt8LOu2G54WeV20AaOstd%2BSPS2ewjZcVoi9%2F%2BOOntn4c%2B%2FeNKU7vGi8%2FP4%2FHXwe9b5PRWG9x8X0YxO%2FY%2Fg9GtEw1kQQAAA%3D%3D)