### PR TITLE
Add smailorcom-setup

### DIFF
--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -1,0 +1,56 @@
+{
+    "providerId": "smailor.com",
+    "providerName": "Smailor",
+    "serviceId": "email-setup",
+    "serviceName": "Smailor Email Routing",
+    "logoUrl": "https://smailor.com/logo.png",
+    "description": "Configure DNS records for Smailor email routing and deliverability",
+    "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64)",
+    "syncBlock": false,
+    "hostRequired": false,
+    "version": 1,
+    "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
+    "records": [
+        {
+            "groupId": "smailor-verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "smailor-verify-%VERIFY_TOKEN%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "smailor-verify-"
+        },
+        {
+            "groupId": "smailor-mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "%RELAY_HOST%",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:%RELAY_HOST%"
+        },
+        {
+            "groupId": "smailor-dkim",
+            "type": "TXT",
+            "host": "%DKIM_SELECTOR%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All",
+            "essential": "OnApply"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADSbM2oC%2F%2B1WYW%2FiOBD9K5alSne6Akk3QC8V0kKht1xLqQJd7aqqIidxqIWJc7ZDy1bcb79xKE3Swqla6XT90A%2BIxPM882bmeZxHrOki5URT7D7iVIoli6gcRtjFakEYF7IeigU%2BfDZdkgVA8WRjBIOicslCmm%2BhZrWmqM7SwlLdgQbmH3ki0yyZAYqLmbiWHBB3WqfKbTRKgRvGWk9zYERVKFmqmUgAfCqSmM0ySVH%2FcoIkDYWMFIohwDZQTgbJTSBEkghFlLMllSRgnOkVuFwSyUjAab%2Fi%2BuDrwBueffen4%2FPB5YGLIgGeEiTuEyrVHUsR%2BGAxC4nBIy3mNDlBB97govvd%2FzKeTGHLlsOGAuVkhe6E0gmUAqD98%2BHInwwuBqfTsQdo847mdIUU5TTUQm4xX7sX14MtIM0CzsIc90tAFG05v5oir5Kwx0U4x25MuKKH2ATy6F8ZkzR6XgTKKs%2FO3my5yoJzuurnmb3qtQF4NAIHod4DeSo4dm8e8QxqnJYlUysXCMB6lRoFTL9N8YYevHw2HSWavNy1qlXLb7ZrUMenlmXB44M2jYc66BHR4R10diQi4%2FxK0pg94J2QJ9urSHh9uIv94qHgPPpWpZwKlmg1FUYmpY7nB4QJaWTl2laJ8%2B4QKo2LGJOrs1E1Cpi9jFMoL2ZJyLOIupVou51Gc7bYU%2B0Xkqv7G02Dloo2LDsGZJ%2BgeUcqcoLSTlmEb%2B2DR2GahHQfxQWR4R6O%2FtZY8Bl1vVPbMElEAgdHZqRjHGnh5tjPL1rwJoJdzgFKlaKJZsTMnXHSTVO%2Bwuvb9SH%2BAZH8Qt23QGf3CXhiDU95mj7L8fuOQEVbVRW8aF%2B1VBA%2FJZIslBnPWyY3FSq3Wy432DznbP4bJuWDaSJ0m81W8%2Bzsj74xFq0wJqdVbx3Vjyz4NT8Zc0WA%2BeZu93k9l5hZ7PV62HSBzRIhqa%2Fgn2gY8tjVMoMxtsi4Zj65J8VSFPrEtA%2BapsAKXmAkVfSVbC6g%2FROnyKOiIT8KTdWZEXAzaEax1W7XHBIe1xzbtmokPqK1ILKbbdK0wlYYlG7JHRfo%2FnuyUFJZlV1%2BT1YKr81BKg%2Bj19lUa11JoTqU3l1C%2B%2Fqz7IAgbbSdfZUE0d8kP8F5lpDku8%2BLEPLGeWvU%2F74VWEnsJwb2v0j1%2F831%2BQ5Y3x7C0P8YIR8j5GOEfIyQnxwh8F2jyJJGPjE44NqqWa2afTy12q7dci2nbju207Z%2BsyzXskwSVOlNCR7h66f83YNPfwS%2FD202C%2BxoSpvX8XEvXjp%2F6pRfPNw3nElDDxxvTI9mzmzYwet%2FAP3kvULQDwAA
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANmcM2oC%2F%2B1W70%2FbOhT9VyxLSJteW9L0BxBUaYGWNwSlrO02EKoiJ3Fbv6ZxsJ1Chrq%2FfdcJpUlp9%2FZlensSH1BJ7rHvufceH%2BcJKzqPAqIotp5wJPiC%2BVSc%2B9jCck5YwEXF43NcegldkTlA8SALQkBSsWAeTZdQ%2FbYsqYqjdaS4AnX0L%2BrzWLFwAqiAT%2FhnEQBiqlQkrf39XOJ9Ha1EKdCn0hMsUoyHAD7l4ZhNYkFR%2B2qABPW48CUaQ4JVopQMElkiREIf%2BTRgCyqIywKmEthyQQQjbkDbha33vnT652e3zrB30bnas5DPYacQ8YeQCjllEYI92Jh5ROOR4jMaHqO9fufSvnU%2B9gZDWLLikFGgAUnQlEsVQisA2r447zqDzmXndNjrA1o%2FoxlNkKQB9RQXK8wX%2B%2FJzZwWIYjdgXop75xJJm%2FX3uslJ6J0E3Jtha0wCSUtYJ%2BrT%2B5gJ6r%2B8BMoyra6aLbmO3QuatNPKXs1aA%2FrUhw08tQPy3HBs3T3hCfQ4ykumnG8QgFUSaQUMb4Y4owcPH%2FREiSKbq5Jysf16uQJ11JqGAf8%2BKj146IPqEuVNYbJd7uvNrwUds0e8FfIce5UJL0vb2M8f15y7N0XKEWehkkOuZZKbeHpAGBdaVlbVyHHenkJG43WOwfVZt5gFwv04oNBezEIviH1qFbJt39SfsfmObm9IruJkmgYtrcewaGlQ9RjNWkKSYxS18iL81Tn0KbiJR3dRnBPh7eDorIJrPl27f1rVTEIewsERMWnpjRS3UuyHjRH8EkE7CABKpaShYkT7Ti%2B0oyhI8HK0LOFvkMlZq3sEdLafgGfWMnbhIa3UYemSXaegIK%2BiEDYmWOwWUIiIIHOpHXpF5q7AZrSic5fyGT0T%2Bj1k8sdTZ7AbjWbj7Ozvtg6uB6JD9WalaVZMA%2F4aNR0uyDBdbNsv71Oh6ZcnJydYz4JNQi6oI%2BGXKLB6bCkRg5nN40AxhzyQ9Svfc4geIoxOQhR2AWMqqCzMrqFsXtudZ11JQUuO7%2BnWMy3kxmHd945Is1yvHhyV66YxLrtjv1YmtZrRrJu1w%2FGBm7stt1yku%2B%2FLgqLyArWDB5JIvNRnKu9L20oqtrxQR9Gh%2FsSqdk9q0QJxVtHKDQtVou8kPdNpqVDp%2F6E4QkjOhCsbtW4asT4Qf7wkC%2FVlZv6qrn8z9J%2Bo9z8v%2BeWaWI5KcC%2B8%2Bcubv7z5y5u%2F%2FA5%2FgS8iSRbUd4iGAt1m2WiWq4dD48Aya5bRqFRN06xX%2FzIMyzB0HVSqrAtP8N2U%2F2LC%2F8w%2BmjfsKDRtH%2FhMGu7X8NROfDvp3S8up4NP9%2BbRV1fWht3r2xZe%2FgBFuYzWEBAAAA%3D%3D
