### PR TITLE
Add seatbeltsecurity.com.m365-dkim template (Microsoft 365 DKIM selector CNAMEs)

### DIFF
--- a/seatbeltsecurity.com.dkim.json
+++ b/seatbeltsecurity.com.dkim.json
@@ -1,29 +1,29 @@
 {
   "providerId": "seatbeltsecurity.com",
   "providerName": "Seatbelt Security",
-  "serviceId": "m365-dkim",
-  "serviceName": "Microsoft 365 DKIM",
-  "description": "Publishes the two Microsoft 365 DKIM (selector1/selector2) CNAME records so Microsoft can sign your outbound email and it passes DMARC.",
+  "serviceId": "dkim",
+  "serviceName": "DKIM Email Signing",
+  "description": "Publishes two DKIM (selector1/selector2) CNAME records so your email provider can DKIM-sign your outbound email and it passes DMARC.",
   "logoUrl": "https://seatbeltsecurity.com/marketing/seatbelt-logo-dc.png",
   "version": 1,
   "hostRequired": false,
   "syncPubKeyDomain": "seatbeltsecurity.com",
   "syncRedirectDomain": "seatbeltsecurity.com",
-  "variableDescription": "dkimtarget1 / dkimtarget2: the tenant-specific selector1 / selector2 CNAME targets read from Microsoft 365 (e.g. selector1-example-com._domainkey.<tenant>.<n>-v1.dkim.mail.microsoft). Not derivable from the domain name.",
+  "variableDescription": "dkimtarget1 / dkimtarget2: the tenant-specific selector1 / selector2 CNAME targets supplied by your email provider at setup time. Not derivable from the domain name.",
   "records": [
     {
       "type": "CNAME",
       "host": "selector1._domainkey",
       "pointsTo": "%dkimtarget1%",
       "ttl": 3600,
-      "groupId": "m365-dkim"
+      "groupId": "dkim"
     },
     {
       "type": "CNAME",
       "host": "selector2._domainkey",
       "pointsTo": "%dkimtarget2%",
       "ttl": 3600,
-      "groupId": "m365-dkim"
+      "groupId": "dkim"
     }
   ]
 }

--- a/seatbeltsecurity.com.m365-dkim.json
+++ b/seatbeltsecurity.com.m365-dkim.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "seatbeltsecurity.com",
+  "providerName": "Seatbelt Security",
+  "serviceId": "m365-dkim",
+  "serviceName": "Microsoft 365 DKIM",
+  "description": "Publishes the two Microsoft 365 DKIM (selector1/selector2) CNAME records so Microsoft can sign your outbound email and it passes DMARC.",
+  "logoUrl": "https://seatbeltsecurity.com/marketing/seatbelt-logo-dc.png",
+  "version": 1,
+  "hostRequired": false,
+  "syncPubKeyDomain": "seatbeltsecurity.com",
+  "syncRedirectDomain": "seatbeltsecurity.com",
+  "variableDescription": "dkimtarget1 / dkimtarget2: the tenant-specific selector1 / selector2 CNAME targets read from Microsoft 365 (e.g. selector1-example-com._domainkey.<tenant>.<n>-v1.dkim.mail.microsoft). Not derivable from the domain name.",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "selector1._domainkey",
+      "pointsTo": "%dkimtarget1%",
+      "ttl": 3600,
+      "groupId": "m365-dkim"
+    },
+    {
+      "type": "CNAME",
+      "host": "selector2._domainkey",
+      "pointsTo": "%dkimtarget2%",
+      "ttl": 3600,
+      "groupId": "m365-dkim"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for the already-onboarded `seatbeltsecurity.com` provider: **`dkim`** (`seatbeltsecurity.com.dkim.json`). It publishes two DKIM selector CNAME records (`selector1._domainkey`, `selector2._domainkey`) so the customer's mail provider can DKIM-sign their outbound email and it aligns for DMARC.

The two CNAME targets are per-tenant — read from the customer's mail provider at apply time — and passed as the `dkimtarget1` / `dkimtarget2` variables. This is a **separate service** from our existing `seatbeltsecurity.com.email-auth` template on purpose: these records only apply to domains whose provider signs with selector CNAMEs, and their targets point at the provider, not at our zone.

> **Updated per review (@pawel-kow):** removed third-party branding — `serviceId` renamed `m365-dkim` → `dkim` (file renamed to `seatbeltsecurity.com.dkim.json` to match), `serviceName` → “DKIM Email Signing”, and `description` / `variableDescription` genericised to “your email provider”. No record changes. Online Editor test links regenerated for the new template.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `seatbeltsecurity.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`seatbeltsecurity.com`) for the synchronous flow
- [x] no TXT record contains SPF content — this template has no TXT records
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [ ] no variable is used as a bare full record value — **JUSTIFICATION:** both CNAME `pointsTo` values are bare variables (`%dkimtarget1%` / `%dkimtarget2%`) by necessity. A DKIM selector CNAME target is a per-tenant hostname (e.g. `selector1-example-com._domainkey.<tenant>.<region>-v1.dkim.<provider-host>`) with no fixed, hardcodable prefix — the entire value is determined per tenant and read from the mail provider at apply time. A `service-foo=%foo%` style wrapper is not possible for a CNAME target.
- [x] no bare variable is used as the full `host` label — hosts are fixed literals (`selector1._domainkey`, `selector2._domainkey`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — not set; these DKIM selector CNAMEs are provider-managed, not intended for end-user modification (mirrors the existing `seatbeltsecurity.com.email-auth` DKIM record)

## Online Editor test results

**Editor test link(s):**
- [Test seatbeltsecurity.com/dkim example.com/@]("https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAON2SGoC%2F%2B1U227aQBD9ldVKlVoVG2MgEKQ%2BRCFqoygkzUUNiRBa1gNsY3vd3TEpjfLvnTXm1uZS5bHKm7175szMmbNzzxGSLBYIvHPPM6NnKgJzGPEOtyBwBDFakLlROPelTnhlhemJhGL4eYli5yWMIBbMTEkoWKJblayPyqDu0eExO0iEitm5mqQqnRAkAiuNylDplCCn%2BShWdgqW4Z1mRcB7CzFI1KZWXX6FH9h%2Bb%2B%2F4gBmQ2kSWWc3mOjcMCvJlrUyKtODwLKVbIHSOI52nUQkV9KWQZcJaytk93jvb96moWE%2F0pYmpoCliZjvV6mOyVBNhbgGpj9W15yK9SPpZ0dwMjC0aq1X4VFs8gx%2B5MkAKjUVsgQSap5J6PoJ5V1NB6dMDcMgziCha4kvYmTBKjGLobmnrZoLCTABrrMrWf2GH4RQYQipS9GwGUo2VZCvZCbwSvtR9EUi651kWK4jYaP7oAARSKOYZQ5WAz3oaGR2rmSuOjY1OisxR0Q5LySVO%2FHKovHNzz3GeOecUWflCw6LtsjR%2FuIi9BWfATKsU7YUmxLuNZt%2FRFSINs74TBBU%2BMTrP1iZ9qLyUJfyXLOELWQYPFf5LpzBcdzcg8y8HCT8FvUco51cWwEuaoSrwCyaKyoQRiXUvdxl%2Fs0UwWDLccPddcGzGb2jjjldqeiWJRyQbPRNnitpqX3izmu%2BCfTdlP1HS0PEYtznDTc7w9ZwkGL1abWDoXq%2FA3NCM0OT0apI8RjUUd2J9FMmhIC%2FOSV9Lt1TD3%2B5JF2voCfdEAsXm7asr3%2FLBMJJuUMo5oS2hLWti5NVa9brXaAQjb7dVb3m70NyRzUbQ2G3XNlbtc%2Bv4kV27Ng3QMktRCbe%2F9uI7Mbf84RGb%2FyFH%2BKwc4X8mx6BC7%2B%2FNIm8WecYitNasmEE0FA4WBuGOF7S8oHERhJ1mu9Oo%2B2GjWW%2FXPgZBJwhcF2BxIco9ba%2FNvcVPrj5f9g6bs%2B%2BXJ6p%2Fshv2W6PT4y62vl2eXojrvN6%2Fir5cjy%2F6R%2FWvn%2FjDb%2FnbKomgCQAA")
- [Test seatbeltsecurity.com/dkim example.com/mail]("https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJJ3SGoC%2F%2B1UTW%2FbOBD9KwSBAi1iyZJsxLGBPaRxDkWatE3aHjYwDJoaO2wkUiVHSpQg%2F71DWf7aupu2x6I3iXzzZubN4zxyhLzIBAIfPfLCmkqlYN%2BkfMQdCJxBhg5kaRXWoTQ576wxFyKnGH7VothVCyOIA1spCQ1LeqvyzVEbND57c85Oc6EydqUWWukFQVJw0qoCldEEeV%2FOMuVuwDG8M6wJeOkgA4nGxt3VV%2FKKnVwcn58yC9LY1DFnWG1Ky6AhX9XKpNANR%2BAo3RJhSpyZUqctVNCXQlYI5yjn%2BPz48iSkojKzMJ9sRgXdIBZu1O3uk6WbC3sLSH2srwMfGaQyLJrmKrCuaSzu8Bvj8BK%2BlsoCKTQXmQMSqNaSej6DemyoIP3jAXjkJaQULfE5bCWsErMMxjva%2BpmgsAvAmHXZ5i8ZMbwBhqCFxsAVINVcSbaWncBr4Vvdl4Gke1kUmYKUzeq9AxBIoVgWDFUOIbswyOhYVb44NrcmbzKnTTtMk0u8%2BO1Q%2Bej6kWNdeOc0WflSw6bttrRwuoy9BW%2FAwiiN7qMhxIutZl%2FQFSINs3cYRR2%2BsKYsNiZ96jyXJfmZLMkzWSZPHf5gNEw33U3I%2FKtBwr2g9wjt%2FNoCvJa8pZqqJmbJRpGFsCJ3%2FvWuOK53SCYrluslzaTl2ebY0sgfr1UNWqKAiLZ6J16NxplQBFUc%2BuDQU4e5kpaO57jLmWxzJr%2FPScLR6zUWpv4VCywtzQptSa8nLzNUU3EnNkepnAryZE06O7qlGr53kV6uo30uClvNU4FiG%2FLb5e%2BYYppKPzHlbREPenF%2FAL1gniS9oD%2Foi2B4OIyDeX8GIAdHMhomW3v3%2F3bznsW76yCg7aZRCb%2FQjrM7UTv%2BtMf3%2F9EleV6X5A%2FUZdKhl%2FnXNH9N80umodXnRAXpVHhoEiWHQTQIov7HqDeK4lHvKBwOhv0oOoiiURT5TsDhUphH2nDbu41%2FXdTj%2FN%2BHZIhf3r89eIg%2Fq1JXp4OT2L1%2BKz8cnFUfTo%2Fu3%2FV0dP7pH%2F70DedCgqDMCQAA")
