### PR TITLE
Create vantapanel.com.hosting.json

### DIFF
--- a/vantapanel.com.hosting.json
+++ b/vantapanel.com.hosting.json
@@ -9,7 +9,6 @@
   "variableDescription": "%ip% = the public IPv4 address of your Vanta Panel hosting server.",
   "syncPubKeyDomain": "vantapanel.com",
   "syncBlock": false,
-  "warnPhishing": true,
   "records": [
     {
       "type": "A",
@@ -45,6 +44,9 @@
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=none;",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply",
       "ttl": 3600
     }
   ]

--- a/vantapanel.com.hosting.json
+++ b/vantapanel.com.hosting.json
@@ -7,14 +7,45 @@
   "logoUrl": "https://vantapanel.com/assets/icon-512.png",
   "description": "Point your domain at your Vanta Panel hosting server: website (A records), mail (MX + mail host), and email authentication (SPF + DMARC).",
   "variableDescription": "%ip% = the public IPv4 address of your Vanta Panel hosting server.",
+  "syncPubKeyDomain": "vantapanel.com",
   "syncBlock": false,
   "warnPhishing": true,
   "records": [
-    { "type": "A",    "host": "@",      "pointsTo": "%ip%",          "ttl": 3600 },
-    { "type": "A",    "host": "www",    "pointsTo": "%ip%",          "ttl": 3600 },
-    { "type": "A",    "host": "mail",   "pointsTo": "%ip%",          "ttl": 3600 },
-    { "type": "MX",   "host": "@",      "pointsTo": "mail.%domain%", "priority": 10, "ttl": 3600 },
-    { "type": "SPFM", "host": "@",      "spfRules": "a mx include:spf.brevo.com" },
-    { "type": "TXT",  "host": "_dmarc", "data": "v=DMARC1; p=none;",  "ttl": 3600 }
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "mail",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mail.%domain%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "a mx include:spf.brevo.com"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600
+    }
   ]
 }

--- a/vantapanel.com.hosting.json
+++ b/vantapanel.com.hosting.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "vantapanel.com",
+  "providerName": "Vanta Panel",
+  "serviceId": "hosting",
+  "serviceName": "Vanta Panel Hosting",
+  "version": 1,
+  "logoUrl": "https://vantapanel.com/assets/icon-512.png",
+  "description": "Point your domain at your Vanta Panel hosting server: website, mail, and email authentication (SPF, DKIM, DMARC).",
+  "variableDescription": "ip = the hosting server's public IPv4; dashes = your domain with dots replaced by dashes (for Brevo DKIM).",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "records": [
+    { "type": "A",     "host": "@",                  "pointsTo": "%ip%",                         "ttl": 3600 },
+    { "type": "A",     "host": "www",                "pointsTo": "%ip%",                         "ttl": 3600 },
+    { "type": "A",     "host": "mail",               "pointsTo": "%ip%",                         "ttl": 3600 },
+    { "type": "MX",    "host": "@",                  "pointsTo": "mail.%domain%", "priority": 10, "ttl": 3600 },
+    { "type": "TXT",   "host": "@",                  "data": "v=spf1 a mx include:spf.brevo.com ~all", "ttl": 3600 },
+    { "type": "TXT",   "host": "_dmarc",             "data": "v=DMARC1; p=none;",                "ttl": 3600 },
+    { "type": "CNAME", "host": "brevo1._domainkey",  "pointsTo": "b1.%dashes%.dkim.brevo.com",   "ttl": 3600 },
+    { "type": "CNAME", "host": "brevo2._domainkey",  "pointsTo": "b2.%dashes%.dkim.brevo.com",   "ttl": 3600 }
+  ]
+}

--- a/vantapanel.com.hosting.json
+++ b/vantapanel.com.hosting.json
@@ -5,18 +5,16 @@
   "serviceName": "Vanta Panel Hosting",
   "version": 1,
   "logoUrl": "https://vantapanel.com/assets/icon-512.png",
-  "description": "Point your domain at your Vanta Panel hosting server: website, mail, and email authentication (SPF, DKIM, DMARC).",
-  "variableDescription": "ip = the hosting server public IPv4; dashes = your domain with dots replaced by dashes (used for the Brevo DKIM CNAMEs).",
-  "syncPubKeyDomain": "vantapanel.com",
+  "description": "Point your domain at your Vanta Panel hosting server: website (A records), mail (MX + mail host), and email authentication (SPF + DMARC).",
+  "variableDescription": "%ip% = the public IPv4 address of your Vanta Panel hosting server.",
   "syncBlock": false,
+  "warnPhishing": true,
   "records": [
-    { "type": "A",     "host": "@",                 "pointsTo": "%ip%",                          "ttl": 3600 },
-    { "type": "A",     "host": "www",               "pointsTo": "%ip%",                          "ttl": 3600 },
-    { "type": "A",     "host": "mail",              "pointsTo": "%ip%",                          "ttl": 3600 },
-    { "type": "MX",    "host": "@",                 "pointsTo": "mail.%domain%", "priority": 10,  "ttl": 3600 },
-    { "type": "SPFM",  "host": "@",                 "spfRules": "a mx include:spf.brevo.com" },
-    { "type": "TXT",   "host": "_dmarc",            "data": "v=DMARC1; p=none;",                 "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" },
-    { "type": "CNAME", "host": "brevo1._domainkey", "pointsTo": "b1.%dashes%.dkim.brevo.com",    "ttl": 3600 },
-    { "type": "CNAME", "host": "brevo2._domainkey", "pointsTo": "b2.%dashes%.dkim.brevo.com",    "ttl": 3600 }
+    { "type": "A",    "host": "@",      "pointsTo": "%ip%",          "ttl": 3600 },
+    { "type": "A",    "host": "www",    "pointsTo": "%ip%",          "ttl": 3600 },
+    { "type": "A",    "host": "mail",   "pointsTo": "%ip%",          "ttl": 3600 },
+    { "type": "MX",   "host": "@",      "pointsTo": "mail.%domain%", "priority": 10, "ttl": 3600 },
+    { "type": "SPFM", "host": "@",      "spfRules": "a mx include:spf.brevo.com" },
+    { "type": "TXT",  "host": "_dmarc", "data": "v=DMARC1; p=none;",  "ttl": 3600 }
   ]
 }

--- a/vantapanel.com.hosting.json
+++ b/vantapanel.com.hosting.json
@@ -6,17 +6,17 @@
   "version": 1,
   "logoUrl": "https://vantapanel.com/assets/icon-512.png",
   "description": "Point your domain at your Vanta Panel hosting server: website, mail, and email authentication (SPF, DKIM, DMARC).",
-  "variableDescription": "ip = the hosting server's public IPv4; dashes = your domain with dots replaced by dashes (for Brevo DKIM).",
+  "variableDescription": "ip = the hosting server public IPv4; dashes = your domain with dots replaced by dashes (used for the Brevo DKIM CNAMEs).",
+  "syncPubKeyDomain": "vantapanel.com",
   "syncBlock": false,
-  "warnPhishing": true,
   "records": [
-    { "type": "A",     "host": "@",                  "pointsTo": "%ip%",                         "ttl": 3600 },
-    { "type": "A",     "host": "www",                "pointsTo": "%ip%",                         "ttl": 3600 },
-    { "type": "A",     "host": "mail",               "pointsTo": "%ip%",                         "ttl": 3600 },
-    { "type": "MX",    "host": "@",                  "pointsTo": "mail.%domain%", "priority": 10, "ttl": 3600 },
-    { "type": "TXT",   "host": "@",                  "data": "v=spf1 a mx include:spf.brevo.com ~all", "ttl": 3600 },
-    { "type": "TXT",   "host": "_dmarc",             "data": "v=DMARC1; p=none;",                "ttl": 3600 },
-    { "type": "CNAME", "host": "brevo1._domainkey",  "pointsTo": "b1.%dashes%.dkim.brevo.com",   "ttl": 3600 },
-    { "type": "CNAME", "host": "brevo2._domainkey",  "pointsTo": "b2.%dashes%.dkim.brevo.com",   "ttl": 3600 }
+    { "type": "A",     "host": "@",                 "pointsTo": "%ip%",                          "ttl": 3600 },
+    { "type": "A",     "host": "www",               "pointsTo": "%ip%",                          "ttl": 3600 },
+    { "type": "A",     "host": "mail",              "pointsTo": "%ip%",                          "ttl": 3600 },
+    { "type": "MX",    "host": "@",                 "pointsTo": "mail.%domain%", "priority": 10,  "ttl": 3600 },
+    { "type": "SPFM",  "host": "@",                 "spfRules": "a mx include:spf.brevo.com" },
+    { "type": "TXT",   "host": "_dmarc",            "data": "v=DMARC1; p=none;",                 "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" },
+    { "type": "CNAME", "host": "brevo1._domainkey", "pointsTo": "b1.%dashes%.dkim.brevo.com",    "ttl": 3600 },
+    { "type": "CNAME", "host": "brevo2._domainkey", "pointsTo": "b2.%dashes%.dkim.brevo.com",    "ttl": 3600 }
   ]
 }


### PR DESCRIPTION
# Description

Adds a Domain Connect template for Vanta Panel Hosting (`vantapanel.com.hosting`). It points a customer's domain at their Vanta Panel hosting server: A records for the website (apex, www, mail host), an MX record for mail, an SPF record via the SPFM merge type, and a DMARC TXT record. The only user-supplied variable is `%ip%`, the hosting server's public IPv4 address.

DKIM is intentionally not included because Brevo generates per-domain DKIM CNAME targets that cannot be expressed as a static template; customers configure those separately using the values Brevo provides.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)


# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [[Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver


# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [[Template Quality Guidelines](https://github.com/Domain-Connect/Templates/blob/master/README.md#template-quality-guidelines)](https://github.com/Domain-Connect/Templates/blob/master/README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)


## Online Editor test results

**Editor test link(s):**

[Test vantapanel.com/hosting vantapanel.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL5TQGoC%2F%2B1W72%2FaMBD9VyxLlToNUvMr0ExIY6umtRMb6%2BhUrarQxTHUmmNnthOgFfvbZwcYsFJt2qdW6ieMfff83t3lyXfYsjQTYBmO7nCmVcETpk8THOECpIUMJBMBVSmu%2FD79CKmLxl%2F9ORr4AHdomC44ZWXmjTKWy8lm934Gev87pmDacCVxVKtgoSbqQguPYW1moqOjXRZHYAyz5ohTJautWj3ISoiEGap5ZksYPFBcWjRXuUaJSoFLBKu%2F2wRWJJGnyHSEpiw23DJ02EOaUaUT86KCXLZAh%2F1L9HK59EluG2SCWLkBub1h0nIK%2FnJ0%2BGXwzsWe9Hvnb18EXhxoDrFgJzsMD3h2gLrIpaIsjwWn6HRQNBEkiWbGIDX%2BG10PbeaSDvL4A5uflCr3tczHvBGKfsfRGIRhFbzShqOrO2znmW9LzwV6eLd87dvsy2eGasXT7VjrOtIICVlU9iVNp9P%2FSfP1%2B%2Be8%2FuWDJD1OcLDs9EE5plxpbuduoMh%2BMNek%2Fi6cycbnuWCuLBhQOkNcUpEnLHL7QaxZocp6bkEML4cbhFGSgqZ%2BDsGCb0O3HIDaK5R1pZLslRc1s2%2BVHLte2z5YeuN62VeJhxpoNuaz%2FSGrsw2kC3MT4icO%2FFfySfayTMx3ina9qOBbd%2Bto0%2BprR%2B3BGVmJcKuJVnk24uuUDDSkxvvCOvnqz%2BzrdfoV9mue%2BVXnOKjV2kGrGYRt7NnwiVSajYz7BZtrJ9rq3M1imgvLRzCFzVZCR%2BAVOfLGnTq43TmVSyd5vSn2zm1bdai4tlBPnntLipuNGADa1QQapNoktF6NwyapEnLc7tAGJe12uGVx%2Bw1wv8dt6rfdmZ6YwtzgxR%2Bzv%2BK%2F%2FGSesoLV1%2FvkJJRGcn%2BKShO5d9eWjl1XeWyqlnZ0X1bRdQ5WQw97GvoJQqyVOqGPXds%2FWe0jmb61OS8W1xXnp89G9mxkz0b2bGRP2sjcI89AwZIR%2BLg6qYdVElbr7WG9HrVI1OgEHdIKj9svCYkI8RqYsUuJd%2B4luP0GxF%2F17WfTMrfyR%2FEtjPvDmaWsCaetj5OzMBUXVn1%2Fd3beORnM%2BEUXL34BvXahUKoOAAA%3D)

[Test vantapanel.com/hosting vantapanel.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEtTQGoC%2F%2B1W72%2FbNhD9VwgCAVLUluUfslMVBuY26FYMXt3W2bIGgXES6YSYRBIkJccLvL%2B9R9murVTBhn1qi3ySSN493rt3etA9dTzXGThO43uqjSoF4%2BYtozEtQTrQIHkWpCqnrS%2Bnv0GO0fR3f05mPgAPLTelSHmVeausE%2FLmsPt1BvnlS0zJjRVK0rjbopm6URcm8xjOaRt3OvUqOmAtd7YjUiXbUbcX6AqCcZsaoV0FQ2dKSEfWqjCEqRyEJLBbHhewK5L4ErmJyYonVjhOTifE8FQZZp%2B1CGZn5HR6SZ5vX30SboNkhFcbULhbLp1IwV9OTj%2FO3mDs%2BXTy4fWzwJMDIyDJ%2BHmtwhOhT8iYYCrRRZKJlLydlQMCjBluLVHLfyvXQ9u1TGdF8itfn1csmyTzMa8ylf5F4yVklrfojhuNr%2B6pW2svywQDPTy%2B%2FuRl9u2zc7WrE3ecQ0X6wzDctJqSVqvV%2F0nz%2FfvPedPLR4v0OMHJVumTakyFMsKtcaDCZjAUaVqHs3r5ocg4toUCye%2BIkGlWMB7jfpAYXqqqn0cQ88v5AWHBcjCpn0Nw4GUYVwPQfUn0WCrJX3pSd%2B61kkvU2k3Bpbeo5VQxDzUzfCnumkN2ZwdIDMMJ8RMH%2Fit5JydaZ%2Bta0643Lfo33ro4SH2NpT06IzUVb4wq9ELsszQYyK23hn3%2B1UOA6z3CVQWBS6H94uxF0O2OgmgQDEfU1yRupDJ8YfEJrjBI3ZkCJzIvMicWsILDFksX4HkhBYunCFefVrn1k23Ju6bX7jvqRwvlST0D4a2JcZ5wBtAeJX3eHowi1k5YcobLMGHDKIySUXRkdc1G2Ox1tT4eizTJVrC2dPPgMziQCH4IItV3%2BP0yqRymabAqXl9deESmbjjfILWtWTVxK8focF3yuOeRfyDL9nSR7XdAcOvGwQOeDY787Yzj3sY3m%2BsW2u6T2T2Z3ZPZPZndD292%2BLNooeRsAT60F%2FaG7XDY7o3mvV48OIsH%2FSCKBlG%2F9zwM4zD0NLh1W5b3%2BEd5%2FC9J8%2FWQT2Zhf3AB5fI2f5dNpn90PxU%2Fh5868z8v3vMJe%2FWRyVS%2FuXg%2FppvPgtxYufgOAAA%3D)