### PR TITLE
Add xnying.xyz dns testing templates

### DIFF
--- a/xnying.xyz.dns-test.json
+++ b/xnying.xyz.dns-test.json
@@ -1,0 +1,55 @@
+{
+  "providerId": "xnying.xyz",
+  "providerName": "xnying Dev",
+  "serviceId": "dns-test",
+  "serviceName": "Test Records",
+
+  "version": 1,
+
+  "syncPubKeyDomain": "xnying.xyz",
+  "syncRedirectDomain": "xnying.xyz",
+
+  "description": "Configure DNS records for xnying Dev testing including domain verification, certificate validation, and edge routing.",
+  "variableDescription": "verification_token: domain ownership token; cert_validation_host/target: CNAME for TLS cert; edge_ip_1-3: A record IPs; edge_hostname: CNAME target for subdomain.",
+
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_xnying-challenge",
+      "data": "xnying-verify=%verification_token%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "xnying-verify=",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%cert_validation_target%.xnying.xyz",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%edge_ip_1%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%edge_ip_2%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%edge_ip_3%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%edge_hostname%.xnying.xyz",
+      "ttl": 3600
+    }
+  ]
+}

--- a/xnying.xyz.test-delegation.json
+++ b/xnying.xyz.test-delegation.json
@@ -1,0 +1,41 @@
+{
+  "providerId": "xnying.xyz",
+  "providerName": "xnying Dev",
+  "serviceId": "test-delegation",
+  "serviceName": "Test NS Delegation",
+
+  "version": 1,
+
+  "syncPubKeyDomain": "xnying.xyz",
+  "syncRedirectDomain": "xnying.xyz",
+
+  "description": "Delegate a subdomain to xnying Dev nameservers for DNS testing.",
+  "variableDescription": "ns_1 through ns_4 are the nameserver hostnames to delegate to.",
+
+  "records": [
+    {
+      "type": "NS",
+      "host": "_xnying",
+      "pointsTo": "%ns_1%.xnying.xyz",
+      "ttl": 3600
+    },
+    {
+      "type": "NS",
+      "host": "_xnying",
+      "pointsTo": "%ns_2%.xnying.xyz",
+      "ttl": 3600
+    },
+    {
+      "type": "NS",
+      "host": "_xnying",
+      "pointsTo": "%ns_3%.xnying.xyz",
+      "ttl": 3600
+    },
+    {
+      "type": "NS",
+      "host": "_xnying",
+      "pointsTo": "%ns_4%.xnying.xyz",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

  Add two DNS templates for xnying Dev (xnying.xyz):
  - `xnying.xyz.dns-test.json` — Domain verification (TXT), certificate
  validation (CNAME), edge IP routing (A records), and subdomain CNAME for DNS
  testing.
  - `xnying.xyz.test-delegation.json` — NS delegation of `_xnying` subdomain to
  xnying Dev nameservers for DNS testing.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [N/A] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[dns-test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALq3OWoC%2F%2B1Wa0vrMBj%2BKyWwT649bTarVgR3nKDoxKPDc0CkZMm7GezSmmQ3xf9%2Bkl7WOSfIOV8U%2FNT0vT7vJQ95RhrGWUI0oOgZZTKdcgbylKEIzcWCi5E3Xzyh5lJzQcaw1DldmBqdAjnlFHInJpSrQelaXHr0jdC5AppKpoxyClLxVKAoMIYLQS8ngzNYdNMx4WI9t9VfAeMSqN5swUBRyTOdR0RHqRjy0USC0724dmSR0xmm0qlhOxakPXNBkwmzJ5aHdgwyPuSU2GBNh4LUxS84U5JwVsqJYA6wETgyndg4nq2JSE4GCXRfoVmNF%2Bv0AURUpUpnwrThnmdOLt%2FPs8V1mvg%2BVfqHJnIEOnKOLjq947yM%2Fvl1brqfQ4h5FgduK3I6Za3O6aUqVTaAMAOovItYeRA1GRQwLPSySSi6fUZ6keUD%2B9M3ChvA%2FMRF51x6T5IExAhs04kmy0G4eZmLg8bbchvGVs%2B1nUrCqe4RTe%2BNRy9lNs2lhCGfbzYpdes5rLFOUNQKff%2BluQScV7gCmdAxvAKcpVxo1U%2BNsrHe6aIxDe%2FVWm3K0qkzHK7FXA6j8e%2B%2B%2BD98W42PdWY2m22KUO3Ku024e2mip1RAXG%2FLnVmD6kbCnBgmAY%2Bm4zqXOY3MFcliXtlnRJKxsmxTed6%2Bcr2rfG%2BRPb%2FdJ6shAxrgltVvHqS1McLAWizHYoWBh72W116VYyvf9kJvx9tdlbesfM8LfC8IvAAvVVWfrJoyYXKYvvCRSCXEynyJNtSDIi0n0ETjSaJ5TGakFjEakyxLFqaNymhNmPVLV0T%2F%2BKUru7EyqyaKGbU95paUgx0CLSBtF%2B%2BG2G37PnMHwIjLQhy0w2063MbbKxz%2Flv3fYfh6xqAUCM1JYjc1mZGFQi8bFrAq7M3VLMuyI3tn%2Bz5ZRZ26msMaf7VdXw13tf1fDffK7fwyy1%2Bwb1mA5Y%2FPvPB3TUPZ3%2FT0TU%2Ff9PRNT5%2BQnsybTJEpsJhYM%2Bzj0PVDF%2BM%2BxlEriDD2%2FL0gDIMt34983%2BI3cYvins2rbfW9hk7aN%2BLG7%2B3KyS990%2F%2B59%2FB4ebbjn2yd9MLfj7vd0L86zU5O947PnzoH6OUv9nj1bjkPAAA%3D)


[dns-test/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB24OWoC%2F%2B1WW2vbMBT%2BK0aQp8WeLefSugzWLYNd2q60WRkrwSjSSaLNkYyk3Fr63yfZcRKnKYztZYU%2BxT7fuX7nEt8jA9M8IwZQco9yJeecgfrEUIKWYsXFOFiu7lBzg1yQKWwwrwdzi2lQc06hMGJC%2Bwa02YrXFn0r9K6ASsW0BeegNJcCJZFVXAl6ORt%2BgVVPTgkX%2B7EdfgWMK6DmsAYDTRXPTeERvZdixMczBV7v4tpTZUxvJJW3TdtzSbpnLmg2Y%2B6JFa49mxkfcUqcs6ZHQZnyFbw5yThby4lgHrAxeErOnJ%2FA1UQUJ8MMerVsdv2lRv4CkVSh5EJYGiY89wr5SREt3YZJJ1Kb14aoMZjEe39xev6hKKN%2Fdl2onhQppDxPIz9OvNN1rd6nS72GnANhG1BZl74KJ3o2LNNwqa9JQsntPTKrvGjY974FnAP7kpbM%2BXRCsgzEGBzpxJBNI%2FyizNWbxuNyG1bXLI3rSsapOSeGTqzFuWQuzKWCEV8eVllj%2BzGcsslQEnfC8KG5SbiocCdlQqdQSziXXBjdlxZs7DNdEtMIamN1KMrpNsLbPZ%2BbZjT%2B3hb%2Fg23c%2BDNmFovFIQ%2FVrDxJwuChie6kgHQ7LQM7BtVGwpLYSwIBldNtLDtl9mVstyRPeWWSE0Wm2h2cyvi2Zj2ozG8L%2B0HzwBI5kAxphGOHH26n07HCyGlsmuOEUYCDOGjtyrGTt4NO0A2OduWxkx8HURhEURDhDVSx5WDKhI1h2eFjIRWk2v4SYw8QSoyaQRNNZ5nhKVmQrYjRlOR5trJkaotaN%2FurV3p%2FvHpByenB9VszstO1JkoZdVRzd56hE2I8jGK%2F1W5Tv8VGoT%2FE3a7fbQ3ZEe22j4e4s3PtH%2F8PPHHra90GrUEYTjI3ttmCrDR6ODCNVX31Pa1X57r3xDj%2Bf4WdbouqFVFN27NMvlqJZ5n8zt4%2Bp5WwB7q%2BBu7A%2FOdrMGjay%2F5ywl5O2MsJezlhz%2FSE2W87TebAUuI0cYg7ftjxMe5jnMRxEkZBN8ZHR%2B1XYZiEoSvBui7ru7dff7vffajT%2FxXOel%2Fbn%2FHkjP38dvftIw6v85urcBnJ0ZfPH29%2BvDruXpy%2Fa%2F1svUEPvwEC7pSYhw8AAA%3D%3D)

[test-delegation/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF24OWoC%2F%2B1VbWvbMBD%2BK0LQT41TW3ZMY9iHjQy6jYXRZq8hGMW6JgJH8iQljRvy33vKS51066DQLyv95Dvd3XP3nPWgFXUwq0rugGYrWhm9kALMB0EzulS1VJP2sr6lrftIn8%2FgPkZ6sMCYBbOQBWyKHFgXCChhwp3UqonuCgcYJ%2F0rrDxIWYCx3soiTK9V8WU%2B%2FgR1T8%2B4VA8H8fFLENJA4f6eIcAWRlYb7IzuGgHhxM7HYlNBnCYNA6JwND8lTkGutSE9nM%2Fz8JB%2BOm4kH5fQO8JVNo%2BImxo9n0wJOgnhBvAADuDIVFu3cX1HsZ%2FEaQ%2BLBLQRlmbDFXV15ZfTv8JzX4N2vh3Qr15L5exA4%2BGJ73rSPqLrXEmzOA3DdetpQOy5gOLnAkoeBRqtW%2FRWK8ibrY3wT%2B%2F%2FPyw5XmJoF3rWtEFrgr%2BnyuU%2Bv%2BKGz6y%2F6PvK4VHpaF87pN72y%2Fa2stHOZVuX7dx468Y7N9m6CfXTyonSBnKLX%2B7mBnfgzBxadDYvncz5DW%2BORJHzqiprJGcxiigProTaaqfZm%2BCOb%2B5g9MjCWjQXhScqvSjTOOUpg26QJiINEp50gi4TImBReh6GUYedd%2FiBxv9U%2F78V3uwbrAXlJMcp6NvyhteWrh9egsfJsJdEJn5JZJL%2FgMyohRJ%2FFc6rcF6F80Th4Otl%2BQJEzn0aC1kahGnA2ICxLE6ysNMO0zhJw9MwzMLQ08AWW4orfOkO3zjajb9f%2FVL2veh87fy4vliyKr0YJGf61Jy9%2B3j5e9qNPvfHS%2Bipbz%2Ff0PUdN0W9Nn4KAAA%3D)

[test-delegation](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE24OWoC%2F%2B1VUWvbMBD%2BK0bQp8XBlt00NewhLAzKWOnWZKwLwcjWNRHYkpHkNE7If98pTpqkWwuDvqz0yf50uu%2FuO91Ja2KhrApmgSRrUmm1EBz0FScJWcpGyFl32axI59FyzUp4tHlDWKDNgF6IHLZOFoz1ORQwY1YoebDuHEdo965v0fNoywK0cX9JiNsbmd%2FU2RdohqpkQj5NxNm%2FAxcacvv3HRxMrkW15U7ILhB4zDN1xrcenlXeQYEnMTWXJWbh3SvtDTE%2Fp8NRuuyYFiwrYHjCK00aenauVT2bewhij2nABTii8%2BbK2C10Efk%2BE6scLQpQmhuSTNbENpUrzvUtrjsf%2FE%2FbBF3plZDWjBQunrmoZ90TudYWJIl6QbDp%2FBsRfS2i6LWI4meJppsOWSkJ6aFqUzzp%2FfnDkmETQzdX5SEMHjeCGZ5QlYq9S8U0K43r9b3z5MR7unefbP0RupI7KE24g7SFdAejFkY7GLcwJi5nMZNKQ2rwy2ytsRJW19AhZV1YkbIHdljiecqqqmhQokErsjxpDNlO0K563VYeZ5ZtuzF8pnQdkvLc6RVuPGlML%2BCCcf%2FiPgz8OLvM%2FCzMM%2F%2B8z3hEe1kY5Oxo2v%2B8B16e9ZPKgzEgrWCYCBkUD6wxZPO0I17WRN%2BgpugNaor%2FD03TDt4A70P1PlTvQ%2FWKQ4WvnmEL4ClzO2lAe37Q8ykdUZpEURJfdvth0It7H4IgCQKnBKO0Ktf4Qh6%2FjWT8eXX74%2BpO3VBVL877eln%2Bipt8ANE3NRjZTzfxai7N3eDnePz1I9n8BgG3HqK8CgAA)