### PR TITLE
Adding getfernand.com.email.json template

### DIFF
--- a/getfernand.com.email.json
+++ b/getfernand.com.email.json
@@ -1,0 +1,36 @@
+{
+    "providerId": "getfernand.com",
+    "providerName": "Fernand",
+    "serviceId": "email",
+    "serviceName": "Email Sending",
+    "version": 1,
+    "logoUrl": "https://app.getfernand.com/images/favicon/icon_512.png",
+    "description": "Configure DNS records for sending emails with Fernand (https://getfernand.com).",
+    "variableDescription": "%dkimSelector%: DKIM selector identifier; %dkimPublicKey%: DKIM public key (base64)",
+    "hostRequired": false,
+    "syncPubKeyDomain": "getfernand.com",
+    "syncRedirectDomain": "getfernand.com,app.getfernand.com,fernand.app",
+    "records": [
+        {
+            "groupId": "dkim",
+            "type": "TXT",
+            "host": "%dkimSelector%._domainkey",
+            "data": "k=rsa; p=%dkimPublicKey%",
+            "ttl": 3600
+        },
+        {
+            "groupId": "return-path",
+            "type": "CNAME",
+            "host": "fernand20220202._domainkey",
+            "pointsTo": "fernand20220202._domainkey.getfernand.com.",
+            "ttl": 3600
+        },
+        {
+            "groupId": "return-path",
+            "type": "CNAME",
+            "host": "fbounces",
+            "pointsTo": "pm.mtasv.net",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Domain Connect template for **Fernand** (https://getfernand.com).
Contains DKIM and two CNAMES for allowing Fernand to send emails on behalf of the domain in question.


## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

[Test getfernand.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAZWPmoC%2F%2B1VW2%2FiOhD%2BK1GklXZVLiFAoKz6kBaWIlpoFyjVVhUyyRAMie3aTlJa9b8fG8IC3W51dM5LHyohMJ7LN%2FPNxc%2BmhIiFSILZeDYZpwn2gXd8s2EGIGfACSJ%2BwaORmfst7aFIaZs%2FNkIlEMAT7MHaCiKEw91dptvSt8YAiI9JoKQJcIEpMRulnBnSgI54qLTmUjLRKBYRY4VD9CKOUACiOEPKKSVF%2FTWpluwCW7vzQXgcM7l2aZ5RMsNBzMFo9gYGB49yXxgzyg2xCcBYBymMFMu5kaVhfN2iHyJ%2FK%2BhwEcdoGkLzAOeLv8TRAELwJOVfGkaz27lUEJv%2FhmKKSDzDwL8ba82reBpirwurrSpbXxhLWBlfp0iAU%2FmmsOZUyJ%2FwEGMOis8ZCgUoNlfEU%2FbKuElV7OSt8midn%2BArO0%2F%2BRSv3J7O57VmJlJOMLbNx92wGnMZsXVQdvhLKFdPFHN4Oszj%2FIKEw8dfIKiddFiSRUlmecIG%2BG%2BzkFQ3ao1R1LzuW9ZLbx%2BMgY07yDMn5Dvas5162dsBZ3LZlq49lHyIziokUQ%2Fqu3ismCv8znimNiQfiEJ1FhUgikRQIyAP%2F9y8584kSmOwYv1eMbesGj0iNJWSlzSDUaR3TBG%2F1GeIoEnp0t5Z3B6b3W9s7U5%2F3a6XvWKQYcSzHdrbS39XRYtypUqcSdX79YkOvdNxsP67sUuo2j08v%2BspsccVK6aDd9xcO7Q57dXdsLxed1XLxNIakRW5FYHXH7Xi2PLtktDVI2%2BPzdnPeOhYPzbl8qF0Njkbh%2BDxOaq2ge3FEmO2yUfTYj0USwnUnkm5%2FMb%2Bau8su7%2F0YCS%2B5CR7STtO9dk9NzR4OCOUwEeoXqfKokkgeq1mJ4lDiCUrR7sr3Jqq9w5UiWyipyk2190E3k82e2hHyfid%2FXGb2eixnTnxP9wbWPVxDlVptWivlq3Wo5yulejlfn9Xr%2Banlg%2BVV%2FGOvVtpb8m8%2FAW9t%2Bl1zghB65yG9y90wRSthvuhBejUwGdfvDnBG%2BH8b3o%2Be%2BG5TZGn%2BbUt8jETuc2rVfA7M58B8Dsy%2FHBj1mAqUgD9BWk1PSN5y8rYzLFmNcrVRtQp2xapWy0eW1bAsnQAIuUntWb1s%2B2%2BamXrXw3L%2F6SKt3NzcYumwxHY6vRkQ77E%2FWJ67F6PT8KxNzmupODFf%2FgGwrUjI0AsAAA%3D%3D)

[Test getfernand.com/email example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF91PmoC%2F%2B1VW2%2FaShD%2BK5alSq3CxTbEKVR5oIESRAKkwKEnUYQWe2wv2Lub3TWXRPnv3TVQcJr24fSlR4pkYbxz%2BWa%2BueyTKSFhMZJg1p9MxukS%2B8A7vlk3Q5ABcIKIX%2FJoYhZ%2BSHsoUdrml61QCQTwJfYgs4IE4fhwttNt6VNjCMTHJFTSJXCBKTHrdsGMaUjHPFZakZRM1MtlxFgpj17GCQpBlAOknFJS1j%2FTU9spscydD8LjmMnMpXlBSYDDlIPR7A0NDh7lvjACyg2xDcDIghTGCsvI2KVhvN%2Bj55E%2FlHS4iGM0i6GZw3nnL3AyhBg8Sfm7utHsdq4VxPbbUEwRiQMM%2FJORaQ7SWYy9Lmz2qiw7MBawMd7PkAC3%2BkFhRVTIr%2FCQYg6KzwDFAhSbG%2BIpe2XcpCp28lp5tM5X8JWdJ3%2BhVfiZ2cL%2BvxIpJzu2zPrdkxlymrKsqDp8JZQbpos5%2BjbaxfkTCaWpnyGrnHRZkERKZXHOBfpksPMXNGiPUtW94lrWc%2BEYj4NMOSkyJKMD7EWvcd06AO%2FidixHPZaTR2YUEylG9Ld6L5go%2FWE8M5oSD0QenSWlRCKxLBGQOf%2F3zwXzkRKYHhi%2FV4zt6wZrpMYSdqXdQYh0pj6ysKZ4b8IQR4nQ07s3vstZ3%2B%2FN7zJ7DXJUMX3MEsWLa7mOu5f%2BqJEW484pdatJ5%2FaWjTy71myvN469ajRrn6%2F6ymw%2BYPZq2O77c5d2R72PjYmzmHc2i%2FnjBJYt8k2EVnfSToPFxTWjreGqPblsN6NWTTw0I%2FlwNhiejOPJZbo8a4XdqxPCnAYbJ%2Bt%2BKpYx3HQS2ejPo0HUWHR578tYeMt%2FwodVp9m4aXw2NYc4JJTDVKg3UkVShZE8VROTpLHEU7RChyPfm6omjzeKcqGkKjfV5LmeJtttdSDkuFu27L%2Fs6b%2BXnaNuK5hT39MtgnU3BxVkz2ozu1izHa9YrX5ERQTWrHjmuzpvp%2BJBcLTuX78MXtv5uTYFIfQCRHqxN%2BIV2gjzWU%2FVi%2BnZUf6bKc3x%2Ft%2Bm%2BX%2BQ%2F2575LP91fb4a%2FK5L6gV9DZFb1P0NkV%2FMkXq2hVoCf4UaU0NV7TcouOObKderdUrpyXHcWqn7oll1S1L5wBCbrN7Unfg8e1n3qYXMxIswpu130tWk39X0fU4vXxsTfqVs%2BqVDRErDxiD9cS6OTefvwMEZupoAAwAAA%3D%3D)