### PR TITLE
Add mailblastr.com.click-tracking template (custom open/click tracking domain)

### DIFF
--- a/mailblastr.com.click-tracking.json
+++ b/mailblastr.com.click-tracking.json
@@ -11,6 +11,6 @@
   "logoUrl": "https://www.mailblastr.com/logo.svg",
   "hostRequired": true,
   "records": [
-    { "groupId": "click-tracking", "type": "CNAME", "host": "@", "pointsTo": "%trackingedge%", "ttl": 3600 }
+    { "type": "CNAME", "host": "@", "pointsTo": "%trackingedge%", "ttl": 3600 }
   ]
 }

--- a/mailblastr.com.click-tracking.json
+++ b/mailblastr.com.click-tracking.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "mailblastr.com",
+  "providerName": "MailBlastr",
+  "serviceId": "click-tracking",
+  "serviceName": "Custom Open/Click Tracking Domain",
+  "version": 1,
+  "syncPubKeyDomain": "mailblastr.com",
+  "syncRedirectDomain": "www.mailblastr.com",
+  "description": "Configure a custom domain for open and click tracking — links render on your own subdomain instead of the shared host (better domain alignment + reputation isolation).",
+  "variableDescription": "trackinghost is the tracking subdomain label (e.g. t); trackingedge is the MailBlastr tracking edge the CNAME points to (the host that terminates TLS for customer tracking subdomains).",
+  "logoUrl": "https://www.mailblastr.com/logo.svg",
+  "records": [
+    {
+      "groupId": "click-tracking",
+      "type": "CNAME",
+      "host": "%trackinghost%",
+      "pointsTo": "%trackingedge%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "caa",
+      "type": "CAA",
+      "host": "%trackinghost%",
+      "data": "0 issue \"amazon.com\"",
+      "ttl": 3600
+    }
+  ]
+}

--- a/mailblastr.com.click-tracking.json
+++ b/mailblastr.com.click-tracking.json
@@ -7,22 +7,9 @@
   "syncPubKeyDomain": "mailblastr.com",
   "syncRedirectDomain": "www.mailblastr.com",
   "description": "Configure a custom domain for open and click tracking — links render on your own subdomain instead of the shared host (better domain alignment + reputation isolation).",
-  "variableDescription": "trackinghost is the tracking subdomain label (e.g. t); trackingedge is the MailBlastr tracking edge the CNAME points to (the host that terminates TLS for customer tracking subdomains).",
+  "variableDescription": "trackinghost is the tracking subdomain label (e.g. t); trackingedge is the MailBlastr tracking edge the CNAME points to (the host that terminates TLS for the customer's tracking subdomain).",
   "logoUrl": "https://www.mailblastr.com/logo.svg",
   "records": [
-    {
-      "groupId": "click-tracking",
-      "type": "CNAME",
-      "host": "%trackinghost%",
-      "pointsTo": "%trackingedge%",
-      "ttl": 3600
-    },
-    {
-      "groupId": "caa",
-      "type": "CAA",
-      "host": "%trackinghost%",
-      "data": "0 issue \"amazon.com\"",
-      "ttl": 3600
-    }
+    { "groupId": "click-tracking", "type": "CNAME", "host": "%trackinghost%", "pointsTo": "%trackingedge%", "ttl": 3600 }
   ]
 }

--- a/mailblastr.com.click-tracking.json
+++ b/mailblastr.com.click-tracking.json
@@ -6,10 +6,11 @@
   "version": 1,
   "syncPubKeyDomain": "mailblastr.com",
   "syncRedirectDomain": "www.mailblastr.com",
-  "description": "Configure a custom domain for open and click tracking — links render on your own subdomain instead of the shared host (better domain alignment + reputation isolation).",
-  "variableDescription": "trackinghost is the tracking subdomain label (e.g. t); trackingedge is the MailBlastr tracking edge the CNAME points to (the host that terminates TLS for the customer's tracking subdomain).",
+  "description": "Configure a custom domain for open and click tracking — links render on your own subdomain instead of the shared host (better domain alignment + reputation isolation). Apply this template at the tracking subdomain (the host parameter).",
+  "variableDescription": "trackingedge is the MailBlastr tracking edge the CNAME points to (the host that terminates TLS for the customer's tracking subdomain).",
   "logoUrl": "https://www.mailblastr.com/logo.svg",
+  "hostRequired": true,
   "records": [
-    { "groupId": "click-tracking", "type": "CNAME", "host": "%trackinghost%", "pointsTo": "%trackingedge%", "ttl": 3600 }
+    { "groupId": "click-tracking", "type": "CNAME", "host": "@", "pointsTo": "%trackingedge%", "ttl": 3600 }
   ]
 }


### PR DESCRIPTION
# Description

Adds `mailblastr.com.click-tracking.json` — a Domain Connect template that configures a **custom open/click tracking domain** for [MailBlastr](https://www.mailblastr.com), a developer email platform built on Amazon SES. It lets a sender serve open/click tracking links from their own subdomain (e.g. `t.example.com`) instead of the shared host, for better domain alignment and reputation isolation.

The template is applied **at the tracking subdomain** (the Domain Connect `host` parameter) and installs a single record there:
- **CNAME** `@` → `%trackingedge%` (the MailBlastr tracking edge, which terminates TLS for the customer's tracking subdomain)

`hostRequired` is `true`: the tracking subdomain is supplied via the `host` parameter rather than a bespoke variable (per linter DCTL1039 / the merged `ulama.ai.customdomain` pattern). No customer-side CAA record is included: because the tracking host is a CNAME, a CA performs CAA checks by following the alias to the MailBlastr edge zone (RFC 8659 §3), so CAA authorization is controlled at the edge, not in the customer's zone — and DNS forbids a CAA from coexisting with a CNAME at the same name.

It is a companion to the already-merged `mailblastr.com.email.json` (#1292). `dc-template-linter` reports no warnings or errors (only an informational note, addressed by using the `host` parameter).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://www.mailblastr.com/logo.svg (200, `image/svg+xml`)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Notes on the checklist:**
- The tracking subdomain is supplied via the `host` parameter (`hostRequired: true`), so no variable is used in any `host` field — the single CNAME uses `host: "@"`.
- This template contains no TXT record, so the SPF and `txtConflictMatchingMode` rules are not applicable; there is no DMARC or user-removable record, so `essential: OnApply` is not applicable. The single CNAME is the template's purpose.

## Online Editor test results

<!--
  Required. Run the template in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
  load -> Check template -> set domain + host (the tracking subdomain) -> Test apply -> Copy Markdown.
  hostRequired=true, so a single test with a host set is sufficient (apex test not required).
-->

**Editor test link(s):**

[Test mailblastr.com/click-tracking example.com/t](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOGPQGoC%2F91Ua2%2FaMBT9K5alaa3KwzwGNNKkdbTauq4vRqWtXYVMcglWEzuzHShD%2FPddmwToqPYD9imx7zn3nnt97CW1kGYJt0CDJc20mokI9HlEA5pykYwTbqyuhSqllU30iqeIppcY%2F%2BjjGDOgZyIETwwTET5Vrebhk5DxNljw%2BrmxKiXXGch630HJsICSU4VFJTJmoI1QkgYNZC9keJOPL2BRhF%2BR5jADiISG0G5Q8%2Fm8toeMwIRaZNZnp30lJyLONRBOwrWuyNPJRGmiUCLhMiK%2BI1J2RH7mTdZok0TIJ0M0SJwJUZIsVI7fuSQmHxdZhDQWeETUhNgpEDPlGiIyVcaSgzFYi8QCyRMRyxSkJUeYMsstdxKJMCrxf4c1cpJlyQLzCEPKQyPc%2BsQbadvSB27fV8q4xsljrcOaGy3Xgo8TOH0xiDIBRDEQVwDJ2wPe5vdxF%2BxfnVyekUwJaRGtdsrZqRMFOhUSFRoy%2FPrNT9MB1jMG%2Fda8ItnLS1Ss7nSCkqbWZiao1%2FePse5ANTNz3nIlB%2FArx6NH71mdQ4WiC5SODA0eltQuMm86J7eA4%2FKDs7PXPlS4fLPb%2FhuMWYsKWh3GVo%2BrCv2tJIy2SR%2FRRaXH4JnjSUBhriK7xd9YqzwbiZLgz8C4O1ZSH15wH0vyA7JxsSvIbxbrvw3t5KFxlIaRwS%2B36OVyDGmeWDHic77disIRdy7CbgxGMfP%2BiOT6mromIm75jjn2b9NmThU6ikLXnnAvQKc76bVZ%2BK7KjttQbfMuq%2FbYuFGNjvkYWq1JK2x3dh6U15%2Bbfz4pO5MGY%2FDaCO48c5LM%2BcLQ1eqxglP%2FX3tDfxg%2Bg2jEHa7Jmp0q61SbvSFrBawbNFq1XqPbbLEjxgLGXCtg7LrfJfpl1yl08uO8e9u%2Fjgc3wzqCvs9O72afLuX97d3ndnwWN24u7p%2B%2FDGz7WMbv6eoPLQla2i8GAAA%3D)