### PR TITLE
Add email setup configuration and update TXT record matching

### DIFF
--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -1,0 +1,56 @@
+{
+    "providerId": "smailor.com",
+    "providerName": "Smailor",
+    "serviceId": "email-setup",
+    "serviceName": "Smailor Email Routing",
+    "logoUrl": "https://smailor.com/logo.png",
+    "description": "Configure DNS records for Smailor email routing and deliverability",
+    "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64 encoded)",
+    "syncBlock": false,
+    "hostRequired": false,
+    "version": 1,
+    "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
+    "records": [
+        {
+            "groupId": "smailor-verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "smailor-verify-%VERIFY_TOKEN%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "smailor-verify-"
+        },
+        {
+            "groupId": "smailor-mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "%RELAY_HOST%",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:%RELAY_HOST%"
+        },
+        {
+            "groupId": "smailor-dkim",
+            "type": "TXT",
+            "host": "%DKIM_SELECTOR%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All",
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -10,6 +10,7 @@
     "hostRequired": false,
     "version": 1,
     "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
     "records": [
         {
             "groupId": "smailor-verification",

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -10,7 +10,6 @@
     "hostRequired": false,
     "version": 1,
     "syncPubKeyDomain": "smailor.com",
-    "syncRedirectDomain": "smailor.com",
     "records": [
         {
             "groupId": "smailor-verification",

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -17,8 +17,7 @@
             "host": "@",
             "data": "smailor-verify-%VERIFY_TOKEN%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Prefix",
-            "txtConflictMatchingPrefix": "smailor-verify-"
+            "txtConflictMatchingMode": "Replace"
         },
         {
             "groupId": "smailor-mx",

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -3,12 +3,10 @@
     "providerName": "Smailor",
     "serviceId": "email-setup",
     "serviceName": "Smailor Email Routing",
+    "version": 1,
     "logoUrl": "https://smailor.com/logo.png",
     "description": "Configure DNS records for Smailor email routing and deliverability",
     "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64 encoded)",
-    "syncBlock": false,
-    "hostRequired": false,
-    "version": 1,
     "syncPubKeyDomain": "smailor.com",
     "syncRedirectDomain": "smailor.com",
     "records": [
@@ -32,7 +30,8 @@
             "groupId": "smailor-spf",
             "type": "SPFM",
             "host": "@",
-            "spfRules": "include:%RELAY_HOST%"
+            "spfRules": "include:%RELAY_HOST%",
+            "ttl": 3600
         },
         {
             "groupId": "smailor-dkim",
@@ -48,7 +47,8 @@
             "host": "_dmarc",
             "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "All",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
             "essential": "OnApply"
         }
     ]


### PR DESCRIPTION
Changed TXT record conflict matching mode from 'Prefix' to 'Replace'.

# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test smailor.com/email-setup smailor.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADCjM2oC%2F%2B1Wf2%2FaSBD9KquVIt3pgJifaR0h1QS4pgRoDa1aRZG1eBfYw%2Fa6u2sSJ%2BI%2Be2dNCXYKp6q60%2BWPICHbO7Mzb2ae3%2FoBaxbGAdEM2w84lmLNKZOXFNtYhYQHQlZ8EeLSo2lEQnDFk60RDIrJNfdZtoWZ1bJiOon3luIO1DNX5IpE82gBXoFYiI8yAI%2Bl1rGyT09ziU%2BNtRJnjpQpX%2FJYcxGB84WI5nyRSIa6owmSzBeSKjSHBLtEGRgkt4kQiSiiLOBrJsmMB1ynEHJNJCezgHULoU8%2B9dzL%2FhdvOh70Ric2ogIiRUjcRkyqJY8RxOBz7hPjj7RYsegcnbi9K%2BeL93Y8mcKWHYYtBBaQFC2F0hG0Aly7g8uhN%2Bld9S6mYxe8zTNasRQpFjBfC7nz%2BeRcfeztHOJkFnA%2F8%2FttRhRrNRCLfEEZ%2Fd00O438TiD8FbbnJFCshE1Cl31NuGT0cRGgq6zK6nbL%2B2Q2YGk3q%2FCHmX%2FvKravH%2FACGhnneVHOdwGcdRqbMU8%2FT%2FE2Nzy8MWMjmjzdlZaLPTbbNVCg3rIsuL3TZrpQrB4S7S9hfEMoE4K4DKjqM7wpHQIU3u1hDD8XUcSCR1pNhRlvblIZsbmQhg521crBOJxCxfN9jsn7%2FrCYBcxuEjDoGOaRHySU2YVsh4PSFQ%2BPNPAJVSrelovAgX1n123jVD1Hq7ZU5BzF7Tx5%2Fp3W0pBI%2FwhGb2fc4xk67kXVIIlEBISXCWmbQFrYme%2BbJyP4KYBOEIArU4pFmhOjF%2BPIieMgxZubTQnfQyZvT9gbgHOY1N9Rw11Wpscz%2F2OsLnCryIIn4yu2CvLHRJJQGVndIbkuQLnZYbnG5j5D898gyb9rJoPTbLaa%2Ff6fXWPcj8KYGq1Kq1apWfBv1o25QMBss%2BM8rmcUM4udTgebKfBFJCTzFFyJBnHGtpYJyE6YBJp75Jbsl6jvETM%2BGJoCK0QBlSnwK9oeHMdFZF9HgUMe9U3XuSGwT6wWpa8b5cZZlZYb9Torz6o1v1yf1eBXbxFCWO50O3DwHT%2Ff9kzKs9IJbkmq8Ma8SHkx%2BrGaYq8LJRRF6dkVdGw%2B6zYQsop22lcoEP1Nsjc4qxKKfPZ1Qcaf1FvD%2FufNwEJhvyDY%2F0DV%2F7fWxzNgc1MC0X%2BRkBcJeZGQFwn5RQmB7xpF1ox6xPgB1lbZapWrr6bWmd20bOtV5axaf31m%2FWHBg2WKYEpvW%2FAAXz%2F57x74IB2%2FSx2%2B%2BOv%2BvisHd6dWvSYGazd0l6zXT752RnTkjKjuvZt9aOPNNzoNPaOIDwAA)

[Test smailor.com/email-setup smailor.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADyjM2oC%2F%2B1W72%2FiOBD9VyxLle50QEP5sTQV0qaFXrmWdg%2FoarsVikxsqIUT52yHNlexf%2FuOQykJC3f34Va3J%2FVDReMZe96beXnOMzYsjAUxDLvPOFZywSlTPYpdrEPChVSVQIa49Bq6JiGk4uEqCAHN1IIHLNvC7GpZM5PEm0hxB%2BraXzSQieHRDLKEnMlbJSDjwZhYu4eHucKHNlqJs0TKdKB4bLiMIPlMRlM%2BSxRDneshUiyQimo0hQLrQhkYpFaFEIkookzwBVNkwgU3KRy5IIqTiWCdwtEHH7uD3vmdP7q57F4fuIhKOClC8jFiSj%2FwGMEZfMoDYvORkXMWnaCDQffKu%2FMvboYj2LLGsILABEnRg9QmglZAauey1%2FeH3avu2ehmANn2Gc1ZijQTLDBSrXM%2Bele33XVCnEwED7K8nyZEs2YdsSiQlNGfbbPTKDgVMphjd0qEZiVsCw7YHwlXjL4uAnSdsayutnxIJpcs7WQMv5n5S1exe%2F%2BMZ9DIOK%2BLcr4LkGzS2I559GmEV7Xh4b0dGzFke1daLvbYbjcggVrTceDfJ2OnC2RNn5jgAcbXB5pwyICBVAOGl6VdgMKnDYz%2BpyKKWPLI6JG0481NKhM2l8rKwa06ORi7S%2Bh4uqkx%2FHDeL1aB8CARDDqGeRSIhDK3UG33oXTOwz0N3JJKxV9pETSw6eyibZOqJ2jeVpqcoLidF8%2B%2F01oaEhXsweivgxs8fW9wVrVIIhmB4FVC2vYgI90s9%2F3WCP4RQE8ISGVas8hwYv3iJvLiWKR4OV6W8J9Qyd8Idgxwdov6BbVOJvCQMfV5tmWfsAvyKgpha4LFbgGEmCgSauusazD3BTTjNZz7DM%2F4BdD3AZN%2F42wFr9FoNs7Pf%2B3Y4GYgNlRvVppHlSMH%2Fho1Gy7IMNvsea%2FrmdDs4unpKbaz4LNIKuZr%2BCUGLBq7RiVgPmEiDPfJI9ks0cAndogwOg1ROAW8pqCyaHV9rOa120w2TApa8mlgW8%2BtkGtOndYCwsqE1o7K9XrDKbcak1q5xWrHTrVBpvS4lbvldlyA%2B%2B%2B5gqLyAvXEI0k1Xtp3Ku9LuygVW17gUXSoH5HV%2Fkkt2iDOKlq7YYEl%2BkKydzqjCkz%2FD%2BQIITkTrmxx3TZi%2B0L88JIs8FuZ%2BTe8%2Fs7Q%2F0K9%2Fznl12tiOS7BvfDmL2%2F%2B8uYvb%2F7yPfwFvog0WTDqE5sKcJtlp1mutkbOO7fhuEdOpV5vHreqvziO6ziWB9Nm1YVn%2BG7KfzHh357Snmixi8fb%2BSyiPXHXuH732fv8expGon5GEza6uO1fzvt3g1kbL78Cc57QDsgPAAA%3D)