### PR TITLE
Update bytxt.co hosting template to v2 (delegated DCV)

### DIFF
--- a/bytxt.co.hosting.json
+++ b/bytxt.co.hosting.json
@@ -3,10 +3,10 @@
   "providerName": "bytxt",
   "serviceId": "hosting",
   "serviceName": "bytxt website hosting",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://www.bytxt.co/assets/brandmark.png",
   "description": "Connect your domain to your bytxt-hosted website",
-  "variableDescription": "Points www at your bytxt site and validates the HTTPS certificate.",
+  "variableDescription": "Points www at your bytxt site and keeps your HTTPS certificate auto-renewing.",
   "syncPubKeyDomain": "bytxt.co",
   "syncRedirectDomain": "bytxt.co",
   "records": [
@@ -17,9 +17,9 @@
       "ttl": 3600
     },
     {
-      "type": "TXT",
+      "type": "CNAME",
       "host": "_acme-challenge.www",
-      "data": "%acmetxt%",
+      "pointsTo": "%dcvtarget%",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
# Description

Update to the existing `bytxt.co.hosting.json` template for **bytxt** (website hosting driven by SMS/email), **version 1 → 2**. It connects a customer's domain to their bytxt-hosted site:

- `CNAME www → customers.bytxt.co` (traffic, via Cloudflare for SaaS)
- `CNAME _acme-challenge.www → %dcvtarget%` (HTTPS cert validation via Cloudflare **DCV delegation**)

**What changed from v1:** the cert-validation record changes from a per-certificate `TXT _acme-challenge.www = %acmetxt%` to a **delegated-DCV** `CNAME _acme-challenge.www → %dcvtarget%`. With delegated DCV the customer adds the record **once** and the certificate auto-renews forever with no further DNS changes — the per-cert TXT required the value to be refreshed at every renewal. Both records are now static CNAMEs.

**Signed synchronous flow:** `syncPubKeyDomain = bytxt.co` (RS256 public key published as TXT at `_dcpubkeyv1.bytxt.co`); `syncRedirectDomain = bytxt.co`. providerId `bytxt.co`, serviceId `hosting`.

**Justification — bare variable as full CNAME value:** the `_acme-challenge.www` record uses `%dcvtarget%` as a bare full value (no prefix). This is required: a CNAME target is a single hostname and cannot carry a prefix. The value is the Cloudflare for SaaS DCV-delegation host for the customer's domain (`www.<domain>.<zone-uuid>.dcv.cloudflare.com`), computed per domain and provided by bytxt in the signed apply request.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — *(n/a: no TXT records in v2)*
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description *(justified above: a CNAME target is a single bare hostname)*
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description *(host `_acme-challenge.www` is fully fixed, no variable)*
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — *(n/a)*

## Online Editor test results

**Editor test link(s):** tested in the online editor against the v2 template (apex + subdomain):

- Apex (no host): [Test bytxt.co/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGheOGoC%2F%2B1U227aQBD9FWulPAUb43BxkfoQJZF6S4RSKrWNkDXsjmEb2%2BvsrnFcxL93FkKAhqpSn1qpT96dmT1zzly8ZBbzMgOLbLhkpVYLKVC%2FFWzIpo19tAFXrPVsv4Ectx4yG9QLyXEdPVfGymK2s%2B7HejVOjbTo7aIWqI1UBRtGLZapmfqkM4dibWmG7XZd18E2fxuMQWvaUw2FyEHfB%2BUaQaDhWpZ2jcIuVFEgt16jKu0JlYMsPKs21zWS73Kj2FJxFEBLmGZ4eQA0UrKwxiMGHti9995aAFHw7hFLs%2FG8GY9HHz2O2spUcnABlVW%2BxgJr0hm4cjQFH1XT99hcrlkdVtZ5b1FITdyP%2BcmutDBseLdktildRS9uzq%2BvyOX00JWIug6tWY8VGXhlrMqpvMEejrVU3rN%2BGK5avwJKgOfo8zlkGRYzDF4Anwi%2BsKBnaE8OECerFvuuCkx2ZCfUnq0afASaMCQe%2BS4ZnWZaVWUit%2FElaMiNm8Lty7uDp5Pt2zvmzs9cnMGNy15sEHf4NBa8F6Ucom63F1B0wDNViTQD%2FYRHrOWsUBoTQ1%2BwlaaiWF1hi%2BVVZmUCNexMgidQlllDIg15KevLjhSbkd8UToCF33ajxRLBnWbpdijFdDAQcerzQTf2uyJ85cfdqO%2FHPRiknTg%2B65zh3jb%2BvKXH13FXcKQ9KqwEt2jnWQ2NYasj4%2FCk4vg4PKn6k4L%2FVbInLZq5%2Fx38lztIPwEDCxQJuLAopHxh348646gz7MXDMAz6Ya8%2FiE7DkC6OPBq7Ub%2Bk3d%2Ffevbhuve5x99VfD4ur8pFGffD6PKL1t8e0mlsq1PxML8Km9vu9df6NVv9AL%2FELPw1BwAA)
- Subdomain (host = `www`): [Test bytxt.co/hosting example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJxeOGoC%2F%2B1UW0%2FbMBT%2BK5ElnkjSJL3QRtoDAsYuWsegPEyoik7s0%2BCRxJnttJSq%2F312StYWOk3a0zTtKcq5fOf7zsUrorGoctBI4hWppJhzhvI9IzFJl%2FpR%2B1QQ96d9DAW2HmNWKOecYhN9L5TmZba17sY6C0wV1%2Bhso%2BYoFRcliSOX5CITtzK3KFpXKu50FouF39bvgFKoVSeVULIC5INfNQgMFZW80g0KORNliVQ7S1FLh4kCeOlosfltkDxbG1lLxVIAySHN8XwP6ErwUivHMHBA7%2BQ7jQBDwXlArNTG824yubpxKErNZ5yCDai18CSWuDA6fduOZUmv6vQjLs8bVvudtd5rZFwa7of8xi4kUyS%2BWxG9rGxHz8anny6My%2Boxv4aonVDDeiKMgdZKi8K019%2FB0dq0tzsIgrX7K6AEaIEevYc8xzJD%2FxXwEaNzDTJDfbSHOF275EmUmGzJTs14WjX4CGbD0PAoXrLOpKirhLcpFUgolF3ENvluL3vapt81%2BbZIy%2BjZ5u%2BE%2B8OQpkNG%2B9GMQtTr9X0T7dNc1GyWg3yGNNx5VgqJiTJf0LU0rdGyRpcUda55AgvYmhhNoKrypZGqjNdUfT2XcrP4ls1GJQMNv52LSxJGrXRur4kOhmm3H%2Fa9wPi8HmDkpaNRzxvCCYzScDYahic7d%2FnyXg8f5l7r0RxVqTnYqzvNF7BUZH1gN57FHNiNfXF%2F0vu%2FTf3UNUv4f57%2FzjzNA6FgjiwBGxkF0cALBl4UTqIw7g%2FjfuR3o2gYdI%2BDIA4Cyx%2BV3jRgZd6F3ReBPJ0E379%2Bm4yjHr1%2Fe%2FZUHfevLy87ny84HYTpoPvhSzqahzfZbZCqN2T9A7UPAtBXBwAA)
