### PR TITLE
Add email configuration and update DMARC settings

### DIFF
--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -1,0 +1,54 @@
+{
+    "providerId": "smailor.com",
+    "providerName": "Smailor",
+    "serviceId": "email-setup",
+    "serviceName": "Smailor Email Routing",
+    "version": 1,
+    "logoUrl": "https://smailor.com/logo.png",
+    "description": "Configure DNS records for Smailor email routing and deliverability",
+    "variableDescription": "%VERIFY_TOKEN%: domain ownership verification token; %RELAY_HOST%: Smailor mail relay hostname; %DKIM_SELECTOR%: DKIM key selector; %DKIM_VALUE%: DKIM public key (base64 encoded)",
+    "syncPubKeyDomain": "smailor.com",
+    "syncRedirectDomain": "smailor.com",
+    "records": [
+        {
+            "groupId": "smailor-verification",
+            "type": "TXT",
+            "host": "@",
+            "data": "smailor-verify-%VERIFY_TOKEN%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-mx",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "%RELAY_HOST%",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-spf",
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:%RELAY_HOST%",
+            "ttl": 3600
+        },
+        {
+            "groupId": "smailor-dkim",
+            "type": "TXT",
+            "host": "%DKIM_SELECTOR%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace"
+        },
+        {
+            "groupId": "smailor-dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Replace",
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -48,6 +48,7 @@
             "data": "v=DMARC1; p=none; rua=mailto:dmarc-reports@smailor.com",
             "ttl": 3600,
             "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
             "essential": "OnApply"
         }
     ]

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -16,7 +16,7 @@
             "host": "@",
             "data": "smailor-verify-%VERIFY_TOKEN%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Replace"
+            "txtConflictMatchingMode": "All"
         },
         {
             "groupId": "smailor-mx",
@@ -39,7 +39,7 @@
             "host": "%DKIM_SELECTOR%._domainkey",
             "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Replace"
+            "txtConflictMatchingMode": "All"
         },
         {
             "groupId": "smailor-dmarc",
@@ -47,7 +47,7 @@
             "host": "_dmarc",
             "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
             "ttl": 3600,
-            "txtConflictMatchingMode": "Replace",
+            "txtConflictMatchingMode": "Prefix",
             "essential": "OnApply"
         }
     ]

--- a/smailor.com.email-setup.json
+++ b/smailor.com.email-setup.json
@@ -45,7 +45,7 @@
             "groupId": "smailor-dmarc",
             "type": "TXT",
             "host": "_dmarc",
-            "data": "v=DMARC1; p=none; rua=mailto:dmarc@%RELAY_HOST%",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc-reports@smailor.com",
             "ttl": 3600,
             "txtConflictMatchingMode": "Prefix",
             "essential": "OnApply"


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test smailor.com/email-setup example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHS4M2oC%2F%2B1W8U%2FiSBT%2BVyaTmNxGwLYIYg3JIrC3RlEX0LgxphnaB0wsnWZminYN97ffm2KldSW32cvm9hJ%2FANq%2Bb%2BZ9772Pb%2FpENSzikGmg7hONpVjyAORJQF2qFoyHQtZ8saCVl9A5WyCUjtZBDCiQS%2B5DtgTM06oCncSbSHkF6ZtfMhSJ5tEMUUuQiouIunaFhmImrmSI6LnWsXL39gok9ky0FmeLAlC%2B5LHOFtKuiKZ8lkggvfMRkeALGSgyxWR50owYkeukhEUBCSDkmJpNeMh1angwydkkhF5p653r%2FvDk01dvfHHaP99xSSBwp4iIhwhpz3lMcA8%2B5T4zeKLFPURHZGfYP%2Bt89T5fjMa4JOewpgAhS8lcKB1hWxDaOz0ZeKP%2BWb87vhgi2tyTe0iJghB8LWSOue6cXfVzQJxMQu5nuD8mTEFzn0DkiwCCD6bxaeRfJpNTSHsZ3e%2BGaQBDCDi2Sm%2BBPHeRurdPdIaNi4uaqBarRrBOYzPi8c0Yb0xxePPRjIlp9npVWi331CzXOPJ607Lw8lGbaWJxesC0P8dxDbAs3KQThnRVeYvM4nFDYXBTZhALHmk1FmaUhalkguZCmtG7tlWg8HYKFU83OUaXnwblLBgeJiFgtyiP%2FDAJwH2V7R%2F2D%2B75YksfXymk5q0liKPfNHjZNiD7iNy3pWJHJG4XNfPvOxwsmPS38PPy4IbLoDPs2oZFJCLUuExY22ykhZthqxJiIbX6WFbcD3G8lDDlZt6gFESaM2MWF1EnjsOUru5WFfoNc3ob9d4hsVzh8MjQ6%2BA53zN%2FvMoK9niG3ybxktjKsng1xHLTMH%2FMJFso4685k9sSlbucyy011xmbX8Ok%2BMczGdjEt526iWzUap7vN2tNp%2BZY%2BGlk4ZIGDaLT6bw8z1RmHh4fH1MzAj6LhARP4S%2FTaMvU1TKBCl0koeYee2CbR4HvMTM7nJjCKO6CflOSWbQ%2BPrbbyXMRJQF5gW%2F6zY2IpwfTQ6dlQXW%2FbuOX71jVSctqVf2GPZ0ErcPmtN4sHHBvnH3bj7iNhop67IQPLFV0Zf5MRV%2F6vpRyo0sllP3ptyto23CWbZSiTXIbLBVI%2FmJoMb%2F3oEp1McZ%2B0G%2BN9P9Hhf0K0%2F5vK345A1Z3FTT9dxd5d5F3F3l3kZ93EXy7UWwJgccMDrXXrFrNqt0aW4euY7kNp2bVncbhwa5luZZligCl1414wneg4tsPlaPeYCjjrm2f7dbPD77Ixqw32k9vrq%2Fmn3db17u92Z%2FOl0unCyOrTVd%2FAxlDz%2BeUDwAA)
[Test smailor.com/email-setup example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ%2B4M2oC%2F%2B1Wf2%2FiOBD9KpalSndaQhMKtKRC2rRlr1VL6QGt%2BkMoMokBb5M4Zzu0XMV99hsHKDELupNWq9uT%2BkdF4xl73sx7ec4bVjROI6Iodt9wKviUhVRchNjFMiYs4qIc8BiX3kPXJIZU3FsEISCpmLKA5luoXrUkVVm6jpg7UEv%2Foi7PFEvGkDWlQjKeYNcp4YiP%2Ba2IIHuiVCrd%2Ff0CiH0dLaf5ppDKQLBU5RvxKU9GbJwJis6ue0jQgItQohEUWxXNgSGxKIpIEqKQRgxKkyGLmJppHEQwMozomXH03l2re%2FHlwe93LlvXey4KOZyUIP6SAOwJSxGcwUYsIDofKf5Mk2O0121deQ%2F%2BeafXhy0rDAsINCIzNOFSJTAWSD27vGj7vdZV67Tf6UK2fkbPdIYkjWiguFjl3HlXt61VQpoNIxbkeb8MiaT1KqJJwEMa%2FqoHP0uCm2x4SWdnOdxvyNQJXRoyGJXakbKcInaf3vAYBpcWNWEVu4ZkNUs1xf37Pjzo5uDhs6aJKLK5a2aZM9XbFVB%2BULdt%2BPdVaTahOdUmKpgAXW1oCw7xogjPS9vAxK9rCO17E0HKWaJkn2sqC6zkgmZcaOpdxy5A2F5CpqN1jd7Nl7ZZBcLdLKIwLcySIMpC6m5U%2B4fzw2cW75jjhkLK%2FkKCQP16wNOmTnKO0XNTSHKM0mZRM98%2F4TAmItiBz18F11jaXvfU0SgSnoDGRUaa%2BiDF3TzXEjTlQsnPpuL%2BFcYbQUdM802lpIliRJtFJ%2FHSNJrh%2BWBewn9CTX%2Bt3gEAWymcvhLwOrqst8QvsyE85D37LN%2ByS%2BWG3kxlbPBozg0gpESQWGqLXYF5MtAMVnCecjyDJaAfA6b4%2BukKZBg4lQMdWWtWr1fr5XqlXLHhr5aHDSXqDM%2Fz3tdzrenFk5MTrIlg44QL6kv4JQrMGbtKZLSE4yxSzCcvZL0UBj7RDAJvEqJwCriOIbZkcYksyNpuK8s2DCH5YaCHzrSYg6PR4ahWq1j1oXNoVRtOaB2RgFqNRqNSCYaN8IAEhYtuyx24%2B6oztFSUphe9kJnEc%2F1eFS1qWz%2FmvI0%2BTLP6GbvaTdO0CbJ00MoYjS7RXwRM56enzGiOEFIw4fJGr5tGrN%2BG%2F1d%2FC0P%2Fpq%2FvNvX%2FvPH3a2I%2BKMG98GExHxbzYTEfFvODLAa%2BiySZ0tAnOhXEWLfsuuUc9e2GW3Hcg1q57tSqzuEn23ZtW%2FdBpVrM4g2%2BnorfTbhP1UQ9Xtz%2Bdn%2F6%2BDLJLtP65Nx%2BuP39%2FOGr99XuTD5VJn%2FcZWH0qKpNPP8bpDWRhNQPAAA%3D)