### PR TITLE
Add ulama.ai.customdomain-apex template (apex A record)

### DIFF
--- a/ulama.ai.customdomain-apex.json
+++ b/ulama.ai.customdomain-apex.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "ulama.ai",
+  "providerName": "Ulama",
+  "serviceId": "customdomain-apex",
+  "serviceName": "Ulama Custom Domain (apex)",
+  "version": 1,
+  "logoUrl": "https://ulama.ai/assets/logo.svg",
+  "description": "Connects an apex domain to an Ulama site and adds the ownership verification record.",
+  "variableDescription": "%token%: ownership verification token issued by Ulama for the domain.",
+  "syncPubKeyDomain": "keys.ulama.ai",
+  "syncRedirectDomain": "app.ulama.ai",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "46.225.221.225",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_ulama-verification",
+      "data": "%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **Ulama** (`providerId: ulama.ai`), service **Custom Domain (apex)** (`serviceId: customdomain-apex`).

It connects an **apex** domain to an Ulama site:

- `A` record (`host: "@"`) → `46.225.221.225` (the Ulama app server), instead of the previously used `APEXCNAME`, which is poorly supported by many DNS providers (`DCTL1038`).
- `TXT` at host `_ulama-verification` carrying the ownership-verification token (`%token%`), with `txtConflictMatchingMode: All` so re-application stays idempotent.

This is the apex companion to `ulama.ai.customdomain.json` (subdomain, `hostRequired: true`, CNAME). The two are split into separate templates because `hostRequired` is a template-level flag: the subdomain case requires it (CNAME applied with `host`), the apex case must be applied **without** `host`, so they cannot coexist in one template.

`syncPubKeyDomain` is set (`keys.ulama.ai`) to enable cryptographic verification of the synchronous flow.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`ulama.ai.customdomain-apex.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://ulama.ai/assets/logo.svg`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`keys.ulama.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (`app.ulama.ai`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the verification TXT record (`All`)
- [x] no variable is used as a bare full record value unless necessary — the only variable `%token%` is an opaque ownership-verification token scoped to the dedicated, fixed host `_ulama-verification`, so a fixed content prefix adds no security value here
- [x] no bare variable is used as the full `host` label (host `_ulama-verification` is fixed)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — not required; neither record needs independent user modification

## Online Editor test results

**Editor test link(s):**

- Apex test (example.com/@): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGBDOmoC%2F%2B1TUU%2FbMBD%2BK5GlSZtI0jQJpUSaBIIXNLEhVLYhVEWufTQeSRxspzRU%2Fe87J5QEJrZXHia1in3%2B7u677%2B42xEBR5dQASTakUnIlOKgzThJS57SgPhXEfbZ%2FpQXiyJV9QbMGtRIMWjSrtZEFlwUVpUcrWPfvQy%2FnpMU5py3Q%2BWiRnxC6AqWFLEkydkkul%2FJK5eiSGVPpZDTaURlRrcHokUX4erVERw6aKVGZ1pmcyLIEZrRDS8eGdjpCjpHW0jHQwgDeuEM5147JwJEPJabPROUgDXErGLXhHAVMKu5bdlQJusjh9EWyD0beQfkhecu%2FfXaE1jVwZ9E8pb%2BVqk3aMbPRdVOyi3rxBZpOFQx9B432Bw2wkEvgAimZZxCtqiGmo6tJcrMhpqms5MdozqQ2eDyybZSiNHom8RpP%2FDDcx%2F%2FYfvHNGBQ8mgTB1n12n%2F2c9QHSNpU3rNDKTw3tpRjGwePaYD9uc8HMOTUsE%2BXyXPKWV56T7XzrkkdZQtoTn2PAXXWwpjiY4DNZ9CTwtFSyrlKxw1dU0ULb4d153rxwne98b4g9tzztxWRCe%2FijXmeybMSylApSjV9qaoVMjarBJUWdG5HSB9qbOEtR%2FrxB8hpfMeJL1ctu5o96id5W3CUpZ7YCYRcpjsYxW7CJF%2BJ8enF0GHiH4yn3OIviKZ8ChAfhYCVfr%2Bq%2FdrIXEnCXSiNo3jbkgTaabP9o%2FlMdf23%2BaynfaWlzF%2Bflf5fee5dwSTVdAU%2BphYVBOPEC5BLNgmkSHiTj0J8GB9F%2BvBcESRDYMkCbrsYN7vBwewnje3vnV6EQ99HZ4%2BJYfLufjH5dqotFcf39Wp7%2BiLN4fRLkch0Hn8n2NwxQ0RUMBwAA
- Subdomain (with host) test (example.com/go): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGxDOmoC%2F%2B1Ta2vbMBT9K0ZQ2GjsOI7jtIbB1pTB1gdbSelYCUaRFFurLRlJduOG%2FPdd2U3jdiv7usEgwdLVOfee%2B9ogw4oyx4aheINKJWtOmfpEUYyqHBfYwxwNnuyXuAAcurYvYNZM1ZywFk0qbWRBZYG5cHHJ1vv3PsuZtTjntAU6byzyLUBrpjSXAsWjAcplKq9VDpTMmFLHw%2BFOyhBrzYweWoSn6xSIlGmieGlaMppJIRgx2sHCsa6dTpBjpLV0CjQ3DG7UwZRqx2TMkfcCwme8dEAGX3GCrTtHMSIV9aw6rDhe5uz0WbADI%2B%2BYOIhf47fPDte6YtRZNo%2FhV1K1QTtl1rtuBPlSLc9Y01UFXN%2BxRnu9BljIFaMcJJknEC7LPqaTq1F8u0GmKW3JP4A5k9rA8b1to%2BTC6LmEaxh5QTCB%2F8h%2B4c0YKPg48v3t4Ik%2B%2FzbfO0jaUG4%2FQ1t%2BbPC%2BFH0%2FcFwb6Mcq58RcYEMyLtILSVtdeY62i%2B0APUjBkr3wBTjcZcfWGAaTeUQWexGphHOqZFUmfMcoscKFtuO7494%2BIy927FtLh1ur1V5NxrULP%2Bx2JquIp0Iqlmj4YlMpUGtUxQaoqHLDE3yP9yZKEmhB3kACGl7B4%2FPKi27uW82PdXq97AOUUGKT4Hab%2FEkwDSZ%2B6E5WR5EbhoS4%2BCicuoRRcnw8HZFwvOrt5ct9%2FdNi9qvJYKWE4Thv%2B3KPG422v8zAYyq%2FmQGvn97Lgv61%2BS0GMDn%2Fu%2FWvdAuWVuOa0QRbYOAHketHbjCe%2B0dxMI2D0DsOx1EwOvT92PdtIkybLssN7HR%2Fm9HDd3FWf9T1TZbehMt0drk6OTk%2FTGdfx%2FPRmoyv6osfkQqvxedIv0PbnzmniQsgBwAA