### PR TITLE
Create fommo.ai.website.json

### DIFF
--- a/fommo.ai.website.json
+++ b/fommo.ai.website.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "fommo.ai",
+  "providerName": "fommo",
+  "serviceId": "website",
+  "serviceName": "fommo website",
+  "version": 1,
+  "description": "Connects a customer domain to their fommo published website (CNAME to fommo's edge).",
+  "syncPubKeyDomain": "fommo.ai",
+  "syncRedirectDomain": "app.fommo.ai",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "domains.fommo.site",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **fommo** (fommo.ai), a website builder. The template connects a customer's
domain to their published fommo website by creating a single `CNAME www` record pointing to
fommo's edge (`domains.fommo.site`, Cloudflare for SaaS custom hostnames).

The template is signed: `syncPubKeyDomain` is set to `fommo.ai` and the public key is already
published at `_dck1.fommo.ai` (TXT, RS256).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — *n/a: `logoUrl` is not set (no public logo asset yet; omitted rather than pointing to a dead URL)*

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead — *n/a: the template has no TXT records*
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — *n/a: no TXT records*
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — *n/a: the template has no variables*
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description — *n/a: fixed host `www`*
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead — *n/a: no variables*
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — *n/a: the single CNAME record is the service itself*

## Online Editor test results

**Editor test link(s):**
[Test fommo.ai/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGmrRWoC%2F91STY%2FTMBD9K5EvgDYpbvqVjcShtHtAKxa0WxaJqoqm9rS1FNuR7TRbqv537H4vIHHnlHjemzfzZmZLHMqqBIck35LK6LXgaD5xkpOFllK3QJD4HH8AiSfEhy2atWC4Zzc4t8KrnKPX3OiCrtFYoRXJ2zHhaJkRldu%2FyUgrhczZCCJWW6clmohrCUJFTkduhcJEB7WqnpfCrpCfdKO3o4fh57vA2zPe2Aj5Et%2B1Qjsbxb7W83vcjPdir50F9BG5ML7yGYeqal1xPKYNtySfbonbVMHVvpyHVtq6YL5pwpS0UM5OtA8c%2BrZHlaN150qSd%2FqU7ma7mPzUCouL9Cw%2BJvlsfAG%2FE2wxLS81%2FN%2FS6LoqxIlfgQFpw95OmdNXqbNT7pSQUFEslTZYWP8FVxvvw5kaYyLr0okCGriEOCv8EMqNb9B61Ev86V0dFnzwzsHBP33HpOAs9CvCxbA29LoZhSTrYDvpQocnt6yXJlm%2F36UDnmLG4Or2fr%2FJvx%2FfZVhoLSonwNcmw7KBjSW73Sz2g%2FtPrPj1WlgjLyDQUpr2EzpIaDqhNKf9nLZbt%2B2sR9Ob8KahebTuYG7rr%2BH6DshYvHfiaejuHjtqIsZN98vHetSsbhbPC7n8fv884Bl9kj9Kvvj2gex%2BAW3orYQ1BAAA)

[Test fommo.ai/website example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALCrRWoC%2F91STYvbMBD9K0aXtsQ2spNsYkMPIemh3TaEsLCFEIxszSYqtmUk2Vkn5L%2FvKN%2FpLvTek9C8mTfz3syOGCiqnBkg8Y5USjaCg%2FrOSUxeZFFInwniXuJTVsAZwbAG1YgMDtkbSLVAlkv0Nte5og0oLWRJ4sAlHHSmRGUOfzKWZQmZ0Q5zslobWYByuCyYKB0jHbMGoZwjW1WnudBr4Gde5%2FN4Ovr1zeYdMj5pB%2FgKvvh2nLbMZnX6CO3kQHavzKJz4EJh5wvOqsq%2FyUFMKq5JvNgR01ZW1aEdQmupjRW%2F2ViXpCiNfpIYOM6tTywn6cbkJO4%2BULpf7l2ylSUkV%2BqleyrCanhluBPwM1lce6S5XOFvpWRdJeJcUzHFCm13d65e3JUvz%2FWLI4HtLFalVJBofJmpFeoxqgaXFHVuRMI27BriWYJm5C0OqhFFmvcelMdFowf%2BaUbODPunCS5JeGYHF%2FZ8BnzQi3i371Eaca8XBZGXAgy8HvBgGPajYTpkN4f494F%2BfIn3zoHWUBrBsD8Z5RvWarLfL1108X%2FThEvXrAGeMJsa0vDBowOPhk%2BUxnQQB6Hfx2AYdOyfWgGgzVHgDu%2Fj9jLIaxFtm9%2BTn%2BP5JH%2Be9fr0x7b9Mx9mzUu%2FW48mXRVMZtPOc%2BfRDL%2BS%2FRuID%2BRsTwQAAA%3D%3D)
