### PR TITLE
Add Nex Mail Domain Connect template

### DIFF
--- a/nexudo.email.mail.json
+++ b/nexudo.email.mail.json
@@ -6,83 +6,51 @@
   "version": 1,
   "logoUrl": "https://cdn.nexudo.email/nex-mail-public/brand/logo.png",
   "description": "Configures mail DNS records (MX, SPF, DKIM, DMARC) for Nex Mail deliverability on your domain.",
+  "variableDescription": "%mxHost%: MX target hostname (e.g. mail.nexudo.email); %serverIp%: IPv4 for the mail A record; %spfRules%: SPF rules without the v=spf1 prefix (e.g. include:mail.nexudo.email ~all); %dkimSelector%: DKIM selector (e.g. mail); %dkimTxt%: full DKIM TXT value (v=DKIM1; k=rsa; p=...); %dmarc%: full DMARC TXT value (v=DMARC1; p=none; rua=...)",
   "syncPubKeyDomain": "domainconnect.nexudo.email",
   "syncRedirectDomain": "nexudo.email",
   "hostRequired": false,
   "warnPhishing": false,
-  "variables": [
-    {
-      "name": "mx_host",
-      "description": "Mail server hostname (MX target)",
-      "dataType": "STRING"
-    },
-    {
-      "name": "mail_a_host",
-      "description": "Mail subdomain (e.g. mail)",
-      "dataType": "STRING"
-    },
-    {
-      "name": "server_ip",
-      "description": "Mail server IPv4 address",
-      "dataType": "STRING"
-    },
-    {
-      "name": "spf",
-      "description": "SPF record value",
-      "dataType": "STRING"
-    },
-    {
-      "name": "dkim_selector",
-      "description": "DKIM selector (e.g. mail)",
-      "dataType": "STRING"
-    },
-    {
-      "name": "dkim_txt",
-      "description": "DKIM public key TXT value",
-      "dataType": "STRING"
-    },
-    {
-      "name": "dmarc",
-      "description": "DMARC policy TXT value",
-      "dataType": "STRING"
-    }
-  ],
+  "syncBlock": false,
   "records": [
     {
-      "type": "MX",
       "groupId": "mail-mx",
+      "type": "MX",
       "host": "@",
-      "pointsTo": "%mx_host%",
+      "pointsTo": "%mxHost%",
       "priority": 10,
       "ttl": 300
     },
     {
-      "type": "A",
       "groupId": "mail-a",
-      "host": "%mail_a_host%",
-      "pointsTo": "%server_ip%",
+      "type": "A",
+      "host": "mail",
+      "pointsTo": "%serverIp%",
       "ttl": 300
     },
     {
-      "type": "TXT",
       "groupId": "mail-spf",
+      "type": "SPFM",
       "host": "@",
-      "data": "%spf%",
+      "spfRules": "%spfRules%",
       "ttl": 300
     },
     {
-      "type": "TXT",
       "groupId": "mail-dkim",
-      "host": "%dkim_selector%._domainkey",
-      "data": "%dkim_txt%",
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "%dkimTxt%",
       "ttl": 300
     },
     {
-      "type": "TXT",
       "groupId": "mail-dmarc",
+      "type": "TXT",
       "host": "_dmarc",
       "data": "%dmarc%",
-      "ttl": 300
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
     }
   ]
 }

--- a/nexudo.email.mail.json
+++ b/nexudo.email.mail.json
@@ -1,0 +1,88 @@
+{
+  "providerId": "nexudo.email",
+  "providerName": "Nex Mail",
+  "serviceId": "mail",
+  "serviceName": "Business mail (MX, SPF, DKIM, DMARC)",
+  "version": 1,
+  "logoUrl": "https://cdn.nexudo.email/nex-mail-public/brand/logo.png",
+  "description": "Configures mail DNS records (MX, SPF, DKIM, DMARC) for Nex Mail deliverability on your domain.",
+  "syncPubKeyDomain": "domainconnect.nexudo.email",
+  "syncRedirectDomain": "nexudo.email",
+  "hostRequired": false,
+  "warnPhishing": false,
+  "variables": [
+    {
+      "name": "mx_host",
+      "description": "Mail server hostname (MX target)",
+      "dataType": "STRING"
+    },
+    {
+      "name": "mail_a_host",
+      "description": "Mail subdomain (e.g. mail)",
+      "dataType": "STRING"
+    },
+    {
+      "name": "server_ip",
+      "description": "Mail server IPv4 address",
+      "dataType": "STRING"
+    },
+    {
+      "name": "spf",
+      "description": "SPF record value",
+      "dataType": "STRING"
+    },
+    {
+      "name": "dkim_selector",
+      "description": "DKIM selector (e.g. mail)",
+      "dataType": "STRING"
+    },
+    {
+      "name": "dkim_txt",
+      "description": "DKIM public key TXT value",
+      "dataType": "STRING"
+    },
+    {
+      "name": "dmarc",
+      "description": "DMARC policy TXT value",
+      "dataType": "STRING"
+    }
+  ],
+  "records": [
+    {
+      "type": "MX",
+      "groupId": "mail-mx",
+      "host": "@",
+      "pointsTo": "%mx_host%",
+      "priority": 10,
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "groupId": "mail-a",
+      "host": "%mail_a_host%",
+      "pointsTo": "%server_ip%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "groupId": "mail-spf",
+      "host": "@",
+      "data": "%spf%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "groupId": "mail-dkim",
+      "host": "%dkim_selector%._domainkey",
+      "data": "%dkim_txt%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "groupId": "mail-dmarc",
+      "host": "_dmarc",
+      "data": "%dmarc%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Introduces a new Domain Connect template for **Nex Mail** (`nexudo.email` / `mail`), enabling automatic DNS configuration for MX, SPF (SPFM), DKIM, and DMARC records on customer domains.

Bare `%dkimTxt%`, `%dmarc%`, and `%spfRules%` carry provider-supplied values at apply time (keys and policies generated per domain). Fixed host suffixes (`mail`, `._domainkey`, `_dmarc`) limit misuse.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

1. **Apex domain test** (host empty):

[Test nexudo.email/mail nexudo.dev/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIwTPGoC%2F%2B1YbU%2FiShT%2BK02TTXYjlJYXEYzJlhexYBGQdVm9hgztUEbaaW2nUDTe335n%2BgJFUHfvJzfhiw4z55w50%2FM8z7w88wRajgkI5KvPvOPaC6RDV9H5Ko9h4Ou2AC2ATD6zHusCi9ryXRhwajTiQXeBNBg6WVtdsW3N9xCGnsexUe6rOspw173zDNfoKCr9q8qD%2BjfqtICuh2zMV6UMb9qG%2FcM1qfOMEMer5nKajoV0Sjn6I8saWcefmEjLTVyA9RxzFBxs0Hg69DQXOSSMyddtPEWG78I4jUb3mnOhZru690ZK3NR2uWSdnA5NRDMEE2QisuJszK1s3%2BV0m0bDAksfuAhMTNjYmvaLFVzYHvlS5dQRR4BrQMLNaAemn4b7CgVDCNPZWtq3U%2B4L%2B4K0EA51VHqLYpgLmcEodznOnNk504FvQo%2Fa0QVwLmtzS0Rmtk9Ch8UZNZE4x4VTFMQzIqyZvg6rOzNz%2FwIznF6fI%2BsamlAjtktDs8%2FCefHvVNqJ6TBgK5z6phmZDkdDbgFMny5xccZ6pFNufuZ64JRzzgRBCP0s4GprL%2FbFX7mxLok5YBvDU7o0ELoyeK2w1vMnHbhqhJ%2BffueoDpqNMc1ReIVdZj%2BAOqJfjaw9Xtmwogzgo0%2BNKJCnwPRghl8CF%2FdmyJshiqikk0WrmbY2X%2FfEOOKrd8%2B84dq%2Bs%2BZC1gpobLJyGA%2FUUTwPbX9nlLIRJt7QTsEkJBqyXQoxygORuhJKgoIovmR2QoNNZHkTOKFrKvYaS%2Fy78ShONhEpmNTtbBOkhRET1L0fkUFjE5JWdxNxG2HCOKrfHK4YcQEBiQlD1geTMBy9Mcs4GVyHDEGXCkhbAWHaQCWEqIBorNSqrbNQvZAz%2FF6TeKzKJ0ClZlTiICYIMNm6wrLjmCv%2B5f4lwz9RAI83ILnPxHDdoFCHi03WtBWucYwScwe4wPKYRCeOd2nP%2B8T1jmftCEvs1w7B2XACB2aQFwuCKEhSQZDEcGxd5Dv%2BfZVg1ukaJtMl%2FbRwrGuX%2Fqqi1JQHuVsz5o%2BzOWpVlmJN7jfPZfmqLvdPZDZeNzq03ZSdjjWYli6R7AyfdGXVD1q%2FmvN2yXUe%2B2qu7YLS5bClXupSk1y2G6SJfL91oWNNnNevZw%2BFlrOwGxPUmF8bT%2FK8Z%2FnN1vBKsW9O8O3gh3T7U1sqN49X%2BeENlgqrsiRDBZ%2Bf9B%2F9W%2FzjvDIZBOhmjg1LOm7n5lr5uoEKhcug314og6N8u2VOveHJU%2BGn153nH24q50dSqX7zJEKAfuWGHfXike5GqH2s9wb1o9kvUgPNkYZKnea1PpMHP9W2lIervGo8WZ1aHZcfsL4MJAW17BMz130qyoPK1VJ5NAtlzxxNmkY3vxCNB62p32IwmlXEoDe6LU3EC1jo3C4H%2FVIR9LWLRkM8GQGvdNxpyZOZ3BlpU7%2BtXC3rwchezPDiYmUf5%2BWbpdKQ%2B3ItLFRIj6hMe%2BSW1ZPY1dDq%2BzaMKKqRgW0Xjj36HxC6sfJV4vpUDS3fJGgMqHauu3RtDBgdKAk8OkpnpEqZVkUcnRS%2Bb6i6C900abdFcqxrjBuIaQIdnkjFcilb0Y%2F1bFGCMFuRJJCdaGBaBGWpSMdSx5l9R509B5oNM9Mkl80lWHn8C1OllBLHi4ld4%2FVsMS29lE%2BUfKSdu7WIzxDvC0KkCn%2FDysL89%2B04B7H6tGL1N%2BDq9WnjT0X1M6xxfW55uc%2FQk8dBpg8yfZDpg0wfZPrTyjS7tYEF1MeAhPqVP86Kx9l8cSiVq%2FlytSgKZUmqSPkjUayKoaZBj0RLfw7b4b1SdmAQP2ZxrJP1JS9aoUFyqdyr%2BJsr5WsBTb0afHCffH2dXAtzcpk88P4z8z6%2BSv4PNu1%2FCwlfQNjrxwt7X2O3xuh9bc9xZOMnbJEz5rck7j6x8m%2BfBYQPwm0B%2FC2N%2BSDGP3%2BwV%2F%2FD87%2B5Qwq%2FMeuBQZ%2BTQe9UOdqvfqu4f8I8NuM93ST56F2fbiCR7u9uBdQm%2FcrDF7tXXk8KLFN7MNW%2BK1Ycu9W%2FaPtN1%2B9g11Qs48hEztzM3Z6c8S%2F%2FAeW3tP9jGgAA)

2. **Subdomain test** (host `www`):

[Test nexudo.email/mail nexudo.dev/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKMTPGoC%2F%2B1Z%2B2%2FiOBD%2BV6JIK%2B2qEJJQKFBV2vAoDTQtr1K2vRUyiQE3wQ558GjF%2Fe1nh4RHYVt6upNaiV9ax54ZezzffGObF96DI9sCHuRzL7ztkAkyoKMafI7HcOYbRIAjgCw%2Bthq7ASMqy9%2FAGactR1zoTJAOA6XRVlcom%2FddhKHrcmyU%2B651YlyzdhnjilVVo381pVH4QZUm0HERwXxOivEWGZA7x6LKQ8%2Bz3VwioRtY2FxSgn7EWSNu%2Bz0L6YmeA7CRYIqCjQfUngFd3UG2F9jkCwT30cB3YLiM4k2Tc6BOHMP9w5K4PnG4yE%2FOgBaiKwQ9ZCFvzhHMzYnvcAah1rDAlg8cBHoWLG5N%2B200uyKu9y3HaR3OA84AetyQdmC6Ndx3KAyEYDlbrv04576xHaSBsKmiWpucBmvxhnC5diVcOZOz%2Bw3fgi6Vow5wDmtzU%2BQNie8FCpMLKiJxtgP7aBbOiLBu%2BQbM7czM%2FQ2sYHrDRKMmtKDuEYeaZtvCueH3xrIj0daMedj3LWsp2uq0uAmwfOri5IL1SOeceeG44JyzLwRBCPRGwNFXWmzHX6mxLokpYILhOXUNBKoMXnOs1%2FxeFc6LwfbTfV7GQScY0zUKr7DL5BvQQHTXvJXGKxkWlAYc%2B1SIArkPLBfG%2BClwcG2I3CGiiIo6mbW8RXRz1RPiiM89vvADh%2Fj2Khfioxm17c1tlgdaJ5yHtn%2BylCIIe26LbMAkSDREHAoxmgciVfVoEiRFcRHbMQ3WlpW14ShdN2yvsMS%2FaY%2FiZG2RgknbXm2EtMBihLq3LTJorE3S6K4tbiNM6C7jZ8I5S1zggUiEIeudSRiO%2FjBLNxpcmQxAt2GQtmYe4wZKIZ4GPJ2FWiMGM1ULcobfKxKO5fgIqFSMUhzEHgKMtm6xYtvWnF%2F8XsT4Zwrg7hokv2MhXNcoNOBkverpdEo%2FAje7KNKwgQNGLmPpSPdxU%2Fl3pP0YqNPPJaJYx06as%2BEIFExAFpOCKEhSUpDEYGwV6kf%2Bba5g0puRjKaL%2Bmn4WNcuCWiqmleflJv8wBwPTVTOTsW8Ui9dKsptQalnFDZeGFRpu6TY1VGjn7pGit16NtR5fVb%2BVTIrKcce17VExQGp61ZZuzakknddKXol5PvlKwProlloDp%2BSZXtCij1UNJuDZ8WsjfxSuXWrknYGPzTupId7faq2x7dyq42l5PxMUqCKLzP1sf%2BA7y6zvcYMtU08GEnpSsLUz5pFlExez%2BqVido4kStlq%2B%2B2Ms%2FJe%2FfGlJ%2Fa2csTKVVoP4sQoF%2BJVlW7GtOahCppo9YonAx%2FeXlQ6ugoVS01jaHSuNcqkgznsjZ4HlXzBXz2hI3pTFJRmWSsxM3zqdLI3k7VsZU8c61OrzS4kSfi4EkvGQ8YdIZZcVbrPKR64hVMVh%2BmjXrqFNT1q2JRzHSAm0pXy0pvqFQ7et%2BvqLfTwqxDJkM8uZqTtKy0p2pRqSv5IFBBkizDtId0WTw9kgukfm7DiGIbDTBxYNel%2F4FHyyuf8xyfcuLItzzUBZRBV12G3gUsKWgquHSUzkj5cpMb8fK8sMR%2FmLK74N1M3m2y7Bo6SxDEuCF9KvayKakXB9lkMn4K0yAOpEwyftaTUj25LycNADaONfuOPHsONlsZupnvijUFc5dfMILaIOXQo8CJLbe2Um7To8%2Flw5JN98UlPFe8TQ9Ljvgi7gUurAuR8MrdI4N9Ugb7IvBankV2UPUhwv0krq4ON4vfMXo2ObL4kcWPLH5k8SOLf1UWZ3c%2BMIFGF3gBq8npuJiOy6ct6SwnZ3KU5bKZrCzLJ6KYEwOmg6639P4laAcXU8WGs%2FBBjGOdrC96FQsEoivp3nKwvpC%2BptWNl4d3bqOvL6PRHqyuokcG%2BMwMEF5E%2F0VC7X9PCZ5Q2PPJgr3RsTvn8o1uz2llrSds5WeY4pK4%2B0zLv3FKeMfcFsD%2FRDXv2PjrA8X7L54%2FtF4eMOsxgz5nBr0R5bBsHRLcj2Qem5ElV9PvHXn%2FiNrPwvu77%2BiHFQGqIPzHheAAkwcVgwPs%2FE8F4cCZj%2Bn1VYvCoQH%2BeGFYMHZnnExvFsvC8LpSUInNnw54MnS1y7uEnZ7rzUY%2BP1Xa5iB7nyF2sZLSkJiHvjwuzBXV7GQu%2BMU%2F1s3c8b4gAAA%3D)