### PR TITLE
Add email setup configuration and update TXT record matching

### DIFF
--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -47,8 +47,7 @@
             "host": "_dmarc",
             "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Prefix",
-            "txtConflictMatchingPrefix": "v=DMARC1",
+            "txtConflictMatchingMode": "Replace",
             "essential": "OnApply"
         }
     ]

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -1,0 +1,56 @@
+{
+    "providerId": "smailor.com",
+    "providerName": "Smailor",
+    "serviceId": "email-setup",
+    "serviceName": "Smailor Email Routing",
+    "logoUrl": "https://smailor.com/logo.png",
+    "description": "Configure DNS records for Smailor email routing and deliverability",
+    "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64 encoded)",
+    "syncBlock": false,
+    "hostRequired": false,
+    "version": 1,
+    "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
+    "records": [
+        {
+            "groupId": "smailor-verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "smailor-verify-%VERIFY_TOKEN%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "smailor-verify-"
+        },
+        {
+            "groupId": "smailor-mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "%RELAY_HOST%",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:%RELAY_HOST%"
+        },
+        {
+            "groupId": "smailor-dkim",
+            "type": "TXT",
+            "host": "%DKIM_SELECTOR%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All",
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -10,6 +10,7 @@
     "hostRequired": false,
     "version": 1,
     "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
     "records": [
         {
             "groupId": "smailor-verification",

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -10,7 +10,6 @@
     "hostRequired": false,
     "version": 1,
     "syncPubKeyDomain": "smailor.com",
-    "syncRedirectDomain": "smailor.com",
     "records": [
         {
             "groupId": "smailor-verification",

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -17,8 +17,7 @@
             "host": "@",
             "data": "smailor-verify-%VERIFY_TOKEN%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Prefix",
-            "txtConflictMatchingPrefix": "smailor-verify-"
+            "txtConflictMatchingMode": "Replace"
         },
         {
             "groupId": "smailor-mx",

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -3,12 +3,10 @@
     "providerName": "Smailor",
     "serviceId": "email-setup",
     "serviceName": "Smailor Email Routing",
+    "version": 1,
     "logoUrl": "https://smailor.com/logo.png",
     "description": "Configure DNS records for Smailor email routing and deliverability",
     "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64 encoded)",
-    "syncBlock": false,
-    "hostRequired": false,
-    "version": 1,
     "syncPubKeyDomain": "smailor.com",
     "syncRedirectDomain": "smailor.com",
     "records": [
@@ -32,7 +30,8 @@
             "groupId": "smailor-spf",
             "type": "SPFM",
             "host": "@",
-            "spfRules": "include:%RELAY_HOST%"
+            "spfRules": "include:%RELAY_HOST%",
+            "ttl": 3600
         },
         {
             "groupId": "smailor-dkim",
@@ -48,7 +47,8 @@
             "host": "_dmarc",
             "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "All",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
             "essential": "OnApply"
         }
     ]


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [ ] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [ ] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [ ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [ ] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [ ] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [ ] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
