### PR TITLE
Add Mailercloud email authentication template

### DIFF
--- a/mailercloud.com.email-auth.json
+++ b/mailercloud.com.email-auth.json
@@ -1,0 +1,56 @@
+{
+  "providerId": "mailercloud.com",
+  "providerName": "Mailercloud",
+  "serviceId": "email-auth",
+  "serviceName": "Mailercloud Email Authentication",
+  "version": 1,
+  "logoUrl": "https://www.mailercloud.com/mailercloud-logo.png",
+  "description": "Authenticate your domain or subdomain to send email with Mailercloud (tracking, DKIM, SPF, DMARC).",
+  "syncPubKeyDomain": "dns-connect.mailercloud.com",
+  "syncRedirectDomain": "app.mailercloud.com",
+  "multiInstance": true,
+  "variableDescription": "cloudnskey: per-account tracking key. track_host/dkim_host/img_host/spf_host/dmarc_host: server-computed relative hosts (apex mc / k1._domainkey / img<key> / @ / _dmarc; subdomain adds the sub-label; occupied-subdomain tracking mc-<label>). img_value: img<key>.<imgdomain>. dmarc_value: server-computed DMARC TXT (merged with existing policy, or default policy with rua/ruf@trackdomain).",
+  "records": [
+    {
+      "groupId": "tracking",
+      "type": "CNAME",
+      "host": "%track_host%",
+      "pointsTo": "mc%cloudnskey%.mlrcloud.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim_host%",
+      "pointsTo": "dkim.mlrcloud.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "groupId": "img",
+      "type": "CNAME",
+      "host": "%img_host%",
+      "pointsTo": "%img_value%",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "%spf_host%",
+      "spfRules": "include:mlrcloud.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "%dmarc_host%",
+      "data": "%dmarc_value%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/mailercloud.com.email-auth.json
+++ b/mailercloud.com.email-auth.json
@@ -9,7 +9,7 @@
   "syncPubKeyDomain": "dns-connect.mailercloud.com",
   "syncRedirectDomain": "app.mailercloud.com",
   "multiInstance": true,
-  "variableDescription": "cloudnskey: per-account tracking key. track_host/dkim_host/img_host/spf_host/dmarc_host: server-computed relative hosts (apex mc / k1._domainkey / img<key> / @ / _dmarc; subdomain adds the sub-label; occupied-subdomain tracking mc-<label>). img_value: img<key>.<imgdomain>. dmarc_value: server-computed DMARC TXT (merged with existing policy, or default policy with rua/ruf@trackdomain).",
+  "variableDescription": "cloudnskey: per-account tracking key. track_host/img_host/spf_host: server-computed relative hosts (apex mc / img<key> / @; subdomain adds the sub-label; occupied-subdomain tracking mc-<label>). dkim_selector: DKIM selector (e.g. k1). dkim_suffix: subdomain suffix after ._domainkey (empty at apex, .<sub> for a subdomain) — the ._domainkey label is fixed in the template. dmarc_suffix: subdomain suffix after _dmarc (empty at apex, .<sub>) — _dmarc is fixed in the template. img_value: img<key>.<imgdomain>. dmarc_value: server-computed DMARC TXT (existing policy preserved, with rua/ruf@trackdomain).",
   "records": [
     {
       "groupId": "tracking",
@@ -22,7 +22,7 @@
     {
       "groupId": "dkim",
       "type": "CNAME",
-      "host": "%dkim_host%",
+      "host": "%dkim_selector%._domainkey%dkim_suffix%",
       "pointsTo": "dkim.mlrcloud.com",
       "ttl": 3600,
       "essential": "Always"
@@ -46,7 +46,7 @@
     {
       "groupId": "dmarc",
       "type": "TXT",
-      "host": "%dmarc_host%",
+      "host": "_dmarc%dmarc_suffix%",
       "data": "%dmarc_value%",
       "ttl": 3600,
       "txtConflictMatchingMode": "All",


### PR DESCRIPTION
# Description

Domain Connect template for **Mailercloud** (`mailercloud.com`) — email authentication for sending/marketing domains. Configures Mailercloud's tracking CNAME, DKIM (CNAME delegation), SPF (`SPFM` merge), and DMARC for a customer's domain or sending subdomain.

Public signing key TXT is live at `_dck1.dns-connect.mailercloud.com` (RSA-SHA256).

**Bare variables in `host`:** `%track_host%`, `%dkim_host%`, `%img_host%`, `%spf_host%`, `%dmarc_host%` are server-computed per-domain host labels, fixed at apply time from the customer's stored record set (domain apex → `mc` / `@` / `_dmarc` / `<selector>._domainkey`, or a customer sending subdomain). Same pattern as `senderz.app.mail.json` (`%trackingSubdomain%`) and `resend.com.mail.json` (`%clickTrackingSubdomain%`). `multiInstance: true` is set so multiple sending subdomains under one root apply without conflict.

**Bare variables in `data` / `pointsTo`:** `%img_value%` (image-CDN CNAME target) and `%dmarc_value%` (full standards-prescribed DMARC TXT, pre-merged with any existing policy) carry complete server-computed values per domain. Same pattern as `senderz.app.mail.json` (`%dmarcValue%`) / `keplars.com.email.json`. Tracking/DKIM/SPF values use fixed affixes (`mc%cloudnskey%.mlrcloud.com`, `dkim.mlrcloud.com`, `include:mlrcloud.com`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`mailercloud.com.email-auth.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://www.mailercloud.com/mailercloud-logo.png` → HTTP 200, `image/png`, 200×200)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`dns-connect.mailercloud.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.mailercloud.com`)
- [x] no TXT record contains SPF content — uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on the DMARC TXT (`All`)
- [x] no bare variable as a full record value unless necessary — `%img_value%` / `%dmarc_value%` are full server-computed standard values (justified above)
- [x] no bare variable as the full `host` label — `%track_host%` / `%dkim_host%` / `%img_host%` / `%spf_host%` / `%dmarc_host%` are server-computed per-domain hosts, fixed at apply (justified above)
- [x] no variable in `host` to create a subdomain — `multiInstance: true` is used (justified above)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is `OnApply` on the DMARC TXT (the user-editable record); tracking/DKIM/img/SPF use `Always`

## Online Editor test results

**Editor test link(s):**

- [Test mailercloud.com/email-auth acme-test.com/@ (apex, no host)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPqqQmoC%2F%2B1XC2%2FbNhD%2BK4QAAwlqybLj2LPyQLKk27zCWZGlxbosEGiKdjhLpEZSfizwfvuOlPWwG68YugEtECBAyOMd77u77070k6NpksZYUyd4clIp5iyichg5gZNgFlNJYpFFHhGJ0yyPb3AC6s6oUoBDReWcEWpNqbF1caYfq4OPjdBro4YuQY1yzQjWTHAwmFOpzCpoN51YTMU7GYPho9apClqtxWLh7UBr1fausfBSPoWLIqqIZKm9NnBqfihaiUyiSIAhR0IilY03Gy2QojxCNgS0YPoR1SEfaInJjPFpE12%2FGY6a6Oe338FydHl7deiZYFecvM3Gb%2Bjq2t4HfiOuXCI4p0R7H%2BfUGNzSiEk4Lk1wmj6jmmSxZkOuNOYEUqllRiFZWDI8jun1VqzWjKsZXQUopdLFhIiMa1SgR3Di5bvwUSjdYsk0X6h0YhcBMnUDU%2FCdZppGSFKgCZtTZI4VOsApXaKEoBYC41O48ByWFye1XOIoUgiSbkRujMc0PkGCkCxlNHJrKS9AJcQ9tWrnhx6KZiwJFY0hL0IGNtuo2KID6k09NGuXetlkwpZBzXcuQXiiqURemEsBJJgmqV4hrJEJoIm8UzA6RxO4FVf2h%2Bi3rOO3uxZ%2B3dziQ0whuB2SYuCDRtFEACfBknwKT2i19kApXW%2B09vsyRZvjOKNBWQLvFFa5y%2FMCzEZlt56WtOjulzvAsWRKmwqkImZkhVJJrXbUzDtAZrgls8mFrdQmQYbtQFohI%2BUE90%2FOVIostd1f1BMU9Co1TX91czl6DVvDHNg2KuI1zFgRjGt1J8zMIY2Kug0vibcaQGsYBEc93286VCnTy9hMhst4gVfKWTfrIAwt9gPYIlejVt9GjU472MzJ5yCCwuwHVPTfjs9GWeLGv%2FQGfVx5gyE1qjkretzcCevbLKbKAOQkziIafE7WDeEqv0Cuym1O50a9QQyACGtsS1JxdSdWvdRXgk%2BAmXqENXkEao1ERC2G2NlG9RO%2FTNN45awf1k3nT8FpWHH0AZyVE5Yk1NVU6U2QG4ywssGErLBIscSJMh%2FHwvZ%2Bx%2FihsL53zLritpEkxMgqThvZrG1kWxTcFdvsFDcW3DB7WOd6JTFK6TY3H2xpS7sLe3ct9cXltbQb0fzMjoX2CUrPOKTvxPT%2BmfkWaRFY3Yu6G3M8%2BYdjx5SBTbmQNFTwH%2BtMlp8u%2Bz0L8QJXooiE2NQPqqbgFBDBZNlpGZ4%2FJBJSkSchu%2BFvESiMiCkgswztjPvkqDt2CR37brc36bmDQbfvksHRhLT7fr%2FjD2pPnT0vob2PnYpHz%2FWKaZbnowH81RCqAvvEzPkKAssJWwb0DFO%2F%2BIjyKbaJ56KKZX4GHdZGz41N9Be2o%2BlriiwshncZ3n87Cr6sbJQfivVDE%2Bb8y5h5GTMvY%2BZlzPyPY8a8yDD8pgqx0ev4nZ7r99zO4K7dDzrw1%2FFA1O13X%2Fl%2B4PsmDnhh5kl6gldU%2Ff3kqD9%2B%2F%2Fbm11Hc%2FvGYDCm%2BHuJF%2FIodXw%2BOx%2FwHsex%2B8%2BH9u6T3%2FvbD98MzZ%2F03jV17W%2BURAAA%3D)
- [Test mailercloud.com/email-auth acme-test.com host=mail (subdomain via host parameter)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPyqQmoC%2F%2B1XbW%2FbNhD%2BK4QAAwliybKTObHygmRJuwWFu%2BalW4ssMBiStrlIokZSdrwg%2B%2B27oyxLduMVQ%2FehAQIECHm84z1399yJfvSsSLKYWuFFj16m1URyoc%2B5F3kJlbHQLFY5D5hKvObi%2BD1NQN3rVwpwaISeSCacqUBbn%2BZ2XB18aUTeoBo5ATWRWsmolSoFg4nQBldRu%2BnFaqQ%2B6hgMx9ZmJmq1ptNpsAKtVdv7aBFk6Qgu4sIwLTN3beTV%2FAgyU7kmXIFhSpQmJr%2Bbb6wiRqScuBDIVNoxqUPesJqye5mOmuTs3Xm%2FSa4%2BvIVl%2F%2BTydDPAYGcp%2B5DfvROzM3cf%2BOWp8ZlKU8Fs8GVO0eBScKnheGFCs%2BwZ1SSPrTxPjaUpg1RanQtIFtWS3sXibClWZ5aaezGLSCa0TxlTeWpJiZ7ASVDsBmNlbEsmo2JhsqFbRATrBqbgO8ut4EQLoImcCILHhmzQTDyQhJEWAeMDuPAIlsf7tVxSzg2BpKPIj%2BmdiPeJYizPpOB%2BLeUlqIT5B07taDMg%2FF4mAyNiyIvSkcs2KbdkQwSjgNy3F3r5cCgfoprvQkLo0ApNgkEhBZBgmmR2RqglGECTBAdgdESGcCut7DfJ73knbO84%2BHVzh49IQ%2BB2SArCB42yiQBOQjX7Gp6B01oDZeF6rrXeFxZtQuNcRIsSBAewKlwelWDmKqv1dKQl15%2BuAceDNBYrkKlYshnJtHDavFl0gM5pS%2BfDY1epeYKQ7UBapbnxoptHb6RVnrnuL%2BsJCnaWYdOfvj%2Fpv4EtMge2jYp4DRwrSqbWXCucOaxRUbcRJPFSA1gLg2C7G4ZNTxiDvUxxMpzEUzoz3lOzDgJpsR7AErkatfo2anRawYYn34IICrMeUNl%2FKz4bixI3%2FqM36OPKGwypfs1Z2eN4J6wv81gYBJiyOOci%2BpasI%2BEqv0Cuym1B50a9QRAAp5a6klRcXYnVPthTlQ6BmbZPLRsDtfqKC4ch9pZR%2FZKeZFk8855un5reXyoVg4qjt%2BBsMWFZInwrjJ0HOceIQxd2LqCBLK0yqmli8ANZ2t%2BsXHBb3nBTXAH7iuNOylBWcRtl922ULVFxVeyyhEIUlRzBPawLvQVBFtJljt66Ei%2Fsjt3dtRKUl9fSj6LJoRsP7X2SHaaQxn2cAYcYm1WR0z2uu8Hj4b8ce1gOOUqVFgMD%2F6nN9eIT5r5rAzqllYizAcU6QvUMnAIimDArrZMWD4qEBfOqzZmUsNUcLLFpwBlWUiJdf%2BA9zsJex%2B91e6G%2Fs9fu%2BHQYcj%2Fc26XbvLfd6VFWe%2FeseRatffksk%2Bq55sHueT4siKGaSisRfmUSvZAI52RdiuwZAr%2BI0IpBVzJyKaTJIfRfmzw3XMnf1A2wlxZgMcmD1Tj%2F34nx%2FaVl8W15um3CZ%2BF1Ir1OpNeJ9DqRvo%2BJhO88Cr%2FYBhR1O2Gn64ddv9O7bu9GHfjbCbrh3vZeZysMozDEWODtWiTqEd5m9VeZZ43e%2Fm24Nfrp%2BuJqdjW66H76tfvn7uc%2FdrYubEInyY%2BTn0MxlvTj5%2F6h9%2FQPAA3SSUMSAAA%3D)

_Both links were re-minted through the Online Editor against the updated template (the editor embeds and HMAC-signs the exact template JSON). They cover the required apex (no host) + host-set cases. Local coverage simulation (`docs/prds/dns-connect/test/coverage-sim.mjs`) additionally verifies 18 record-build scenarios across SPF states A1–A4 and DMARC states B1–B5._

