### PR TITLE
Add Kodo status-page template (kodostatus.com)

### DIFF
--- a/kodostatus.com.status-page.json
+++ b/kodostatus.com.status-page.json
@@ -1,0 +1,19 @@
+{
+    "providerId": "kodostatus.com",
+    "providerName": "Kodo",
+    "serviceId": "status-page",
+    "serviceName": "Status page",
+    "version": 1,
+    "logoUrl": "https://kodostatus.com/apple-touch-icon.png",
+    "description": "Configures a sub-domain for use as a Kodo status page",
+    "syncPubKeyDomain": "kodostatus.com",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "kodostatus.com",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
Adds a Domain Connect template for **Kodo** ([kodostatus.com](https://kodostatus.com)), a hosted status-page product.

- **Provider:** `kodostatus.com`
- **Service:** `status-page`
- **Record:** a single `CNAME` (host → `kodostatus.com`) so a customer's subdomain serves their Kodo status page. SSL is provisioned on our side via Cloudflare for SaaS.
- **Signed:** `syncPubKeyDomain: kodostatus.com` (public key published at `_dck1.kodostatus.com`).
- `hostRequired: true` — the subdomain is supplied at apply time.

Validated with `dc-template-linter -loglevel error -tolerate info -logos` → no errors.