### PR TITLE
Update godaddy.com.aab: add SPF, DKIM, and DMARC records

### DIFF
--- a/godaddy.com.aab.json
+++ b/godaddy.com.aab.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
   "description": "Enables a domain to work with GoDaddy Airo App Builder",
-  "variableDescription": "v1 is the IP address of the server. dcv is the certificate validation CNAME value for SSL provisioning.",
+  "variableDescription": "v1 is the IP address of the server. dcv is the certificate validation CNAME value for SSL provisioning. dkimSuffix is the domain-specific DKIM identifier (e.g. example_com.c98).",
   "syncPubKeyDomain": "domain-attach.api.godaddy.com",
   "records": [
     {
@@ -25,6 +25,30 @@
       "pointsTo": "%dcv%",
       "type": "CNAME",
       "host": "_acme-challenge",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "v=spf1 include:secureserver.net -all",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "secureserver1._domainkey",
+      "pointsTo": "s1.dkim.%dkimSuffix%.onsecureserver.net",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "secureserver2._domainkey",
+      "pointsTo": "s2.dkim.%dkimSuffix%.onsecureserver.net",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=reject; rua=mailto:dmarc_rua@onsecureserver.net; adkim=r; aspf=r;",
       "ttl": 3600
     }
   ]

--- a/godaddy.com.aab.json
+++ b/godaddy.com.aab.json
@@ -28,9 +28,9 @@
       "ttl": 3600
     },
     {
-      "type": "TXT",
+      "type": "SPFM",
       "host": "@",
-      "data": "v=spf1 include:secureserver.net -all",
+      "spfRules": "include:secureserver.net",
       "ttl": 3600
     },
     {

--- a/godaddy.com.aab.json
+++ b/godaddy.com.aab.json
@@ -3,7 +3,7 @@
   "providerName": "GoDaddy",
   "serviceId": "aab",
   "serviceName": "Airo App Builder",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2020/02/godaddy_logo_new.png",
   "description": "Enables a domain to work with GoDaddy Airo App Builder",
   "variableDescription": "v1 is the IP address of the server. dcv is the certificate validation CNAME value for SSL provisioning. dkimSuffix is the domain-specific DKIM identifier (e.g. example_com.c98).",

--- a/godaddy.com.aab.json
+++ b/godaddy.com.aab.json
@@ -30,8 +30,7 @@
     {
       "type": "SPFM",
       "host": "@",
-      "spfRules": "include:secureserver.net",
-      "ttl": 3600
+      "spfRules": "include:secureserver.net"
     },
     {
       "type": "CNAME",
@@ -48,6 +47,9 @@
     {
       "type": "TXT",
       "host": "_dmarc",
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1;",
       "data": "v=DMARC1; p=reject; rua=mailto:dmarc_rua@onsecureserver.net; adkim=r; aspf=r;",
       "ttl": 3600
     }


### PR DESCRIPTION
# Description

Add email authentication records (SPF via SPFM, DKIM, DMARC) to the GoDaddy Airo App Builder template. The \`%dkimSuffix%\` variable captures the domain-specific DKIM identifier (e.g. \`example_com.c98\`) required by GoDaddy's onsecureserver.net DKIM infrastructure.

- Add SPFM \`@\` — \`include:secureserver.net\`
- Add CNAME \`secureserver1._domainkey\` → \`s1.dkim.%dkimSuffix%.onsecureserver.net\`
- Add CNAME \`secureserver2._domainkey\` → \`s2.dkim.%dkimSuffix%.onsecureserver.net\`
- Add TXT \`_dmarc\` — DMARC reject policy with \`dmarc_rua@onsecureserver.net\`
- Updated \`variableDescription\` to document the \`%dkimSuffix%\` variable
- Bumped version to 2

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern \`<providerId>.<serviceId>.json\`
- [x] resource URL provided with \`logoUrl\` is actually served by a webserver

# Checklist of common problems

- [x] \`syncPubKeyDomain\` is set — set to \`domain-attach.api.godaddy.com\`
- [x] \`warnPhishing\` is **not** set alongside \`syncPubKeyDomain\`
- [x] \`syncRedirectDomain\` is set whenever the template uses \`redirect_uri\` — N/A, no redirect_uri used
- [x] no TXT record contains SPF content (\`"v=spf1 ..."\`) — using \`SPFM\` record type
- [ ] \`txtConflictMatchingMode\` is set on every TXT record that must be unique per label (e.g. DMARC) — not set on the \`_dmarc\` record; \`_dmarc\` is a fixed label so conflicts are unlikely, but this can be added if required
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full \`host\` label — \`%dkimSuffix%\` only appears in \`pointsTo\`, not in \`host\`
- [x] no variable is used in the \`host\` field to create a subdomain
- [x] \`%host%\` does not appear explicitly in any \`host\` attribute
- [ ] \`essential\` is set to \`OnApply\` on records the end user may need to modify — DMARC record does not set \`essential\`; this is intentional as GoDaddy manages the DMARC policy

## Online Editor test results

**Editor test link(s):**
[apex test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKJzS2oC%2F%2B1XbW%2FiRhD%2BK6uVkFoVjG04Ao6Qwh1Jm97llCZUahtF1rIeYBvbu7e7tkOj9Ld3FswBebl%2BOKlt1Hzyenben5nH8h21kKmUWaDRHVValiIBfZrQiM5lwpJk6XGZ0ebnq48sQ1X6vRy7S7wwoEvBYWXC2HQrqTVHQksyUoq8LUSKDlChBG2EzGkUNmkq5%2FJnnaLiwlplona7qiovkRkTOZd5Dtx6Us%2FblWrhq4XctguVSpaYduiHftsP23WisXMV51B5Kp9jlAQM10LZVSR6nLNpCoYwsvZNrCSV1DekEnZB6nLIU8kyLZzpeM9dGRBhiF0AOT0naKrBGCJnK4mrH7RHEl5ulDhoK2aCY59JyVKRMOeHvPs4Ojt2ggLITGpyefmBrBrt2iPyOfq4EdllMZuJ242rdfoto4A7j2T8%2FvSMIDK5CwCafAMe2sEtQ1ghRvA8Puh%2F6zlcljk%2FL6bvYTle%2BcAyamfMWsYXHlPC20ddA5c6MTS6wuGQIrdmItGsUQYNvLVLtUIYjwtpLB6PnNQimp2e798394yOtharurdWiPgX7BrYx8aztjHjGbT4gqUp5HN46Kc2ujw%2FOdvP0qjZRYEDga84aGmRQGSAF4jjGr0c7DO%2BHiSwaxV48bqjN%2BBWY6cIE3gOSq%2BxBbThyfzrQ4bPhwy%2FJuTkl8lOk5OMae52ilnmpn84PhtdvAsOiRpq%2BB139JDogg0xj9TKaKUdo%2BDocbhD3BbMZ6jxgBjgcy%2BB6%2Fsm%2FUPmEG8n77pZjykGrse6ns46OzzNtSxULDb6immWGcdoG8urPdPrje0VdecycKfAC72O13UCnDgnYVMehJ2V4HMLd1xtlou6pMU8lxpig09msWIaWV1Ak2ZFakXMKrYVJTxmSqVLrNHgLXq8utvdpXxNnEfbfm9S2%2BlUE0HhrkLhiHfQSbr9btdvMdbvtrpBf9qaAsxaPBl0Ov03Yf%2FA7%2B2Q%2BBP8%2FpjGt91FbnP0whxLj9KKLQ29f2I667zX21xnvg%2FYC8j%2BMZ%2FUldTD8N8sYr2tjwenHOKO4afqGYYjf2KZLwOXL9BsXeuGYh9s599Q3suoOHy64vCFV7w3tv%2FYR%2BZfb8B1Ez9Sr5z%2FyvmvnP%2FK%2Ba%2Bc%2F%2F%2FgfPyLMKyEJGZOLfTDXss%2FaPm9iT%2BIwiDq9D0%2FDMM3%2Fne%2BH%2Fm%2Byx2MXbflDv8vdv8saO%2FD7MdjbqDXX%2FxwMT3hA3Vz%2FNOvnwR%2Fe5JNPsFo%2FFvntjwZHVR6NKT3fwE6IR0G5BEAAA%3D%3D)
[subdomain test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANZzS2oC%2F%2B1XbW%2FbNhD%2BK4QAAx1my5LsJbUCA3HqbvDaZEnjYhuCQKCpk81FElWSkuIF6W%2FfUZZry7W3D8WABvAniUc%2Bx3vuFXyyNCRZTDVY%2FpOVSVHwEOQktHxrLkIahkubicRqf9m6ogketX4RY7OJGwpkwRlUEEpnG0l9csSlIKMsIxc5j1EBHihAKi5Sy%2FfaVizm4qOM8eBC60z53W5ZlnYoEspTJtIUmLaFnHfLrINLDanu5lksaKi6nuM5Xcfr1oYGRlWQQmln6RxvCUExyTNd3WS9TeksBkUoWekmWpBSyAdScr0gNR2yz1gquYGOG%2BoKl3BF9ALI5JogVIJSRESVxPAHaZOQFetDDKTmEWfoZ1LQmIfU6CFvrkaXb40gBxIJSW5v35PK0cY9PJ2jjgee3OZRxB%2FXqlbmd1QGzGgk43eTS4KRSc0FIMkrsBEHjxTDCgEGz2aD1z%2FYJi7LlF3ns3ewHFc6kEatjGpN2cKmGbebUZfAhAyV5d9hcgieajUVCGsVbgt39TKrIoy%2FC6E0%2Fp4bqcZo9k4c57ndAJ1vEBXvDQoj%2Fi%2B4FvqxdRAbUJZAhy1oHEM6h109Nej2%2BufLppUqiz7kmBC4xESL8xB8BSzHOK6il4I%2BoGvHgG2Uawcrjz6AKY0tEsq1TSjt1iagLVuk336ld%2FhK71uunP4x3XJymFDJTE1RTU32D8eXow9v3DOSDSX8hTV6RmROh2hHrIVfnQ5QcP71dWdYLWjPUOIPxgC%2FDQPun9vW3yKFYJN59%2B06TfHiOq3r7Fy7IzddZy5FngV8DcmopIkyTW0Nvmug79fwuwqPy8I1C9f27J7dNwLMOyOhM%2BZ6vUrwxZFb2tYlZhnT%2BTwVEgKFX6qRt%2BVrmUPbSvJY84CWdCMKWUCzLF4iU4W7qPHuabui0lX7XJGr%2Fb42bstjbQwOMzS5acCz%2FsBzI9bv9BlEnX7khJ2ZN%2Bh32GA2%2B8nt9cKZB1vNfE%2Bf%2F7qdN7yMbc50Gmoa9igu6VJZz3sStTbetPIGAVzYzRi%2BDCI7XaZJqk6Q75bLqpT35VMxxBLESXagAZLPyPfFxOhQI97JwLoR71TvfzTGF0PcO0zce%2FnEG5m8Gkr2TkL%2FT4Ppe%2FDDfRsH23FIHIfEcUgch8RxSByHxN4hge8URQsIA2pOeo530nFOO87J1Bn4nuf3HPt0cHryuv%2Bj4%2FiOY8wHpVeeecIXzPbbxXoMr1U3uhhPH38%2FTcqbCbz%2FVFxI0Dfdq3h544x%2B%2FfNjlk76v5WcDa3nfwDFnOHsTBIAAA%3D%3D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)