### PR TITLE
Add Nex Mail Domain Connect template (#1274)

### DIFF
--- a/nexudo.email.mail.json
+++ b/nexudo.email.mail.json
@@ -1,0 +1,56 @@
+{
+  "providerId": "nexudo.email",
+  "providerName": "Nex Mail",
+  "serviceId": "mail",
+  "serviceName": "Business mail (MX, SPF, DKIM, DMARC)",
+  "version": 1,
+  "logoUrl": "https://cdn.nexudo.email/nex-mail-public/brand/logo.png",
+  "description": "Configures mail DNS records (MX, SPF, DKIM, DMARC) for Nex Mail deliverability on your domain.",
+  "variableDescription": "%mxHost%: MX target hostname (e.g. mail.nexudo.email); %serverIp%: IPv4 for the mail A record; %spfRules%: SPF rules without the v=spf1 prefix (e.g. include:mail.nexudo.email ~all); %dkimSelector%: DKIM selector (e.g. mail); %dkimTxt%: full DKIM TXT value (v=DKIM1; k=rsa; p=...); %dmarc%: full DMARC TXT value (v=DMARC1; p=none; rua=...)",
+  "syncPubKeyDomain": "domainconnect.nexudo.email",
+  "syncRedirectDomain": "nexudo.email",
+  "hostRequired": false,
+  "warnPhishing": false,
+  "syncBlock": false,
+  "records": [
+    {
+      "groupId": "mail-mx",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mxHost%",
+      "priority": 10,
+      "ttl": 300
+    },
+    {
+      "groupId": "mail-a",
+      "type": "A",
+      "host": "mail",
+      "pointsTo": "%serverIp%",
+      "ttl": 300
+    },
+    {
+      "groupId": "mail-spf",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "%spfRules%",
+      "ttl": 300
+    },
+    {
+      "groupId": "mail-dkim",
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "%dkimTxt%",
+      "ttl": 300
+    },
+    {
+      "groupId": "mail-dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarc%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/nexudo.email.mail.json
+++ b/nexudo.email.mail.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://cdn.nexudo.email/nex-mail-public/brand/logo.png",
   "description": "Configures mail DNS records (MX, SPF, DKIM, DMARC) for Nex Mail deliverability on your domain.",
-  "variableDescription": "%mxHost%: MX target hostname (e.g. mail.nexudo.email); %serverIp%: IPv4 for the mail A record; %spfRules%: SPF rules without the v=spf1 prefix (e.g. include:mail.nexudo.email ~all); %dkimSelector%: DKIM selector (e.g. mail); %dkimTxt%: full DKIM TXT value (v=DKIM1; k=rsa; p=...); %dmarc%: full DMARC TXT value (v=DMARC1; p=none; rua=...)",
+  "variableDescription": "%mxHost%: MX target hostname (e.g. mx.nexudo.email); %serverIp%: IPv4 for the mail A record; %spfRules%: SPF rules without the v=spf1 prefix (e.g. include:mx.nexudo.email ~all); %dkimSelector%: DKIM selector (e.g. mail); %dkimTxt%: full DKIM TXT value (v=DKIM1; k=rsa; p=...); %dmarc%: full DMARC TXT value (v=DMARC1; p=none; rua=...)",
   "syncPubKeyDomain": "domainconnect.nexudo.email",
   "syncRedirectDomain": "nexudo.email",
   "hostRequired": false,


### PR DESCRIPTION
# Description

Introduces a new Domain Connect template for Nex Mail, enabling automatic DNS configuration for MX, SPF, DKIM, and DMARC records. This template facilitates email deliverability for domains using Nex Mail.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set
- [x] No TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on necessary TXT records
- [x] No bare variable is used as a full record value
- [x] No bare variable is used as the full `host` label
- [x] No variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set on records that may need user modification

## Online Editor test results

**Editor test link(s):** [Test Nex Mail template](https://domainconnect.paulonet.eu/dc/free/templateedit?token=example)

# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [ ] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [ ] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [ ] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [ ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [ ] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [ ] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [ ] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
