### PR TITLE
Add Moxi page template (moxi.fan.page.json)

### DIFF
--- a/moxi.fan.page.json
+++ b/moxi.fan.page.json
@@ -10,7 +10,7 @@
   "syncPubKeyDomain": "moxi.fan",
   "syncRedirectDomain": "moxi.fan",
   "records": [
-    { "type": "A", "host": "@", "pointsTo": "76.76.21.21", "ttl": 3600, "groupId": "moxi" },
-    { "type": "CNAME", "host": "www", "pointsTo": "cname.vercel-dns.com.", "ttl": 3600, "groupId": "moxi" }
+    { "type": "A", "host": "@", "pointsTo": "76.76.21.21", "ttl": 3600 },
+    { "type": "CNAME", "host": "www", "pointsTo": "cname.vercel-dns.com.", "ttl": 3600 }
   ]
 }

--- a/moxi.fan.page.json
+++ b/moxi.fan.page.json
@@ -1,0 +1,16 @@
+{
+  "providerId": "moxi.fan",
+  "providerName": "Moxi",
+  "serviceId": "page",
+  "serviceName": "Moxi Page",
+  "version": 1,
+  "logoUrl": "https://moxi.fan/icon.svg",
+  "description": "Points your domain at your Moxi page: an A record on the apex and a CNAME on www.",
+  "variableDescription": "No variables. Fixed Vercel targets: A @ to 76.76.21.21, CNAME www to cname.vercel-dns.com.",
+  "syncPubKeyDomain": "moxi.fan",
+  "syncRedirectDomain": "moxi.fan",
+  "records": [
+    { "type": "A", "host": "@", "pointsTo": "76.76.21.21", "ttl": 3600, "groupId": "moxi" },
+    { "type": "CNAME", "host": "www", "pointsTo": "cname.vercel-dns.com.", "ttl": 3600, "groupId": "moxi" }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `moxi.fan.page.json` — the Domain Connect template for **Moxi** (https://moxi.fan), a platform that hosts artists' and creators' pages on Vercel. It points a creator's own domain at their Moxi page: an `A` record on the apex (`76.76.21.21`) and a `CNAME` on `www` (`cname.vercel-dns.com.`), which are Vercel's documented generic targets. The template is signed: `syncPubKeyDomain` is `moxi.fan`, and the RS256 public key is published at `_dcsign1.moxi.fan`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Validated with the official `dc-template-linter` — passes `--merge-or-fail` with zero findings. The RS256 signature was verified end to end against the published key at `_dcsign1.moxi.fan`. Note: the free Online Editor returns HTTP 403 on "Test apply template" (it requires an onboarded account), so a shareable editor link could not be generated. Happy to add one if an account can be provided.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the template uses `redirect_uri`)
- [x] no TXT record contains SPF content (no TXT records in this template)
- [x] `txtConflictMatchingMode` is set where needed (N/A, no TXT records)
- [x] no variable is used as a bare full record value (N/A, template is variable-free)
- [x] no bare variable is used as the full `host` label (N/A, variable-free)
- [x] no variable is used in the `host` field to create a subdomain (N/A)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` where the user may need to modify records (N/A)

## Online Editor test results

**Editor test link(s):** Pending. The free Online Editor returns 403 on "Test apply template" (account required). The template was validated with the official `dc-template-linter` (clean) and the signature verified against `_dcsign1.moxi.fan`.
