### PR TITLE
Update gofarther.dev.email to v2 — self-hosted mail server records

### DIFF
--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -9,6 +9,7 @@
   "syncBlock": false,
   "shared": false,
   "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",
+  "syncPubKeyDomain": "gofarther.dev"
   "records": [
     { "type": "TXT", "host": "s1._domainkey", "data": "v=DKIM1; k=rsa; p=%dkimp%", "ttl": 3600, "txtConflictMatchingMode": "All" },
     { "type": "SPFM", "host": "@", "spfRules": "include:_spf.gofarther.dev", "ttl": 3600 },

--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -9,7 +9,7 @@
   "syncBlock": false,
   "shared": false,
   "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",
-  "syncPubKeyDomain": "gofarther.dev"
+  "syncPubKeyDomain": "gofarther.dev", 
   "records": [
     { "type": "TXT", "host": "s1._domainkey", "data": "v=DKIM1; k=rsa; p=%dkimp%", "ttl": 3600, "txtConflictMatchingMode": "All" },
     { "type": "SPFM", "host": "@", "spfRules": "include:_spf.gofarther.dev", "ttl": 3600 },

--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -2,18 +2,16 @@
   "providerId": "gofarther.dev",
   "providerName": "Go Farther",
   "serviceId": "email",
-  "serviceName": "Go Farther — send email from your domain (Sendra)",
-  "version": 1,
-  "description": "Adds the DNS records that let Go Farther / Sendra send email from your domain (Amazon SES DKIM + a DMARC policy).",
-  "variableDescription": "Your domain's three Amazon SES DKIM tokens.",
+  "serviceName": "Go Farther — send email from your domain",
+  "version": 2,
+  "description": "Adds the DNS records that let Go Farther send email from your domain: a DKIM key, an SPF include, and a DMARC policy.",
+  "variableDescription": "Your domain's DKIM public key (issued by Go Farther when you add the domain).",
   "syncBlock": false,
   "shared": false,
   "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",
-  "syncPubKeyDomain": "gofarther.dev",
   "records": [
-    { "type": "CNAME", "host": "%dkim1%._domainkey", "pointsTo": "%dkim1%.dkim.amazonses.com", "ttl": 3600 },
-    { "type": "CNAME", "host": "%dkim2%._domainkey", "pointsTo": "%dkim2%.dkim.amazonses.com", "ttl": 3600 },
-    { "type": "CNAME", "host": "%dkim3%._domainkey", "pointsTo": "%dkim3%.dkim.amazonses.com", "ttl": 3600 },
-    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none;", "ttl": 3600 }
+    { "type": "TXT", "host": "s1._domainkey", "data": "v=DKIM1; k=rsa; p=%dkimp%", "ttl": 3600 },
+    { "type": "SPFM", "host": "@", "spfRules": "include:_spf.gofarther.dev", "ttl": 3600 },
+    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none; rua=mailto:dmarc@gofarther.dev", "ttl": 3600 }
   ]
 }

--- a/gofarther.dev.email.json
+++ b/gofarther.dev.email.json
@@ -10,8 +10,8 @@
   "shared": false,
   "syncRedirectDomain": "gofarther.dev,lkpfeqrelvziltfwpuxi.supabase.co",
   "records": [
-    { "type": "TXT", "host": "s1._domainkey", "data": "v=DKIM1; k=rsa; p=%dkimp%", "ttl": 3600 },
+    { "type": "TXT", "host": "s1._domainkey", "data": "v=DKIM1; k=rsa; p=%dkimp%", "ttl": 3600, "txtConflictMatchingMode": "All" },
     { "type": "SPFM", "host": "@", "spfRules": "include:_spf.gofarther.dev", "ttl": 3600 },
-    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none; rua=mailto:dmarc@gofarther.dev", "ttl": 3600 }
+    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none; rua=mailto:dmarc@gofarther.dev", "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" }
   ]
 }


### PR DESCRIPTION
# Description

Updates the existing `gofarther.dev.email` template (originally #1285, Amazon SES) to Go Farther's own self-hosted mail server. Same `providerId`/`serviceId` (`gofarther.dev` / `email`); `version` bumped 1 → 2. Records change from the three SES Easy-DKIM CNAMEs to a single DKIM `TXT` (public key passed in as `%dkimp%`), an SPF include of `_spf.gofarther.dev` (via `SPFM`, so it merges), and a DMARC `TXT`.

## Type of change

- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — n/a (this template has no `logoUrl`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain` (neither is set)
- [x] `syncRedirectDomain` is set (used with the synchronous redirect flow)
- [x] no TXT record contains SPF content — `SPFM` is used for the SPF include
- [x] `txtConflictMatchingMode` is set on the unique TXT records (DKIM selector + DMARC)
- [x] no variable is used as a bare full record value (DKIM is `v=DKIM1; k=rsa; p=%dkimp%`)
- [x] no bare variable is used as the full `host` label (hosts are fixed: `s1._domainkey`, `@`, `_dmarc`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record (the user may modify their policy)

## Online Editor test results

**Editor test link(s):**
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM7dRGoC%2F%2B1UW0%2FbShD%2BK6uVqvaoSeQYlBSjSIQiWlSltEDVC0XW2DtJlqy97u7aYFD62zvrAEkovTxUOudIfbLn%2Fn0zs3PNHWaFAoc8uuaF0ZUUaA4Ej%2FhEj8G4KZqOwIq37oyvISNn%2FkKz%2FYWdbBZNJVNs4jADqZa679zZ5zIMupvMYi5Y48zGRmes1qVhQpMip%2BgKjZU651HY4gJtamThGpkPhbCMErG918fMYKpNI4NjCh1bqfOTAhEDtvfqYMRmWLcY5Oz4zT6TeapKgV4W3j4aHj1nhVYyrTseERgJicK9NTQfl0kf20XOokwoxqdmT6S1JQqW1KvALqaYezQMhGiYLOL%2F8VVsnae7SqczHo1BWSTNFAyKpUgORygkMXd7i27dm1VLzYoxfjGoqiup3PiiKC9lx5YFJGCxk%2BqbMm%2FK5BXWD%2Bcgl5vW8uj0mru68EM8%2BXBChqm2jgTb7cQL4MSU1AIckLoa%2BCZ0t9lsYCxss2LwSMxkVjwiF%2BcUjzZ6QUC%2Fl%2B65zsfUKDcCl05lPhlp4YsMleLz1l1NmsxoWXTHYy%2FGR6VCQsZvRhbFpOvcJ3BXbSXbGoNYZGDSNeh%2B5l0POtc5bjNTwsAvkNNR47vzwxq%2FYtTiaGkhnQQK4If5sChUzedn8xa%2FolLxsttnhOd2JngJ9Dr9zLIlbPqbGF0Wsbz1L8BAZv0Lvo08XQs9u4095f6%2FmYcXpufTasI9BjnJtcHY0hdcaQi1MyVtW1YqJ2O4gKVKpDF48ATZkpXy3F%2BQfPHkf3tBFjDWmhmL1NOR%2FqCEwUY%2FCAPR7ve7W%2B3NLqZtCMOAxKS3kfbFFuCzlfv04PF66EAt27k6mqG6gNry%2BXdLc8NqZ5UJrV2X%2FXgJ2VdoRv%2B%2FIPZnX8O%2Fx%2FPubc3PWvQ4%2Fi7n3%2BX8Ty4nHWILFYoYXAMj7LWDfjvongRbUfgs2ux1Nvv9cKP3NAiiIPAE0LoF%2FWu62Ku3mpuToHd8cPlyloze7n9Kqt33xr3Y6p0f7l7NhodPX2Zve9Pq3SwZnusBn38DlmOgvvUJAAA%3D
https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFXeRGoC%2F%2B1UW0%2FbMBT%2BK5YltE20VdICLUGV6ECgCcoYMGkTQ5ETn7SmTpzZTiFU3W%2FfcUNpy2V72MOExFNyjs%2Fl%2B85tQi2kuWQWaDChuVZjwUF%2F4jSgA5UwbYegGxzGtPbweMJSNKaHihxU7%2FhmQI9FDDM%2FSJmQC90Tc%2FKjaHr%2BBjGQcTIzJolWKSlVoQlXqMjQewzaCJXRoFmjHEysRW5nMu1xbggGIvsn50RDrPRMZpZIsGQpzx8SBISR%2FaNPfTKCskZYRs5PD4jIYllwcDJ37%2F3e2R7JlRRx2XCImBYskrC%2Fgub7Iug7U8XMiwh9XGjyXhhTACdRuQzsZgiZQ0MY5zMmlf8Hl8WUWfxRqnhEg4RJA6gZMg18IaLBGXCBzO1%2BVa1HvarJUZ7ATw1yfCekTW7y4lY0TJGziBloxOo%2BzWkRHUH5fAw0uS8tDS4n1Ja5a%2BLFtwt8GCpjUTB%2BI6yAI1NUc2YZqsddVwR%2Fh4y62rAdknfX%2BEik%2BRqaWCtp0NryPPy9tXsqS7BQts9sPBTZoK%2B4S9KTkk5rDzmxM%2F1F0l2HPU%2FOCgmIjN63LAhR13hM4CHbUrQVBiFPmY5XoLue%2Bw50pjLYIbpgXTdAVgUz290Xc%2FyNUY2CwYG0gqED%2FZz18lyWdHo1rdE7TBUuqn2FeOY9gVuG2%2Bl6li4VvohQGGhV5KGYu%2BRMs9S4JZ47X654X83dL2f%2BLonripOH18PxgDokYpApDaHBL7OFRuxWFzhzaSGtCNkNW6h4HDJHAYEbfMU4j8ckqxZ%2FZUwaFfYXR6WCslLWkMeOlXCnxUv8VsuPoO51Nlr1jWhjq97pwFa9ud2OIvA7CWwnS5fq2TP23KlaKexyn3ryhpWGTp9M0JzcKh2cQp%2B8PJPkF5tNwmthV%2B3Hk579w478V7oPSze9quHKvM3r27y%2BlnnFc23YGHjInGnTa27VvXbd8y%2B87aDlB57f8Df9zU5n3fMCz3McwNiqAhO868sXnXrH11qdqaz99aD9pbfXWofj5l58ZHl82OfHt4cHR%2F7gpLTrpvS6dPob8RIbeCEKAAA%3D