### PR TITLE
Add GoDaddy Airo App Builder templates (aab, aab_subdomain)

### DIFF
--- a/godaddy.com.aab.json
+++ b/godaddy.com.aab.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "godaddy.com",
+  "providerName": "GoDaddy",
+  "serviceId": "aab",
+  "serviceName": "Airo App Builder",
+  "version": 1,
+  "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
+  "description": "Enables a domain to work with GoDaddy Airo App Builder",
+  "variableDescription": "v1 is the IP address of the server. dcv is the certificate validation CNAME value for SSL provisioning.",
+  "syncPubKeyDomain": "domain-attach.api.godaddy.com",
+  "records": [
+    {
+      "pointsTo": "%v1%",
+      "type": "A",
+      "host": "@",
+      "ttl": 3600
+    },
+    {
+      "pointsTo": "@",
+      "type": "CNAME",
+      "host": "www",
+      "ttl": 3600
+    },
+    {
+      "pointsTo": "%dcv%",
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "ttl": 3600
+    }
+  ]
+}

--- a/godaddy.com.aab_subdomain.json
+++ b/godaddy.com.aab_subdomain.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "godaddy.com",
+  "providerName": "GoDaddy",
+  "serviceId": "aab_subdomain",
+  "serviceName": "Airo App Builder Subdomain",
+  "version": 1,
+  "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
+  "description": "Enables a sub-domain to work with GoDaddy Airo App Builder",
+  "variableDescription": "v1 is the IP address of the server. dcv is the certificate validation CNAME value for SSL provisioning.",
+  "syncPubKeyDomain": "domain-attach.api.godaddy.com",
+  "records": [
+    {
+      "pointsTo": "%v1%",
+      "type": "A",
+      "host": "@",
+      "ttl": 3600
+    },
+    {
+      "pointsTo": "%dcv%",
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two new Domain Connect templates for the GoDaddy Airo App Builder service:

- `godaddy.com.aab.json` — connects an apex domain (sets A record for root, CNAME for www, and ACME challenge CNAME for SSL provisioning)
- `godaddy.com.aab_subdomain.json` — connects a subdomain (sets A record and ACME challenge CNAME for SSL provisioning)

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — both templates set `"syncPubKeyDomain": "domain-attach.api.godaddy.com"`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — `warnPhishing` is absent from both templates
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — neither template uses `redirect_uri`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — neither template contains TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — neither template contains TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — `%v1%` (A record IP) and `%dcv%` (ACME challenge CNAME) are bare variables; both are justified: an IP address cannot carry a fixed prefix by nature, and the ACME challenge value is fully prescribed by the CA
- [x] no bare variable is used as the full `host` label — all `host` values are fixed strings (`@`, `www`, `_acme-challenge`)
- [x] no variable is used in the `host` field to create a subdomain — subdomain targeting is handled via the Domain Connect `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — none of these records (A, www CNAME, ACME challenge CNAME) are independently user-modifiable in normal operation; `essential` is not required

## Online Editor test results

**Editor test link(s):**

[Test godaddy.com/aab example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF%2F%2BPGoC%2F%2B1V32%2FaMBD%2BVyxLPJWE%2FCiwIk0qG2iqxrp27Z4qFB2OCd5C7NlOUlbxv%2B8MocDa7mkPm9QnLuf7zvfdd2ceqOVLlYPldPBAlZaVSLm%2BSOmAZjKFNF35TC5p%2B%2FHoEpYYSj%2FIkTvEA8N1JRjfQABme08TORRakqFS5F0pckyAARXXRsiCDsI2zWUmv%2BocAxfWKjPodOq69lO5BFEwWRScWV%2FqrFMrDz8tL2ynVLmE1HSiIAo6QdRpCk1cqqTgta%2BKDG9JuWFaKLu5iY4LmOXcECDb3MRKUkv9ndTCLkhDhzxXLGjhoKOjdFVIhCF2wcnFFUGo5sYQOd94HH%2BufZKyahfEuLZiLhj2mVSQixRcHvL%2Bcvhp7BwlJ3Opyc3NhGwa7dojisx33VwV7KqcfeSr0aZwvHzLwANrgS18UMI%2F1kpzJnVq6OAOJZWisOZWIqxVhS08tSu10QXNhTQWzXPntahB3AuCdfsIdL5HbKrdo1CnP%2BBayL71IjYBtuQeW0Ce8yLjR3mm6zb9KQue7GlM2w1nhPJ7wIHlDdUmH1qZlqVKxC5egYalcUO9Q94dQac77B11dhU6i4R%2B5Mf%2BqfNg%2Fc4FMxZGsY%2BCivnqqM%2BuTpEVUvPE4C%2FYUiNTq0vepssytyKBGvaulCWgVL5CWgZPMTeqc6BFsV0X12%2BcDkDzsZqD7rRpkjLHSrh9687ezCE%2Bm3lzBnPvlPVTD%2FgMvG486%2Fd7vTSO5tHB7j6z1k%2B3d99RHGlcNwFuOYd5DStD107l3yRtCt%2BOQ1P6sUj%2FQfVPB7Jh8rL%2B%2FxKvaRtn%2FnWeXufpb80TPoAGKp4m4MLwn7bnBT0v6t6GwSA4G8RdPwr6cS88CfA7cLVzY7cUH%2FBdPHwR6Si6LsYnk89nZXkTKT75NqrG4TUElZzE4f0PcfulJ%2B6F%2FqGW2Vu6%2FgVqB2L4kggAAA%3D%3D)

[Test godaddy.com/aab_subdomain example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB3%2BPGoC%2F%2B1U72%2BbMBD9VyxL%2FTQgQNIsIE1auqZV1aWt1K4fVkXoYgyxSjCzDSyr8r%2FvnB9NqLR%2B3qR9At%2FdO%2B695%2BOFGr6sCjCcxi%2B0UrIRKVdXKY1pLlNI05XH5JI6r6kbWGIpvZTnNokJzVUjGN9AAOaJruepXIIoD7kdZiyUJOOqIme1KLAVuT8qbbjSQpY0DhxayFx%2BUwVCFsZUOu712rb1tqVMliVnxpMq77WVi0fDS9Orq0JCqnuhH%2Fo9P%2Bzthk9sq6TkrVeVOX4l5ZopUZnNl%2BikhHnBNQGCQ7vb%2FsRI0kr1TFphFmRHk7wd3Q4MSlj4eadlExChiVlwcnVHEKq41kRmm4hVgyuPpKzZFzGujMgEQ%2F1JA4VIwfYhX27G04kN1JxkEoW6%2F0o2BliJRJl7VttVye7q%2BTVfnW81jOmWgQvGAFt4UAmv66HiTKpU0%2FgJrZaiNPpBIuykCU4wa1bVxiV8XUht8PWzjRr0oT%2F0%2FbXTBSGLI9Rm4gMyAbbkLltAUfAy550%2Bs7VDf8mSJ4dxZs5udoTyn4AXku9G3vVDf%2FCQK1lXidhDKlCw1Pbe7sFPHfRsD3%2Fa4PHYBPZAAi%2F0%2Bt7ARpCFDcGcBWHfQ3tEtuqoZqcVeSkVTzQ%2BwdQK%2BRpVc4cu68KIBFo4hFKWQFUVKySnMYu9UesjZcvtKmz5oNuAh9d5jlRyaJIyS03YvRqczkfZaZa5URCN3EE0ZC6Mhr4LfR4Nwj5kERY7763ve1va0RjvK%2B6TALt946KFlaZra%2F0bn3c83vjsdXj9WdS%2FlujMwYv137F%2FyTFcYg0NTxOwlfj%2FH7r%2B0A1PHwI%2F9kdxGHl%2B9DEaRh98PPuWCNdmy%2FcFd%2Ft4q%2Bnl92I6ve7nV7fyuf9jOrkN1QMvVJbdNexicHHzeFaGjwuYnKXtJ7r%2BDSBq4To8BwAA)