### PR TITLE
Add bytxt.co hosting template

### DIFF
--- a/bytxt.co.hosting.json
+++ b/bytxt.co.hosting.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "bytxt.co",
+  "providerName": "bytxt",
+  "serviceId": "hosting",
+  "serviceName": "bytxt website hosting",
+  "version": 1,
+  "logoUrl": "https://www.bytxt.co/assets/brandmark.png",
+  "description": "Connect your domain to your bytxt-hosted website",
+  "variableDescription": "Points www at your bytxt site and validates the HTTPS certificate.",
+  "syncPubKeyDomain": "bytxt.co",
+  "syncRedirectDomain": "bytxt.co",
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "customers.bytxt.co",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_acme-challenge.www",
+      "data": "%acmetxt%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/bytxt.co.hosting.json
+++ b/bytxt.co.hosting.json
@@ -9,7 +9,6 @@
   "variableDescription": "Points www at your bytxt site and validates the HTTPS certificate.",
   "syncPubKeyDomain": "bytxt.co",
   "syncRedirectDomain": "bytxt.co",
-  "warnPhishing": true,
   "records": [
     {
       "type": "CNAME",


### PR DESCRIPTION
# Description

New Domain Connect template `bytxt.co.hosting.json` for **bytxt** (website hosting driven by SMS/email). It connects a customer's domain to their bytxt-hosted site:

- `CNAME www → customers.bytxt.co` (traffic, via Cloudflare for SaaS)
- `TXT _acme-challenge.www = %acmetxt%` (per-request HTTPS cert validation value)

**Signed synchronous flow:** `syncPubKeyDomain = bytxt.co` (RS256 public key published as TXT at `_dcpubkeyv1.bytxt.co`); `syncRedirectDomain = bytxt.co`. providerId `bytxt.co`, serviceId `hosting`.

**Justification — bare variable as full TXT value:** the `_acme-challenge.www` record uses `%acmetxt%` as a bare full value (no `service-foo=` prefix). This is required: it carries the ACME DNS-01 challenge response, which by protocol must be exactly the challenge token with no prefix, or certificate validation fails.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description *(justified above: the ACME DNS-01 challenge value must be bare)*
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** tested in the online editor against the current template (apex + subdomain):

- Apex (no host): [Test bytxt.co/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAACFN2oC%2F%2B1T227TQBD9FWslnogTJ3bcxBIPvRcQbSgBgarIWu9O0wXba3bXcdwo%2F86sUzcJrSrxBhJP9s7lzJkzMytiICtSaoBEK1IouRAc1FtOIpLUZmm6TJLOo%2F2SZtB60KxBLQSDJvpOaiPy%2Bda6G%2BtUkGhhwNlGLUBpIXMS9TsklXP5WaUWxZhCR71eVVXdtn6Pag1G9xJFc55R9aNbNAgcNFOiMA0KOZZ5Dsw4tSyVw2VGRe4YuXk2SK6tDbylYilQJWiSwske0ESK3GgHGTjU7OQ7TQNIwVnQVHBUTDvmDpyL6XTyyWGgjLgVDM1dq0Gds0mZvIf6pKGyL6f1XgMXCgk%2F50e7VFyT6GZFTF1YGY8vDz%2Bcoss2gU9kZ8fSUJ1KNLBSG5mhpt0dHGNQUz%2F0vHXnEWj6dbqFiSnLwGV3NE0hn0N3A4u9UXS%2Bsk7EerWHNFt3yL3MId6SnGFK2wUsKa4TYP1sWwb%2F5kqWRSza%2BIIqmmm7cm3mzV7qrM29Ifb%2FgYl9ouymoR0%2F0o55mWV1jGMpIfb6Az8Yhgej8eHR8cnpmUMsYzHPpYJY45eaUqEQRpXQIVmZGhHTim5NnMW0KNIaG9ToxZpPp5BvdntPrpcn0CExZ7ZfYY8FbocHQZhwF5iXuAELqZvAcOwmHusPfXbLoc92zu73c3z%2B7rZiAx5MbgS1F3WYVrTWZP1kBR56eHEF%2Flzsv6rlWQd37f%2F0%2FtXp4eFrugAeUxs28Aah64XuoD%2F1wsj3okHQHfd9fzR67XmR51ny2PCm9xXe%2FO61kyr9WAwD8yX4mY%2FBuzq%2FSEdn1eD%2BnTxbfpsEl1dH%2Fvdyci3Ol%2BPRG7L%2BBUgJ7YoWBwAA)
- Subdomain (host = `www`): [Test bytxt.co/hosting example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADmGN2oC%2F%2B1UUW%2FaMBD%2BK5alPpVAIBAgUh%2B60m3Vtgq1TFpXocjEB7Wa2JHtEFLEf985lAJttZe9TNOeIHe%2Bz9%2F33Z3X1EKWp8wCjdY012opOOgrTiM6q%2BzKNhNFGy%2Fxa5bBLoNhA3opEqhPPyhjhVzso4dnSQkzIyyQ%2FaklaCOUpFG7QVO1UN916lCszU3UapVl2dzd32LGgDWtmWaSZ0w%2FNvMagYNJtMhtjUIvlJSQWFKpQhOuMiYksWr7WSN57m7gOyqOAtOCzVIYHQGNlZDWEGRAmD2oJ7UApECWLBUcHTPEPgD5PJmMb0kC2oq5SDDcdB5UMhkXsy9QjWoqx3a67A1woZHwe3mMK80Nje7X1Fa5s%2FHi%2BvzbJaacCPxEdq4tNdWJwkBSGKsy9LR5gGMtehqEvr9pvABNfkz2MDFLMvCSB5amIBfQ3MKiNobJE5dErJMjpOmmQZ%2BUhHhPcoolOxWwYjhOgPdnr9kutCryWOxKcqZZZtzU7Yrvj6qnu%2FL7uh4%2Fn%2Fm4yPNfckawDbaWEb%2FIiHmRZVWMbSog9tudoNsL%2B4Ph%2BYeL0eVHQp0CsZBKQ2zwl9lCozFWF9CgWZFaEbOS7UM8iVmepxUKNpjF2992RW5n3U3tkYW%2F70qDxjxxBgi3QGzYDgeD3tBrD7tzr9se%2BN6gC8yDIBj0e%2FMeD2ZwsIqvV%2FT9XTxqAOAeSSuYW7TztGSVoZs3k%2FEs5Z3JOJb2Jx342zyYNnAg%2F3f1X%2BsqPhmGLYHHzJ3s%2BJ3Q80Ov0574YRT0oqDf7LZ7gR%2Be%2Bn7k%2B44%2Fat4ascY34vB1oLfSlOV1KyxHC6Z%2F3jzNYb6Ud6cc5p8eiz7LHy%2F74693K%2F%2FKLM7o5hdGMHmXVgcAAA%3D%3D)
