### PR TITLE
Add unitops.app.portal template (signed-sync CNAME)

### DIFF
--- a/unitops.app.portal.json
+++ b/unitops.app.portal.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "unitops.app",
+  "providerName": "UnitOps",
+  "serviceId": "portal",
+  "serviceName": "Storage rentals & tenant portal",
+  "version": 1,
+  "description": "Point your custom domain at your UnitOps rentals & tenant portal.",
+  "variableDescription": "target is the UnitOps hostname the CNAME points to (e.g. unitops.app).",
+  "syncPubKeyDomain": "unitops.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/unitops.app.portal.json
+++ b/unitops.app.portal.json
@@ -4,6 +4,7 @@
   "serviceId": "portal",
   "serviceName": "Storage rentals & tenant portal",
   "version": 1,
+  "logoUrl": "https://unitops.app/images/logo.svg",
   "description": "Point your custom domain at your UnitOps rentals & tenant portal.",
   "variableDescription": "target is the UnitOps hostname the CNAME points to (e.g. unitops.app).",
   "syncPubKeyDomain": "unitops.app",


### PR DESCRIPTION
# Description

New signed-sync template for **UnitOps** (self-storage facility-management platform). It lets an operator point a subdomain (e.g. `rent.theirstorage.com`) at their UnitOps rentals & tenant portal with a single CNAME, via Domain Connect.

Single CNAME at `host: "@"`, `hostRequired: true` (subdomain-only; a CNAME can't live at the apex), signed sync (`syncPubKeyDomain: unitops.app`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) <!-- pending: editor link below -->
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`unitops.app.portal.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://unitops.app/images/logo.svg` → HTTP 200, `image/svg+xml`)

Additionally validated locally: passes the repo `template.schema`, and `dc-template-linter` reports no findings (exit 0). The signed-sync chain was verified end to end — a signed apply request verifies against the public key published at `_dck1.unitops.app` (RSA-SHA256).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`unitops.app`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — N/A, this template does not use `redirect_uri`
- [x] no TXT record contains SPF content — N/A, no TXT records
- [x] `txtConflictMatchingMode` is set on TXT records that must be unique — N/A, no TXT records
- [ ] no variable is used as a bare full record value — **bare variable used, justified:** `pointsTo: "%target%"` is the UnitOps service hostname supplied by the service provider (not user free-text), same pattern as `approximated.app.subdomaincname`. It is a single fixed param we pass so the one-click target stays in sync with our manual-setup instructions.
- [x] no bare variable is used as the full `host` label (`host` is `@`)
- [x] no variable is used in the `host` field to create a subdomain (uses the `host` parameter / `hostRequired`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the user may modify — N/A, the single CNAME is the template's purpose and isn't user-modifiable

## Online Editor test results

**Editor test link(s):**
<!-- PENDING — to be added before marking ready for review. hostRequired=true, so only a subdomain (host set) test is required. -->
