### PR TITLE
Add mailblastr.com.email template (Amazon SES email sending)

### DIFF
--- a/mailblastr.com.email.json
+++ b/mailblastr.com.email.json
@@ -1,0 +1,17 @@
+{
+  "providerId": "mailblastr.com",
+  "providerName": "MailBlastr",
+  "serviceId": "email",
+  "serviceName": "MailBlastr Email Sending",
+  "version": 1,
+  "syncPubKeyDomain": "mailblastr.com",
+  "syncRedirectDomain": "www.mailblastr.com",
+  "description": "Enable email signing (DKIM) and specify authorized senders (SPF) for sending through MailBlastr (Amazon SES).",
+  "variableDescription": "domainKey is the BYODKIM public key (base64); region is the SES region (e.g. us-east-1); mailfromhost is the custom MAIL FROM subdomain label (e.g. send).",
+  "logoUrl": "https://www.mailblastr.com/logo.svg",
+  "records": [
+    { "groupId": "outbound", "type": "MX", "host": "%mailfromhost%", "pointsTo": "feedback-smtp.%region%.amazonses.com", "priority": 10, "ttl": 3600 },
+    { "groupId": "outbound", "type": "SPFM", "host": "%mailfromhost%", "spfRules": "include:amazonses.com", "ttl": 3600 },
+    { "groupId": "dkim", "type": "TXT", "host": "mailblastr._domainkey", "data": "v=DKIM1; k=rsa; p=%domainKey%", "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `mailblastr.com.email.json` — a Domain Connect template that configures email **sending** for [MailBlastr](https://www.mailblastr.com), a developer email platform built on Amazon SES. It installs the records a domain needs to send authenticated mail: a DKIM key (BYODKIM public key), an `SPFM` SPF record + MAIL FROM MX on the custom MAIL FROM subdomain.

The record set mirrors the already-merged `resend.com.mail.json` (same Amazon SES records). `dc-template-linter` reports **no warnings or errors** for this file.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://www.mailblastr.com/logo.svg (200, `image/svg+xml`)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description — **see justification below (`%mailfromhost%`)**
- [ ] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead — **see justification below**
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Notes on the checklist:**
- This template contains no DMARC or other uniqueness-sensitive TXT record, so `txtConflictMatchingMode` is not applicable; the single DKIM key TXT uses a fixed selector host (`mailblastr._domainkey`).
- The MAIL FROM host is the variable `%mailfromhost%`. The SES custom MAIL FROM subdomain is chosen per domain by the user (default `send`), so the MX and `SPFM` records must use it as the host. This matches the merged `resend.com.mail.json`, which uses `%spfDomain%` the same way, and the linter reports no issue.
- No DMARC / user-removable record is present, so `essential: OnApply` is not applicable.

## Online Editor test results

<!--
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
-->

**Editor test link(s):**
[Test mailblastr.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG%2BFPWoC%2F%2B1WW0%2FbShD%2BKytLSKCSxA6JSVLxYCcOGJN72oRWKFrba2fja3fXNg6iv%2F3sBgihpZXOWx94sVZz2flm5ptZP0gMRWkIGZI6D1JKkhy7iJiu1JEiiEM7hJSRqpNE0uleO4QRt5YGXK%2Fv9FxHEcmxg3aOSHi%2Byn4zB4YwADMUuzj2uWGOCMVJLHUU7lTGzjizLVT2Em4WvwdE2EyRiwly2N6qKIrqb5Yuog7BKdvdLhkxtEMEdvgAxX7Mw4PjnmUOTgCMXUBT5GCvBDBj64TgLeIiDpKjA8ezcf8EeAnZSYQfW5Mk89fgIK9jLYLbJAYzY3ZSFXlBgkXE3hsU7g4xTxBgym9BQL8dCQwgzewQOyDgmmMbUqQ2Tj4Dgnzu9mLKb36RHKOqXwUZrSAeu6JwU5GWR5JonVD24uBklCURGGjmDehPRwNAM%2FsJAAihjcLna0RSO8hh4idfSMhhrhlLaadW%2B72uNWFUpbloHW9BQlwqdb4%2FSD4vSLpjQJIxO8lilxuwMt11f8nPAhg%2FHx0CPRLESnDM6DzhOg8h14ZOUKERS6tHT7keVeGusBTRPRUxbxArOWVkHoNxwGeqLD%2Be%2Fh0Fb%2BLgLzho6k2zEPFsJBw7Yeaizq%2BB%2FxDKDXD0Gma%2BnL9GOajd6qnyvMGCmpBBrs4vRO%2BVzyC4IBR%2BBunF0Z4gR28C3j2eShwLWr3W%2FO70mU1i6u4hH2T0jPM5OD%2FtQK7wi30KCYyoGPYXz%2B9vXO9efL9L4nxYIiETRBHyp8YIyZ6B0h4Nhy40A9PUzY021P3gxzrAl%2B1C1rWJ0de0UVebtDSh7%2FoWPxsaKWAcO%2Bd2Pc1Kt6UE7Wn3%2FqY9miySrqNp%2FSi6aspNNzeb%2FlUJvxUbdTPz7YaFXThptKLi%2BnxTux3oCxnNdZKgeHj2w9CHzctGudgWuhxtNTfwyq%2BBifWZNt2qoxzihVkL60mgFv66dn3TNcYLue1o%2FV7ZVdVRZkwHJdzEzm3GZvg8SEdpPTAtSKylz27beC4Xzrwu65ferVkvgntbwZN0aU48a9nKnJY6msiG7zFjMVim48SxvljfWt1tY1xezmeN8%2BlmfJldk8Zm0J5lX1t671NuGBMyjJJFc2pEi8vaWe71rcxXIMuvWWh5a7xguE%2BGOFDHVi1NzfVWXn7xdJoHZ%2BkMbSZ60Uy3zlmrZ0VX94NpbzzpfSrMnjbRdEkwh2%2B7hKCV2HqQZYTTlJEM8QZnIcMrWMBXkeusYJqGJSca5VreSj7ch3McP230HRf2RH47uXtWVP84Qb9O8cp1BC2xmCdPtmW3DZVK47zRrDRgXalAu8k%2FzpnsearLlejgRXr%2FvXrvTXqdC0Q5foah2HVaWMCSSo9iqN%2FM8LuZ5hd8USjg3RUBfsIwfJvlP5zX%2F95NHyP9j4z0P8ewu1P%2BunzsiY898bEnPvbE3%2FYE%2F0ukMEfuCgqzulxXK7JaqTfnSrvTaHaaSrXVaKlN%2BZMsd2RZJIAoeyLaA%2F%2BPOfyDkZRercSmvk0Vzeivx%2Bry27pb5vFVsHbktT4emDbMy7k%2F7KW3F9LjfyLedp3sDgAA)

[Test mailblastr.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI6FPWoC%2F%2B1WW2%2FiOhD%2BK1GkSq1aIAQIl1UfEghtyHKnC%2B2qQk5igsl1bSdpqHp%2B%2B7GhpbDtnofztA99S%2Bbi%2BWbmm7GfRQqD2AcUiq1nMcZRihyIDUdsiQFAvuUDQnHRjgLx6qAdgIBZi32m13Z6piMQp8iGO0fIPd9lH8wFnRsIUxg6KHSZYQoxQVEotsrMKQ%2FtUWKZMO9EzCz8DAi3mUAHYWjTg1WWZcUPlg4kNkYx3Z0u6iGwfCjs8AkEuSELL5x3TKN%2FIYDQEUgMbbTKBZDQdYTRFjIRA8nQCefTUfdCWEV4J%2BF%2BdI2jxF0LR3mdqwHYRqEw1acXRZ4XwIhH7JygcHaIWYICIuwUKGj3Q45BiBPLR7bgMc25BQhUqhffBAxd5vZmyk5%2Bk5zDolsUElKALHahzEx5WiscBeuI0DcHOyE0CoS%2BanwXupNhXyCJtQcg%2BMCC%2FusxPKkdZD9yozvsM5hrSmPSKpU%2B1rXEjYok5a1jLYiwQ8TWz2fRZQWJdwyIEmpFSegwA5rHu%2B4v2DcHxr7PjoGecWJFKKRkFjHdCkLHArZXIAGNi2f7XM%2BKYFdYAsmBiog1iOaMMhKLQRngiiJJL1f%2FjYI1sf8fOEi8miQ%2BZNmIKLT9xIGt3wP%2FIZTjoeA9zGwxe49yVLvlvvKswZyagAKmTq9578vfBO8aE%2FBNiK%2FPDgQ5Own4%2BHIlMixw%2BV7zx6tXNvGpewJskOErzqPg7G8HdInefGKAQUD4wL95%2Fzxxf3zz%2F7k%2FgP0fl4rLOWG4fN8gLjkwUTygYilwTd8wNGOjDjTX%2B7X20E0zkzR1rHdVddhWxw2V69uuyb51FWcgDO26JcdJ7jTKXnPSfvreHI7nUdtW1W4Q3NakmpMaNfc2Bw%2FZRtlMXatqIgeMq40g69U3pfu%2BNpfgTMMRDAeVX7o2qN1U8%2Fk206RgqzreKv%2FhGUibqpOtMkwBmhslX448JXPXpd73tj6aS01b7XbytqIME33Sz8EmtO8TOkV1Lx7GsmeYAJsLl9430UzK7JksaTere0POvCerjMbxwhivzEUjsRvKcCzp7orq8%2F4iHkW2eWc%2BNNrb6ii%2FmU2r9clmdJP0cHXTb06THw2tc5nq%2BhgPgmhem%2BjB%2FKZUSVddM3HLgKY96purNZpT1MUD5CkjsxTHxnorLe5WGkm9SjyFm7GW1eKtXWl0zOD2qT%2FpjMady8zoqGNVEzmD2NaLMFzy7QdoghldKU4ga3DiU7QEGXgXOfYSxLGfM8IRpmWtZEN%2BPM%2FhfrNzLhRfmfbK6tMxPlCj%2BMdx%2Bn2kl47N%2BYn4cFm2A2qK1CxUalVQqEr1aqFhVWGhYtlyvd6Q6k5FPrqePr%2B8PrugTocEEpYIRYAvP9XPQE7EFz7lJ0P955TTa7Y%2BysKni0P4B%2Fj%2Babp%2FeYKfbq0PGf%2B%2Bur4m%2FS%2BZ9L%2BSao9X7PL5WiFfK%2BRrhXytkP%2B5QtjbkoAUOkvATWVJVgqSUpBrs3KzVVVaslys1OSaJF1KUkuSeBKQ0D3Zntnr5%2FjdI4Kn7jRFg87WJk3nsn1fLdu6XL%2BN7IeuWpPy4cO817u77Pb6ZeNafPkXRx06pSoPAAA%3D)

