### PR TITLE
Add Senderz mail template (senderz.app.mail.json)

### DIFF
--- a/senderz.app.mail.json
+++ b/senderz.app.mail.json
@@ -10,7 +10,7 @@
   "hostRequired": false,
   "description": "Enable email authentication and tracking for Senderz (SPF, DKIM, DMARC, MAIL-FROM, tracking CNAME) via Amazon SES.",
   "variableDescription": "%dkimSelector%: DKIM selector; %dkimValue%: Full DKIM TXT value (v=DKIM1; k=rsa; p=...); %dmarcValue%: Full DMARC TXT value; %trackingSubdomain%: Tracking subdomain label; %trackingTarget%: Tracking CNAME target; %mailFromSubdomain%: MAIL-FROM subdomain label; %mxExchange%: SES feedback SMTP host",
-  "logoUrl": "https://senderz.app/logo-text-dark.png",
+  "logoUrl": "https://senderz.app/logo-text-primary.png",
   "records": [
     {
       "groupId": "authentication",

--- a/senderz.app.mail.json
+++ b/senderz.app.mail.json
@@ -6,7 +6,10 @@
   "version": 1,
   "syncPubKeyDomain": "senderz.app",
   "syncRedirectDomain": "senderz.app",
-  "description": "Enable email authentication and tracking for Senderz.",
+  "syncBlock": false,
+  "hostRequired": false,
+  "description": "Enable email authentication and tracking for Senderz (SPF, DKIM, DMARC, MAIL-FROM, tracking CNAME) via Amazon SES.",
+  "variableDescription": "%dkimSelector%: DKIM selector; %dkimValue%: Full DKIM TXT value (v=DKIM1; k=rsa; p=...); %dmarcValue%: Full DMARC TXT value; %trackingSubdomain%: Tracking subdomain label; %trackingTarget%: Tracking CNAME target; %mailFromSubdomain%: MAIL-FROM subdomain label; %mxExchange%: SES feedback SMTP host",
   "logoUrl": "https://senderz.app/logo-text-dark.png",
   "records": [
     {
@@ -28,7 +31,10 @@
       "type": "TXT",
       "host": "_dmarc",
       "ttl": 3600,
-      "data": "%dmarcValue%"
+      "data": "%dmarcValue%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
     },
     {
       "groupId": "tracking",

--- a/senderz.app.mail.json
+++ b/senderz.app.mail.json
@@ -1,0 +1,56 @@
+{
+  "providerId": "senderz.app",
+  "providerName": "Senderz",
+  "serviceId": "mail",
+  "serviceName": "Mail",
+  "version": 1,
+  "syncPubKeyDomain": "senderz.app",
+  "syncRedirectDomain": "senderz.app",
+  "description": "Enable email authentication and tracking for Senderz.",
+  "logoUrl": "https://senderz.app/logo-text-dark.png",
+  "records": [
+    {
+      "groupId": "authentication",
+      "type": "SPFM",
+      "host": "@",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "authentication",
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "ttl": 3600,
+      "data": "%dkimValue%"
+    },
+    {
+      "groupId": "authentication",
+      "type": "TXT",
+      "host": "_dmarc",
+      "ttl": 3600,
+      "data": "%dmarcValue%"
+    },
+    {
+      "groupId": "tracking",
+      "type": "CNAME",
+      "host": "%trackingSubdomain%",
+      "pointsTo": "%trackingTarget%",
+      "ttl": 300
+    },
+    {
+      "groupId": "returnPath",
+      "type": "SPFM",
+      "host": "%mailFromSubdomain%",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "returnPath",
+      "type": "MX",
+      "host": "%mailFromSubdomain%",
+      "pointsTo": "%mxExchange%",
+      "ttl": 3600,
+      "priority": 10
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Domain Connect template for **Senderz** (`senderz.app`) — email/SMS marketing for Israeli e-commerce. Configures Amazon SES authentication: SPF (apex + MAIL-FROM), DKIM, DMARC, tracking CNAME, and MAIL-FROM MX.

Public signing key TXT is live at `_dck1.senderz.app`.

**Bare variables in `host`:** `%trackingSubdomain%` and `%mailFromSubdomain%` are tenant-configured subdomain labels (fixed at apply time per domain, same pattern as `resend.com.mail.json` `%clickTrackingSubdomain%`).

**Bare variables in `data`:** `%dkimValue%` and `%dmarcValue%` carry full externally-prescribed TXT strings (DKIM/DMARC standards); see `variableDescription` and `coreware.app.emailverification.json` / `keplars.com.email.json` for the same pattern.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — uses `SPFM` instead
- [x] `txtConflictMatchingMode` is set on DMARC TXT (`Prefix` / `v=DMARC1`)
- [x] bare `%dkimValue%` / `%dmarcValue%` justified above (full standard-prescribed TXT values)
- [x] no bare variable as full `host` label — DKIM uses `%dkimSelector%._domainkey`
- [x] `%trackingSubdomain%` / `%mailFromSubdomain%` in `host` justified above (fixed per-tenant at apply)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is `OnApply` on DMARC

## Online Editor test results

**Editor test link(s):**

[Test senderz.app/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMAKNWoC%2F%2B1Wa0%2FbSBT9K6ORKrXa2DgPAhhFqgkJiqghJVmEhFA0sSfJNH4xMw5JEf3te8fxcxN2u9uVtpX4As5937nnnplnLKkfeURSbD7jiIcr5lI%2BcLGJBQ3g86tOogjXctUV8cEUj7ZKUAjKV8yhiYtPmFeIUlN7K1xRLlgYYLMOBpvAGcbTS7o5D8En2MmmDG6oyzh15F%2BYnHmhs8TmjHiC1vAiFPKGPsbg5eZClwqHs0gmqXEvIFOPIqoKRSSWCxpI5hClRSRwkeTEWbJgjmYhR2mP6P1o2K%2Bh88uBDX9t66ZbQ7Y1%2BKT1b65Bkrt0ryy79wGtGEGWT75CxFFvpKvOCWcq7XmllHfukvkj6kGHIX9nJvGRSH%2BfokR9S7yYgq4fe97WYHw3RislRe9XHSWpn6JlhwtyiqKOrusflKdPuFN1VVUXvmCTVT2Kp25yvmA6zjoRmRB5ZEq9kvmY8DmVZdukayQTORiqg%2B3z0C%2FHzQ9rT2B%2F3Vs7CxLMVa1wXmhGqTuF2Ghkj4dIjRRO0Avn4e%2Fcg1NbSBkJ8%2BCghIUDpdUkXUst4gx63%2BhRMAcvAE%2FIXYHN%2B2c852EcJRitTh3M5CZKED3s23gLIvj1USkkZGy2DQPAFs1uYo9CLMwCx4tdapJkxoIK3Ql9%2FFL7nhwwgSJFFQD6ZHsyS7qppnaJJJn1dqj%2FJtkkAcUrkQu8KIO17IbBzGOOtIl0FjBkO3RVwCGnM7beb5LqTAyoVGCrgxkVQtVF1NyuAyuKvM2fSs9gVRSdwKl0Rrs4VVwUskCKcVg2SJGZd2gY1VScypgHQyIXr418D3Z%2FCAT7Mtp3f5ev3FtpOaqVAM5DzuQGyNR4eXipYSiCTgq8P8BwM9akawIET5MC89zwlRQ6YZl9RDjxhboEMs%2F7iutD5nuP1XcZu0qW7mOmStCk5LskZQ8GZ4Mv1tXZfPm4WLKLkyfjzPrc61vWddf6fGwpfXd%2BCd89Ky0giZqDNA2boEwFDKD3U8Rj0lEHKkMzMf1YYohToPNOXUXZgZMKlgjL2i2WcpVevnjAbGduynIaxoGTVFpMTckzPtOELyOdxloQcrnQ6noVOmqIbA46OhHwnwB0wF3yGK4wP%2FYkm5AnUohcZ0LUPsHMBWghEXBcZe%2BD7eWreCzd81UHAFxHe6GLvhHPq2Js4joKDUxB2Z01GofNBtHc2ayhtYzmiUaa0yOt3jw%2BJO4JNVqElt4Ie54Pe14JBRTLRGF5T2Qj8IvapX0NZWErdJl3%2BF%2BA7Vc4hZzOi87%2F%2BT78DI3m90Kp0%2BwOSHvdrmfe6u5KFpT%2F084rZYdffxeTC%2ByVpr6T6l69yf7%2FPh9qcBW%2BMekbk74x6RuTvjHpjzApPIQFWVF3QpRZw2i0NaOt1U%2FGxonZaJn1tt5sNZuHjd8MwzQM1QoVctv%2BM7yFy69gfHRZX8aP5Oq2fRtYbmN8fHHRH326%2BHLnGt3z1uHdYtXiR48BY027g1%2F%2BAGbcBsvTEgAA)

[Test senderz.app/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFgLNWoC%2F%2B1Wa2%2FiRhT9KyNLK%2B2q2DEsoeAIaU0CFUqdkMC2aaMIDfYAE2yPd2bMY6P0t%2FeOH2AvZLt9qEorvvC499z3mTvzpEkSRD6WRLOetIizJfUI73uapQkSws%2FPBo4irbJVXeEAoNowVYJCEL6kLklMAkz9nSiDOqlwSbigLNSsKgA2oTuIJ5dkc8HAJtyLpgC3xKOcuPIrkI7P3IVmTbEvSEWbMyFvyacYrLyt0CPC5TSSSWitG%2BKJTxBRiSIcyzkJJXWx0iIcekhy7C5oOENTxlFWI3o7HPQq6OKy78CnY9%2BeV5Bj93%2FUe7fXINmanF%2FZTvcdWlKM7AB%2FBo%2FD7tBQlWNOVdiLUipvvAUNhsSHChl%2FYyX%2Bkcj%2Bn6FE%2FRP2YwK6Xuz7KWB0N0JLJUVvl20lqZ6hRZsLfIaitmEY75RlgLlbNlVZ72wBk2c9jCde0l%2BAjvJKRC5EPp4QvwAfYT4jsohNqkYykQNQNbbHWVD0u23WAcfBurt25zicqVyhX2hKiDcB32jojAZIjRQ66LMZ%2B8h96NpcykhYJycFLpworS7JWuoRp1D7xojCGVgBeRj3hGbdP2kzzuIo4Wh56gCTmyhh9KDnaCmJ4N8HpZAQ8X3DNIFs0fQ29gn40mjo%2BrFHLJzMWBBhuCzQnivfEgMmsAtRJoAxTjuzIJtyaA9LnKPTof6VYOOEFC943vFFAdbynIVTn7rSwdKdw5Ad5imHA06mdH0YkuksDVipyFYFGBFC5YXV3K5DO4r8zRep57TaJZ3QqdCjfZ6qXcRoKMWIFQEZM7cVmmY5FCcy5uEAy%2FlLIz%2FA3b9FgkMRnbs%2FilesrXA4ypkAzxmncgPL1Hx%2BeK5okAQZ7%2Fj%2BAMPNtyZZY1jwJElwGztb1EmyY5rbRJjjQKiLILe%2BL5k%2F5Pb3qQMVpsBhJc%2FOZa5KWKXk%2B8vK6fc7%2FUf7qjNbfJov6A%2Btldmxb7o9274%2Bt2%2BattKfzy7hd9fOkki8bsmauU3YphyG0IMzxGPcVslJZiXQD4VNcQZrvV1VXvZopZwlwqI25dRWZRQvIIDtzU8hJywO3STT3fSUPN9rughkZJBYDxmXc71qlCmkhklnoCNjAd8YKATmksdwlQWxL%2BkYr%2FBO5LljrM4VzF6AFgLBriud%2FzC9hLOBZ0d%2B2QYuV9FBFqPfsO%2BX6Tb2XEUKqlg98erNGp56esMkWK%2FXp67eJN5UN8n7Vr2OzdPTFik8Fw68JA48GMqsLO4N21%2FhjdCe1dE6VFfuerc9jS9L%2FSeI919pR7rm91vw5w%2FJa6l4e3EUSs4viazo9HCWa94%2FsLuL4VVPMN0fxv%2FovCZ33teq%2B8bV%2BOIN%2BDoKfqjAFXrcvsfte9y%2Bx%2B173L7%2F9vaFB7fAS%2BKNsYLWzFpDNxt6tTUyW1atYdWbhlk1T2ut70zTMk1VDhEybcETvLmLr21tKK7uOqvmzfd34fKSXj1Sl%2F3ccJqbXzfYXTEx%2BOVRLnzSWXZWH9va8%2B97Xoi1QxMAAA%3D%3D)
