### PR TITLE
Add Brimble custom domain template (brimble.io.domain)

### DIFF
--- a/brimble.io.domain.json
+++ b/brimble.io.domain.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "brimble.io",
+  "providerName": "Brimble",
+  "serviceId": "domain",
+  "serviceName": "Custom Domain",
+  "version": 1,
+  "logoUrl": "https://www.brimble.io/favicon.ico",
+  "description": "Point your custom domain to Brimble so it can serve your project.",
+  "variableDescription": "%cnameTarget%: Brimble gateway hostname for subdomain CNAME records. %ip%: Brimble A record IP for apex domains.",
+  "syncPubKeyDomain": "brimble.io",
+  "syncRedirectDomain": "brimble.io,brimble.app,app.brimble.io",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "subdomain",
+      "host": "@",
+      "pointsTo": "%cnameTarget%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "groupId": "apex",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `brimble.io.domain.json` for [Brimble](https://brimble.io) custom domain onboarding via Domain Connect (Cloudflare synchronous flow).

The template supports:
- **Subdomain** (`host` parameter set): CNAME `@` → `%cnameTarget%` (default `gateway.brimble.app`)
- **Apex** (no `host` parameter): A `@` → `%ip%`

Brimble signs apply URLs with an RSA key published at `_dck1.brimble.io`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`brimble.io`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`brimble.io,brimble.app,app.brimble.io`)
- [x] no TXT record contains SPF content
- [x] N/A — no TXT records in this template
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain — uses `host` parameter with `hostRequired: true` and record `host: "@"`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] N/A — no user-modifiable essential records

## Online Editor test results

**Editor test link(s):**
- Subdomain (`host=api`, `cnameTarget=gateway.brimble.app`, domain `stackfront.digital`, group `subdomain`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMSRQmoC%2F91UbW%2BbMBD%2BK5alfhqhQJO0RZq0rJnUtFrXNW21qYqQgUvqDTC1TVIW5b%2FvzEtC2uwPTCIB7uW55%2B45vKYa0jxhGqi%2FprkUSx6DnMTUp6HkaZiAzQW1tp4blmIk%2FVz70KFALnkEVUYsUsaznbEJviiUFikZt94lSMVFRn3XoolYiAeZYNSz1rnyj49Xq5W9K308Z4gkMhv%2FMDUGFUme6yqd3gqeaVKKQpKorlEzIFqQhiFRgnBNIpYRQwrqaOzmF0TaNmSY5AwDx3vIR1GG3O%2BZXIA%2B8rdgC5zTipXkWShtAshcSKKKsCl7cTP6%2BoVIiISMlU2OeN7JHTUOMrmt0lgOrw1fZYioMotui%2FAaymZQbxQw%2FjuIOaLoAxFW%2B8jy3MKfvZdsCN%2FBS4HZKJSWBVi04Un9pzXVZV4pZRrA8IUURV5Jum2uAUHTJ7MOZvLqXrwdFbq0RjVPho6zsba4oz1M0%2Fm%2F4XBoeyizjUX%2FiAyCHd%2BZ1a4aEtQs%2Bj2XItN2zBdcs2QHzXLeFg54ldnpB0FyJlmqzOK3cE%2BH8GYt4FOFiK%2Bdlo21WQu7I4GJ4rlxng5tvDwXL2Os2Lxhgh3yRSYkBArvTBcSWpHSItE8YCu2M8VRgAWSEgei0ItY7wXM6i%2BvHkDMNMOXQyw7g7ZoEEdmFtxo1PecCMIB68HAiXt91w17DPApGrDImZ%2BETgxe51h4f2AcPBf2dAGlINOcmY9%2FlCAzRTebmYXq%2Fk%2F9oOSKLSEOmIn0HG%2FYc4Y97%2FzeHfgn537%2FzDZk%2B%2B4Hx%2FEdxzQAStcdrnEvuhtBX6%2BnDneFOnv88fj954N3VbyejsdpubpOb65UObicTqfw7cW7nEw%2B0s1f8UI6WNsFAAA%3D

Template JSON: https://github.com/pipethedev/brimble-cloudflare-template/blob/add-brimble-domain-template/brimble.io.domain.json