### PR TITLE
feat(everinbox): add subdomain sending templates

### DIFF
--- a/everinbox.domain-auth-subdomain.json
+++ b/everinbox.domain-auth-subdomain.json
@@ -1,0 +1,46 @@
+{
+  "providerId": "everinbox",
+  "providerName": "Everinbox",
+  "serviceId": "domain-auth-subdomain",
+  "serviceName": "Domain Authentication (Subdomain)",
+  "version": 1,
+  "logoUrl": "https://everinbox.com.br/everinbox-logo-dark.svg",
+  "description": "Configures domain authentication records for email delivery on a subdomain, including DKIM, DMARC and mail routing",
+  "variableDescription": "SUBDOMAIN is the sending subdomain (e.g., 'marketing' for marketing.yourdomain.com), MAIL_SUBDOMAIN is the mail routing subdomain (e.g., 'em5027'), MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy configuration",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.everinbox.com.br",
+  "syncRedirectDomain": "everinbox.com.br",
+  "warnPhishing": false,
+  "records": [
+    {
+      "groupId": "mail_routing",
+      "type": "CNAME",
+      "host": "%MAIL_SUBDOMAIN%.%SUBDOMAIN%",
+      "pointsTo": "%MAIL_TARGET%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%DKIM_SELECTOR1%._domainkey.%SUBDOMAIN%",
+      "pointsTo": "%DKIM_TARGET1%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%DKIM_SELECTOR2%._domainkey.%SUBDOMAIN%",
+      "pointsTo": "%DKIM_TARGET2%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc.%SUBDOMAIN%",
+      "data": "%DMARC_POLICY%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/everinbox.domain-auth-tracking-subdomain.json
+++ b/everinbox.domain-auth-tracking-subdomain.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://everinbox.com.br/everinbox-logo-dark.svg",
   "description": "Configures domain authentication, DKIM, DMARC and link tracking records for email delivery on a subdomain",
-  "variableDescription": "SUBDOMAIN is the sending subdomain (e.g., 'marketing' for marketing.yourdomain.com), MAIL_SUBDOMAIN is the mail routing subdomain, MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy, URL_TRACKING_SUBDOMAIN is the URL tracking subdomain, URL_TRACKING_TARGET is the URL tracking target, CLICK_TRACKING_SUBDOMAIN is the click tracking subdomain, CLICK_TRACKING_TARGET is the click tracking target",
+  "variableDescription": "SUBDOMAIN is the sending subdomain (e.g., 'marketing' for marketing.yourdomain.com), MAIL_SUBDOMAIN is the mail routing subdomain, MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy, TRACKING_SUBDOMAIN is the tracking subdomain, TRACKING_TARGET is the tracking target",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.everinbox.com.br",
   "syncRedirectDomain": "everinbox.com.br",
@@ -45,15 +45,8 @@
     {
       "groupId": "tracking",
       "type": "CNAME",
-      "host": "%URL_TRACKING_SUBDOMAIN%.%SUBDOMAIN%",
-      "pointsTo": "%URL_TRACKING_TARGET%",
-      "ttl": 3600
-    },
-    {
-      "groupId": "tracking",
-      "type": "CNAME",
-      "host": "%CLICK_TRACKING_SUBDOMAIN%.%SUBDOMAIN%",
-      "pointsTo": "%CLICK_TRACKING_TARGET%",
+      "host": "%TRACKING_SUBDOMAIN%.%SUBDOMAIN%",
+      "pointsTo": "%TRACKING_TARGET%",
       "ttl": 3600
     }
   ]

--- a/everinbox.domain-auth-tracking-subdomain.json
+++ b/everinbox.domain-auth-tracking-subdomain.json
@@ -1,0 +1,60 @@
+{
+  "providerId": "everinbox",
+  "providerName": "Everinbox",
+  "serviceId": "domain-auth-tracking-subdomain",
+  "serviceName": "Domain Authentication with Tracking (Subdomain)",
+  "version": 1,
+  "logoUrl": "https://everinbox.com.br/everinbox-logo-dark.svg",
+  "description": "Configures domain authentication, DKIM, DMARC and link tracking records for email delivery on a subdomain",
+  "variableDescription": "SUBDOMAIN is the sending subdomain (e.g., 'marketing' for marketing.yourdomain.com), MAIL_SUBDOMAIN is the mail routing subdomain, MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy, URL_TRACKING_SUBDOMAIN is the URL tracking subdomain, URL_TRACKING_TARGET is the URL tracking target, CLICK_TRACKING_SUBDOMAIN is the click tracking subdomain, CLICK_TRACKING_TARGET is the click tracking target",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.everinbox.com.br",
+  "syncRedirectDomain": "everinbox.com.br",
+  "warnPhishing": false,
+  "records": [
+    {
+      "groupId": "mail_routing",
+      "type": "CNAME",
+      "host": "%MAIL_SUBDOMAIN%.%SUBDOMAIN%",
+      "pointsTo": "%MAIL_TARGET%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%DKIM_SELECTOR1%._domainkey.%SUBDOMAIN%",
+      "pointsTo": "%DKIM_TARGET1%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%DKIM_SELECTOR2%._domainkey.%SUBDOMAIN%",
+      "pointsTo": "%DKIM_TARGET2%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc.%SUBDOMAIN%",
+      "data": "%DMARC_POLICY%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "tracking",
+      "type": "CNAME",
+      "host": "%URL_TRACKING_SUBDOMAIN%.%SUBDOMAIN%",
+      "pointsTo": "%URL_TRACKING_TARGET%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "tracking",
+      "type": "CNAME",
+      "host": "%CLICK_TRACKING_SUBDOMAIN%.%SUBDOMAIN%",
+      "pointsTo": "%CLICK_TRACKING_TARGET%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/everinbox.domain-auth-tracking.json
+++ b/everinbox.domain-auth-tracking.json
@@ -1,15 +1,15 @@
 {
   "providerId": "everinbox",
-  "providerName": "Everinbox", 
+  "providerName": "Everinbox",
   "serviceId": "domain-auth-tracking",
   "serviceName": "Domain Authentication with Tracking",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://everinbox.com.br/everinbox-logo-dark.svg",
   "description": "Configures domain authentication, DKIM, DMARC and link tracking records for complete email delivery service",
-  "variableDescription": "MAIL_SUBDOMAIN is the mail routing subdomain, MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy, URL_TRACKING_SUBDOMAIN is the URL tracking subdomain, URL_TRACKING_TARGET is the URL tracking target, CLICK_TRACKING_SUBDOMAIN is the click tracking subdomain, CLICK_TRACKING_TARGET is the click tracking target",
+  "variableDescription": "MAIL_SUBDOMAIN is the mail routing subdomain, MAIL_TARGET is the mail server target, DKIM_SELECTOR1/DKIM_SELECTOR2 are DKIM selectors, DKIM_TARGET1/DKIM_TARGET2 are DKIM targets, DMARC_POLICY is the DMARC policy, TRACKING_SUBDOMAIN is the tracking subdomain, TRACKING_TARGET is the tracking target",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.everinbox.com.br",
-  "syncRedirectDomain": "everinbox.com.br", 
+  "syncRedirectDomain": "everinbox.com.br",
   "warnPhishing": false,
   "records": [
     {
@@ -23,7 +23,7 @@
       "groupId": "dkim",
       "type": "CNAME",
       "host": "%DKIM_SELECTOR1%._domainkey",
-      "pointsTo": "%DKIM_TARGET1%", 
+      "pointsTo": "%DKIM_TARGET1%",
       "ttl": 3600
     },
     {
@@ -45,15 +45,8 @@
     {
       "groupId": "tracking",
       "type": "CNAME",
-      "host": "%URL_TRACKING_SUBDOMAIN%",
-      "pointsTo": "%URL_TRACKING_TARGET%",
-      "ttl": 3600
-    },
-    {
-      "groupId": "tracking",
-      "type": "CNAME", 
-      "host": "%CLICK_TRACKING_SUBDOMAIN%",
-      "pointsTo": "%CLICK_TRACKING_TARGET%",
+      "host": "%TRACKING_SUBDOMAIN%",
+      "pointsTo": "%TRACKING_TARGET%",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
## Description

Adds subdomain sending support for Everinbox templates. When customers send email from a subdomain (e.g. `marketing.example.com`) rather than the root domain, the existing templates place DKIM, DMARC and mail routing records under the root zone — causing DKIM verification failures.

**New templates:**
- `everinbox.domain-auth-subdomain` — DKIM + DMARC + mail routing for subdomain sending domains
- `everinbox.domain-auth-tracking-subdomain` — same as above + URL/click tracking CNAME

**Updated template:**
- `everinbox.domain-auth-tracking` bumped to version 2 — consolidated two tracking CNAMEs (`URL_TRACKING` + `CLICK_TRACKING`) into a single `TRACKING_SUBDOMAIN`/`TRACKING_TARGET` pair, matching real-world usage

**Why `%SUBDOMAIN%` in host instead of the `host` parameter:**
Cloudflare — the primary DNS provider for our users — explicitly does not support the Domain Connect `host` parameter (it is ignored per their documentation). Using `%SUBDOMAIN%` as a variable in the host field is the only viable workaround for providers that do not implement this part of the spec. The non-variable parts of each host are fixed (`._domainkey.`, `_dmarc.`, `em*.`) to limit misuse, consistent with the spirit of the quality guideline.

## Type of change

- [x] New template
- [x] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible) — `domain-auth-tracking` v2 renames tracking variables

## How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

## Checklist of common problems

- [x] `syncPubKeyDomain` is set — present on all templates
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — `warnPhishing: false` on all templates
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — DMARC uses TXT with `v=DMARC1`, not SPF
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — set to `"All"` on DMARC record
- [x] no variable is used as a bare full record value — all variables are combined with fixed text
- [x] no bare variable is used as the full `host` label — all host labels contain fixed parts (e.g. `%DKIM_SELECTOR1%._domainkey.%SUBDOMAIN%`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — set on DMARC record

**Note on `%SUBDOMAIN%` in host:** The guideline recommends using the `host` parameter instead of a variable in the host field to create a subdomain. However, Cloudflare (our primary provider) explicitly ignores the `host` parameter in their Domain Connect implementation. The `%SUBDOMAIN%` variable is therefore the only working solution for subdomain scoping on Cloudflare. All other host parts remain fixed.

## Online Editor test results

**Editor test link(s):**

[Test everinbox/domain-auth-subdomain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHvOQmoC%2F%2B1WbW%2FaSBD%2BKytLkVqd7RgHSOoq0hFAp6ghIEKrXqPIWrwL7GG81u6aQCP%2B%2B83axi%2BQpr3TfbhI%2BWTvzDwzOzPPjP1kKLqKQ6yo4T0ZseBrRqi4JoZn0DUVLJryjWEWilu8AkOjX1FJKtYsoCmE8BVmkYUTtbBkMs2OpU2O7qVi1AErGikWYMV4hN7d7QHvAQEBJEgNr2EaIZ%2FzzyIE5EKpWHqnp8XV7ICv7KkoBZY2tggWS1uu5%2BCIUBkIFqvUmdHl0YzNE0ElymIhXL%2BFoAEXRKIZF4iCQYgIDRl43yLQYlRkZSIWBWFCWDRHvU%2FXAxP1Bp1xF%2BGIoBQneKJAqXPBguFpSHu1q9x9vuoNB53rW8QkgjsgSaPUWxECvaP23DbBnVhS7eu9iQBw4x9BqwGP8XTVctzzPXjSGf%2FRn9SQuj1UIIXFnCozTce%2F69%2F0u5PhuHFaO7oIC5paACqkgeJC5ojMcW6fHSrWmXOZl8kfDW%2Buu3%2Fub5GVLuYhC7YoyHuUNkSTZxsFVyEPloY3w6GkmWSUTD%2FRbUalgnkAjeBO9iE%2Fci9jShg0WBWoZ%2BwesYhGCyYXunf7gDkrDO%2F%2ByZhDneOU7bp2ftlmtY01u7u3nUEfjgsuFRxP6h07sU%2FKdz1YnEVKTnhhmRVOq5QCyp%2B1HWdnVqOSJVv9OFq9dye2nxVmSbcvBK6277%2BJ7P7zyO5LkWEEgjL05OukDOynyoMYBCuc%2Bq%2BQreYfXjdKbwOgnBpgFeh%2BDzjR7jthCKZUSr0XsN47w6gTx%2BHW2D3sTOM7j6hfMuLBzMmn%2BbTBsEypZlN5QXhLM%2FHZ3j7GAq%2BkXrh75H0N%2BrDH3hv6vc6g1DidaK2VFSmPBjPw7MWAr4Sop%2BeS%2Bx7GZFHD%2BCM1r3FcyTpYxOuwaxv%2FWQpbcEkJXi0VBQsrwHVb7V4Tq%2B4gRJ3bF6M3XNuCuLO%2BZs5NNE6p4%2Fn8U%2B4PpADAAA%3D)

_Note: editor test link for `everinbox.domain-auth-tracking-subdomain` uses the same variable structure; separate link available on request._