### PR TITLE
Adding SMailor email setup

### DIFF
--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -1,0 +1,56 @@
+{
+    "providerId": "smailor.com",
+    "providerName": "Smailor",
+    "serviceId": "email-setup",
+    "serviceName": "Smailor Email Routing",
+    "logoUrl": "https://smailor.com/logo.png",
+    "description": "Configure DNS records for Smailor email routing and deliverability",
+    "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64 encoded)",
+    "syncBlock": false,
+    "hostRequired": false,
+    "version": 1,
+    "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
+    "records": [
+        {
+            "groupId": "smailor-verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "smailor-verify-%VERIFY_TOKEN%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "smailor-verify-"
+        },
+        {
+            "groupId": "smailor-mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "%RELAY_HOST%",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:%RELAY_HOST%"
+        },
+        {
+            "groupId": "smailor-dkim",
+            "type": "TXT",
+            "host": "%DKIM_SELECTOR%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All",
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -10,7 +10,6 @@
     "hostRequired": false,
     "version": 1,
     "syncPubKeyDomain": "smailor.com",
-    "syncRedirectDomain": "smailor.com",
     "records": [
         {
             "groupId": "smailor-verification",


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test smailor.com/email-setup smailor.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAESfM2oC%2F%2B1WbW%2FiOBD%2BK5alSndaoKFAFlIhLS0vV7WULtBq96oqMo4BHybO2Q4tW3G%2FfcehlKSFU7XS6fqhHxCJ5%2FHMMzOPx3nEhs0jQQzD3iOOlFzwgKmzAHtYzwkXUhWonOPcs%2BmSzAGKB2sjGDRTC05ZsoXZ1bxmJo62luwO1LL%2FqC9jw8MJoIScyGslADE1JtLe4WEq8KG1FqIEGDBNFY8MlyGAT2U45pNYMdS8HCDFqFSBRmMIsAmUkEFqHQiRMEABE3zBFBlxwc0SXC6I4mQkWDPj%2BuCm1T9rf%2FeHvfPW5YGHAgmeQiTvQ6b0lEcIfPAxp8TikZEzFh6jg37rovHd%2F6M3GMKWDYc1BSbIEk2lNiGUAqDN87OuP2hdtE6HvT6g7TuasSXSTDBqpNpgbhoX160NIIpHgtME99uIaOaWEQupDFjwuy32MqQnQtIZ9sZEaJbDNmCf%2FR1zxYLnRaCukyyL6y1X8eicLZtJhq96bgF9FoADavZAngqPvdtHPIFaR2np5NOFArBZRlYJw29DvKYHL19sZ4khL3ct89k22O0GVFJyHQceH4wVANTDdImhU%2BhwFyoBTq4UG%2FMHvBPyZHsVCa9yu9jPH7acu9%2BylCPJQ6OH0sol1fnkoHCprLy8opPivDuEjsbbGIOrdjcbBcz9WDAoL%2BYhFXHAvEy03U6DGZ%2FvqfYL6RX8tbZBU9s2LOoWVDxGs7rS5BhF9bQY39qHPoOpQtk%2BinOi6B6O%2Fsa45dNt9E%2BLlkkoQzhAKiZ168hIL8F%2BedGCNxFsCAFQpjULDSd2%2FvTCRhSJJV7drXL4B0Tyt%2Bq%2BAzq7T8ATa3hK0vR5gt93BDLayqrgRfuypYL4EVFkru2Y3jC5zVC523C5xfY5YfPfMEkfTBuhUam4lXa707TGbSusqewW3KPCkQO%2FSsmaMwJMNjcaz%2BuJxOziyckJtl3gk1Aq5mv4JwaGPfaMimGMzWNhuE%2FuyXYpoD6x7YOmabCCFxhJGX2F64to%2F8TZ5pHRkB9QW3VuBVyp1mqjolPOu27NyZdHNZofFYNqvuayMS0zWnKDUuq23HGR7r8vt0pKq7Ih7slS45U9SOlh9DqbbK0zKWSH0rtLaF9%2FFnUQZBFtZl8mQfQPSU5wkiUk%2Be7zIoS8cd5a9b9vBWYS%2B4WB%2FS9S%2FX9zfb4DVnc5GPofI%2BRjhHyMkI8R8osjBL5rNFmwwCcWB1zdvOPmi9Wh89krlbyjcqHoOkWn%2BslxPMexSTBt1iV4hK%2Bf9HcP7py5n4P2lKi%2BmV3%2F1Qul%2FirIabXTYT%2FozZ%2BK3yxHlbmofOrct%2Bp49RNvvbcW2A8AAA%3D%3D)

[Test smailor.com/email-setup smailor.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALqfM2oC%2F%2B1XbW%2FiOBD%2BK5alSnc6oKG8LamQNi30livQXqCrogpFJjHgI4lT26HlKu633zgpJaFwt19Wtyf1A4J4Hs88M%2FN4HF6wokHkE0Wx%2BYIjwVfMo6LrYRPLgDCfi5LLA1x4Mw1IAFA8TI1gkFSsmEuTLVSvFiVVcbSz5Hegjv5GNo8VC%2BeA8vmc3wkfEAulImmenmYCn2prKUqAHpWuYJFiPATwJQ9nbB4LitqDIRLU5cKTaAYBtoESMkikgRAJPeRRn62oIFPmM7UGlysiGJn6tJ1zffK1Y3evxs7o5rozODGRx8FTiPhTSIVcsAiBDzZjLtF4pPiShufoxO70rLHz5WY4gi1bDikF6pM1WnCpQigFQNvX3b4z7PQ6l6MbG9D6GS3pGknqU1dxscV8tXp3nS0giqc%2BcxPcT1Miab2KaOhyj3o%2F62KvQ%2FfC5%2B4SmzPiS1rAOqBNH2MmqPe2CNRlkmU53XIbT6%2Fpup1k%2BK7nGmBTDxy46gjktfDYfHjBc6h1lJVOMVsoAKt1pJUwuh%2FhlB48fNadJYrs71oX823Q2xWopFI3DPj5rLQAoB6qT5S7gA73oRLg5FbQGXvGByGvtneR8KZwiH3wvOPcv89TjjgLlRxxLZdM55ODwrjQ8jLLRobz4RAymu1iDG%2Bv%2BvkoYLZjn0J5MQtdP%2FaomYt22Km3ZMGRau9Jr%2BSk2gZN7dqwamlQ%2BRwtW0KScxS1smL81j7YFKaKS49RDIhwj3B0tsYdn75lX5Y1k5CHcIBETFrakeJmgv2814JvImj5PkCplDRUjOj5cxNaUeSv8WayKeA%2FIZKzU%2FcE6Bw%2BAa%2BsZTyFhyRThyVbjp2CnLzyQtjrYL5aQCEiggRST%2BotmYccm8mWzkPCZ%2FJK6PuQyR5PHcGq1eq1q6tf29q4a4g2Veul%2BlnpzIBPraLNORkmmy3rbT0Rml68uLjAuhdsHnJBHQnfRMHIx6YSMQyzIPYVc8gT2S15rkN0E6F1EqzgBQZTTmVheh2l%2FTo8eXaZ5LTkeK4uPdNCrtZms0a5MStO3XK5WJ2RSpE0SbPYrFSrpNms0ppbzdyaBy7U4%2FdmTlFZgVr%2BE1lLvNFnKjuXDqWUL3kuj%2FyE%2BhGzOt6pVQvEWUbbaZjLEv1FkjOdpAqZ%2Fh%2BSI4RkhnBpL9f9QawPxA8vyVx%2B6TB%2Fl9e%2FDfR%2FUO9%2FnvLbNbGZFOBe%2BJgvH%2FPlY758zJfvMV%2FgjUiSFfUcoqFAt1406sXyp5HRMCs18%2BysVKtXG5%2BMXwzDNAydB5UqrcILvDdl35hwlwwHAbP%2B6D73KPyrrt%2FZvfHt0PiyuF%2B6%2FcfB7xFr%2BONHfjn%2Bjbfw5m8dsaHKGBAAAA%3D%3D)