### PR TITLE
Create grapecloud.eu.website.json

### DIFF
--- a/grapecloud.eu.website.json
+++ b/grapecloud.eu.website.json
@@ -15,13 +15,6 @@
       "host": "@",
       "pointsTo": "%ip%",
       "ttl": 3600
-    },
-    {
-      "type": "A",
-      "groupId": "subdomain",
-      "host": "%subdomain%",
-      "pointsTo": "%ip%",
-      "ttl": 3600
     }
   ]
 }

--- a/grapecloud.eu.website.json
+++ b/grapecloud.eu.website.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "grapecloud.eu",
+  "providerName": "GrapeCloud",
+  "serviceId": "website",
+  "serviceName": "GrapeCloud Websites",
+  "version": 4,
+  "description": "Allows customers to connect their domain to GrapeCloud",
+  "syncPubKeyDomain": "domainconnect.grapecloud.eu",
+  "syncRedirectDomain": "grapecloud.eu",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "A",
+      "groupId": "apex",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "groupId": "subdomain",
+      "host": "%subdomain%",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Added website template for GrapeCloud, a soon-opening hosting provider.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test grapecloud.eu/website example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADyiNWoC%2F9VTbW%2FaMBD%2BK8hSPy2kIUDWRJo01k3dVGlrq2ovQihy7AO8JnFmO0BA%2Be87B8Jrte8TH8LdPc%2F57vHjDTGQFSk1QKINKZRcCA7qCycRmSlaAEtlyV0oibMvfqUZgsmdLd%2FaMtY0qIVg0PCWkGiB%2FfbZC0LnxxaiEbMApYXMSTRwCAfNlChME5NRmsql7rBSG5khqmNkh8k8B2Y6Zg5CdbjMqMht%2FnSYKmcPZXIP1ccGgL22yB3bPd%2FMEp6AC4XFPeUcNJfaPMGfElG4pVElOAQJUnFNovGGmKqwW44QOlOyLBotsMVqx8XovVVRitzoZ4nhlSiuMGNMSqJ%2B4Hn1pHbIWuYQH%2FpOnN3siIcVxasCl8ns0BNVNO2RsWg5BVU00%2FZKW%2Fb4hD5p%2BeNtA4xFYaOe2%2FyIHUXMcqkg1vilplTQbp2VqRExXdJDirOYFkVa4eQaq9jpVJF8a4HdsJwailF71pEEDok5s2MLqx73k6DnD4NuL6TT7mCQ%2BN0b5ofdBIbwNgynQQ%2BGR8Z81bWvO%2FNUPNAaciNo2rhuSStN6nrioJD%2F%2FxZ4s5ougMfUQn3PD7qeHeXZ96Keh%2BO6XtAf9vtvPC%2FyPLsFdtuutmn%2BNy6imtvPgipBkxSanDXM0fb%2FtmkhcjoDJqbwu3wpTUVbz1q%2F1vYlWd9cvKSd4hds9%2BgQ91T6s2vBR1Vb%2FVJ826hCo1XU7IPpY2%2BT8FN1raYs8L9fC2%2F0C%2BYmnX3%2Btn4ZflDybr16%2BHl%2Fu7qR88fHUL8j9V%2F3OObbOQUAAA%3D%3D)
[Test grapecloud.eu/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHWiNWoC%2F9VT247aMBD9FWRpnxqihCBKIlUqaumq2gq1CC3aIhQ58cC6JHZqO7Apyr93HAjLZdX3Kg%2BxZ84Zz%2BXMnhjIi4waINGeFEpuOQP1lZGIrBUtIM1kyVwoiXNyTmiOYHJv3Z%2BsG30a1Jan0PB2kGiO8U7WG0JnfoBoxGxBaS4FifoOYaBTxQvT3Mkoy%2BROd9JSG5kjqmNkJ5VCQGo65hm46jCZUy6s%2FTKZSqTfy%2BQBqs8NAGMdkEe2e12ZJUyBcYXOE%2BUa9Cy1mcLvElFYpVElOAQJUjFNosWemKqwVY4QulayLJpeYIiXIxdvH20XJRdGzyRe73hxhxZjMhIFA8%2Brl7VD%2FkgB8WvcpXPMHfHwQnFU4KYyv4zZvBfzllBQRXNt59lSFxfcZUteIBsvvLBH320%2BYpPgayEVxBr%2F1JQK2nrzMjM8pjv6amJpTIsiqzBnjV6MdNkLcRi%2BTZNRQ%2FHYPnRWuUNiltqEuW1aAEkSsqTXDZOV3%2B33QsATeN0whPfQAxYkFM70%2BKZY3xbkWc9AaxCG06xR2o5WmtT10sH%2B%2Fc%2F54zQ13QKLqcX1vN6g6w26fjjreZHvR0HgDgfhYBi%2B87zI82wJoM2hrn1zbmRDNbO%2FLVWcJhk0NiuSs9L%2FLcqCC7qGlK%2FgV7kpTUVbkVqB1nZvrFZu9ubY6xu2e%2FaIe9n3q5ngCtW2eRluMnbBVmS3EOtB87meSfZz%2FGM08%2B9Hq8l08xg%2BPnyr%2BmM2fxrP8%2FXqixjPhsPNE5%2FMRDD8QOq%2FFKsnLycFAAA%3D)
