### PR TITLE
Add mailblastr.com.domain-verification template (domain ownership TXT)

### DIFF
--- a/mailblastr.com.domain-verification.json
+++ b/mailblastr.com.domain-verification.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "mailblastr.com",
+  "providerName": "MailBlastr",
+  "serviceId": "domain-verification",
+  "serviceName": "Domain Verification",
+  "version": 1,
+  "syncPubKeyDomain": "mailblastr.com",
+  "syncRedirectDomain": "www.mailblastr.com",
+  "description": "Verify domain ownership for MailBlastr.",
+  "logoUrl": "https://www.mailblastr.com/logo.svg",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "ttl": 3600,
+      "data": "mailblastr-domain-verification=%verificationToken%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "mailblastr-domain-verification="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `mailblastr.com.domain-verification.json` — a Domain Connect template that proves **domain ownership** for [MailBlastr](https://www.mailblastr.com), a developer email platform built on Amazon SES.

It installs a single apex **TXT** record with a prefixed value:
- `@ TXT "mailblastr-domain-verification=%verificationToken%"`, with `txtConflictMatchingMode: Prefix` so re-verification updates the existing record instead of duplicating it.

It is a companion to the merged `mailblastr.com.email.json` (#1292) and the `mailblastr.com.mail-send-and-receive.json` (#1293). `dc-template-linter` reports **no warnings or errors** for this file.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://www.mailblastr.com/logo.svg (200, `image/svg+xml`)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Notes on the checklist:**
- The single TXT uses a fixed `@` host and a prefixed value (`mailblastr-domain-verification=%verificationToken%`) with `txtConflictMatchingMode: Prefix` + `txtConflictMatchingPrefix`, so the bare-host, bare-value, subdomain-via-variable, and SPF rules do not apply.
- The record is the template's sole verification record (not a user-modifiable record like DMARC), so `essential: OnApply` is not applicable.

## Online Editor test results

<!--
  Required. Run the template in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
  load -> Check template -> Test apply (apex AND subdomain) -> Copy Markdown.
-->

**Editor test link(s):**

[Test mailblastr.com/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIMYQGoC%2F%2BVTXY%2FaMBD8K8jSPR2BEAIJkSq1vapVS6lQj57aIhQ58QasJnGwHSAg%2FnvXfBxQqK7vfYqdmdnd8e5uiIasSKkGEmxIIcWCM5AfGQlIRnkapVRp2YhFRurP6BeaIZsMEH%2B7wxFTIBc8hp2QCZTm1gIkT3hMNRf5iXEQv9txak%2BXHJQocwpayK%2FyeFhGfaj23FsVGc5XYFxCrJ9Zy%2BWyccVkoGLJi12egOzSVrV9oTWxzDHvjBe1RMjayVYDdamYim8yRc1M60IFzeZ1%2BKYhNdRiinysREimSDDeEF0Vxuro%2BwiBmVAaL6%2FxqDXGa3dtG8uiml4Ys2483qu789tI%2FIL8zoRZ6QeRJymP9YDqeMbz6UAwk3EoIeGr25QD9mJOsp1s62QtcghPnib1Q3NRDyuKgwOH9z3Yw9NUirII%2BZFfUEkzZYbrqBxfSCdH7ZiY85VTA2TRvrbKaic96sRe1AKfEVMgn%2BZCQqjwS3Up0b2WJdRJVqaah3RJT79YHNKiSCv0oxDFwH%2F2KN%2FPpunRvzXmL4VdtDhksXHPzWZErte2e93Y8nuub7ldx7b8hEZWxFq9xAPX7VH%2FbNFur%2BHLq3ZqBigFuebUDPCbdEkrRbbbSR0b8796xxlTdAEspIbm2E7XsruW441aftD2gk6n0fFabsu9t%2B3Ato0dUHr%2FIhuct%2FNJIw8%2FnR%2BP771y%2FST6eX%2B4cH1n%2Fem%2BzDiwD48amnOnPW%2FP9WeVurhPvwEMY0L5awUAAA%3D%3D)


[Test mailblastr.com/domain-verification example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALQYQGoC%2F%2BVT72%2FaMBD9V5ClfioBJwFCI03aj2pb11KxjU6VKhQ5thOsJnFqO4QU8b%2FvHGgpK1P3fZ9i597z3bt7t0aG52VGDEfhGpVKLgXj6oKhEOVEZHFGtFE9KnPUfY5ekxzQaALxj20cYpqrpaC8JTIJ1MJZciUSQYkRstgjduTzFtP5dYgBiran0AV8U9BpFV%2FyZos9VpHF%2FOBMKE7NM6qu694rJOOaKlG2eULUpm0620I7si4g70KUnUSqzl5WD3iZTOWNyoCzMKbUYb%2F%2F%2Bvm%2BBfX0MgU8VCIV0yi8WyPTlFbq7HYGgYXUBi7v4WgMvOePMIayiCEHwpwjzXt38vI2k%2Fe8OLHPrMwnWSSZoGZCDF2IIp1IZjNOFU%2FE6jhkF3szJ9rMN130KAse7TXNu7vhAp%2BvCBiH7%2Fq7k6erGC6pklUZiSdKSRTJtfXXE%2FnugD1%2Fot%2B1%2FHnrg0O9NpbH2wobx0%2FOiEeD2OVjhmyZIi2k4pGGLzGVgh4YVfEuyqvMiIjUZP%2BL0YiUZdaAKg1RePjPSRVbh26l%2FNuA%2FlLawagjRm0LhN2QoU%2FoKMDEGdFg4Axc%2F8yJPS92MMEjOmQBw7H7YuGOr%2BPbK3cwFK41L4wg1ssfspo0Gm028y4M6L9uALhNkyVnEbFID3sjB48cL5i549Afh4NBz8U4GA5PMQ4xtoq4NtumrMF5Lz2HTi8e6vr2azz94i%2FLy%2B%2F3%2Ffjn%2BLNXFcpLr8%2B%2FXXnJQ7Ly3ebmKr2H%2FfoNnc9nGnsFAAA%3D)