### PR TITLE
Add Anypost templates (mail, tracking)

### DIFF
--- a/anypost.com.mail.json
+++ b/anypost.com.mail.json
@@ -1,0 +1,35 @@
+{
+	"providerId": "anypost.com",
+	"providerName": "Anypost",
+	"serviceId": "mail",
+	"serviceName": "Mail",
+	"version": 1,
+	"syncBlock": false,
+	"syncPubKeyDomain": "anypost.com",
+	"syncRedirectDomain": "anypost.com",
+	"description": "Verify your domain for sending and enable DKIM signing.",
+	"logoUrl": "https://anypost.com/brand/wordmark.svg",
+	"records": [
+		{
+			"groupId": "verification",
+			"type": "CNAME",
+			"host": "anypost",
+			"pointsTo": "%label%.c.anypost.email",
+			"ttl": 3600
+		},
+		{
+			"groupId": "dkim",
+			"type": "CNAME",
+			"host": "s1._domainkey.anypost",
+			"pointsTo": "s1._domainkey.%label%.c.anypost.email",
+			"ttl": 3600
+		},
+		{
+			"groupId": "dkim",
+			"type": "CNAME",
+			"host": "s2._domainkey.anypost",
+			"pointsTo": "s2._domainkey.%label%.c.anypost.email",
+			"ttl": 3600
+		}
+	]
+}

--- a/anypost.com.tracking.json
+++ b/anypost.com.tracking.json
@@ -1,0 +1,22 @@
+{
+	"providerId": "anypost.com",
+	"providerName": "Anypost",
+	"serviceId": "tracking",
+	"serviceName": "Open and Click Tracking",
+	"version": 1,
+	"syncBlock": false,
+	"hostRequired": true,
+	"syncPubKeyDomain": "anypost.com",
+	"syncRedirectDomain": "anypost.com",
+	"description": "Configure a branded domain for open and click tracking.",
+	"logoUrl": "https://anypost.com/brand/wordmark.svg",
+	"records": [
+		{
+			"groupId": "tracking",
+			"type": "CNAME",
+			"host": "@",
+			"pointsTo": "track.anypost.email",
+			"ttl": 3600
+		}
+	]
+}


### PR DESCRIPTION
# Description

Adds two templates for Anypost (anypost.com), an email sending platform:

- `anypost.com.mail.json` — domain verification + DKIM. One verification CNAME and two DKIM selector CNAMEs delegating to Anypost-managed DNS under `c.anypost.email`. The single variable `%label%` is the per-domain delegation label; the target suffix is fixed in the template.
- `anypost.com.tracking.json` — branded open/click tracking CNAME pointing at `track.anypost.email`. The tracking subdomain is supplied via the standard `host` parameter (record host is `@`).

Both templates pass `dc-template-linter -cloudflare` with informational notes only.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes: the templates contain no TXT records (all CNAME), so the SPF/`txtConflictMatchingMode` items are vacuously satisfied. All records are required for the service to function, so none are marked `essential: OnApply`.

## Online Editor test results

**Editor test link(s):**

- [Test anypost.com/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANCpRmoC%2F%2B1UXW%2FaMBT9K5GlPg2CE0opkfbQrvtoK6pqYp8IRTexoR6JndkmNEX8910HKHSjnSbtpVLf4vvhc%2B7JuV4Qy%2FMiA8tJtCCFVqVgXJ8zEhGQVaGM9VOVk8Z96gpyLCUnqyQmDNelSHndkoPItqF1aX8VLLk2QkkSBVhQyfQ0U%2BmURGPIDF9FrmfJJa%2FOFN4i%2F8B3BR85E5qn9pESxk2qRWFrFPKZazGuvErNtMfqBm%2BstGe4ZEJOPJDM4xKSjHtnl%2Bd9z4iJxLiP92Rqoj7pDO%2B4sbYwUau1g9NKNLa25kqzHPTUN%2BUEW5AVBgyJhgsy0WpW1HKUjoJIoWbUILYqnB5vrk76b%2FF44%2FS7n8FJrIS0ZqAweJBBwrMDP%2FU30HytrbVIrH1E6bKxC8WmIn8UwgR%2BvJJgyit%2FL%2BDDkv8MH%2F4dPvxX%2BNGyQe6U5PFW%2BhFaYOMMfgtoa752xpoIftWUY7GpL0BDbpz1N53DB62jTe%2BQuO%2Balzuw2%2BoOkpQRRwOdozSPnYPAzjQqYPUMPZ3PMitimMM2xNIYiiKrkLXBLF6FhvlNNblam61ODCw4jdeYT8nSIDFL3TjC%2FZUkaCfQ69Bmh3YPm4cd6DZ7IUuaYTpOux3g0KNHO6u9Z%2Bv3LPdWS25wmawAtykn2RwqQ5bOFvvnecyE6%2Bkepp%2F7rOHTs4bPb9ZRA%2FflxawvZn0WZsW32kDJWQyuLKThUZN2mzQcBMdREEThsd9p94JD%2BorSiFJHnhu7GniBL%2FruW04uvs1b%2BY93%2BueN%2FDIfCHp7%2Bp1dtquz96VsF9nFKVOTrx8u4K64pq%2FJ8hcE9752UQkAAA%3D%3D)
- [Test anypost.com/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB2qRmoC%2F%2B1VTW%2FiMBD9K5GlngohuCyhkfZAP3ZbVa0q1O1hEYqG2FCLJI5sJ22K%2BO87TkKBLt0PaS9d9ejxzLw3L2%2BcJTE8yWIwnARLkilZCMbVJSMBgbTMpDZuJBPSerm6gQRTybC%2BxAvNVSEiXpUkIOJNqEm9roMFV1rIlARdTCjT6CSW0YIEM4g1ryO3%2BfSKl2cSu6Q%2F4duEEWdC8ci8kcK4jpTITIVC7rkSs9IpZa4cVhU4M6kczVMm0rkDKXN4CtOYO2dXl9eOFvMU4y72ieVcflMx9ngwJtNBp7OF05kqLO08SsUSUAtXF3MsQVYY0CQYL8lcyTyr5CgsBRFBxahFTJlZPU5vhtfneHyw%2Br3MYCWWIjX6TmLwIIYpjw%2FcyF1D80ZbY5DYUd%2FzVq1tKLYQyZsQuuuGtQQLXrp7AXdT%2FjE8%2FT08%2FVv4yapFnmXKw430E7TA2hn8CdDWvHFGQ6RpUtEOxbomAwWJtvZfV493yifr%2BnHdAM8VPxtgT%2BUzTCNGLB10kFQ8tE4CkytUwqgcvZ3ksREhPMImxKIQsiwukb3GW2yFxnmlXlqvz1qChjwDA1bwBvhXGrVIyCI7l7CfiPYoY8wftH3odds9z%2FPb0PP9tn%2FEB%2F5s0KMzoFt7vucJ2LPpu8JyjdtlBNjVGcaPUGqysj7ZP9heV74aczfnfxia%2FsHQ9H0OPWnhOn34%2BMPH793H%2BMJrKDgLwaZSj%2FbbiO3Ru%2B4g6NKg98kdeP1B1z%2F0vMDz7ABcm3roJf4Htv8A5MvIlAbEafFwkR%2Byp9MR%2B2qAJndldHLcv%2FieHZ%2BPRvca%2Bjd6%2BJmsfgARKdyDjwkAAA%3D%3D)
- [Test anypost.com/tracking example.com/track](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALGrRmoC%2F91TXW%2FaQBD8K9a9ho8DEn9JlZrQRK2ihpYQqSpC1uJbyBX7zr07TCjiv3dtcEnTRn3vk3W3M7Ozc%2Bsdc5gXGThk8Y4VRpdSoPkgWMxAbQttXSfVOWv9Kt1BTlB2eShSwaIpZYo1xRlIV1ItT9dH%2BKhA5YES3jCT6cqbnHAlGiu1YnGPOFuVXmU6XbF4AZnFFnukHmP8vpYGSd%2BZNR5Qn9bzW9y%2B0zlI9YfVCjBGQZzUvQIRaFMjC1d3ZkOtFnK5NuiBNzdkE4UnaqK30MbTjfm0Nt8M2SGdTC%2F1g8lI49G5wsbd7rM%2B3Vqru9FG5GBWHVtWA5MrurAsnu7Y0uh18TI5ty2qyIZ3lx%2Bv2SECOr6t3kBL5exEN%2FhO0wzJa1ZRHVkZ%2BJzvZ%2FsW%2B6EVJqd2Mxq7SQOfgF4dj2kcW9SadKxdJbIhFWAgt9V6NPTpb%2FxZIzA9KlS95VJpg4mlLzhKtnm8fJ05mcAGTlciTaAosi1ZtVQlHUrmRQjqsEaNQwEO%2Fh1CiyUirXzLKuHQ54GfBlEbuD9on0cC2lF0Du1g0Q94T%2FDBfBE%2B2%2FO%2F%2FAKvbPqL9NBaVE5CtRSX2Qa2lu33sxYl%2BR%2BORW9voUSRQIXt877f5kGb9ye9MO5FcT%2FqBOF5FIRnnMecV1OgdYcxd7Qlz%2FeDjfjAXNz7%2Fa%2BufBiULnz%2F5F%2Fkk5vJ%2FbfxjRvpcPz57Mv17XISXl2%2FYfufxAq5FLkEAAA%3D)
