### PR TITLE
Adding a template to set A record for users to point to simpleurl.tech

### DIFF
--- a/simpleurl.tech.branded-rootdomain.json
+++ b/simpleurl.tech.branded-rootdomain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "simpleurl.tech",
+  "providerName": "SimpleURL",
+  "serviceId": "branded-rootdomain",
+  "serviceName": "SimpleURL Branded Domains (Apex)",
+  "version": 1,
+  "logoUrl": "https://www.simpleurl.tech/favicon.ico",
+  "description": "Configures your root domain to point to SimpleURL's edge network for branded short links and QR codes.",
+  "syncPubKeyDomain": "www.simpleurl.tech",
+  "syncRedirectDomain": "www.simpleurl.tech",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%server_ip%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Adding a template to set A record for users to point to simpleurl.tech's server for branded domain set up

# Description

Adding a template to set A record for users to point to simpleurl.tech's server for branded domain set up

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results
**Editor test link(s):** 
[Test simpleurl.tech/branded-rootdomain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAD2RGoC%2F91T%2FW%2FaMBD9VyxL1TZBQvgIrJEmjW3SWnWfFFZ1FYqc%2BAJeEzuzHShD%2FO87EyiwTdvvk6LE8b139%2B75vKYWijJnFmi0pqVWC8FBX3IaUSMwAJXOfQvpnDYfox9YgWh6vY1PRu8wZEAvRApbXqKZ5MA9rZTlqmBCHgC%2FUsmrGkzebIGGPB2W8PAMCQvQRihJo3aT5mqmJjpH4tza0kSt1nK59E%2F1tTKGBZT08YV0DibVorTbFPS1kpmYVRoMWalKEyeN1NqIVaRUQlq3eNT1xBDgMyAS7FLpe5IpTXZ9ETNX2pJcyHtDcId8HpFUYT3ftbmS6acquYJV3RDW%2Fl3qDjcCLjSk9u%2FIuTJ2BN8rhKK5GcsNNCnSlOaGRndralels3S4w%2BLypTsr15IZK%2Fw9c96DjkV5hgFr0cduPwg2002T%2FlAS4kO2KRq3VwMPzEnxU1Wcpp5pVZWx2BNKpllh3PTsqXcn3OmefIfsaT0JWzVup9%2F1e2H9UKdHzKTSEBv8MovnRSOrK2y4qHIrYrZkhy2exqws8xXKNxjFbKdmyHrUnGLOLMPlcbEjI5o05qnTL9z0pskAWDJIvWQQcq%2FHuj0v6Wd9L2TheZZ1B4NOGh7dhT%2FflH9ehyM7wRiQVjA33sN8yVaGbjbTJlr7P%2FXjDp4tgMfM4TpBp%2B8FAy9oj9vtqN2JgsDvd3vnYa8RBPjj2gFj6z7XOBfHE0Hf2%2BeT29ubbNyYf71525joolL2Ivs2%2FCI615fJhQk6xezKfAwv7l%2FQzU%2FUsqia4gQAAA%3D%3D)

[Test simpleurl.tech/branded-rootdomain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPf2RGoC%2F91Tf2%2FaMBD9KpalaptKQkJKKJEmrbSTOjH1B20ndRWKTHwEtyF2bQfIEN99ZyiFbtP2%2F6QoufjeO797Pi%2BphakqmAWaLKnSciY46C%2BcJtQITEClC99CNqGN1%2BwFmyKa3qzzd4OvmDKgZyKDNW%2BkWcmBe1pKy%2BWUiXIH%2BJVKehswOVsDDXl%2FomDxAQkz0EbIkiZhgxYyl3e6QOLEWmWSZnM%2Bn%2Ftv9TXHDDeQpY8vpHMwmRbKrkvQU1mORV5pMKSWlSZOGtloI1YSJUVpXfCq650hwHMgJdi51E9kLDV56YuYidSWFKJ8MgRXyPWAZBL3812bdZldVaM%2B1JuGcO%2Ffpb7gBsCFhsz%2BHTmRxg7guUIomjtmhYEGRZrU3NDkYUltrZylJy9YDD%2B5s3ItmVuJvwfOe9CpUAeYsBZ9jOIgWA1XDfpDlpDuqg3RuK0aWDAnxc%2FkdFcao1zLSqVii1dMs6lxw7NlPryhDrfcB%2BriVy1uIY78o%2FbmoU6NyEupITX4ZRZPiyZWV9jutCqsSNmc7ZZ4ljKlihrFG8xitbdWlJtBc1ZwZhmG%2B5vt2dCgKc%2BcfOFml0dtOGYQenE8PvaOOq2Ox9rdkceibgTjdsiOQrZ3E%2F58T%2F55GXZmgjFQWsHcbJ8Uc1YbuloNG2jsf9SOO3Y2A54yB2sFrdgLOl4Q3oZhEsZJ0PFb7SiKo8MgSILAdQPGbtpc4lTszwPtPV5%2Bvrg8vFG90%2BbsWz7qLc6v77vfW4ua3fdVlPcfz6Lu7Pz56vjpI139BElSibveBAAA)

[Test simpleurl.tech/branded-rootdomain example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG33RGoC%2F91Ta2vbMBT9K0JQtrHYsZsnhsHSjo3Sd9ayQQhGsW4cEVvSJDlpGvLfdxU3TbKN7fvA2LLuOdI5R1dr6qDUBXNAkzXVRi0EB3PBaUKtwAJUpggdZDPaeK3esBLR9Ou2%2Fji8wpIFsxAZbHkTwyQHHhilHFclE3IP%2BJVKzmow%2BbQFWvJ2oOHpHRIWYKxQkiZxgxYqV4%2BmQOLMOW2TZnO5XIbH%2BppThhsoGeIL6RxsZoR22yXouZJTkVcGLFmpyhAvjdTaiFNEKyGdH7zqemMJ8ByIBLdUZk6mypAXX8TOlHGkEHJuCc6Q%2ByHJFO4Xepsrmd1Vk0tY1YZw79%2BlvuCGwIWBzP0dOVPWDeFHhVAMd8oKCw2KNGW4pcloTd1K%2B0gHL1gcfvRn5S3ZB4W%2FJz57MKnQJ1hwDnNsdaNoM9406LOSkO5XG2NwOzXwxLyUMFPlfuncZ5sbVelU7BiaGVZa3z477uiIPN6xR54%2Brnthq8dPdVthu1M%2F1CsSuVQGUotf5vDEaOJMhZbLqnAiZUu2n%2BJZyrQuVmjAYhVXO45D1s221cyZYzg%2B3O0giwZNeeYdCN%2FA00kGvAXtgJ9CFLRZpxcwYNMg7nQ568X9eALtg%2Bvw58vyzxtxmChYC9IJ5lt8UCzZytLNZtzAdP8vR%2F7w2QJ4yjzwNDrtBlEviOKHOE7ifhJ1wn6%2F127F76MoiSLvB6yrja6xNw67gp5dfr5Vj7ZoXn6%2Fmmf5fVl%2B4dHtczXX7sIN5PA6%2B3Y%2BLO4G%2Bub6A938BHzsOk3oBAAA)