### PR TITLE
Add Ulama custom domain template

### DIFF
--- a/ulama.ai.customdomain.json
+++ b/ulama.ai.customdomain.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "ulama.ai",
+  "providerName": "Ulama",
+  "serviceId": "customdomain",
+  "serviceName": "Ulama Custom Domain",
+  "version": 1,
+  "logoUrl": "https://app.ulama.ai/icon.png",
+  "description": "Connects a custom domain (apex or subdomain) to an Ulama site and adds the ownership verification record.",
+  "variableDescription": "%token%: ownership verification token issued by Ulama for the domain.",
+  "syncPubKeyDomain": "keys.ulama.ai",
+  "syncRedirectDomain": "app.ulama.ai",
+  "records": [
+    {
+      "type": "APEXCNAME",
+      "pointsTo": "app.ulama.ai",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_ulama-verification",
+      "data": "%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}

--- a/ulama.ai.customdomain.json
+++ b/ulama.ai.customdomain.json
@@ -12,7 +12,7 @@
   "records": [
     {
       "type": "APEXCNAME",
-      "pointsTo": "app.ulama.ai",
+      "pointsTo": "connect.ulama.ai",
       "ttl": 3600
     },
     {

--- a/ulama.ai.customdomain.json
+++ b/ulama.ai.customdomain.json
@@ -4,7 +4,7 @@
   "serviceId": "customdomain",
   "serviceName": "Ulama Custom Domain",
   "version": 1,
-  "logoUrl": "https://app.ulama.ai/icon.png",
+  "logoUrl": "https://ulama.ai/assets/logo.svg",
   "description": "Connects a custom domain (apex or subdomain) to an Ulama site and adds the ownership verification record.",
   "variableDescription": "%token%: ownership verification token issued by Ulama for the domain.",
   "syncPubKeyDomain": "keys.ulama.ai",


### PR DESCRIPTION
# Description

New Domain Connect template for **Ulama** (`providerId: ulama.ai`), service **Custom Domain** (`serviceId: customdomain`).

It lets a user connect a custom domain (apex or subdomain) to their Ulama site:
- `APEXCNAME` -> `app.ulama.ai` (apex-friendly CNAME so the root domain can be pointed at Ulama).
- `TXT` at host `_ulama-verification` carrying the ownership-verification token (`%token%`) issued by Ulama, with `txtConflictMatchingMode: All` so re-application stays idempotent.

`syncPubKeyDomain` is set (`keys.ulama.ai`) to enable cryptographic verification. The template validates cleanly against the repository `template.schema` and passes `dc-template-linter` at `error`/`warn` levels (only informational notes DCTL1038 for APEXCNAME and DCTL1021 for the custom verification host, both expected for this use case).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`ulama.ai.customdomain.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://app.ulama.ai/icon.png`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`keys.ulama.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (template does not use `redirect_uri`; `syncRedirectDomain` is provided as `app.ulama.ai`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the verification TXT record (`All`)
- [x] no variable is used as a bare full record value unless necessary — the only variable `%token%` is an opaque ownership-verification token scoped to the dedicated, fixed host `_ulama-verification`, so a fixed content prefix adds no security value here
- [x] no bare variable is used as the full `host` label (host `_ulama-verification` is fixed)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — not required; neither record needs independent user modification


## Online Editor test results

**Editor test link(s):**

- [Apex test (example.com/@)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADK0NmoC%2F%2B1T72vbMBD9V4SgsDE7ceLGrQ2DtWlhY2tJR8rKSjBnSYm12paR5DRuyP8%2ByW5qd1v7eYN90o97J713726LNcvLDDTD0RaXUqw5ZfITxRGuMshhABw7T%2FeXkBscvrYRc62YXHPCGjSplBY5FTnwogv1E9C0gaCzPWbNpOKiwNHIwZlYiWuZGWyqdami4XD%2F%2FRCUYloNLWKg1iuTSJkikpe6ScZTURSMaIUAtSRQywK9gZJtkJBIVUl79RZpgaBALR%2FFNTMnioBShXTKkLgvDKeUl8hw40tOwP6BJCNC0oGlDJJDkrGzZwwOtLhjxUH0Un4TRlypilGU1I%2FfLw0z%2B2lLzb6u6oLMquQzqx9rFOE7VqtBzwkL%2BcooN5T0EwjKso9p6Soc3W6xrktrwMns%2FGZ6eXJxbs0UvNBqLqxpben6yVobE%2FzA83bOU%2Fb8Zm4iqVDaHOIG7PYFWktAQ1eJ%2Fjtmu9HGo2XGib4ATVJerC4EbWhlGd4tdg5%2BEAWLO94L8%2BBeHNuAaVA2ICLvSJjdSoqqjPkeX4KEXNkm3mfePktd7HNvsd03PO1BM6WfiXEhIaOxjy0tviqEZLEyK%2BhKGspaVszBeZVpHsM9dFeUxMaGrDYqlImap%2F9c%2FaKdiA9dzV4zwcExJVYUtzPmj5cA4ch3jyeh7x6S45Eb%2BsGh6yWh54WUBPQo7E3rr1P8yrh2ZWVm2grNIWvsuYda4d1vrfAo4tVWeLGwf5%2B8hWM66L9d%2F4xdZn4VrBmNwcLG3jhwvcAde%2FPRJPLDyPcGE98PA%2F%2Bd50WeZxUYca3OrZnq%2FjzjICg3q%2BHk%2FND7nq4fpmczuNqk305lUs6%2BXKUnH09lWo2nk6Mfp1fv8e4n4XKMGy8HAAA%3D)
- [Subdomain test (example.com/go)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEC0NmoC%2F%2B1TYWvbMBT8K0JQ2FjsOImTEMNgXduNURLKmpZuJZgXSUm02paRntN6If99kp007tb28wb7ZEu6e7p7p7ehKNI8ARQ02tBcq7XkQn%2FhNKJFAin4IGnrcX8CqcXRK3dit43Qa8lEhWaFQZVylYLMDkdNAjmpIOR0j1kLbaTKaNRp0UQt1ZVOLHaFmJuo3d5f3wZjBJq2Q%2FhmvbRELgzTMseKTE9UlgmGhgCpRZBaBXkDuXggShNTzOuttwQVgYzUeoxEYVecAOeG4EoQdZ9ZTSuZE6tNLiQDdwfRginNfScZtIR5Ik6fKDhCdSeyo%2BglfnVMpDGF4GRe7q5fWGXu0lqaq27KjF0U83NR7noU0TtRGr%2BRhIN8FVxaSfgIgjxvYmq5hka3G4pl7gI4vji7OZkcj89cmEpmaKbKhVa3rklGtCH0BkGwbT2ypzdTe7JSBu0irsBe06CLBBAOnWjWsb8PaDNaJJLhGJCtZLYcK17JShK6nW1b9KfKRHzQPbMF9%2BbEA9gHKnym0oOIpbL%2FS62KPJZ7Rg4aUuOe8Z57%2B4Q827NvHd2uKq1uicLgE0MezFmn26NOmlxmSovY2C9goa1s1IVo0bRIUMZwD4ctzmIbRVJaJ8ae2tLPJ5DVU%2FHh0LfXgmjRmDNnS1ZzJhjv9GDkzXth6IUh9L3RaNj3gt5i3gmHYciGw8bE%2Fj7Jr4xss7XCzlyGEpIqpHsoDd3%2B8SB2Np55EH5VZOftxe7%2BjR5nLfuU%2Fqf2r6Vmp9nAWvAYHLAbdAdeMPC6wbTTj3qjKAz9IAh6YeddEERB4DxYe7XTjZ3x5nTTb2eDHx8nl5M7OeKdEV%2Fl5fkwGF5%2Fui6%2FX%2FUvDXY5a4fy87pg4Xu6%2FQVy7W4OQQcAAA%3D%3D)

