### PR TITLE
add Appaloft, Appaloft Custom Domain

### DIFF
--- a/appaloft.com.appaloft-domain.json
+++ b/appaloft.com.appaloft-domain.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "appaloft.com",
+  "providerName": "Appaloft",
+  "serviceId": "appaloft-domain",
+  "serviceName": "Appaloft Custom Domain",
+  "version": 1,
+  "description": "Connects a custom domain or subdomain to an Appaloft-hosted resource.",
+  "variableDescription": "%target%: IPv4 address currently assigned by Appaloft for this custom domain.",
+  "syncPubKeyDomain": "domainconnect.appaloft.com",
+  "syncRedirectDomain": "app.appaloft.com,appaloft.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new Appaloft Custom Domain template that connects a domain or subdomain to an Appaloft-hosted resource using a signed synchronous Domain Connect flow.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality in the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

No `logoUrl` is included in this template, so the logo URL webserver check is not applicable.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

`essential` is not set because the template creates a single routing A record managed by Appaloft. Users should not need to independently modify this record while the Appaloft custom domain remains connected.

## Online Editor test results

**Editor test link(s):**

[Test appaloft.com/appaloft-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJZeO2oC%2F91TYWvbMBD9K0LQT7WN4rjNbBhstNsog9FlbfchBHORlFTDlowkp%2FVC%2FvtOTZzEYewH7NtJ996d3t3ThnpZNxV4SYsNbaxZKyHtnaAFhaaByix9wk1No0PuG9SIpR%2F3Wcw4adeKywEpFqYGpY%2FZMxq5aZ03NbntYWtpnTKaFqOICum4VY1%2FO9Mbo7Xk3hEgfEfa1SbGEtcu9gdvCGjSl4%2BfjfNSECudaS2XSegAVsGikreD6hce7Er6i4Lc3a8zAkIgx2Ena6X2VUfAObXSWGvRHcqTJfb2z8oNXxS6uE7z%2B3bxVXZ7aQXdJflORnI21oCfSqEs5g4MxAxw0RkJwcYKR4vZhvqueRssXgfRGH4I2zJKe%2FdgThTirfcVLcaMbefbiP42WpbHSvNo%2F1CkyFdAU8h9t31ZjFbWtE2penwDFmoXjNMzZwPqvOfOaIihD3Brfcg1%2BuIU5F8PYf16uHxTEE6jPE1YkiajdEyDCFyNsbIMKwLfWpyEt61Eblt5VcILHK8EL3GMVYeaHWax2nB6eufQMD0BHh87aHYcXkRLwYNoFQwvl2wMkMt4kk54nOWLSQxpfh3n2VW2nDD%2BjonJye%2F528%2F69%2F85Th99iZZUUIUHVy%2FQObrdziPcxH8hJBgD1lKUEGApS69jdh2n2QPLivFVMc6SnKV5ll0yVjAWdEjndwI36IRTD9DR1cp9%2FsJvfny%2Fr7g3qXvUYsybl%2FpTVz%2F8epo%2B3V1Ou5VdtD8f39PtH7pKZL0FBQAA)

[Test appaloft.com/appaloft-domain example.com/pocketbase](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJleO2oC%2F91TYU%2FbMBD9K5ElPi3J3CQEEmnSRtkmhpgqhPYFVdEldsEjsTPbKYSq%2F33ntmkbhPYD9s2%2Bu%2FfO7%2B55RSxv2hosJ%2FmKtFotBeP6ipGcQNtCrRY2rFRD%2FH3uJzRYS77sspgxXC9FxUeggKkGhDxk38C8aWesarzLoWzJtRFKknziE8ZNpUVrN3cyVVLyyhoPvGoL2nJ7SnumK3cXqzyQ3kAfPCpjOfM0N6rTFQ9dB9ACyppfjthPLOgHbk9y72q2TDxgDDEGO2nNpa17D4wRDxK5yn5P7y2wt30UZvwi18X0spp15TXvd9Jysk1WWxnhm7G6%2BlvOhMbcHoE1ozr%2FDQiLlWaG5PcrYvt2M1gMO9F4%2FOy2pYS05k4dKcSotTXJY0rX87VPXpXkxYFp7u8eihD%2BAmgKvuu2o21V9cRtCYZj7EGrri3EgGxBQ2OchQaO%2BxHJfGC5P6bBKLiQO%2BAmh2Ml0StDuQvYl%2F2xedkHN6rcbZJFIQ2jcBLFxAnDdSnNC7c2sJ3G6VjdccR2tRUFPMMhxKoCR1v3OAeDWWQbT1RuXTuSzsDiq0ddD5P1ScEqNwex%2BQ1JlNI4PQ1YlaZBskgmwXnM0gA4K7OEnmVRRI%2B%2B1nvf7t%2Bf673VoH3RuQJqp6F%2Bht6Q9Xru45r%2BV23OPrDkrAAHiGiUBjQNouSOJnl8msdnYZxmWZJ8oDSn7lGWG7uVukK%2FHDuFZB%2B%2FftNP35NZdwG3PZ1evf5uJ3JBm5sfvy5mGVzH0zKDyZ%2Fz6%2FNPZP0XTP%2BxhD8FAAA%3D)