### PR TITLE
Add reallyquickemails.com.email-sending template

### DIFF
--- a/reallyquickemails.com.email-sending.json
+++ b/reallyquickemails.com.email-sending.json
@@ -1,0 +1,72 @@
+{
+	"providerId": "reallyquickemails.com",
+	"providerName": "ReallyQuickEmails",
+	"serviceId": "email-sending",
+	"serviceName": "ReallyQuickEmails Email Sending (AWS SES)",
+	"version": 1,
+	"syncPubKeyDomain": "reallyquickemails.com",
+	"syncRedirectDomain": "app.reallyquickemails.com",
+	"description": "Configures DKIM, SPF, DMARC and custom MAIL FROM DNS records to send email through ReallyQuickEmails (AWS SES)",
+	"logoUrl": "https://app.reallyquickemails.com/logo-rqe.svg",
+	"records": [
+		{
+			"groupId": "verify",
+			"type": "TXT",
+			"host": "_amazonses",
+			"data": "%sesVerify%",
+			"ttl": 3600,
+			"essential": "OnApply"
+		},
+		{
+			"groupId": "dkim",
+			"type": "CNAME",
+			"host": "%dkim1%._domainkey",
+			"pointsTo": "%dkim1%.dkim.amazonses.com",
+			"ttl": 3600
+		},
+		{
+			"groupId": "dkim",
+			"type": "CNAME",
+			"host": "%dkim2%._domainkey",
+			"pointsTo": "%dkim2%.dkim.amazonses.com",
+			"ttl": 3600
+		},
+		{
+			"groupId": "dkim",
+			"type": "CNAME",
+			"host": "%dkim3%._domainkey",
+			"pointsTo": "%dkim3%.dkim.amazonses.com",
+			"ttl": 3600
+		},
+		{
+			"groupId": "spf",
+			"type": "SPFM",
+			"host": "@",
+			"spfRules": "include:amazonses.com"
+		},
+		{
+			"groupId": "dmarc",
+			"type": "TXT",
+			"host": "_dmarc",
+			"data": "v=DMARC1; p=%dmarcPolicy%; rua=mailto:%dmarcRua%",
+			"ttl": 3600,
+			"txtConflictMatchingMode": "Prefix",
+			"txtConflictMatchingPrefix": "v=DMARC1",
+			"essential": "OnApply"
+		},
+		{
+			"groupId": "mailfrom",
+			"type": "MX",
+			"host": "send",
+			"pointsTo": "feedback-smtp.%awsRegion%.amazonses.com",
+			"priority": 10,
+			"ttl": 3600
+		},
+		{
+			"groupId": "mailfrom",
+			"type": "SPFM",
+			"host": "send",
+			"spfRules": "include:amazonses.com"
+		}
+	]
+}


### PR DESCRIPTION
# Description

New template for **ReallyQuickEmails** (email marketing platform for LATAM SMBs, sending through AWS SES). The template configures everything needed to authenticate a sending domain:

- **SES domain verification**: TXT at `_amazonses`
- **DKIM**: 3 Easy-DKIM CNAMEs (`%dkim1..3%._domainkey` → `*.dkim.amazonses.com`)
- **SPF**: `SPFM` on the apex (`include:amazonses.com`)
- **DMARC**: TXT at `_dmarc` with `txtConflictMatchingMode: Prefix` and `essential: OnApply`
- **Custom MAIL FROM**: MX + `SPFM` on the fixed `send` subdomain (`feedback-smtp.%awsRegion%.amazonses.com`)

Justifications for checklist exceptions:
- `%sesVerify%` is a bare variable as the full TXT value because the record value is prescribed by AWS SES (an opaque base64 verification token — no service prefix is possible). Same pattern as existing SES templates (e.g. `posthog.com.email-verification-us.json`). Marked `essential: OnApply`.
- The DKIM `host` variables are constrained with the fixed `._domainkey` suffix (`%dkim1%._domainkey`), per guideline 7's recommended form.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`200`, `image/svg+xml`)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — set on the `_dmarc` record; the `_amazonses` verification TXT deliberately has none since AWS allows multiple verification tokens to coexist
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — `%sesVerify%` justified above (AWS-prescribed token value)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- Apex: [Test reallyquickemails.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMjrR2oC%2F%2B1YW0%2FrRhD%2BK5alSK2IE18gBh8hEQGRKMeQJtCeFqFoY6%2BdxZfd7K5zAdHf3l3jxDHkUqQ%2BlCpPtjMz%2B83lm9lRXlQOExIDDlXnRSUUT5AP6ZWvOiqFII7n4wx5EUwAilnDw4laXyrdgEQYqb1c7VepdpmrCRUG6QR5MD8mt9UYTH2UhqVsk7WSP5T%2Bm77yU%2Fv3vtK%2F7P8sLCeQMoRT1THEKfPU62bDazi%2FwMIg3eKvVO1BH1Ho8aUyIKSxycCHzKOI8BxLPcdpgMKMQqZcXF%2B5daXf7dSVC7fdO1dA6itexjhOFLd99V3p9G5d5eKmrwgsTH2mcKzIyJX8fIWPKM7CkfIx6NUwYxziexoL6BHnhDnN5kZnm1JXo2PYYBOZ2wJWdR5e1FBgkbwCIm8omAsxnxOZ87sfd%2BJjhBkXHwOQgGecMijr5gMOxG818fVbblSTVlz4YrV0va5CJqLhCEjnbtM2IfFcfa2vYvkRSkqk85u2e1li1aTUqDUGfl6GCEqnCEYpZ3d4RS4fjaVfRVWWbnwW0NwBaP7bgNYOQOtzgIwEJZ4gn1vCnUl6k6CXxaJ8jopSL8586FQPfud%2BAqi3iQsLYcGDyWlOc%2BObQk5ruayLY%2BTNa98UmoFTSUOOnTdJLwPvyMJnXPaOMOAu4N5ItLOLfQnapTBAM3WtSiErwdV%2FQjvpSkDxSmHcH2VcsgWrdQgg9IfAizSWcNKogSnrwVD0e%2B1DUQhFmCI%2BF1NH31iij%2FDVOhUO7C7V42tdFd9wUHbyoyjHYmrBGRDDGhauFYeLt9yTAcr1y3YvmPrGn0Vpl66KcwmgIGFy8C8QHioQjwuMB1W%2B5yifQ1gOEmlmzs7vb61r3DqM3D%2Fp5OCZ3o87nV%2FaTXZ8714S3OP3VwCCg2eAT6VxPg2kYTAJyDgcjXArSp6ej6KnsEWHHCJ7%2BDSc4SFaKJtSOR0PA59bgNkzED1hKwiH05Dg2fQQxsQWQRbKllTOIgRsPPOsw9YEhiaxMjuOooTZCWXPyRPMlUviS5NxJrIm2JiWQsF9KcnfNQoJppydvUvkkmI5LNMgYFwzVFlwFKaYwgETT8DFRaM6nGZQJDKLORqAKSh%2F8r0BkPQX%2FGBCKs4Sk77SyunbvbpurH8q%2F5VWHvieZAmSXB8eA8OzrZY2BC1LO7SOjjSgHw%2B1E2DrlukdnwDTWNkStq4S2%2FaEkt1r21824LsZXIS%2Biy3V4VzkZqfR9on9X0pRO56COduWoV0tsjZDO43%2BTxnaNRfWZmin0ZfOUGW8nK0uCWL8G8raC035Szi0iFGE%2BKVi3LYNlZdAZRXafAN8oXGab05FDorFZTEkK1vT8hLbRunq%2BvR1il8N%2FOtz%2FLEuFsn9rrDfFfa7wn5X2O8K%2B11hvyvsd4VNu4L84wZMoD8AUs3UzZam25pu3Rm2ox85htnQDcM2jQNdd3RdxgMZfwv%2F5VWEtPJPhnrQ77hsNuOdk248a3rj9Ls9CczuNeqe2weT5ujm7jbq%2FOEH7Xn7VH39GxYboeyPGAAA)
- Subdomain (`host=mail`): [Test reallyquickemails.com/email-sending example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAADsR2oC%2F%2B1YbW%2FiOBD%2BK1EkpDuV0JBQ6GWFtPRt1e2lZYH2VldVyEmc4ObFwXYCtOr%2B9rVDIIQWuEp30nXFpxBmxs%2B8PDMe5VlmMIwDwKBsPMsxwSlyILl0ZEMmEATBbJwg24chQAGt2TiUq0ulaxByI7mXqX0TaueZGlehkKTIhtkxma1CYeSgyCtkm6yl7CH15%2FrSb52%2F%2BlL%2FvP87t0whoQhHslHnp8wiu5tYV3B2hrlBtMVfodqDDiLQZktlEMe1TQYOpDZBMcuw5FMcuchLCKTS2dWlWZX63YuqdGZ2eqcSiBzJTijDoWR2Lv%2BULno3pnR23Zc4FiYOlRiWRORSdr7ERgQn3kh6HfRqmAH28C0JOPSIsZgah4cbnT0UugoZwxpNRW5zWNm4f5Y9jhVnFeB5Q%2B6Mi9ksFjkffB%2FwlxGmjL8MQQiecEShqJsDGOD%2FVfjbXWZUEVaM%2B6I3VbUqQ8qjYQgI526iThwHM%2Fmluorl%2BCgskE6vO%2BZ5gVUR0nqlNnSyMvhQOBVjFDE6wCty8agt%2FcqrsnTjvYDaDkDt3wbUdwDq7wOksVvgcfKZBdxnQe%2FY7SUBL58ho8gOEgca5YPX3A8BsTdxYSHMeZC2M5rXP0lxu5LJujhA9qzySSIJaAsaMmzMJb0ErJGFTZnoHW7ATMDsEW9nEzsCtEugi6bymyq5rACX%2FwnthCsuwSuFMb8XcYkWLNfBhdCxgO0rNGRxrQImtAc93u%2BVV0WJCcIEsRmfOurGEr2GL9cpd2B3qR5eqjJ%2Fh8Oikx94ORZTC04BH9Ywdy0%2FXIDzt8ybIcpsipbP2Trn0KK8S3f52TEgIKRi%2BC9Q7kswDwuc%2BznQQ470PpTlQBFm2vT09ka%2Fws2Gb%2F5N0oMncju%2BuPjaOaTHt%2BZ5jHvs9hJAcPAEcFsYZ1NBGLqpG4%2B90Qg3%2FfDx6ch%2F9JrEYhC1rEdrii20UNaEcjS2XIfpgLamwH%2FEuutZEy%2FG00kDBnGLB5or60I58RFo4amtN5op9LRYT1qB74e0FRL6FD7CTLloAGEyTnjmOCujQsh7QEiy3wqBMSaMfl5L5pJqGSxVIKBMqcui8MiLMIFDyp%2BA8QtHNhhJIE9kEjA0BBNQ%2FOXYQyDagPOEcik%2Fi0%2F8UktH8%2Fu1GO%2B1nCd5b7%2BrCKW%2BHjq2oAvKpolmW60jR1OaOtSVRv3IVv6AmqroVr1xZGkNlz9XVoate8W2paFM9TfngejItaGc52AXbVam9VqSdlpun%2BP%2Ft1x1ggmY0W2p2tU0m1O10%2FJXS9WukbE5VTstP3yqSiOoHHza5rdEXXrz%2FpN%2BcL8WofJIP1yo8wWqth5xsUUVl0Zphdp8Y3ywyZttXXkyxBnr87S0di1vv21cL%2B9fH4sOb2Tg16D%2FQ5WvpfuNY79x7DeO%2Fcax3zj2G8d%2B49hvHP%2FtxiE%2BIoEUOkMgVDVVaypqS1H1Qb1lqE1DPa6pxw1dOz5QVUNVRUyQsnkKnl94WCtfVeQvg5Ozu6uu1ht0gxbA5p11cuN%2FdYLUPyHel8nkIL0aTccTR0Xf2vLLT7K%2FfVIjGQAA)
