### PR TITLE
consent.vn/domain-verify: bump to v2 (fix syncRedirectDomain)

### DIFF
--- a/consent.vn.domain-verify.json
+++ b/consent.vn.domain-verify.json
@@ -3,11 +3,11 @@
   "providerName": "Consent.vn",
   "serviceId": "domain-verify",
   "serviceName": "Consent.vn Domain Ownership Verification",
-  "version": 1,
+  "version": 2,
   "description": "Creates the TXT record that proves you control this domain for Consent.vn consent management.",
   "logoUrl": "https://consent.vn/icon-512.png",
   "syncPubKeyDomain": "consent.vn",
-  "syncRedirectDomain": "app.consent.vn",
+  "syncRedirectDomain": "consent.vn",
   "syncBlock": false,
   "variableDescription": "token: the one-time verification token issued by Consent.vn.",
   "records": [


### PR DESCRIPTION
# Description
Updates the existing `consent.vn.domain-verify.json` template (originally merged in #1271) to **version 2**.

**Change:** `syncRedirectDomain` `app.consent.vn` → `consent.vn`; `version` 1 → 2.

**Why:** the Consent.vn application is served at `https://consent.vn/app/...`, so the `redirect_uri` passed to the synchronous apply flow has host `consent.vn`. The previous value `app.consent.vn` is a *child* of that host, so a `consent.vn` redirect_uri did not match. Setting it to `consent.vn` correctly matches both the apex and any future `*.consent.vn` subdomain. No record or signing changes — `syncPubKeyDomain` stays `consent.vn` and the public key TXT at `_dcpubkeyv1.consent.vn` is unchanged.

## Type of change
- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems
- [x] `syncPubKeyDomain` is set — **this is mandatory**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — N/A (ownership token is per-domain, single record)
- [x] no variable is used as a bare full record value — record uses `consent-vn-verify=%token%`
- [x] no bare variable is used as the full `host` label — host is fixed `_consent-vn-verify`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — N/A (single ownership TXT)

## Online Editor test results

**Editor test link(s):**
- (apex) [Test consent.vn/domain-verify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGefQ2oC%2F%2BVT227TQBD9ldVKfSJONs7NsdSHtoGCkCiCgoAqsib2JNnW9lq7awcT5d%2BZdVrstpQf4GkvczvnzMyeW8yKFCzycM8LrSqZoH6X8JDHKjeY236V894fywfIyJNfdG0GdSVjbIISlYHMvQq1XNet7VkYWzSO7GqXozZbWbCvLkTGYKVySSmDcbfQ7%2FEETaxl0VgoiUaCa5jdIrv%2Bds00xkon9ATLHEwy1apkBN9qldK%2FNOwIi62VZh0M9wxZBjlsMHO%2FVDlVG%2FVFp1Rpa21hwsGgVWIg6e5Nhn6%2FyDeOXp3HH8vVe6yPfJ7K5uyfMJGE0b7scZ6q%2BI6Ha0gNEnPQElYpLh6xtuoO87AhrXL0rMyQVR3JWOPApDElJmxVd3g6UkeRDA9v9nyjVVk03VIP6pOHrQvXIlKUHltlLD2ie6he1WmptaTNSAjqC1ho%2BbROpycNmBN%2BWB56%2FBfhjdr6y979kFAk%2FgQaPuzHKmuL0q1BGMnGvwOSQgvQkBk3qw9Jbh5lWT6kueHu3iR6lqRB534TzJTXvLyhP%2BIOrdzkSmNk6ARbapLE6pK6kpWplRHsoP1K4giKIq2JnCErJSRxH8mYH8f%2BrzK%2BKN4TUF3BoyR21GWzaVPE6Xiy9oYQrL3xKJl7wRwDbzydgT%2BFeBz42Fnc5yv9r7VtW4HGRUhw%2B3CW7qA2%2FHBY9qiN%2Fw1ZmhgDFSYRODdf%2BFNPTL2RuB6KcCLC4aQ%2F80Ugxq%2BECIVwHNDYI%2BM9TVR3lrgv88UtjGw225XzN9vR5XmWBd%2BD5HU8v721dgE%2FxHz2%2Be3l6uLslB9%2BA3jt2bCeBQAA)
- (subdomain) [Test consent.vn/domain-verify example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIyfQ2oC%2F%2BVTYU%2FbMBD9K5YlPtG0SZpSiMSHDQYq02Ca2DQNVZFrX1NDEke2Exaq%2Fved07KkVOwPTKrUnO%2Fu%2Bb135zW1kJcZs0DjNS21qqUAPRM0plwVBgo7rAs6%2BJu5ZTlW0ot%2BzoCuJYe2SaicycKrQctl0%2BUO2shlW0jungvQZiVL8sO1SM6sVA4UEYz7isMBFWC4lmWbQRANSNcQuwJy%2F%2FOeaOBKCwyZJY4mphpVEaRvtcrwXBqypUWWSpMeh51CkrOCpZC7U7w5U6n6rjO8aWVtaeLRqHNiJPHbmwThsCxSJ68p%2BNdq8RmarZ63trn8NxASOdr3Kz5mij%2FReMkyA6icackWGVzuqbbqCYq4Fa0K8KzMgdQ9y0hbQKQxFQiyaHo6naitSYbGD2uaalWV7bTUq%2FtYYZvSjQgdxWCljMUg2VH16t5IrUVvxr6Pc2GWdXq6ovOjlswR3cw3A%2FqCfJPu%2FvlgtyTYCb8ZLh8Mucq7Sxc4AIxalolse3pEsb1kmuXG7esr0MMe0vwV6mGLNd%2BBHQC1LN2pgFx5beQF4Zg61jItlIbE4D%2BzlUZrrK5wOnmVWZmwZ9YdCZ6wsswaFGkwi4Bo8p6dxXb9D%2B0c7sS%2B6%2BQbZn33E8GdB9INMgr42XR5GnhCLKdexE8i7xT8yJtOoygaTyaw9Be9V3z4vv%2F1hvfnAsZ1SeYeyIfsmTWGbjbzAc71%2F1ONO2RYDSJhrjT0wxPPP%2FHG%2Fn3gxxP8hcOJH54F0bHvx77vdICxW9Vr3LH%2BdlGziB75zezmKjXVxcimT7fXvwIOL6dWTq7K42J29ziLouvgS%2FTpnG7%2BADdqBMq4BQAA)
