### PR TITLE
Create www.simpleurl.tech.branded-subdomain.json

### DIFF
--- a/simpleurl.tech.branded-subdomain.json
+++ b/simpleurl.tech.branded-subdomain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "simpleurl.tech",
+  "providerName": "SimpleURL",
+  "serviceId": "branded-subdomain",
+  "serviceName": "SimpleURL Branded Domains",
+  "version": 1,
+  "logoUrl": "https://www.simpleurl.tech/favicon.ico",
+  "description": "Configures a custom subdomain to point to SimpleURL's edge network for branded short links and QR codes.",
+  "syncPubKeyDomain": "www.simpleurl.tech",
+  "syncRedirectDomain": "www.simpleurl.tech",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.simpleurl.tech",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Adding a template to set cname record for uses to points to simpleurl.tech 's server for branded domain set up.

# Description
Adding a template to set cname record for uses to points to simpleurl.tech 's server for branded domain set up.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test simpleurl.tech/branded-subdomain simpleurl.co/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADK8NmoC%2F91TXY8SMRT9K01ffJCBwrA4TGIiog9%2BrYJL1GzIpNNeoGFoZ9sOiIT%2F7i3fK0Z99mVmOvec23NObzfUw6IsuAeabmhpzVJJsG8kTalTWIDKFnUPYkZrp%2BotXyCaft7VR8P3WHJgl0rAjpdbriXIyFW5NAuu9Ln%2BK5O83GPJqx3QIXIJ1imjadqs0cJMzcgWyJh5X7q00VitVvXHuhoTjp2NruMD6RKcsKr0uxa0b%2FRETSsLjnAiKufNgpxkEW9IaZT24eMk6YkjIKdANPiVsXMyMZYcHBE3M9aTQuk59tOSDIZEGNyxHhyutfhU5e9gvfeCu1%2BLPeCGIJUF4f%2BMnBnnh%2FBQIRRj9baCGkWWsdLR9H5D%2FboMYfZvex9eH%2BC4fBEOKrhydwaXQmPk1729x1TjDmPb8bZGfxgN2bn1GGM8Kjszd%2FEeNpmG76k1VZmpI6Xkli9cmKIj%2Bf4xe3yk3wd%2B2FdNtbGQOXxzj6d0dLmoCq8yvuLnX1JkvCyLNcp0WMUm1wno%2FXTtxEnu%2BT%2FYr9FMiqBZhcnlN%2B1nnbgpIugm7ajdlZMoj0FETHRll4Posgm%2FuAe%2FvyV%2FuwqXEYJzoL3iYcR7xYqvHd1uxzWM8%2F91h2Pg%2BBJkxgOwxVqdiHWiFrtrdtJmnMZJPWYsTthTxlLGgh1wfm94gzNzOS3UyL6cf5fzjzB4SL6OjBgmvfkX3xnwm7ff2r0%2BFCLPu8nIr8Vzuv0J13ApB%2BwEAAA%3D)