### PR TITLE
Add WorkRun custom domain template

### DIFF
--- a/workrun.app.custom-domain.json
+++ b/workrun.app.custom-domain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "workrun.app",
+  "providerName": "WorkRun",
+  "serviceId": "custom-domain",
+  "serviceName": "WorkRun Tenant Login",
+  "version": 1,
+  "logoUrl": "https://workrun.app/assets/workrun-logo.png",
+  "description": "Connects a customer-owned hostname to the WorkRun tenant login portal.",
+  "syncPubKeyDomain": "workrun.app",
+  "syncRedirectDomain": "workrun.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "tenant-login",
+      "host": "@",
+      "pointsTo": "login.workrun.app",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Domain Connect Template PR Draft

Use this when opening a PR against:

```text
https://github.com/Domain-Connect/Templates
```

Copy `docs/domain-connect/workrun.app.custom-domain.json` into the repository
root as:

```text
workrun.app.custom-domain.json
```

Then use this PR body.

---

# Description

Adds a new WorkRun custom-domain template. The template lets WorkRun tenants
connect an approved customer-owned portal hostname to `login.workrun.app` by
creating a single CNAME record through the provider's Domain Connect consent
flow.

The template uses the standard Domain Connect `host` parameter for the customer
hostname and sets `hostRequired: true`; it does not use `%host%` or any custom
host variable. Synchronous apply URLs are signed with a public key published at
`_dcpubkeyv1.workrun.app`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set - this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain` - the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) - use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary - prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label - the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain - use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes:

- The template has no TXT records.
- The template has no user-editable records such as DMARC, so `essential: OnApply` is not required.
- `syncRedirectDomain` is set to `workrun.app`; the current WorkRun flow does not require `redirect_uri`, but the domain is declared for provider compatibility.

## Online Editor test results

**Editor test link(s):**

[Test workrun.app/custom-domain example.com/portal](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABzFQGoC%2F91T247aMBD9lcivJZCkENhIlbradntjV11Ku6oQikw8hJTEztoTLkX8e8ekWWB7e%2B9TZM%2BZM2eOT3YMoShzjsCiHSu1WmUC9DvBIrZWeqkr2eZlyVqPpVteEJTdU3FUSSoY0KssgUNLUhlUhStUwbOT2nmPMwbJJTpDlR5AK9AmU5JFfovlKlWfdU7gBWJpok7nREWHGwNomivXgtulTIlDgEl0VuKBh10pKSFB43CnVgTaVWsJwlkog5LUOKgcXIDTSMJaUm4lOaXSyPO21b%2BVycdq9gG2r%2BqVnrpiASMQmaZxf4DYkSN4qAhDFqGuoMUIrrQwLJrsGG5La87V7eXNa4KnWlXlwcxak5v%2FtMny0O1L%2BxYqk2jGio6Havt8IiIZGHrefrpvse9KQnycNyWvGp2w4fT00E5UceSvl2%2BExFnTVXLNC2ND0vRPzgimDcOkobDTs1QqDbGhL8dKQ2NAUeWYxXzNj1ciiUl%2BviWxhqpE9Ks5sg7So0bBkf%2FDhBaLRWJlZ9ZT0e9fJNDvuz2%2FG7rdsBe4s3l37gIPfO77s9k8TE7C%2Fpv%2F4G9xf2ohUF4lZtzm%2BTJf861h%2B%2F20RXb%2Bp6tRCAxfgYi5BQdeELpe6AaDsRdGvW4UeO3BIPD74TPPizzPrgIG6013lJbTnLDSXN9dDJOl93b%2BbXv3Je0J6F9L7Xv3Q%2F4wGn598ylI3296z3GzfMH2PwBAgdXKyAQAAA%3D%3D)

The WorkRun tenant-login template is intentionally `hostRequired: true`. It
supports tenant subdomains such as `portal.example.com`; apex/root-domain apply
is not offered because the target record is a CNAME to `login.workrun.app`.
