### PR TITLE
gofarther.dev email template (Amazon SES DKIM + DMARC)

### DIFF
--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -4,7 +4,6 @@
   "serviceId": "email",
   "serviceName": "Go Farther — send email from your domain (Sendra)",
   "version": 1,
-  "logoUrl": "https://gofarther.dev/logo.png",
   "description": "Adds the DNS records that let Go Farther / Sendra send email from your domain (Amazon SES DKIM + a DMARC policy).",
   "variableDescription": "Your domain's three Amazon SES DKIM tokens.",
   "syncBlock": false,

--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -7,9 +7,8 @@
   "description": "Adds the DNS records that let Go Farther / Sendra send email from your domain (Amazon SES DKIM + a DMARC policy).",
   "variableDescription": "Your domain's three Amazon SES DKIM tokens.",
   "syncBlock": false,
-  "warnPhishing": true,
   "shared": false,
-  "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",  
+  "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",
   "syncPubKeyDomain": "gofarther.dev",
   "records": [
     { "type": "CNAME", "host": "%dkim1%._domainkey", "pointsTo": "%dkim1%.dkim.amazonses.com", "ttl": 3600 },

--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -9,7 +9,8 @@
   "syncBlock": false,
   "warnPhishing": true,
   "shared": false,
-  "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",
+  "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",  
+  "syncPubKeyDomain": "gofarther.dev",
   "records": [
     { "type": "CNAME", "host": "%dkim1%._domainkey", "pointsTo": "%dkim1%.dkim.amazonses.com", "ttl": 3600 },
     { "type": "CNAME", "host": "%dkim2%._domainkey", "pointsTo": "%dkim2%.dkim.amazonses.com", "ttl": 3600 },

--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "gofarther.dev",
+  "providerName": "Go Farther",
+  "serviceId": "email",
+  "serviceName": "Go Farther — send email from your domain (Sendra)",
+  "version": 1,
+  "logoUrl": "https://gofarther.dev/logo.png",
+  "description": "Adds the DNS records that let Go Farther / Sendra send email from your domain (Amazon SES DKIM + a DMARC policy).",
+  "variableDescription": "Your domain's three Amazon SES DKIM tokens.",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "shared": false,
+  "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",
+  "records": [
+    { "type": "CNAME", "host": "%dkim1%._domainkey", "pointsTo": "%dkim1%.dkim.amazonses.com", "ttl": 3600 },
+    { "type": "CNAME", "host": "%dkim2%._domainkey", "pointsTo": "%dkim2%.dkim.amazonses.com", "ttl": 3600 },
+    { "type": "CNAME", "host": "%dkim3%._domainkey", "pointsTo": "%dkim3%.dkim.amazonses.com", "ttl": 3600 },
+    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none;", "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
# Description
New Domain Connect provider template for Go Farther / Sendra. Adds the records to send email from a user's own domain via Amazon SES: three Easy-DKIM CNAMEs (%dkim1–3%) and a DMARC policy.

## Type of change
- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?
- [x] Template functionality checked using the Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: no `logoUrl` in this initial template (will add once the brand site is live)

# Checklist of common problems
- [x] `syncPubKeyDomain` is set — added in the latest commit; the public key is published at `_dcpubkeyv1.gofarther.dev` and resolving.
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain` — removed `warnPhishing`; the apply is signed via `syncPubKeyDomain` instead.
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`
- [x] no TXT record contains SPF content
- [ ] `txtConflictMatchingMode` — DMARC TXT is at the dedicated `_dmarc` label; can add if preferred.
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` OnApply — can add `essential: OnApply` to the DMARC record if preferred.

## Online Editor test results
**Editor test link(s):**
- Apex: [Test gofarther.dev/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP8GPmoC%2F%2B1VbU%2FbMBD%2BK5alaUO0JU3bAEF8YLRsCOgQRQLEUHWJr9RqEme2Uyio%2F33nvqy8VCC0fRgSn5J78XP3nO%2FO99ximidgkYf3PNdqKAXqfcFDfq16oG0fdUXgkJf%2BGNuQkjP%2Fptje1E42g3ooY5ycwxRkstA9c2c%2FC9%2Br1pnBTLCJM%2BtplbKRKjQTihQZ%2B9Iho4YVghmiNlJlPKyWuEATa5nbicx3hDCMEFmz3WEaY6UnMliWoGUPAq6xKdzLIXdSuFMZ67Q6rHmwf8RWGbDm0c7JLstVIuPRSsVlA1pClGDzUSYXC5zPLgWNyJ7CWTXAzDgMM8rir4mKBzzsQWKQNH3QKBYiOZygkMTJNieoT6%2BjlAzyHv7SmAzvZGJ7N3lxKyumyCECg5VYzcIcF9EBjpZjkMusaDy8vOd2lLt72m3vHLXI1FfGkvhJDGRa%2FVTpTtkNcOQ6QcnMmlP1wO4%2BFZhQNmgogZT8rE14WAs8b1x6Ed9%2FBd%2F%2FS%2FzaK%2Fi1N%2BCfnp8u0LsiBR2TLMACycPtScNUt1i%2BnakMtx6BXI1LnPCxuyj7FR2dXw7eAk0izmLPItDftVZF3pVz%2Fxw0pMZN6%2Fzk5aOjV%2FOzl9z9T%2B7HCQAwl30nR1E0l2tOjuOYuwzldaY0dg19wRaaOFtdUFOmRWJlF25goRJxF%2FI8GREhQ1ZCed5H2XT8KfrjO5hVzOlfrn2Jqhw7utItFz%2BIPIiEKK9Hm7VyHX0sb1QDr1yrb4pgs9eoNqrwYFctXWTLltWi3GhoS1gJidswyQ2MDB8v6a8ZL6riUl5O%2F555UTcs5eX074rXdF5nrN40r%2F8FkasSzfzHVH1M1cdU%2FcupoofPwBBFF5yb7%2FlB2QvKfnDq1cPGRljbrARe4Pvrq54Xep7LH42d0runN%2FLh68jbq9XztdZxPw1u11vxnthbLS6EX%2Fy4PjRnUbupegXufm8cntUys83HvwHPqzR%2BcQsAAA%3D%3D)
- Subdomain: [Test gofarther.dev/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ0GPmoC%2F%2B1VbW%2FTMBD%2BK5YlBIi2pF2bjUz7UCgv0%2BgYaxFDY6ou9nUzTeJgO92yaf%2Bdc5vSbuxFCAmBtE%2FW%2Be6e83NvvuAO0zwBhzy64LnRUyXRbEse8WM9BuNO0DQkTnntp3IXUjLmbzV7M9eTzqKZKoEzP0xBJcu7X8zZ16IVNNvMYibZzJiNjU5ZqQvDpKaLjD0ZkNLAU4KZorFKZzxq1rhEK4zK3UzmXSktI0TW2x0wg0KbmQyOJejYSsDnbA53d8huCuc6Y4PXA9bb2e6zZwxYr9%2Fdf8VynShRPm3414BRECfYu%2FKSL0ucx%2F4JBpFdh3N6gpn1GLbMxMtEiwmPxpBYpJsTMCiXIhnso1TEyfVmqNfLUUsm%2BRi%2FG0ym5ypx49O8OFMNW%2BQQg8WG0FWYvSLewfJmDDKpksajwwvuytzX6dVut%2F%2BaVCfaOhIfyYlKm48aozm7CZa%2BE7TKnB3qFb0%2FGjCjbNHSA1Kycy7h0VoYBJe1O%2FFb9%2BC3%2FhB%2F7R78td%2FAHx4Ml%2BgjmYIRJEtwQPJ0a9YwzU2Wb2U6w80rIEeXNU74OFqm%2FYhcF8XBM6BJxCp2FaGapWOji3ykFj45GEitn9iF9%2BEV96OF%2F%2BEcwIfxdfIXALCQW16O43ghr3lZCMH9S9Vxpg2OLJ3gCkPcnSmoOdMicWoEp7C8kmIEeZ6URMySllB%2B7adsvgYo%2BkotGhW9Kn1eeXchapRy4Xkrv2lisSFEKKDeDlvr9XZbxnUQENaxPe6MO8F6EIRyZXHduNVu2lxXc4%2BW1oZTkPiVk5xCafnlDQ1XEaR03k7QK%2F93gtQftxP0yv%2BO4HykK3rzkb5G6865%2FmcYHdVoNzxM3sPkPUze3548%2BkAtTFGOwJu2glZYD8J6KxwG7aizHgXNRicI2hsvngVBFASeA1o3p3hBf%2B3qL8vfp%2BHep%2BGgn9t3vSx%2B%2B6HcLg9OzkJM20n%2F28vu%2BfGnz52P3Qx2RH%2BLX%2F4Au9dnjMELAAA%3D)