### PR TITLE
Add email setup configuration for Smailor

### DIFF
--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -1,0 +1,54 @@
+{
+    "providerId": "smailor.com",
+    "providerName": "Smailor",
+    "serviceId": "email-setup",
+    "serviceName": "Smailor Email Routing",
+    "version": 1,
+    "logoUrl": "https://smailor.com/logo.png",
+    "description": "Configure DNS records for Smailor email routing and deliverability",
+    "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64 encoded)",
+    "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
+    "records": [
+        {
+            "groupId": "smailor-verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "smailor-verify-%VERIFY_TOKEN%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "%RELAY_HOST%",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:%RELAY_HOST%",
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-dkim",
+            "type": "TXT",
+            "host": "%DKIM_SELECTOR%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace",
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -16,7 +16,7 @@
             "host": "@",
             "data": "smailor-verify-%VERIFY_TOKEN%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Replace"
+            "txtConflictMatchingMode": "All"
         },
         {
             "groupId": "smailor-mx",
@@ -39,7 +39,7 @@
             "host": "%DKIM_SELECTOR%._domainkey",
             "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Replace"
+            "txtConflictMatchingMode": "All"
         },
         {
             "groupId": "smailor-dmarc",
@@ -47,7 +47,7 @@
             "host": "_dmarc",
             "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Replace",
+            "txtConflictMatchingMode": "Prefix",
             "essential": "OnApply"
         }
     ]


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test smailor.com/email-setup example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEexM2oC%2F%2B1Wf2vbSBD9KstC4MrZjuRftRUMVRKHhthJkJ2SEoJYadf2Elmr7q6cuMH97DcrR5GUxnel9Lge5A9jaWd25828pyc9Ys2WSUQ0w84jTqRYccrkKcUOVkvCIyEboVji2nPonCwhFU%2B2QQgoJlc8ZNkWZlbriuk0KSLVHWho%2FpEnUs3jOWStmFRcxNixazgSc3ElI8heaJ0oZ3%2B%2FBGLfRBtJtokyFUqe6GwjPhLxjM9TydDx%2BQRJFgpJFZpBsbxoBgzJbVFEYoooiziUJgGPuF4bHERyEkTsuHL03qehd3ry2Z9enA3P9xxEBZwUI3EfA%2BwFTxCcwWc8JCYfaXHH4gO05w1H7mf%2F48VkCltyDFsILCJrtBBKxzAWSD0%2BOx37k%2BFoeDS98CDb3KM7tkaKRSzUQuY5n9zR1TBPSNIg4mGW90dAFOu2EYtDQRl9Zwa%2FjsPLNDhj6%2BMM7ndkmgSPUQ6j0jtSnqaInZtHPIfBJWVN1MtdQ7JeJ4bi6fUUbkxzcPPB0EQ0eblrXa%2FO1GzXQHmra1lw%2BaANm9CcHhMdLoCuMbQFh3gMZBoyvKm9Bmj5UMAYX1dRJILHWk2FobPETCZqLqSh37GtEozXS6hkVtSYXJ6Mq1Ug7KURg4lhHodRSpnzoto%2FnE%2Fv%2BHLHLF%2BopOFvZQj0F0NeDUySfYDuBlKRA5QMyrr5NVOmSyLDHRj9PFjgGbvekW2QxCIGrcuUDMxBWjhZ7odd8%2FkRgDXMlGKx5sTYxUXsJkm0xpvbTQ1%2FhWp%2Bod9bgJRrnD0QcDv2pPEn5HCVterzLH%2BXyCtSq4riBYXVcUH9hEiyVMZhcyQ3FSi3OZYbbK4zNP8OkvKjZyqQILSbLRMpuDDr7W6j22w0Lfh1snBFgSbDdd3n9UxjZvHw8BAbCvg8FpL5Cv6JBmPGjpYpq%2BFlGmnuk3tSLNHQJ4Y7YExBFE4Bx6kILN6%2BQHYbylMTFQX5NDTz5ka%2Bs05AW33arrff02a9TWakHrxv9ustq0UI6fTCVrtZesW98vbb%2FZIrNFTWoxvdk7XCG%2FMYlV3p%2B1aqg660UHWn366hXeSsBiBFG%2BUmWGkQfSNR9JsTVekLyv6g2xrp%2F48a%2Bwm7%2Fhup%2Fre9Prv%2F5rYGdv%2FmH2%2F%2B8eYfb%2F7xM%2F4BXzSKrBj1ickDrN261a3bvanVczqWY3ca%2FX7f7tl%2FWpZjWaYJpvR2BI%2Fw3VP%2B4sHu7P6azVIZ9IVlna72R5eLoPMx%2BkL6rZOeG1wJzxr1h%2B5J0OwN8OYv%2B9u0oooPAAA%3D)
[Test smailor.com/email-setup example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMaxM2oC%2F%2B1WYW%2FaSBD9K6uVIvVUIMYQhzhCKknINU1IKiC5VBGyFnsgq9hed3dNQiP62ztrINgUrvehVXtSPkTEO7M7b%2BY9v%2FUz1RAlIdNA3WeaSDHhAcizgLpURYyHQlZ8EdHSS%2BiSRZhKe%2FMgBhTICfch2wJmtaxAp8kqUtxB2uaXdEWqeTzGrAlIxUVM3WqJhmIsrmWI2fdaJ8rd3c2B2DXRSpJtCkD5kic620iPRTzi41QCObnsEQm%2BkIEiIyy2LJoBI3JelLA4IAGEHEuzIQ%2B5nhocTHI2DOGkcPTOTbt7dvrJ61%2Bdty93XBIIPCkm4jFG2Pc8IXgGH3GfmXyixQPEh2Sn275offLeX%2FX6uGWJYQ4BQjYl90LpGMeCqSfnZx2v175oH%2FevuphtnskDTImCEHwt5DLnpnVx3V4mJOkw5H6W92bIFDh1ArEvAgj%2BMoOfxv7HdHgO05MM7ndkmoQuBBxHpbekLKZI3btnOsbBJXlNlPNdY7KeJobi%2Fm0fH0xz%2BPDO0MQ0W981LRdnarZrpLzmWBb%2B%2B6QNm9ic7jDt3yNdHWwLD%2BkCytQHOittAhQ9rWB0bosoEsFjrfrC0JljJhM1F9LQ71atHIzNJVQyWtXofTztFKtguJuGgBOjPPbDNAB3rdoPzg8eeLRllmsqqXhzGSL9qyFPmiapekgemlKxQ5I087r5OVMOIib9LRi9ZXCFp9PqHlcNkljEqHWZsqY5SAs3y323bT7%2FBWCJglIQa86MXVzFrSQJp3Q2mJXoF6zmrfQ7QEhLjcMTQ7eDhcYXyFU6xIesW49nW7bpvKC2oi7WWCxODCEkTLJIGZNdgrkroBks4dxleAYLQL8GTP4FNBXY0K%2FaNRNZMWLW607FsSu2hX97WbigQ5PRarVe1jOlmcWjoyNqiODjWEjwFP4yjfZMXS1TKNEoDTX32CNbLQW%2BxwyDyJvCKJ6CvlOQWTy%2FRuZkbTaWRRsFJXmBb4bOjYyHtdq%2BPfShPLLtarnuOKPygbVXL%2B836j6zg%2F1GbXSQu%2Bo23ILbL7uClvLSbIWPbKrozLxReYPa1E9x3oU%2Bilb1J3a1naZJE2VZJUtbLHRJvrIw%2FPMpKzTHGMtZcGWt13UbNm%2FD%2F6u%2FuZV%2F19eP7Pxf1PvbW365IGaDEt4Ir%2Bbyai6v5vJqLj%2FdXPBbSLEJBB4zqQjXKVtOudroWw13z3Ztu%2BI0HKfuvLUs17JMH6D0fArP%2BMWU%2F1aiB%2BqsEfVY0rPeis%2FQqL9Pr%2F%2B5AYd%2FONVP8svft3uiqncn40c49Zt09g15tFHzyg8AAA%3D%3D)