### PR TITLE
Add template: xonark.com.aeo (Xona AEO — sync flow, single CNAME)

### DIFF
--- a/xonark.com.aeo.json
+++ b/xonark.com.aeo.json
@@ -9,6 +9,7 @@
   "syncBlock": false,
   "syncPubKeyDomain": "xonark.com",
   "syncRedirectDomain": "aeo.xonark.com",
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",

--- a/xonark.com.aeo.json
+++ b/xonark.com.aeo.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "xonark.com",
+  "providerName": "Xonark",
+  "serviceId": "aeo",
+  "serviceName": "Xona AEO",
+  "version": 1,
+  "logoUrl": "https://aeo.xonark.com/logo.png",
+  "description": "Serves your existing website through the Xona AEO edge so AI assistants (ChatGPT, Perplexity, Google AI) can read and recommend your business. One CNAME; your site keeps working exactly as before, fail-open.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "xonark.com",
+  "syncRedirectDomain": "aeo.xonark.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.xonark.com",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Service Provider template for **Xona AEO** (https://aeo.xonark.com) — an AI-findability edge service for small-business websites. Owners connect their site with a single CNAME; the template lets their DNS provider write it via the synchronous flow.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://aeo.xonark.com/logo.png → 200, image/png)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published at `_dck1.xonark.com` (TXT, `p=N,a=RS256,d=…`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the service uses `redirect_uri` in the synchronous flow)
- [x] no TXT record contains SPF content (template has no TXT records)
- [x] `txtConflictMatchingMode` — n/a (no TXT records)
- [x] no variable is used as a bare full record value (template has no variables)
- [x] no bare variable is used as the full `host` label (host is the fixed label `@`, scoped by the `host` apply parameter; `hostRequired: true`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — the single CNAME is the service's core record, set to `Always` (removing it disconnects the service entirely)

## Online Editor test results

**Editor test link(s):**

[Test xonark.com/aeo example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD8PRmoC%2F91TbW%2FaMBD%2BK5Y%2FbWqgIQxYM00a7aauQy1V202bKoTs5AgWiZ3aDiFF%2FPedQ8PLOmnf98nnu%2Bden7s1tZDlKbNAwzXNtVqKGPRVTEO6UpLpRTtSGfV2lhuWIZL%2BrG2oN6CXIoLagYHaaw6AZPhljIYlaCOUpGHHo6lK1HedImBubW7C01N0bu8znjpAO5cJ%2BsVgIi1yW%2FvSewwPhlSq0ARWwlghE1ICN8ICsXOtimSOL5AmM4E4AWIUGV4RZgx6MGkNeXMxZ%2Fby9sEjt6DzFEPZyiOXSiUpIPQtiZgkGlhMmIxRwKIyQKlOzAsjJBjTJmMJ5OJmeP3lw9ZSl7EAyA0plV644mDFIptWmJxwmCkNHpkxkbZUDrLtBlbJ6DxV0YKGM5Ya2GpuCz6C6rPKmJB%2FkuHsdxALrMruEMcDRNRcGXsHTwXCkB2rC4zs%2BtCxoeHjmtoqdwzV1b%2FA8fvJka0EjuhB4TeSyONxXGuRt27f9z2KIwBpBXNEDtOSVYZuJhuPPisJ032uCZLYlInTwH2DgxpRWZYlfhIkL5%2BKxiVnmmXGrWXj%2FHjkPWncH2t%2F%2FDInO8EUvBHrBhqcU9jVTsxWOyXTCbzosX6RSORpavBlttDQjC8rUiumrGR7VRxNWZ6nFbZr0IohXo9Wbm9h22XMLPvnYKdx5BoX7qyCgM%2F6Pc5bZ%2F1%2Br%2FUOurzF4w60el3GeQw8OOtHBxf6%2BnZf3%2BjR2P9G4mbiIQX%2FRyduH9gS4ilzyMAP%2Bi1%2F0PKDB38Qdjph76zd8QedXvfE90Pfd9WDsdve1rgLh1tAL0ajrz%2BCp%2FfivuLzuxkf3%2F9a6Eimo%2FNx8Pz0LU8v5eBaFidgrz7SzW9%2FCIkXXQUAAA%3D%3D)

(`hostRequired: true`, so the apex test is not required per the template instructions — the record targets a subdomain host supplied by the apply parameter.)
