### PR TITLE
Add domainemaildoctor.com templates (email-spf, email-dmarc)

### DIFF
--- a/domainemaildoctor.com.email-dmarc.json
+++ b/domainemaildoctor.com.email-dmarc.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "domainemaildoctor.com",
+  "providerName": "Domain Email Doctor",
+  "serviceId": "email-dmarc",
+  "serviceName": "Email DMARC fix",
+  "version": 1,
+  "logoUrl": "https://domainemaildoctor.com/icon.svg",
+  "description": "Adds a DMARC policy record at _dmarc so the domain has a published DMARC policy.",
+  "variableDescription": "dmarcRules: the DMARC tags after the version, e.g. 'p=none; rua=mailto:dmarc@example.com'.",
+  "syncPubKeyDomain": "domainemaildoctor.com",
+  "syncRedirectDomain": "domainemaildoctor.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; %dmarcRules%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}

--- a/domainemaildoctor.com.email-spf.json
+++ b/domainemaildoctor.com.email-spf.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "domainemaildoctor.com",
+  "providerName": "Domain Email Doctor",
+  "serviceId": "email-spf",
+  "serviceName": "Email SPF fix",
+  "version": 1,
+  "logoUrl": "https://domainemaildoctor.com/icon.svg",
+  "description": "Adds or merges the SPF record for the domain's email sender so legitimate mail passes SPF.",
+  "variableDescription": "spfRules: the SPF mechanisms for the sending provider, without the leading 'v=spf1', e.g. 'include:_spf.google.com ~all'.",
+  "syncPubKeyDomain": "domainemaildoctor.com",
+  "syncRedirectDomain": "domainemaildoctor.com",
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "%spfRules%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new Domain Connect templates for **Domain Email Doctor** (https://domainemaildoctor.com), a free email-DNS checker. After a scan, a user whose DNS is hosted at a Domain Connect provider can one-click apply the correct email-authentication record:

- `email-spf` — merges the sending provider's SPF mechanisms (SPFM record).
- `email-dmarc` — adds a DMARC policy record at `_dmarc` (TXT, prefix-matched on `v=DMARC1`).

Synchronous **signed** flow only: `syncPubKeyDomain = domainemaildoctor.com` (public key published at `_dcpubkeyv1.domainemaildoctor.com`). No tokens, no OAuth, no DNS write access on our side — the user authenticates at their own DNS host and approves each record.

Note on `email-spf`: it uses a bare `%spfRules%` variable. This is the SPF mechanism set, which is necessarily provider-specific (e.g. `include:_spf.google.com ~all`) and supplied by our scanner from the domain's detected sender. The `SPFM` record type contributes the `v=spf1` prefix, so there is no additional service-specific prefix to add.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`Prefix` matched on `v=DMARC1`)
- [ ] no variable is used as a bare full record value — *`email-spf` deliberately uses a bare `%spfRules%`: it is the SPF mechanism set, which is inherently provider-specific; SPFM supplies the `v=spf1` prefix so no service-specific prefix applies.*
- [x] no bare variable is used as the full `host` label (hosts are fixed: `@` and `_dmarc`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [ ] `essential` is set to `OnApply` — *not set on the SPFM/DMARC records; the user can still modify them at their host. Happy to add `essential: OnApply` if the maintainers prefer (would require regenerating the editor test links below).*

## Online Editor test results

**Editor test link(s):**

- SPF — apex (`example.com`, host `@`): [Test domainemaildoctor.com/email-spf example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP0ROmoC%2F%2BVTbWvbMBD%2BK0Iw8qGOa%2BfFbQyFdXSF0K6UtmPdQjCKdXZUZMuT5KRpyH77TnbStLBlP2BfEvlenrvnubs1tVBUklmg8ZpWWi0EBz3mNKZcFUyUgD%2BSq9Qq7aeqoN5r0A0rMIleNGHks4sjF00gBhnQC5FCA9RAdE2V7e3b3Dbp%2FvaSZOIZvQvQRqiSxqFHpcrVVy0xam5tZeLj4z82dCxSVfpmkWM6B5NqUdkGgp5zbojSpACdgyF2Dk0lDanSnGTocaYWtGNIg0sMlEiNGEUk5MKKApUhjadixiAMQviuU6YFm0m4eFcSOd7VEkz8Wq2AdM5KYQrzWtGVEGVOdjp6ZCnsXNW28UpgjbezOEO0sOMR8HOfdESZyppDnKDVz5XKJTj65BeTsuM6Mqsyva1nV7BqJ3Jggi70DrhAKew%2Fg1u9DI0na2pXlRsbEvuCnrkyFr8%2BOsQtcfz8sHt%2FQLu1OMB%2BFASb6cajL6qEZI839bZF3Y48M1xD2NbcIuMr16quErGLr5hmhXGrusucvEud7nIn1L33bU3oIQGp607kpdKQGPxnttZI1OoaPFrU0oqELdnexNOEVZVcIRmDXoTfi%2FPw%2BIB9l%2B2CO204swyf7TzJoTbaXt6o5tGEp46tcHd0OhzMBoMe74Z8Bt3BqH%2FSnbFs0B2lYcYCyCAbRW%2Fu8%2BAR%2F%2B0%2B98oDrntpBXMXeC6XbGXoZjP1cAr%2FC1e3QGwBPGEurBf0om4QdXv9h2AQD6O4N%2FJPojAahkdBEAeB4wLGtgqscZ%2FebhL9Mbg5LS%2F7t5dXq%2BLT%2BH58tKyu7q%2B%2FPRXjm6Vhw%2BXs5fvj8ufTdTg%2BP6Ob34CprzyWBQAA)
- SPF — subdomain (`example.com`, host `mail`): [Test domainemaildoctor.com/email-spf example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA4aOmoC%2F%2BVT7W7aMBR9FctSxY8FcKDAGqnSKrFq67Su6phUDaHIxJdgybFT26GliD37rhMoVNrYA%2BwPwffj3HPux4Z6KErFPdBkQ0trVlKA%2FSxoQoUpuNSAP0qYzBvbyUxBo9egW15gEh3XYeRjiCPjOhCDHNiVzKAGqiHarlwc7LvcJun73TVZyGf0rsA6aTRN4ogqk5sfVmHU0vvSJd3uHwl1ZWZ0x61yTBfgMitLX0PQKyEcMZYUYHNwxC%2BhrmQhM1aQBXqCqQFtOVLjEgcapRFniIJcellgZ0jtKblzCIMQncCUW8nnCsZvSqLG%2B0qBS16rFZAtuZaucK8VQwmpc7LvY0SepF%2BaytdeBbz2tlaXiBa3IgKdvENaUmeqEpCkaO3kxuQKgnzyiyvVCozcWmd31fwLrJuJnJhgCL0HIbEV%2Fp%2FBTb8cTaYb6tdlGBsK%2B4qepXEeXx8C4k44Ps%2F2%2F8%2FQ7j0OsD9kbDvbRvTFaEgPeLNoVzTsyDPHNYRdzR1y4IKv3JqqTOU%2Bp%2BSWFy6s6z57%2BiZ9ts%2BfNgCzY3pTeqqRNLCUuTYWUodf7iuLgr2tIKJFpbxM%2BRM%2FmESW8rJUaxTl0IvwhyZNHibIXTeLvlMiuOf4akZLTjFp6Bw1MKKpyIJoGU6KxX2WscGwPR%2FFcftcsGH7IsvmbREP2VDE7%2BPR6OLoVE%2Fe899O9e0QALdfe8nDQV6pJ752dLudRTiQ%2F0xyWCe%2BApHyENpjvWEbqfT6EzZI%2BiwZnHdYvzcaDd8xljAW9IDzTRc2uF3He0X1pKce2GN3Uv0cjW8GF4pPzMtCaK8n3%2FpicfPyeH0ji%2BKTAXNJt78BUQfp%2BawFAAA%3D)
- DMARC — apex (`example.com`, host `@`): [Test domainemaildoctor.com/email-dmarc example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOMSOmoC%2F%2BVU70%2FbMBD9VyxLiA%2F0R9KWNg2qNARM21gn6AqahKrI2NfUWxJHtlMoVf%2F3nZN2oRMwvu9LavveO9%2B75%2BuaWkjzhFmg4ZrmWi2lAP1Z0JAKlTKZAX4SobhVusVVSht%2FQN9YiiR6XsLIhcOR8xKIIAN6KTmUicoUTZEyzevIlr2ljU8nZ2QuHzG%2BBG2kymjoN2iiYnWjE8QtrM1N2G6%2FWFRbcpW1zDJGugDDtcxtmYKeCmEI2%2BbPVSL5imjgSgvCLInKmohRxC6AVKnJgjlGXtwn0ixA7HFbrj6mJbtP4HzvojLTpEjAhGWyimVZjMnmFnR5uJXWINCKW%2BQwH2UqgxOiCzZygqwKyzQf4JGhJ%2BCkHborzSrjV8X9JayqZr9hjoNOQEgUaf8JrjphaHi3pnaVOz%2BmP6YYWChjcRPtPBPMMtwvR6Us%2F4Qc1HoPMG4tetTtex4uH%2B2ZyubYLTtmli9kFo%2BVcKmvNFQOvwDZxuor6Ga2adAn7E9UVzlrbKW4R1X3qC4YV7FWRR7JHT5nmqXGve0d826POttx76hb17LcyXsMoq5OGWdKQ2Twl9lCo1qrC2jQtEisjNgDq48Ej1ieJyuUZTCK1%2Fzd%2FKyajNeb%2F66y9kyJBHctkG4aA7%2FfC8Rg2BzwwG%2F25oFoBgF%2B%2FM6g5x%2F3A%2BgyeDblb%2F4VvD7ltSFgDGRWMjfFp8kDWxm62cwaaM5%2FKRwfmWFLEBFzsI7X6Te9frPTnXrHoeeF%2FrDVHfSOA%2F8IN57n1ICxVSfW%2BNKevzHKUju5%2FjqdTMVtdvHzOv8%2Bn35KvKOnti%2Bu7c1wyOcfn%2BJf%2Fq34Mh7RzW9eBb3u6wUAAA%3D%3D)
- DMARC — subdomain (`example.com`, host `mail`): [Test domainemaildoctor.com/email-dmarc example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA4TOmoC%2F%2BVU72%2FTMBD9VyxL0z7QZOlvyFSJaWVooE2jDAk0VZFjX1OjJDa2kzVU%2Fd%2Bxk3RZYYx950tb%2B%2B69u3fP1y02kMmUGMDhFkslSs5AXTIcYiYywnOwHykT1AjlU5Hh3kPSNcksCM%2FrNPTO5aF5nWiTNKiSU6iJagqPZUTRLtKiW9jV2eIcrfjGxktQmosch%2F0eTkUivqjU5q2NkTo8OXmyqRNORe7rMrFwBpoqLk1Ngc8Y04i0%2FFKknFZIARWKIWJQVPeEtEBmDaihRmviELKIU67XwA6wvuuPKE7iFOYHhWqmRZGCDmuyBmVIYslWBlR92UrrIfATHx3LWS5yOEWqIDMnyIiwpnkLG2I9ASft2JXUVU5vivgjVM2wnzHHpS6AcSvS%2FDO5mYTG4d0Wm0o6P26%2F3trAWmhjD9HeM0YMsedyVsvqn6KjTu%2BRjRtjPRpOgsD%2B3Jhzka%2FstMwVMXTN8%2BRKMEd9o6Bx%2BImUNtaVwLvlrod%2F2vlEXZfLXivFPapuRl3DTqE9JUoUMuJ7jCSKZNq97z367gC%2B3OPvGgJX5kGeu32JUdj1y5NcKIi0%2FSamUFa1UQX0cFakhkfknnRXjEZEyrSy8rSN2jK%2Fm5A3G9KY4LfS%2FnDiRb0dOBQx6mbB3WoOVytCBgy8N3T12htN6NSL47jvMUoHoxHtT2E8fbTyz%2F4v%2FH3lD90BrSE3nLi1PkvvSaXxbrfsWaf%2B7wnYZ6dJCSwiLnUQDCZeMPEGw9tgHAb9MBj4w%2F44GE1fBUEYBE4RaNNMY2vf3uNXh398H317n48pLTc3hSyD4oJvLshYmviaVsmlqD5kczP%2F9Fkt6AzvfgHskQksBQYAAA%3D%3D)
