### PR TITLE
add HotDAM, HotDAM Newsletter

### DIFF
--- a/hotdam.media.hotdam-newsletter.json
+++ b/hotdam.media.hotdam-newsletter.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "hotdam.media",
+  "providerName": "HotDAM",
+  "serviceId": "hotdam-newsletter",
+  "serviceName": "HotDAM Newsletter",
+  "version": 1,
+  "description": "Adds DNS records that let HotDAM Newsletter send authenticated email from a branded sending domain.",
+  "variableDescription": "dkimSelector: DKIM selector assigned to the sending domain. dkimPublicKey: DKIM public key without the p= prefix. sesRegion: Amazon SES feedback SMTP region.",
+  "syncPubKeyDomain": "domainconnect.hotdam.media",
+  "syncRedirectDomain": "hotdam.media",
+  "hostRequired": true,
+  "multiInstance": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "p=%dkimPublicKey%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "p="
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.%sesRegion%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the HotDAM Newsletter template for branded sending-domain DNS setup. The template creates DKIM, SPF merge, and feedback MX records for a host-scoped newsletter sending domain.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A: no `logoUrl` is declared)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set -- this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain` -- the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) -- use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary -- prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label -- the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain -- use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (N/A: no DMARC or other independently user-editable policy records are included)

## Online Editor test results

**Editor test link(s):**
[Test hotdam.media/hotdam-newsletter adventurelab.com/updates](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD2QQGoC%2F%2B1WbW%2FiRhD%2BK6uV%2BHTgGkyAWMoHB5IelyNHAlVPF0Vo8Q6wYHt9u2s4GqW%2FvbPmzUDaSv1QtVK%2B7e7MPDPzzIv9Qg3EacQMUP%2BFpkouBQfV5dSnM2k4i50YuGC0vJfdsxh16UdpOkEP3zWopQihYFJJYKUjMAbUQX5kRu6LGktQWsiE%2BtUy5aBDJVKT32nAuSad%2BwFREEqFZzNjhqAhOcMhGhJOWGZmkBgRYkKcQMxERCZKxoSRsWIJx0erJ5Ip4RKliWP9MyXYOILOkW%2B%2BEPEAIgiNVD7p3HV7aLq5Eqa1mCYIZiSGBKeYxNr2s3EkwjtYb43T%2FE4WsCYrYWYyM7lpekVSBRPxw0EU%2FQhT9O6TIGa%2FyYQMbgZkAsDHLFyQQW%2FYRyKsgo1ar5MQfaCDTu7VhpwfQpkkGKZzUj%2Br%2F4hnpNLsLU50ZlKbR%2FieoRKW06gMyjTOIiO6iTYsCWH3uK0H9Z9eqFmntrLDr8MtAl5KRfZKzmgTGeaOKpwZhirpVemIphKKjImo7zVcF48%2FTFsmE5SZHjPhDOntSW4d9XO66JsqW5lFp6%2FlfWyD%2Fm3vEJytliUknTxmEWASFEmLMg4%2By2nHOjihjIvxFLB6X8%2BQUikSo4cSX3bVqujYpE5pX9KSc4qdKiGVMGtse7fo6fm1TFERRgeOn8vb0qIDxpfY4JmCiI23SNtgshSZxXTKdKpklo7EzjZlisXazvcO5ekc5nmH87QHsm4LZbQiBXnKW8m%2BdlbU63avu%2FPg%2Fnq6%2BD5biJ8vV%2B518HBzGwRf2sFDK7Dy9vQOzzcBopvNBB8GGGFupRput9ENF%2BjySxKtqzWvftFoti7d4Lrdsa73pObB6gowbSpVaonDqZQKRnY6mc3uqIlHbMUOTzwcsTSN1sizRilinfZysllZm5wLPewcmN738r%2BU%2FdGIjHhoiyrs5m1MvMtqy61WvOaYV%2Bow9ipjz4NKvdryahcu98J6q7DE31rwf7fIz9oMtLa7lkV2U0crttb0tTAoRyTmFJ7xtrzCIaySN8eP%2FM6i6H%2BVcL4Z%2FjLf4%2B2wb13nT%2FfO6Zr4TzLwXMYt8z4878PzPjz%2FYHjsB40tgY%2BY1a65tUbFbVRqraHr%2BW7Lr184tWazWat%2BcF3fdW1%2BOAEbSl7wi1f81lF1%2BS3i4bS3%2BBy2H26%2FzT%2FMsvkg5lXz6Rc2r39q%2FDS%2Ba%2F7an3sfwxb%2BH%2F0BEvF0evwLAAA%3D)
