### PR TITLE
Add template: refyning.ai.sites (Refyning Sites)

### DIFF
--- a/refyning.ai.sites.json
+++ b/refyning.ai.sites.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "refyning.ai",
+  "providerName": "Refyning",
+  "serviceId": "sites",
+  "serviceName": "Refyning Sites",
+  "version": 1,
+  "logoUrl": "https://refyning.ai/favicon.svg",
+  "description": "Connects your domain to your site hosted on Refyning (www CNAME).",
+  "syncPubKeyDomain": "refyning.ai",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "sites.refyning.ai",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Refyning (refyning.ai) — connects a customer's domain to their Refyning-hosted site via a single `www` CNAME to `sites.refyning.ai`. Synchronous flow only, signed (`syncPubKeyDomain: refyning.ai`; public key published at `_dcpubkeyv1.refyning.ai`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (template does not use `redirect_uri`)
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (template has no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) (template has no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (template uses no variables)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description (template uses no variables)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (single core CNAME record — not applicable)

## Online Editor test results

[Test refyning.ai/sites example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN1ESGoC%2F91SXU%2FbMBT9K5GfhkhSNyFpGmkPiI6JTXQbFGlbVUVOfFMsEjuynZRQ9b%2FPbiktA2nve%2FLHvefee%2B49a6ShbiqiAaVr1EjRMQryiqIUSSh7zvjSJwy5L6EpqU0qunkOmogC2bECthjFNKjD31%2FJzu1zuAOpmOAoHbqoEktxJyuTdq91o9LB4KjwoCSGR3BfdbYUBVVI1ugtFl0IzqHQyulFKx0qasK4o8XuaTtx7oXSQB3BnZcWPqxWK%2Bdien796cS3jfa8%2BN7mX6GfbPFvdEsohKQKpfM10n1j5WzRJmTZzdMQ2vkIxrWaif0Q%2FNc0WhuFYYzxZrFx0ZPgkB2YF0bZvjo8ErMP8AtRH0qY21KKtsnYPr8hktTK7myPnL%2BCLvbYOUK2IltyISFT5iS6lUaGli24qG4rzTKyIocvWmSkaareNKhM1FC8lc53i91Jp0STf8l2UUYL2y6zNhlGeR6MaewFCU68szgsvSSPsDcaBUk5jqIiGudHnnvHju%2BZ7jAsUAq4ZsS66rxakV6hzWbhmsH9J1LMehXpgGbEpgU4iD088nA4C8I0iNLhyE%2FGwSiMTzFOMbbdg9I7cWvjhmMfoHLSPeRXtCrKzxOekLD%2BOf4i1BOc3beXV3ffZr8%2BXpJg%2BmP2%2B%2BEj2vwBnD4dg8UQAAA%3D)
