### PR TITLE
draft2live.ai.blog: add DCV delegation CNAME for SSL cert issuance

### DIFF
--- a/draft2live.ai.blog.json
+++ b/draft2live.ai.blog.json
@@ -3,14 +3,14 @@
   "providerName": "Draft2Live",
   "serviceId": "blog",
   "serviceName": "Draft2Live Hosted Blog",
-  "description": "Connect a custom domain to a Draft2Live hosted blog so visitors reach it as https://example.com instead of https://your-blog.draft2blog.com. Records: one CNAME pointing the apex at the tenant's Draft2Live edge plus one TXT for ownership verification.",
-  "version": 1,
+  "description": "Connect a custom domain to a Draft2Live hosted blog so visitors reach it as https://example.com instead of https://your-blog.draft2blog.com. Records: one CNAME pointing the host at the tenant's Draft2Live edge, one TXT for ownership verification, and one CNAME for automatic SSL certificate issuance via Cloudflare DCV delegation.",
+  "version": 2,
   "logoUrl": "https://draft2live.ai/logo-domain-connect.svg",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.draft2live.ai",
   "syncRedirectDomain": "draft2live.ai",
   "hostRequired": true,
-  "variableDescription": "slug = the tenant's draft2blog.com subdomain; token = the per-attempt verification token Draft2Live generated for this domain.",
+  "variableDescription": "slug = the tenant's draft2blog.com subdomain; token = the per-attempt verification token Draft2Live generated for this domain; fqdn = the full hostname the customer is connecting (e.g. blog.example.com or example.com for apex) — used to build the DCV delegation CNAME for cert issuance.",
   "records": [
     {
       "type": "CNAME",
@@ -27,6 +27,13 @@
       "ttl": 1800,
       "txtConflictMatchingMode": "All",
       "txtConflictMatchingPrefix": "draft2live-verify="
+    },
+    {
+      "type": "CNAME",
+      "groupId": "blog",
+      "host": "_acme-challenge",
+      "pointsTo": "%fqdn%.e93d1f45befd4080.dcv.cloudflare.com",
+      "ttl": 300
     }
   ]
 }


### PR DESCRIPTION
# Description

Follow-up to #1235 (merged). Adds the missing **DCV delegation CNAME** so Cloudflare for SaaS can automatically issue the TLS certificate for the customer's connected hostname.

Without this record, the merged template provisions a working CNAME but every Domain Connect flow ends with `ERR_CERT_AUTHORITY_INVALID` in the browser — CF for SaaS requires one of:

* the DCV delegation CNAME (`_acme-challenge.<host>` → `<host>.<UUID>.dcv.cloudflare.com`), or
* a per-domain `_acme-challenge` TXT token (dynamic, generated by CF at custom hostname creation, NOT expressible in a static template)

This patch adds the DCV delegation CNAME, which is what our production custom-domain flow already uses outside Domain Connect.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`draft2live.ai.blog.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Editor test confirms `%fqdn%` is a DC built-in (derived from Domain + Host inputs) and substitutes correctly for both apex (`example.com`) and subdomain (`blog.example.com`) connections.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `domainconnect.draft2live.ai`, public key live as split TXT at `_dck1.domainconnect.draft2live.ai` (verifiable via `dig +short TXT _dck1.domainconnect.draft2live.ai @1.1.1.1`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`draft2live.ai`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the TXT verification record (`All` + matching prefix `draft2live-verify=`)
- [x] no variable used as bare full record value
- [x] no bare variable used as full `host` label
- [x] no variable in `host` field to create a subdomain — `hostRequired: true` is set instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` not set

## Online Editor test results

**Editor test link(s):**

[Test draft2live.ai/blog example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKaLM2oC%2F%2B1VbW%2FbNhD%2BK4QAYxsqKbLsOI6HAuviou2WFFnqrVuzwKDJk8yVFlWScuwF%2Be87Un6R7KDDvnVAP0nkvfDueZ4jHwILi1JSC8HoISi1WgoO%2Bg0PRgHXNLOpFEuIqQjCnfEtXaBzMPbmSzSjzYBeCgY%2BbiZVvt868iavlbHAyY%2B1GwfDtCitUAW6XaiiAGYJJawyVi0IVwsqCmIVbjVyzOsc7ihiFFkKI6zShmigbE4EJjBkbm1pRicnsKLYIcQM04kC4ygnKtuZ16rSkUsU1w37X%2FSNyQ0wpbkZEVUAuXj74uolKZUorChyYud1EYRa%2F2%2BhoIX9xjSLBJ5D6IMnv09IpjRR9wVoMxclWYIWmWDU9R0SWvDGIc6TVtg9Whl59%2B6SMNC2dgcijKlowQCbpuRCqopnkmog44vfCAcJuc8ZI7R4hvGwpmGATalftUSIt3236D1x9qgGO2I1CbFZeh7XBUOu2MdglFFpoN65rmY%2Fw3rsA5xW%2FM828FA5LuAGuNBo3IccODk0b%2BBThV6oIqsrPGlJtaAzCeOWSIyscvK8DXubO2KqWV3S9yidj1Bs3EvQEbVO8bbFwMapwV0OyBR1GnNs2LkwZJsw%2B8S3%2BbJKSi%2BDAlXud2rZgkaayAYOJ5dvIc5jL9e4KUdM3Vx64ktYfUf%2BrNKk2yeVwQJQ%2B7NKSO7zt1luCMZJZKcNx76u1RuMbh8Cuy7dEHpvNOVaVWVzVl0LuPrBTblTuJkoXHYc0J2DsUAXa1FH3WGSPIa71KjwzySe7smOPO5rN%2FnU0pYONqbnHc9Gp3kS%2Fq4sXg6ZFMxeUcvmiOqV4u7oF1IGT9qvNWRi9eQRQaP0f0NlStkCIjanUkKRwwFGTg2dGM57vJv1T2eQ8X4yTGLOljHbDWcTuB7idvcYBn%2FjwE%2F3JN2FmyHCpA1N7MvYFOWrnIptTEk1XRh3d2%2Bjb1vhd9v42zoBrh2rbr1Y46UJbsfj7bZqdCI6Y920F7gqRV4oDVODX2orDdvJXFTSiim9p%2Fstzqa0LOUamzJoxXzHyivq12DTy0YBdSGf0VmIAmKuR%2BHY6fdmZ%2F3Tbjca9s57Ea54NMxSFp2y7iDp8xQgY43n6sm37In3qg0zGAN401PpBXZP1yZ4PJL7pptjdcftBo%2F11wb6i271gLqDaTjo9PCG%2B4%2BD8aV0fxfibH1V71f1%2Fj%2FV6y55ugQ%2Bpc41TdJBlAyi7nCSDEbJ%2BaifxqfDdDhMniXJKElcB2BsjcED3vnN2z64BOi9%2F%2FCL%2BPDmj5PXL88m5U%2BvJmN5dnmjB9kAZq%2Bq99d%2Fqevx6pnq46v6DyaQIxlPDAAA)

## Records (3, was 2 in v1)

- `CNAME @ → %slug%.draft2blog.com` _(unchanged from v1)_
- `TXT _draft2live-verify → draft2live-verify=%token%` _(unchanged from v1)_
- **NEW** `CNAME _acme-challenge → %fqdn%.e93d1f45befd4080.dcv.cloudflare.com` — DCV delegation for automatic SSL cert issuance via CF for SaaS; uses our pre-issued DCV delegation UUID for the draft2blog.com zone

## Why not part of #1235

Honest answer: we missed it. Discovered the gap during pre-launch testing when realising that without the DCV CNAME the cert pipeline waits indefinitely (or falls back to slow HTTP-01 with delegated_dcv configured). Re-submitting as an isolated follow-up so the SSL story is end-to-end on the Domain Connect path before we start onboarding customers through it.

Cloudflare onboarding email (per https://developers.cloudflare.com/dns/reference/domain-connect) will be sent only AFTER this PR merges, so they activate the complete template.

