### PR TITLE
Add agentcollect.com.email-whitelabel (SendGrid white-label sending, sync flow)

### DIFF
--- a/agentcollect.com.email-whitelabel.json
+++ b/agentcollect.com.email-whitelabel.json
@@ -1,0 +1,36 @@
+{
+    "providerId": "agentcollect.com",
+    "providerName": "AgentCollect",
+    "serviceId": "email-whitelabel",
+    "serviceName": "AgentCollect White-Label Billing Email",
+    "version": 1,
+    "logoUrl": "https://agentcollect.com/logo-512.png",
+    "description": "Authenticates a billing subdomain (DKIM via SendGrid) so AgentCollect can send accounts-receivable emails from the customer's own domain.",
+    "variableDescription": "%emLabel%: SendGrid-generated mail CNAME label (e.g. em6456); %sgTarget%: SendGrid account link prefix (e.g. u17558810.wl061).",
+    "syncPubKeyDomain": "agentcollect.com",
+    "syncRedirectDomain": "dashboard.agentcollect.com,backend.widr.app",
+    "hostRequired": true,
+    "records": [
+        {
+            "groupId": "sendgrid",
+            "type": "CNAME",
+            "host": "%emLabel%",
+            "pointsTo": "%sgTarget%.sendgrid.net",
+            "ttl": 3600
+        },
+        {
+            "groupId": "sendgrid",
+            "type": "CNAME",
+            "host": "aco._domainkey",
+            "pointsTo": "aco.domainkey.%sgTarget%.sendgrid.net",
+            "ttl": 3600
+        },
+        {
+            "groupId": "sendgrid",
+            "type": "CNAME",
+            "host": "aco2._domainkey",
+            "pointsTo": "aco2.domainkey.%sgTarget%.sendgrid.net",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **AgentCollect** (agentcollect.com, YC S23) — accounts-receivable automation. The template authenticates a billing subdomain via SendGrid (mail CNAME + two DKIM CNAMEs) so our customers' AR emails send from their own domain. Sync flow only, `hostRequired: true` (applied as `domain=customer.com&host=billing`), apply URLs are RSA-signed (`syncPubKeyDomain` set; public key already published at `dck1.agentcollect.com`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` — n/a, the template has no TXT records
- [x] no variable is used as a bare full record value — CNAME targets have the fixed suffix `.sendgrid.net` / fixed prefixes `aco.domainkey.` and `aco2.domainkey.`
- [ ] no bare variable is used as the full `host` label — **one exception, justified below**: `%emLabel%`
- [x] no variable is used in the `host` field to create a subdomain — the billing subdomain comes from the `host` apply parameter (`hostRequired: true`), not from a variable
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — n/a, no user-modifiable records (all three CNAMEs are required for the service to function)

**Justification for the `%emLabel%` host variable:** SendGrid's domain-authentication API generates an opaque, per-domain mail-CNAME label (e.g. `em6456`) that the service provider cannot fix or predict, so the label must be a variable. Misuse is bounded: the record is scoped under the customer-chosen `host` (never the zone apex), it is a CNAME whose target is pinned to the fixed suffix `.sendgrid.net`, and every apply URL is RSA-signed (`syncPubKeyDomain`), so the variable cannot be tampered with in transit. The two DKIM selector labels are fixed (`aco`/`aco2` via SendGrid's `custom_dkim_selector`) precisely to avoid two more host variables.

## Online Editor test results

**Editor test link(s):**
[Test agentcollect.com/email-whitelabel example.com/billing](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP%2FuRmoC%2F%2B1VbU%2FjRhD%2BK6uV0B1q7DhL4oCrfkgPaA%2FK9e5KRVsURevdwVmwvb7ddUKK8t9v1nmBBK6ID%2F1y4pOleXnmmZlnx3fUQVHl3AFN7mhl9ERJMO8lTSjPoHRC5zkIFwpd0Nba%2F4EXGE8HPuLdIgK9FsxECWiSoeAqD6Zj5SDnKeT37idyyYWPC37zgeRnleeqzMiRR8C0CRirdEmTTovmOtN%2FmhzTx85VNmm3t0m2fUjQ67CwKjPMlmCFUZVrEOigdmOMVwL7tYSTdFnL1qnUWK8kbw9P35%2BRieLkDyjlL0bJXWI12WAreEksegkXQtels4EBAWrC0xxI07glV0YXBIsRUVunCzBvLNHTkizKhL4vbpTPONxguANFM4adZE0gwNpgkLEkHpu8%2BzA4OyLNVMlbCLMQa8bdXrz7I9mx2Tk3GbgH6SuWBDu9IZWBK3W7zKs7%2FV5vf78ThdM8iju7npadleJjnZ7C7LCh%2BrQQfNRnkAobd%2Bs4ye041dzIcDujlXJxg3zCqZIm5FWFEGNt3Wf4UiMGCsaZGloU4bSRliaXdzQzuq4aLflZZ9gJJrlZ5cXTjGCJ8XBoXqJa4UbOtTevpxGuIMISvFKdQw3txVE0b72oEBc6HC1WeAOzzWret3aF%2F0tt9l%2FF2QurD%2Bct%2Bq8uYXQ%2F9CG%2Bl9Uy4ZbjXYDlvpcclu8FDQ3xkVqlVdzwwvoTsgK43EAYriAu1xhoWq6tCW4k7I0r6t66JVDqOaus1AZGFr%2Fc1QZW2inq3KkRn%2FJ7kxQj1Fo%2BwxYtehERdbU13XJxjhb1w%2FsGJXcc7VsMvjnOFh1J4ftXfpldwSTrMhawjuwH3ZTvB1xCGvTlwdVBv3fV6aT8wTn91rl95qA%2BWgpY668b9wdykE%2F5zNK5V9nTLW%2BK%2BXHrm4L%2BvgfBnpsE%2B65GMWzho319C69v4fUtzIf%2Bn8MnIEfcR7OIxUHUDyJ2zvaSKE72DsK4G7P9%2BIcoSqLINwXWLaZxh%2F%2Bjh38iyn69vRA5m5bXjF%2BffDo5te6fwdlx3Tv9S59c%2F304dcfd36N2%2B8ue%2FYnOvwJMwJSJfQsAAA%3D%3D)

Apply result (domain=example.com, host=billing, emLabel=em6456, sgTarget=u17558810.wl061) matches the live SendGrid API output for the same inputs byte-for-byte:
```
em6456.billing.example.com.          CNAME 3600 u17558810.wl061.sendgrid.net
aco._domainkey.billing.example.com.  CNAME 3600 aco.domainkey.u17558810.wl061.sendgrid.net
aco2._domainkey.billing.example.com. CNAME 3600 aco2.domainkey.u17558810.wl061.sendgrid.net
```
(hostRequired=true, so no apex test per the PR-template exception.)
