### PR TITLE
feat: add GitHub Pages templates for apex and subdomain domains

### DIFF
--- a/github.com.pages-apex.json
+++ b/github.com.pages-apex.json
@@ -1,0 +1,76 @@
+{
+    "providerId": "github.com",
+    "providerName": "GitHub",
+    "serviceId": "pages-apex",
+    "serviceName": "GitHub Pages (Apex Domain)",
+    "version": 1,
+    "logoUrl": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+    "description": "Connect an apex domain to GitHub Pages by pointing it to GitHub's published IP addresses. Also sets a www CNAME so both the root and www subdomain resolve to your Pages site.",
+    "variableDescription": "%username%: GitHub username or organization name that owns the Pages site (e.g. octocat for octocat.github.io)",
+    "warnPhishing": true,
+    "records": [
+        {
+            "groupId": "ipv4",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "185.199.108.153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "ipv4",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "185.199.109.153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "ipv4",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "185.199.110.153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "ipv4",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "185.199.111.153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "ipv6",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "2606:50c0:8000::153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "ipv6",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "2606:50c0:8001::153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "ipv6",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "2606:50c0:8002::153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "ipv6",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "2606:50c0:8003::153",
+            "ttl": 3600
+        },
+        {
+            "groupId": "www",
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "%username%.github.io",
+            "ttl": 3600
+        }
+    ]
+}

--- a/github.com.pages-subdomain.json
+++ b/github.com.pages-subdomain.json
@@ -1,0 +1,20 @@
+{
+    "providerId": "github.com",
+    "providerName": "GitHub",
+    "serviceId": "pages-subdomain",
+    "serviceName": "GitHub Pages (Subdomain)",
+    "version": 1,
+    "logoUrl": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+    "description": "Connect a subdomain (e.g. www, blog, docs) to GitHub Pages using a CNAME record pointing to your GitHub Pages site.",
+    "variableDescription": "%username%: GitHub username or organization name that owns the Pages site (e.g. octocat for octocat.github.io)",
+    "warnPhishing": true,
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%username%.github.io",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds two Domain Connect templates for **GitHub Pages** custom domain setup — one of the most widely used static hosting platforms that was not previously covered in this registry.

- **`github.com.pages-apex.json`** — connects an apex domain (`example.com`) to GitHub Pages using all 4 IPv4 and 4 IPv6 addresses published by GitHub, plus a `www` CNAME. Grouping separates `ipv4`, `ipv6`, and `www` so DNS providers can apply them selectively.
- **`github.com.pages-subdomain.json`** — connects any subdomain (`www`, `blog`, `docs`, etc.) to GitHub Pages via a CNAME to `%username%.github.io`. Uses `hostRequired: true` since the target subdomain is supplied via the protocol's `host` parameter.

Both templates use `warnPhishing: true` because GitHub does not host Domain Connect signing keys (`syncPubKeyDomain` cannot be set). See justification in the checklist below.

**Reference:** https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file names follow the pattern `<providerId>.<serviceId>.json` — `github.com.pages-apex.json` and `github.com.pages-subdomain.json`
- [x] `logoUrl` (`https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png`) is served by GitHub's asset CDN

# Checklist of common problems

- [ ] `syncPubKeyDomain` is set — **omitted with justification**: GitHub does not run a Domain Connect provider endpoint and does not publish signing keys. This is a legitimate "service infrastructure genuinely cannot support key-based signing" exception per the README. Async flow (`syncBlock: true`) is not applicable since GitHub Pages does not implement OAuth-based Domain Connect. `warnPhishing: true` is used as the last-resort fallback.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — only `warnPhishing: true` is set; `syncPubKeyDomain` is absent.
- [x] `syncRedirectDomain` is not required — neither template uses `redirect_uri`.
- [x] No TXT record contains SPF content — these templates contain no TXT records.
- [x] `txtConflictMatchingMode` — no TXT records present.
- [x] No bare variable used as full record value — `%username%` is always embedded in `%username%.github.io`.
- [x] No bare variable in `host` field — `host` values are `@`, `www`, or absent (all literal).
- [x] No variable in `host` to create a subdomain — subdomain is driven by the protocol's `host` parameter via `hostRequired: true`.
- [x] `%host%` does not appear in any `host` attribute.
- [x] `essential` not required — GitHub Pages A/AAAA/CNAME records are not expected to be modified independently by users.

## Online Editor test results

**Editor test link(s):**

[Test github.com/pages-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMdENWoC%2F%2B1XDWvbMBD9K0Iw1rHEkePESQyDhXXfrCtsK2ylhIut2docyZXkZGnpf9%2FJceaE0nWwFtotIWBFunv33tl3F59Ty2dFDpbT6JwWWs1FwvXrhEY0FTYrp16sZrT16%2BQAZmhJXwr7qpzivuF6LmJeORSQctOGgv9oDrbsyaGzIHtjNCH7agZCPkLTOddGKEkjv0VzlapPOkeXzNrCRJ1OTWN1AWO4NY5TR8wcWGemkjLHq3M0E0ehswrWfgf6u1fIFCMk3MRaFLaKQp8pKXlsCUjiyJKkYkKsIls0p0tSKCGtkCkRtjl%2BaEhRTnNhMp6Q14cEkkRz5GU8Ms6NIo4hAbJYLMizg%2FG75wT3pspmxGacaKVc4KQ6NuW0jo0AKp9zF2SpSl0zMMJyzyUItIBpzve3ZDwoMccS8%2FsgWhNf7xCl8ZuCFGfgrEm1aTOwRC2kqZg0Icge91KPqNiqGC2%2BOufVus66J5S7TwvQ8jBD3ZgRGlld8hbVPFY6MTQ6PqepVmVRPQmimPfQwS4Ld%2FPHuMyUsbh86h4ll1TzUeFPf9j3%2FNHI89nQ8%2FuBc7F474OQsYvW3wGObhjQZzcN6F8LGG4A4udKzG7IwqjPYhYNGWNRdCu4%2Fi3hdm8JN7gGFwuwga0KtcFdnW0gN7XWlMQW9MlFi54pySdNQZxg36mqG%2F35D8Auy%2BtmWkfBVUVnItb2BWiYGdeJ157HW64na99j6tZrUu53XbHUERGpVJpPDF7Blpqvi3VW5lZMAOv411YST6Ao8iXyNniKSFjIGw%2FxCr5KdAIWfl%2BzLTpJYsdeuAQzCIf9oD9od4EN2j0IBu3hlA3bgyDxA5587fVGg43JcnnmXDlbmvy5vosdGtzAGOcLWBp64W7zHyoY3XcFl7vSvVPg330Fq55zWcQ1ffeeCvH%2FFSHdf0VIcPeFrAdorWQ1QGstl%2F5M3kElJy2cv7vRtxt9u9G3G3270bcbff%2FR6MM3SQNznkzAmXVZN2yzsO2PPvpBFPhR3%2FeGg0HYDR9joTPmFHBjVwLP8W1z8z2TQqgGb56%2FOZKf9198%2BSAPRkdvl9%2FEqYVTlZksty%2Fff5NnnS4f9b4%2FoRc%2FAWNXZuB%2BFAAA)

[Test github.com/pages-subdomain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABBFNWoC%2F91Ta2vbMBT9K0JQaKkfSuImjWGwku5R0kfoug%2BjBCNbqiNmW44kx0tD%2FvuuYruNKewHDAyyrs7RPefq3h02PC8zajgOd7hUciMYVzcMhzgVZlXFXiJz7Lyd3NMckPibMN%2BrGOKaq41I%2BIFQ0pRrV1cxkzkVxftpj4QWFoZOf3S4MwBuuNJCFjgcODiTqfypMiCsjCl16PutkmahWnOjrSxf5PYqP5esymC1RB1ZFX6Tyr2j6rdXFilkYFwnSpTmkAXPZFHwxCCK3uSiU%2B6lHqrr2kExXOUgJhN9hoxEPeGVFkUKxNn91d0XpHgiFUOlFIWxcUBvZaX6FC0M96xLqgSNM37d03JSQZkKKNFJ2NG6CJIKvpQW4pVaNDoEzYoaJOtCwx8%2FStE6kImRCSBeLLn5b0vnCWmLXVNVLFZCr0AwDo2quINXUptHvq6E4qyLNd40Dp932GxL%2B4QH07iBw%2Faz7QxrXT%2FJnpP3hIAwBh5zNCZkv9w7%2BFUWPHq%2FeglP07RLiPkfCr3I25Zrc8CDwCZVsioj0VFKqmiubct25Ocee9nRnw982HbSbKitCrZyRFpIxSMNKzWV4p35vMqMiCjU6i3EkoiWZbYF9RpO4aaPhWlStKIZNRQ2Hx7huCYOjlhijQg7QsPxcDBNLgKXvPCpG5DJ2L0MOHXj0QWdBBcsTibkaBo%2Fzum%2F57FXUg6DBE1L7aRdZTXdarzfLx0o739oCzpA0w1nEbXIIRmOXTJ2B9OnwSgcjUISeJeEBOTynJCQWC2Ga9MY3UGXHPcHHixmTzAr8zSe%2B4vH63l2fuNTQh7q9ez84Subr8fT9eRWD35VwSe8%2FwsgT6QGYgUAAA%3D%3D)