### PR TITLE
Add DMARC record to ImprovMX email template

### DIFF
--- a/improvmx.com.email.json
+++ b/improvmx.com.email.json
@@ -3,9 +3,9 @@
     "providerName": "ImprovMX",
     "serviceId": "email",
     "serviceName": "Email Forwarding",
-    "version": 1,
+    "version": 2,
     "logoUrl": "https://improvmx-public-assets.s3.eu-west-3.amazonaws.com/improvmx_logo.svg",
-    "description": "Set up the DNS records needed to forward emails for your domain with ImprovMX: MX records for inbound mail, SPF for forwarding, and DKIM for sending through ImprovMX SMTP.",
+    "description": "Set up the DNS records needed to forward emails for your domain with ImprovMX: MX records for inbound mail, SPF for forwarding, DKIM for sending through ImprovMX SMTP, and a DMARC policy.",
     "syncBlock": false,
     "hostRequired": false,
     "syncPubKeyDomain": "improvmx.com",
@@ -46,6 +46,16 @@
             "host": "dkimprovmx2._domainkey",
             "pointsTo": "dkimprovmx2.improvmx.com",
             "ttl": 3600
+        },
+        {
+            "groupId": "dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none;",
+            "ttl": 3600,
+            "essential": "OnApply",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1"
         }
     ]
 }


### PR DESCRIPTION
# Description

Adds a DMARC record to the existing ImprovMX email forwarding template (`improvmx.com.email.json`) and bumps the template `version` from 1 to 2.

Major mailbox providers (e.g. Yahoo) now require senders to publish a valid DMARC policy with at least `p=none`. Today the ImprovMX template provisions MX, SPF and DKIM but no DMARC, so domains onboarded via Domain Connect have no policy. This adds a `_dmarc` TXT record defaulting to `v=DMARC1; p=none;` (monitoring-only, safe to apply on a user's behalf).

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- Apex (`example.com`, all groups incl. dmarc): [Test improvmx.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB80PWoC%2F%2B1XXXPaOhD9Kxq91ji2CZS4k5lyQ9NmWqeZQKbpzWQ8wpJBjW25kgy4GfrbuzIfhiS03Pty27l5wt5dnd0j7R6Ze6xZmidEM%2Bzf41yKCadMnlHsY56a13RmRyLF1tp3TlKIxWeVN7gGj2JywiNWLWIp4UltWwa%2FMVZ0KuSUSMqzEQRMmFRcZNj3LJyIkbiSCQSOtc6Vf3Cwyt3Ii2HCowZRimllq6bNisaUKd1o2iQl30RGpsoUuF4RGjBbTUwOylQkea6rPLjPNCpypMcM9c77SLJISKpQxhhlFGmB4kV9qOKgzCsqRSERFWDI0JTrMVrR9lFwvYYwkTwbiiKjyKy1UP%2FitLLGa8oW6r0%2FCyqjYpmxQCVSFKMaE%2FWDwYWFCKAQ1Au6lycoF8C%2BtM2Glln0VyKiO%2BzHJFHMwmOh9CX7WnDJ6Npowi6K4XtW9qqqH5%2BjibhkFFZF%2BskYi%2BS5%2FWDRkin2b%2B7xCKrOq8NOZ%2BDSZW6OuOoEUxI8vzbtInim1UBUYa79qJm4kFyX2HcdgNBw9s2248ytfwXv7Yb3dsOrPK7x4cCC7QzgviwSpszuZFFSUOaDaTvTNiC942mNeHLeDd7UkMa5WOna4aKj7li5zWQz5gGjHRz2TOntkdLbN2VKZFTnHFwP6ozhykmJJvA%2BOa7a2H2F8uNMZOzVJqyFGUx1pjkxk%2F8x6%2BZ5YqrTM30ishgaXwdER2MYlUBQk%2BtCspjPng5Z%2BuqceH47tzAoBAvr7r2F0lY9z2YElI8t2S4ZwFNFNeRV%2FKIHF52y3OsFRQDKiSSpMrK5grzZwrxdgd5g81zB%2FhQSyuWjTEgWKvglupBAWssCxjotEs1DAlqyNtEoJGbHgJ0CLyDDbG5OS7bQ3tf1cfysrx7OZEgjQ42bI2%2B53pHLWKvhDaO4cdhp0cYwfgmqHHfoy0Pmup3m0cYN8dTt8dQdUW%2F5ZiN0kykpFZ6brvsVHW8vOt5vRmcxMo%2F5TI6hK1y0S23Qd5IkK45A8TdjtRKfJa%2Bdercku4%2FW%2FSEEvV8Q9P4Qglt9%2BQ%2Bl%2FD%2Fjsbo35vNbC%2BT9WQOfNfBZA5818P%2BqgfChqciE0ZCYOM%2Fx2g2n3fBaA7fptzp%2Bq2U3vU7nsPPCcXzHMfXDn%2BkFvXv4%2Ftz88sSletdPe0U8Fd%2FGH2nZ%2F%2Fv0y4vgS%2FfkQ%2Fm5E12NPjgyOThqv21ffbo7xvMfZ%2BAs7koQAAA%3D)
- Subdomain (`example.com`, host `mail`, all groups incl. dmarc): [Test improvmx.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJc0PWoC%2F%2B1X227bOBD9FYKvlVRZvm1VBNhs0mCzrdzUcYoAgSHQ0tjmRhK1JOXLBu63dyjJt9QJjH3ZFvBTwpnhmTnkzKH8RDWkecI0UP%2BJ5lLMeAzyOqY%2B5alZpgsnEim1Nr4eSzGWXpfe4B49CuSMR1BugpTxZGurgz8YK7kScs5kzLMJBsxAKi4y6nsWTcRE3MkEA6da58p%2F%2B3ad286LUcIjmykFWjmq6UBhz0Fpu%2BmwlP0rMjZXpsDNjtCAOWpmcsSgIslzXeaht6BJkRM9BXLZuyUSIiFjRTKAGGKiBRlX9ZGSgzJLshSFJLFAQ0bmXE%2FJmrZPgvsNhInk2UgUWUzMXovc3lyV1vGGskUuP14HpVFBZixYiRTFZItJboPBjUUYojByGZz3L0gukP3SMQe6zKI%2FEhE9Un%2FMEgUWnQql%2B%2FBPwSXEG6MJuylGH2F5WVb94z2aiD7EuCvSB2MslufOs001U%2Bo%2FPNEJVp2Xl50u0KWXubnishNMSfj%2F76ZdBM%2B0GogyrOH80ExcSK6X1G%2B4CKHx7psd111Z%2Fwneexneexle5eMtPl5YsJ8B3f0iAWVOJ4uSIgYfTfuZ9gHjR55uES9658GHLaRxVjsbTlh11CMs95nsxjxj9AKHI1N6R6T0jk2ZMhltcw7uB9uM4doZM81wPTsr27jxnuRnmcjg%2FS6sRQGnOtOcmcn%2FnJ3neWKq0wt9IbIxNr4OmI6mOCqBiE2uGwljvjgcUvu2OelquLIoKgSE2%2B4dYmnrnocFQ%2BWDmm3NoJavkm7Iyz1VH1bdUp93RRPBciZZqox0rmEf9nCHa%2BCHCnlYQ78Ki2XzSSYkhAr%2FMl1IJK9lgeOdFonmIUNN2ZjiKGTm5JClQi8i44zuTk1WaXDNrL6Z11rs%2BXiGcWQYcnP73rt2pxGNmd1y3ZbdanWb9mj0bmy3G93fOl6rA13wdh6LQw%2FJoedi%2F%2FR3%2B%2BI8mbOloivThEew8o5i5f2ErKpBOkhrdoZt0iAvyRD5xpJkTRWZ%2FoTk1spU0zsshs4%2B62PU8Bdi6h3D1PuFmO41bKX8zvO%2BfVX%2B%2F1dC6%2FdmtRpa%2BCycNPOkmSfNPGnmSTOP00z8kFVsBnHITKzneh3b7dhee9Bo%2Ba7rt9uO2%2FTa7cYbXLiu4YA%2F2iuKT%2Fh9u%2FtlS%2F%2F6%2B%2BtdW4ziXl99uuv2Hr%2BoLx70g4H%2BOrl%2B8%2FnPabcQV96S5RLmZ3T1HX958iKyEAAA)
