### PR TITLE
Add mylocalpress.com custom-domain template

### DIFF
--- a/mylocalpress.com.custom-domain.json
+++ b/mylocalpress.com.custom-domain.json
@@ -1,0 +1,80 @@
+{
+  "providerId": "mylocalpress.com",
+  "providerName": "My Local Press",
+  "serviceId": "custom-domain",
+  "serviceName": "My Local Press Custom Domain",
+  "version": 1,
+  "logoUrl": "https://mylocalpress.com/favicon-light.svg",
+  "description": "Points a custom domain at My Local Press: the branded feed is served at www, the bare/apex domain 301-redirects to www, and AWS SES email authentication (DKIM + custom MAIL FROM + DMARC) is configured so the publication's newsletter can send from its own domain. Only the three DKIM selector tokens vary per domain; every other value is fixed.",
+  "variableDescription": "%dkim1%, %dkim2%, %dkim3%: the three AWS SES DKIM selector tokens generated for this domain (the only per-domain values). Every hosting value (www CNAME target, apex A IPs), the MAIL FROM host, the SPF include, and the DMARC policy are fixed literals.",
+  "syncPubKeyDomain": "mylocalpress.com",
+  "syncRedirectDomain": "mylocalpress.com",
+  "records": [
+    {
+      "groupId": "hosting",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "d3s4upn96zzeha.cloudfront.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "hosting",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "75.2.89.162",
+      "ttl": 3600
+    },
+    {
+      "groupId": "hosting",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "166.117.141.54",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "MX",
+      "host": "bounce",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "bounce",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **My Local Press** (https://mylocalpress.com), a local-news and community-content platform. The template lets a publisher connect their own domain in one consent: the branded feed is served at `www` (CNAME) with the apex A-records 301-redirecting to it, and AWS SES email authentication (3 DKIM CNAMEs, MAIL FROM MX/SPFM on a `bounce.` subdomain, conflict-aware DMARC) enables their newsletter to send from its own domain. Only the three SES DKIM selector tokens are per-domain variables; every other value is a fixed literal.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated locally with `dc-template-linter -merge-or-fail -logos` (v119): exit 0, zero findings.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

[Test mylocalpress.com/custom-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI6TRWoC%2F%2B1YbW%2FbNhD%2BK4SAYi1qK5L8GhcBaiQNlrZugiTDMhSBQUm0zJgiFZKyLQfeb99RL7OdOXE7FEMz2B9siby7557j3fHgB0uTOGFYE6v3YCVSTGlI5Flo9aw4YyLALJFEKTsQsVX7e%2F8LjkHeGmTosxFBF0YG9hWRUxqQXD1IlRZxPRQxpny1t1UVHefC6KQSnhKpqOBWz61ZTETiN8lAaax1onoHB489OxhhMC14ndForG01jcBESFQgaaJzM9aFoFwrhFHhFircQlijTU96SI8J8iXmIQnRiMAXVcj4Dk8gPZvNaoUIluQAJ2RemWo4bl2SkEoSAJAWhSjYQf3fr9DVhytEQI4hnII61zTAxjX0%2BuTT2QC9rfwa9M8%2Bo9PLc7N0MuhfHr8x%2BMBtRKMUzCMlcvgk9Vlp4heFOJkpRrQmEgWYg7uAOpJgjoIrYsZLH210zlmW6%2BuxJATl2IowcFlI8HlCuEJTLDOUgKlC6R0icBoZEqAmYZOlxLg0onMS2uaosKTYZ%2BRkI96vwgmN3Vc1lD941UPjVW8NvgrMVjciwomEvAQmZnEMmGWkXxsLwjABL8sEKxxTb2z0Ifd2LJSmPCr9fQ1ngY6%2F9AcfkMYyIhoOxhxdH51dqDfFga4ib3SLtauLU0R5wNKQFEdpFvNjQYmA%2BGcIsqAIBWIUwo%2BZMjFRGQ8uUv8TycqM3lpNRuqyzJjn5GBfyFBZva8PViRFmuT1VTKEfZ0lpqRyfvBqNuAVKJuKzfP%2BWsBC2FDNNOGH7cWCjLEdMJGGkCRc25xoY0ZDjTXajrOsPYvTX2G830TotGzP7h7abtv7Ifbcdtt23Y7tNl271XzapMmsJ%2BNQZqI9LBJlQrJNkGrf%2FNg4xgvBFalC%2F68BvR2A3o8GbOwAbHwfoGlVpoOsQAc3K0RfpDwgmyimV%2Fo4mNRVrBM7VXWCla67%2FwBMJBWS6gx6u%2FMd8FCKgy0OqGR0mTICxWGVhdrbBHwUxxjLYGX0%2BuZ6ZXNYbYZYY3ifHuWV7r5DyREXnLxbj1bNgvo0bRybi%2Bmc95OEmbDruT6GZg29QQ%2BwDsaQ6QMRGiy4XqBRbBcp91aY1vJ2WbOABhmuqv8WXKvaBJljuLZJGdOSATzlVIe0kk%2BwxLEyV3ul%2BXVD9bbS%2FWqZ57wUzMs4aqn2hMrO5D5eBA1MIj26ixvCm97dZZzfV8KeEfY78WiuvPuEBXzWDMcaMlAu2imdRgLftVQl3DDCs8b0nnezcO5rOU5EK5h4MRstDglVOG1Gd5YhTiMuJBkq%2BMUarj2rp2VKalacMk2HeIZXS2EwxCb2ECcFuwABXfJRnfBi5ig6Ynm639wNa5AYgYkgNQmEDw%2FdbhMH9bBN3Hoz6Dbq3dZhs95t%2BB3f8f2GOxqtDUpPDVLPDUqrw1xPsT6b4UxZS5PPa42zpPZ%2BReyJJvzSaDzd%2B39eJo%2FybVcRbTbskvdOpee7%2BIsJzq6msTU4O5X%2BJ8HZ1SS3Bmen0ksNTj55VGlTXfwl6W%2BdOtZobg4gPyvpYjR5gvX0COYeF22deNCfmLGKMRB%2BKRy%2Fc%2Fz6KThVc99yeVuDcWs%2Feewnj%2F3ksZ889pPHfvLYTx77yeO%2FmTxuQR9PSTjERs5zvHbd6dQd99rzel6z5zZtr9uBz1vH6TmO4UKULqg%2BLIHO2r8s1h8LZz751c9OWdg%2FPr08cBY3WH1sZef%2BCcvmn5W6n34UpzdvFT07spZ%2FATbGPGs9GgAA)

[Test mylocalpress.com/custom-domain example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGl2RWoC%2F%2B1YbW%2FaSBD%2BKytL1aUqODbmLVSRDiWtLm1ociGnq1RFaLEH2GDvOrtrwIm4336zfimQhtCe%2BqE58QXbuzPzzDM7MzviwdIQxSHVYHUerFiKGQtAngVWx4rSUPg0jCUoZfsisipf9z%2FRCOWtXkrOjQi5NDK4r0DOmA%2BZup8oLaJqICLK%2BGrvSVVykgmT01J4BlIxwa2OW7FCMRZ%2FyRCVJlrHqnN4%2BNizwxFF04JXQzaeaFvNxmgiAOVLFuvMjHUpGNeKUJK7RXK3CNVk05MO0RMgQ0l5AAEZAf4wRYzv%2BIbS8%2Fm8kotQCYc0hkVpynPcqoSASfARSItcFO2Q7t990n%2FXJ4ByIaEJqnPNfGpcIwenH8965E3pV697dk7eX12YpdNe9%2BrktcFHbiM2TtA8USKDj5NhWJj4TREOcxWC1iCJTzm6i6gjieYYuiLmvPDRJhc8TDN9PZEAJMNWEKLLQqLPU%2BCKzKhMSYymcqW3BPA0UiJQTeJmmIBxacQWENjmqKhkdBjC6Ua8XwVTFrmvKiR7qZUv3qvOGnwZmCfdGAMHiXmJTMziBDGLSB8YC8IwQS%2BLBMsdU69t8i7zdiKUZnxc%2BHuAZ0FOPnV774imcgwaD8YcXZecXarX%2BYGuIm9087X%2B5XvCuB8mAeRHaRazYyGxwPinBLMgDwUJGYafhsrERKXcv0yGHyEtMvrJajJSV0XGPCeH%2B0IGyup8ebDGUiRxVl8FQ9zXaWxKKuOHn2YDP5Gyqdgs768FLgSeqicxP2re38OE2n4okgCThGubgzZmNNaY13ScZeVZnO4K4%2FdNhFbDrtntI9tt1n6KPbfZtF23Zbt1127Ut5s0mbU1DkUm2oM8UaaQboKU%2B%2BZh04jeC66gDP1%2FBqztAKz9bEBvB6D3Y4CmVZkOsgLtfV4hDkXCfdhEMb1ySP1pVUU6thNVBap01f0GMJZMSKZT7O3OD8BjKfaecEDFo6skBCwOqyjUzibgozhGVPoro9efr1c2B%2BVmQDXF79lxVunuWxIfc8Hh7Xq0KhbWp2nj1FxMF7wbx6EJu17oE2zW2Bt0j2p%2FgpneE4HBwusFG8XTIsXeCtNa3iwrFtKAwar6b9C1sk3AguK1DUVMCwbmGsCvjO6AlToxlTRS5novtb9sqN%2BU%2Bl9yAwbGlIRZmIwbqjllsjW9i%2B59j8JYj24jT9Rmt7cp53elcM0ID1vRaKFqd3Ho83k9mGjMRHnfTNhsLOht46tlzwjPvdkdb6fBYqjlJBYNf1qLwtH9ETBFk%2Fr41jIBYGMuJAwUPqnG68%2FqaJlAxYqSULMBndPVUuAPqDkDjJfCXYTAbvmoXng%2Be2BntItQFUf93a2xglnim1Ayk03DWnPoQN2renXfq9YbbafaBupVjyDwgkbbG8EwWJuatk1Vz01Nmye7nnPdcE5TZS1Ngq910oLjJr8tjfmFstl%2BLfzahB6l4a7aWuvnj9J1p%2Bbznf5FRWlXU9kepZ2a%2F6Mo7eqm26O0U%2FMlRymbWcpEykaGR%2By%2Fd2hZ47s5v%2FzK7PPp5jn6s2Ocn1zy5ORE%2FqFhWFJH5i%2BJbD7KfUP22XnulyFXDpPL5U0F57f9GLMfY%2FZjzH6M2Y8x%2BzFmP8bsx5gXOMbcoA06g2BAjWzNqTWrTqvquNc1p%2BMedRqeXW%2B1W673xnE6jmP4gNI53YclUlr7%2F8fq07M%2FR7f9Pw75grXj%2BacP5%2BkwZUkU%2BrNzGrXk1aFL2cdJ1K%2BfHVvLfwEG5aE43xoAAA%3D%3D)

<!-- Internal tracker (dobbsryan/my-local-press): Part of #5969 -->
