### PR TITLE
add Swarmix AI, Swarmix AI verified sending domain

### DIFF
--- a/swarmixai.com.resend-sending.json
+++ b/swarmixai.com.resend-sending.json
@@ -1,0 +1,38 @@
+{
+  "providerId": "swarmixai.com",
+  "providerName": "Swarmix AI",
+  "serviceId": "resend-sending",
+  "serviceName": "Swarmix AI verified sending domain",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "swarmixai.com",
+  "syncRedirectDomain": "swarmixai.com",
+  "hostRequired": true,
+  "logoUrl": "https://swarmixai.com/icon.png",
+  "description": "Configure the Resend DNS records Swarmix AI needs to send approved outbound email from a workspace-owned domain.",
+  "variableDescription": "Use the Domain Connect host parameter for the Resend return-path host, usually send. %returnPathMx% and %returnPathPriority% are the Resend MX target and priority. %dkimSelector% and %dkimValue% are the Resend DKIM TXT selector and public key value.",
+  "records": [
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "return-path",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%returnPathMx%",
+      "priority": "%returnPathPriority%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey.%domain%.",
+      "data": "%dkimValue%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Swarmix AI verified sending-domain template for configuring Resend DNS records used by approved outbound email sending.

The template applies the return-path records to the requested host, such as `send.example.com`, and anchors DKIM to the requested domain, such as `resend._domainkey.example.com`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Additional validation:

- JSON Schema validation against `template.schema` passed locally.
- Official linter passed with:
  `dc-template-linter -loglevel error -tolerate info -logos swarmixai.com.resend-sending.json`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes:

- The DKIM TXT `data` value is intentionally variable-only because Resend supplies the full DKIM TXT public-key payload for the workspace domain.
- The template is `hostRequired: true` because Resend return-path SPF/MX records are applied to a host such as `send`, while DKIM remains anchored to `%domain%`.
- No DMARC or user-editable TXT records are included, so `txtConflictMatchingMode` and `essential: OnApply` are not needed for the current record set.

## Online Editor test results

**Editor test link(s):**

[Test swarmixai.com/resend-sending example.com/send](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAI7SGoC%2F%2B1W227bRhD9lcUCfqook7omBAzUjRHENZQIthy4NQRhRQ6lhUjudi%2BSVcP99s5yKYuE7SaPKZAXSZzL2ZkzZ4d6pAYKmTMDNH6kUoktT0FdpjSmesdUwR8Y7yaioJ1n52dWYDC98W5yfok%2BDWrLE6jyFGgo08B98HJ1dL7II1tQPOOQkjqWpKJgvMQU9GguShpHmL4vk99ykWxonLFcg7dM7fIK9hc%2B4WWxLuQaUq4gMW8GrYU21%2FCXxSgs3CiL2LlYiVuVY%2FTaGKnj09NW1ilPRNmVVV8p6ERxaapC6QdRZnxlFRCzBnJdkUAuPt8QLEGoVJNG4yUAGoyoGidMOmqRBmHNUli0ABack0yJgjCyE2qjJUsgELsSozxJXccSU5wtc7hoFXKrfQm%2BbYJ1lUgCcc0SyRROwYAimVDNQhUYq8pAMrOuIjvEasvyfF%2BV2CUnPmCK%2FsnDCWGY0jBNFReKmz062v1P7ohhagWmypB1GMKlG17cQI6FCVXDOdNXllt4gXJxdTkhs7sZ1uIzPJpd5jwhG9iTrUtzjNRc0%2Fj%2Bka6UsNIrWWboM3tZ6W%2F6cVLPHp9%2BdVqR2bXNAbMoL5PcphCzgv0tSg26VooxqIj%2BKAyfOk3gBmvHAyZ3bXgpeGn0TOBjm8XqTnlG2r5nOt8%2B2ZF1PBK5OZ7Z5ra78HpBmron%2FueJYyplhh2CPeutw%2BZPHYoMwOLI6ByTDjcJHhhuDWjcI0czzgqfqiIXvMqpqW%2FzVNWOaJUYtds7B9z7FvD8gHzvoec19rdwmyS72Axv25Ilm0AXRnbBBjvQJoi67SG3EqfPc7mnUeh8TVKd1W%2B5g6di0JnlmXHgzhZ4gQbIPHV08lUpFCw0fjM8Bw4bp7C54QuG2%2BHZlCYLXAr5HtnX6EVg1HNr1qVfpjXl9TC3Z0hLRF4VMfkHb3NzxB26SBNHPq%2F0lLyHZRSNgxEbhsHg%2FZAFy2w0DrLhu2ScJkPoDcLGO%2BDVF8R%2FvgTaGgGNPwxnbs%2Be5zu21%2FTJCbx5hV5t8ftm2WrzeMeiH7rp1mA9VOPyHil4Q2I%2F9GjnHVwfPzX8U8P%2FZw3jrtcM%2F6ctmAvthb1REI6DsD%2Fr9eJBP44G3TCKRr3hL2EYh64c16Nv%2BBH3f3PzUzmyw4c%2FB307u4p42P%2Fjy6dpUY7fDa96PM1%2BZ4zfrrkwH76q8fkZffoXm4xr6qYLAAA%3D)
