### PR TITLE
add Tellam, Email sending

### DIFF
--- a/tellam.app.email.json
+++ b/tellam.app.email.json
@@ -6,6 +6,7 @@
 	"version": 1,
 	"syncBlock": false,
 	"syncPubKeyDomain": "tellam.app",
+	"syncRedirectDomain": "tellam.app",
 	"description": "Authorize the DNS records Tellam needs to send email from your domain (DKIM, SPF, DMARC).",
 	"logoUrl": "https://tellam.app/android-icon-192x192.png",
 	"records": [
@@ -14,7 +15,8 @@
 			"type": "TXT",
 			"host": "unosend._domainkey",
 			"ttl": 3600,
-			"data": "v=DKIM1; k=rsa; p=%domainKey%"
+			"data": "v=DKIM1; k=rsa; p=%domainKey%",
+			"txtConflictMatchingMode": "All"
 		},
 		{
 			"groupId": "spf",
@@ -28,7 +30,9 @@
 			"type": "TXT",
 			"host": "_dmarc",
 			"ttl": 3600,
-			"data": "v=DMARC1; p=none; rua=mailto:dmarc@%mailDomain%"
+			"data": "v=DMARC1; p=none; rua=mailto:dmarc@%mailDomain%",
+			"txtConflictMatchingMode": "All",
+			"essential": "OnApply"
 		}
 	]
 }

--- a/tellam.app.email.json
+++ b/tellam.app.email.json
@@ -1,0 +1,34 @@
+{
+	"providerId": "tellam.app",
+	"providerName": "Tellam",
+	"serviceId": "email",
+	"serviceName": "Email sending",
+	"version": 1,
+	"syncBlock": false,
+	"syncPubKeyDomain": "tellam.app",
+	"description": "Authorize the DNS records Tellam needs to send email from your domain (DKIM, SPF, DMARC).",
+	"logoUrl": "https://tellam.app/android-icon-192x192.png",
+	"records": [
+		{
+			"groupId": "dkim",
+			"type": "TXT",
+			"host": "unosend._domainkey",
+			"ttl": 3600,
+			"data": "v=DKIM1; k=rsa; p=%domainKey%"
+		},
+		{
+			"groupId": "spf",
+			"type": "SPFM",
+			"host": "@",
+			"ttl": 3600,
+			"spfRules": "include:unosend.co"
+		},
+		{
+			"groupId": "dmarc",
+			"type": "TXT",
+			"host": "_dmarc",
+			"ttl": 3600,
+			"data": "v=DMARC1; p=none; rua=mailto:dmarc@%mailDomain%"
+		}
+	]
+}


### PR DESCRIPTION
# Description

Adds `tellam.app.email.json` — the Domain Connect template for [Tellam](https://tellam.app), a referral/recruiting platform that lets each user send email from their own custom domain. The template publishes the three records our sending provider needs:

- **DKIM** — `TXT` at `unosend._domainkey` (`%domainKey%` is the per-domain public key)
- **SPF** — `SPFM` merge of `include:unosend.co` (merges into any existing SPF instead of clobbering it)
- **DMARC** — `TXT` at `_dmarc` (`p=none` with a per-domain `rua`), `essential: OnApply` so the user can later tighten/remove it, `txtConflictMatchingMode: All` so an existing DMARC is replaced rather than duplicated

Synchronous flow only (`syncBlock: false`), signed requests (`syncPubKeyDomain: tellam.app`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes: all TXT records carry a fixed prefix (DKIM `v=DKIM1; k=rsa; p=…`, DMARC `v=DMARC1; …`); hosts are fixed labels (`unosend._domainkey`, `@`, `_dmarc`) with the subdomain supplied via the `host` parameter.

## Online Editor test results

**Editor test link(s):** generated with the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) ("Test apply template" → "Copy Markdown").

- subdomain (`domain=tellam.app`, `host=send`): [tellam.app.email apply test — subdomain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAZRM2oC%2F%2B1VbW%2FaOhT%2BK5GlSvdqQBNIeUmFtPDWMQoU2u4yVRUyiQEPJ85sBxoq7m%2FfcSiFtkzbx03qBxTsc47P8zw%2B5%2FgRKRJEDCuCnEcUCb6kPhFtHzlgYAwHORxFKPNs6eEAPNFNaoN9ScSSeiQNIAGmbL%2F35NrUu4YkoU%2FDGViXREjKQ%2BRY4JmEXo1xb4GcKWaSbHeu4kmHJA0OgeFrHNo%2BJD4VxFPHPXwiPUEjleZAbqzmXNA1MdScGI3etQGRXPjS2FIwQkJgoXiK0EgpGFPBAyPhsTD8NIXxT6PT7maM66tWxmh03WH93xxkYnzGbwWDLHOlIumcnu6BnOLQF5z6WerxMGtV8g%2Fwy0WpAk8IkHP3iGaCx1Gqnr%2BgWlCVRKnAoxtYzLlUsIhDrtHlxls4C5JoRwWZC0XTBMpYYXBbVjVM69xYVIXE50ZUPdkGgJonOuJB1Xk4ZdRTXay8OdxHl%2Fs6m8sY2mQO0chougcDvLt7NB9fJgfPYcwI0EE09FjsE2eH1%2BOvTvUDLLyfkBw%2FG48R06JbmlLIQ3JuiBhX9VUp7qRhH0%2F0alsQv6aaQUQCQEWxvrx%2B6EYRS9DmfpNBazh%2BvL%2Bge8BwtMqeQGuasEoZjukuJMICB1I31C747jD6fhd%2Bt41%2FTgL3pDe77Xat%2Fc3t1WaL7%2FMFvaiszJo7aLZct193B2VX2%2BuzDvxvut8fFsPOZWwtLz038rp9Puiym3kSfHm4mI8uR6P%2Fapd1txXSXlzxg6TU%2Fra%2BKhD3NikmZ2rU77dMxidKxp86dnm1bCmxJp8vuFVctRvuwK1paHthd4Bzh1xAMzoLuSBjCV%2BsYgEqKxFDLwcxU3SMV3i%2F5XtjrMUGiSVY4UTogRfVEG6nxtuSzz1p%2FdNi%2F4Nke1HEY9%2FTpUDTEZk3zyYT28zaxamdtb1SKTspT%2BxsHtslq%2BwVy%2FZZ8WDavp3Dx%2Bbty1o8LG2XrXAi0UZ34TGVX0sKvWwZb7vY%2BB%2BnXfN3kNoOkrfl8qsR8rq0%2FxS%2Bz%2FNpc5%2BB6fLeMO8N894wv9kw8H5JvCT%2BGGvfvJkvZs1i1irfmJZzVnEKds6uFO1S5YNpOqapGRCptgo8wst2%2BKah5rR5USLlkikLo2G%2Bs6wM8tfr3udBwWYeXkynX61gXR5e3%2FabzSra%2FACq%2FErtWQsAAA%3D%3D)
- apex (`domain=tellam.app`, `host=@`): [tellam.app.email apply test — apex](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAApRM2oC%2F%2B1VUW%2FiOBD%2BK5GlSrdaoAltA6RCqoHCcpRS2HYXbVVFJjHEJYlT24GmFffbbxxaoF1Wd2%2B7D31AxJ4Zz%2Fd9nhk%2FI0WjJCSKIucZJYIvmE9F10cOGMKQRCWSJKiwsVySCDzRdW6DfUnFgnk0D6ARYeF278X1XO8aksY%2Bi2dgXVAhGY%2BRY4FnFnuNkHtz5ExJKOl65yqd9GjW4hAYv8eh7SPqM0E9td%2FDp9ITLFF5DoRTFXDBnqihAmq0Lr8aEMmFL401BSOmFBaK5wiNnIIxFTwyMp4Kw89TGH%2B1et1%2Bwfh61S4YrT4eNT%2BVIFPIZ%2FxGhJAlUCqRzuHhFsghiX3BmV9kHo%2BLVq38CL9SkivwggA5t89oJnia5Or5c6YFVVmSCzy%2BhkXApYJFGnONruSu4cxpph0VZD6yTRMoE0XAbVHXMK1TY14XkpwaSf1gHQBqHuiIR9Xk8TRknuoT5QVwH33u62w4DNGqsItGJtMtGODd36I5e5scPEdpSIEOYrEXpj51XvF6%2FN2pfkSE9wuS7sa4j5gW3dKUYh7TU0OkpK6vSnEnDzs70Kt1Qfw31QKiEgAqRvTlDWKcJGGGVnerAnqC493tBd0Bhr1V9gIavnJ2Lnt1T4ggkdTN9Bp4uxt59xp6i9DmcLgfvdHvdhvde3zZmM0fgjnr1JZmAw%2FP2xgPmnhYxdrenPXg%2Bxw%2FPM5HvYvUWlx4OPH6Az7sh9dBFn177ATji%2FH4e%2BOiidsxu0xrfpRVuvdPV0cU32R2dqLGg0HbDPlEyfRL77i6XLSVeKJ%2Fd7hlL7stPMQNDW0r6HsKIBObxVxQV8I%2FUakAYZVIoX2jNFTMJUuy3fI9l2h9QVUJVjgMyv5NAcTrQbG3yn9Z2n%2BQWG9K1vU9ffksL3fruHZiT6xi5dj3isdVixRJeVIuEtsmVnlKatPJZGe2%2Fjx1903XbeXtFjEOlySTaKX7bZ%2B4Z7taQstaxs%2FNavxD8ub489lsZsX%2FHxBvkPx%2Bhpuhs7orwNj4aImPlvhoiU1LwPMjyYL6LtF%2BZbNsF027aFWvTcs5qTlH1VKtYlfN8mfTdExTo6dSrYk%2Fw%2Bu0%2By6h5Ie1%2BNJKK6MT9b3SuY%2BWw%2FaADzxSxiS7kkFw2Gmpweek83Azq6PVv%2BgxN1MQCwAA)
