### PR TITLE
add CloudBac, CloudBac Custom Domain

### DIFF
--- a/cloudbac.org.customdomain.json
+++ b/cloudbac.org.customdomain.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "cloudbac.org",
+  "providerName": "CloudBac",
+  "serviceId": "customdomain",
+  "serviceName": "CloudBac Custom Domain",
+  "syncPubKeyDomain": "cloudbac.org",
+  "syncRedirectDomain": "app-sites.cloudbac.com",
+  "version": 1,
+  "logoUrl": "https://app-sites.cloudbac.com/cloudbac-symbol.svg",
+  "description": "Point your domain at your CloudBac website and validate its SSL certificate.",
+  "variableDescription": "cnametarget - CNAME target for routing traffic to CloudBac; ownervalue - Cloudflare custom hostname ownership token; acmevalue - ACME SSL validation (DCV) token",
+  "hostRequired": true,
+  "syncBlock": false,
+  "records": [
+    { "type": "CNAME", "groupId": "cname",      "host": "@",                   "pointsTo": "%cnametarget%", "ttl": 300 },
+    { "type": "TXT",   "groupId": "ownership",  "host": "_cf-custom-hostname", "data": "%ownervalue%", "txtConflictMatchingMode": "All", "ttl": 300 },
+    { "type": "TXT",   "groupId": "ssl",        "host": "_acme-challenge",     "data": "%acmevalue%",  "txtConflictMatchingMode": "All", "ttl": 300 }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template connecting a customer's custom domain to a CloudBac website (Cloudflare for SaaS custom hostname). It applies the traffic CNAME plus the Cloudflare custom-hostname ownership TXT and the ACME (SSL DCV) validation TXT. Subdomain-only by design (`hostRequired: true`), since the traffic record is a CNAME and a CNAME cannot live at a zone apex.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
  - **Justification (bare by necessity):** the two TXT data values are bare because the DNS provider must publish the *exact* opaque token the validating system issues, with no prefix: `%ownervalue%` is Cloudflare's custom-hostname ownership token and `%acmevalue%` is the ACME (SSL DCV) token — a prefix would break validation. The CNAME `pointsTo` (`%cnametarget%`) is the service's fixed routing host, the same pattern as the merged `unkey.com.custom-domain` template. All three are guarded by fixed hosts and (for the TXTs) `txtConflictMatchingMode`.
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)
  - **N/A:** none of the records are user-modifiable. The CNAME, ownership TXT, and ACME TXT are all service-managed and required for the connection/SSL to function; removing any breaks the service, so none are marked `essential`.

## Online Editor test results

**Editor test link(s):**

[Test cloudbac.org/customdomain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEJAQGoC%2F%2B1UbW%2FbNhD%2BKwSBAiti2bJsK7WLAkudrg3aBF2bDQUCwzhTZ5soJaokJdcL8t93lGTZToK2%2B9YB%2FSKB5HPP3T33cssdprkCh3xyy3OjS5mguUj4hAuli2QBoqvNinfatytICcun%2FvUlCHqxaEopsDYqrNNpolOQ2f7png2bVih23sK2mXhfLN7itrl64N0jPmAiDQrXYiDPAysd2m6LFjoldInGSk2QfocrvdJ%2FGUXwtXO5nfR6j5v1dofAbtOFVl1bescJWmFk7io6%2Fl7LzLGtLgyrc2TQHNvcNrjw5AyyhJWgZELaMuks%2B%2FjxHRNonFxKQXddHycYCQuF50dOREZyOTArdCxg06uzy1esOS61YUYXTmYr5gwsiYo53Tp%2FzvQmI8lBFehN%2FfVSgUFW14WttXWevcbZtczJ%2FDNmzxmIFHd2Z1Py6MNt4qew2G%2Fn07%2Bf1mAK3PN8wC8F1YOq7kyBdYleKi0%2B88kSlKUbKpY2ieWTm1vutnnVAj4bIlhRFnndMT6ehpKOv%2FtW8yrba03HJwdiPKEn56iSgzC867SU15%2Bujwjb1Pakc7EMagWCnQK%2BtODAu9hrVnn46qY6Wyop3CU4sSapL3XiHZ0p9WMRWKsOfHtlA7EGpTBbHfptJf9Pbmd3Hf6PznC%2BV3dGnLuZwK9A84zNIDQxbDabXYBzWZm0sh%2Bq5eMmrhwMpNbvgx3rzRHtbMd7UxHPGubvsB4U0iPvDaCf8lljV2niMWE%2FGgxH8emzMSxEgsv7Z2%2FRiugNElFWHRrQO2G510quMm1wbukPrjC4a9e0UE7OYQP7q0TMaTeoLUlr6ZUYHzZuVq%2ByWtGmko%2Fksi9Yh88T4cWUvjWGY4gH8WgYDBejOBj26QP9MQYhHcUQhiJMooNl%2B9gi%2Fsa6PSo3WouZk6CqHtrA1vK7B03bpPPIgHSPUvxuKf5vCR9P5XGy99voZ81t1qHR%2F9Wiv1r0J25RWtEWSkzm4JFRGMVBGAfR6XXUn0SnFHB3%2FCwexdFJGE7C0OeB1tVJ3tL2Ptzb%2FE%2Fx5qIciHT8OlavFifi4tOJunr7Oh%2F9IQZluoqzd2WvF30JB6F9we%2F%2BBQZ0DBLbCgAA)

Tested with `domain=example.com`, `host=www` (subdomain). Apex test is not required because `hostRequired: true`.
