### PR TITLE
add TensorHost, TensorHost Email

### DIFF
--- a/tensorhost.com.email.json
+++ b/tensorhost.com.email.json
@@ -1,0 +1,46 @@
+{
+  "providerId": "tensorhost.com",
+  "providerName": "TensorHost",
+  "serviceId": "email",
+  "serviceName": "TensorHost Email",
+  "version": 1,
+  "description": "Points your domain's email at TensorHost by adding the MX, SPF, DKIM and DMARC records needed to send and receive mail. Your website records are left untouched.",
+  "variableDescription": "dkimselector: the DKIM selector Stalwart generated for this domain. dkimkey: the base64 public key (the p= value of the DKIM record).",
+  "syncPubKeyDomain": "tensorhost.com",
+  "syncRedirectDomain": "tensorhost.com,console.tensorhost.com",
+  "records": [
+    {
+      "type": "MX",
+      "groupId": "email",
+      "host": "@",
+      "pointsTo": "mail.tensorhost.com",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "SPFM",
+      "groupId": "email",
+      "host": "@",
+      "spfRules": "a:mail.tensorhost.com"
+    },
+    {
+      "type": "TXT",
+      "groupId": "email",
+      "host": "%dkimselector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimkey%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "TXT",
+      "groupId": "email",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; rua=mailto:postmaster@%domain%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **TensorHost Email**, a hosted email service for small businesses. Applied to a customer's domain it sets the records needed to send and receive mail through TensorHost — MX, SPF (via `SPFM` merge), DKIM, and DMARC. Existing website records are not modified.

- `providerId`: `tensorhost.com`
- `serviceId`: `email`

## Type of change

- [x] New template

# How Has This Been Tested?

- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver — N/A, no `logoUrl` is set

Validation performed:
- `dc-template-linter` — zero errors.
- Local sign/verify round-trip of the synchronous apply query string (RSA PKCS#1 v1.5 / SHA-256, base64), with the public key reconstructed from the segmented `p=,a=RS256,t=x509,d=` TXT format — confirms the signature scheme matches the reference verifier.

The full Online Editor signed-flow test requires the public key to be published at `_dcsig1.tensorhost.com`, which is part of our go-live (in progress). We will add Online Editor results once that record is live.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on the DKIM and DMARC TXT records
- [x] no variable used as a bare full record value — DKIM data is `v=DKIM1; k=rsa; p=%dkimkey%`
- [x] no bare variable used as the full `host` label — DKIM host is `%dkimselector%._domainkey` (fixed `._domainkey` suffix)
- [x] no variable used in `host` to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is `OnApply` on the DMARC record

## Online Editor test results

Pending — see the note under "How Has This Been Tested?". The signed apply flow depends on the public key at `_dcsig1.tensorhost.com`, which is being published as part of go-live. The template passes `dc-template-linter` with zero errors and the signing scheme is verified by a local round-trip. We will follow up with Online Editor results once the key is published.
