### PR TITLE
Add reply.cv.email template

### DIFF
--- a/reply.cv.email.json
+++ b/reply.cv.email.json
@@ -1,0 +1,52 @@
+{
+	"providerId": "reply.cv",
+	"providerName": "reply.cv",
+	"serviceId": "email",
+	"serviceName": "reply.cv Email",
+	"version": 1,
+	"syncBlock": false,
+	"logoUrl": "https://reply.cv/icon-512.png",
+	"description": "Sets up sending and receiving email on your domain with reply.cv: DKIM signing, inbound MX, SPF, and DMARC.",
+	"syncRedirectDomain": "reply.cv",
+	"syncPubKeyDomain": "reply.cv",
+	"warnPhishing": true,
+	"records": [
+		{
+			"groupId": "dkim",
+			"type": "CNAME",
+			"host": "reply._domainkey",
+			"pointsTo": "%dkimtarget%",
+			"ttl": 3600
+		},
+		{
+			"groupId": "mx",
+			"type": "MX",
+			"host": "@",
+			"pointsTo": "%mxtarget%",
+			"priority": 10,
+			"ttl": 3600
+		},
+		{
+			"groupId": "mailfrom",
+			"type": "MX",
+			"host": "mail",
+			"pointsTo": "%mailfrommx%",
+			"priority": 10,
+			"ttl": 3600
+		},
+		{
+			"groupId": "mailfrom",
+			"type": "TXT",
+			"host": "mail",
+			"data": "v=spf1 include:spf.reply.cv ~all",
+			"ttl": 3600
+		},
+		{
+			"groupId": "dmarc",
+			"type": "TXT",
+			"host": "_dmarc",
+			"data": "v=DMARC1; p=none; rua=mailto:dmarc@reply.cv",
+			"ttl": 3600
+		}
+	]
+}

--- a/reply.cv.email.json
+++ b/reply.cv.email.json
@@ -6,10 +6,10 @@
 	"version": 1,
 	"syncBlock": false,
 	"logoUrl": "https://reply.cv/icon-512.png",
-	"description": "Sets up sending and receiving email on your domain with reply.cv: DKIM signing, inbound MX, SPF, and DMARC.",
+	"description": "Sets up sending and receiving email on your domain with reply.cv: DKIM signing, inbound MX, SPF (SPFM merge), and DMARC.",
+	"variableDescription": "%dkimtarget%: the DKIM CNAME target supplied by reply.cv (a full hostname). %mxtarget%: the inbound MX host (a full hostname). %mailfrommx%: the custom MAIL FROM MX host (a full hostname).",
 	"syncRedirectDomain": "reply.cv",
 	"syncPubKeyDomain": "reply.cv",
-	"warnPhishing": true,
 	"records": [
 		{
 			"groupId": "dkim",
@@ -36,9 +36,9 @@
 		},
 		{
 			"groupId": "mailfrom",
-			"type": "TXT",
+			"type": "SPFM",
 			"host": "mail",
-			"data": "v=spf1 include:spf.reply.cv ~all",
+			"spfRules": "include:spf.reply.cv",
 			"ttl": 3600
 		},
 		{
@@ -46,7 +46,10 @@
 			"type": "TXT",
 			"host": "_dmarc",
 			"data": "v=DMARC1; p=none; rua=mailto:dmarc@reply.cv",
-			"ttl": 3600
+			"ttl": 3600,
+			"essential": "OnApply",
+			"txtConflictMatchingMode": "Prefix",
+			"txtConflictMatchingPrefix": "v=DMARC1"
 		}
 	]
 }


### PR DESCRIPTION
# Description

Adds the reply.cv email service template (`providerId` **reply.cv**, `serviceId` **email**). One apply sets up sending and receiving on a domain: DKIM (CNAME), inbound MX (apex), custom MAIL FROM (MX + SPF via SPFM merge on the `mail` host), and DMARC. Signed template (`syncPubKeyDomain: reply.cv`; public key published at `_dcpubkeyv1.reply.cv`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the SPF policy uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (DMARC uses `Prefix` / `v=DMARC1`)
- [x] no variable is used as a bare full record value — the only bare variables are `pointsTo` targets on CNAME/MX records (`%dkimtarget%`, `%mxtarget%`, `%mailfrommx%`), which are inherently full provider-supplied hostnames; there is no fixed prefix to add for these record types
- [x] no bare variable is used as the full `host` label (all hosts are fixed: `reply._domainkey`, `@`, `mail`, `_dmarc`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

## Online Editor test results

**Editor test link(s):**
[Test reply.cv/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMHoSGoC%2F%2B1Wa2%2FbNhT9KwSBAC1mKfIjLxUB4iXNkCZK0yTdMgSBQYnXNhdJFEjKjwXeb9%2BlLFmW5w7dsGEdkC%2BGRd5z7oPnXvKFGkiymBmg%2FgvNlJwIDuqCU58qyOK5G01oa7V%2BzRJo7mhQExFBAYCEibhe2zAm78vtCSgtZEr9NprO0%2Bj7WEbP1B%2ByWEOLxnIkP6sYgWNjMu3v7lYEuyKSqbPX7rhZOkIeDjpSIjMFF70Do0meEQ0pF%2BmIsJQTBRGIif0qQiMyJXOZK8IlfqZkKsyYVOw%2BObu8CIgWoxQBLSLSUObIETy0yN3NOXmDPwFJQI3gbatgPwv6t6euTYgpwcIYzhoB7fBnkRiG9mbHJ2YMSwen1%2F3gPVmuE51nWSyAk3C%2BCoS8YWSYxzEZS21SrOFbl%2BwkswZTHVxhtR2CGQ%2BVTJJZCYpybWRCgv7FFTm%2F%2FRj8CZouT%2BYWuMAamrOiXhsHj%2Fs3eXgJ8227iJKKa%2Bo%2FvtCRknlWCMRWBDfNPLPCKCqBn9btCj1Yns0zzK3spEiNvpcb1bQUBhXS3fe8RWvdQTKr6YOHmvtkg2xVzkLbQiph5qhH78vEZTG305fCbnioq%2F%2F3fVjJ%2FcGLzoa3eQxYWyrSKM45%2BLjkrhX%2FC%2Fw8YSqqye8f7mvuQbXJmWH4PTku1N1%2BR7LjVKbwjqicHdsIjPQL25NtDlsUNDagEcw28Me0j%2FK2B2lm5lSmw1hEJmAmGmOHBZLbKG4UDMVsu0m5V0dDF0%2BLFv0V4xnUAnvCoCsFwozhMAM3KqpY5ob%2FiiIMRGWfMcUSbQdehXxsQJ8q7CO1%2F2vp2ZVNnbprSNeauixhGKMGXZFVcrPwsnUdnZjMzbUDTBunXWLYtMasBGRRQwAesuh5O2zlCquD80sqGNg5xkyusMZG5ThXkzw2YsCmrF7i0YDZA8JiatxFP9itG82Zrg%2FxRnOWSvmr5WioZcAjewrCyvOwNwx7R7znDA8jcHphO3TC3l7H8bxwLzroeqyz31u7ijavqG0XUS2AdVn24ymba7qw3bHezGWqJ3VuX3VWjYSajf4tpldiywy%2FTlf%2FgxSX02xrjpNjnI9tsm1Ykt9YHH%2Bbkmwk9I%2BN5%2F8ku%2BoeWCyeWjh%2BX4fM65B5HTKvQ%2BZfGzL4etJsAnzArF3H6%2Bw73oHj9e7bbd%2Fr%2Bd2u2%2Bsc7rf3vvM83%2FNs7KDNMukXfEGtv51o5xofbmp29MvVT8nh0fTunI%2FHXXV5IDoq%2B%2FnTh0%2Bdq8vPM0%2F9%2BIOcHtPF7w6eDftODwAA)
[Test reply.cv/email example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKLqSGoC%2F%2B1W72%2FbNhD9VwgCAVrMUmTXThwVBuolLWYkaoI0RYMFgUGRlM1FEgWScqwG3t%2B%2BoyxZlusMXb%2B0A%2FLFAH%2B8d3eP705%2BwoYnWUwMx%2F4TzpRcCMbVhGEfK57FhUsXuLPZ%2F0gS3j7RXC0E5SWAJ0TEzd7OZfS%2BOl5wpYVMsd%2BFq0VKf48lfcB%2BRGLNOziWM%2FlZxQCcG5Np%2F%2FCwJjgUVKbOoNtzs3QGPIxrqkRmSi78iRuN8gxpnjKRzhBJGVKccrGwqzI1JFNUyFwhJmGZokdh5qhm99HZ%2BSRAWsxSAHSQSEOZA0dw20Gfrj6gV%2FAToISrGX%2FdKdnPgvH1qWsLIkqQMOZnrYQO2INIDIH75sBHZs7XAU4%2FjoP3aL2PdJ5lseAMhcUmEfSKoCiPYzSX2qSg4WsXHSTLFlOTXHlrPwQqjpRMkmUFork2MkHBeHKBPlxfBv%2BCxuuXueZMgIbmrNRr5%2BHh%2FCoPz3mx7xRQUjGN%2FbsnPFMyz0qDWEXg0BSZNUapBCxt2A16un6bB15Y20mRGn0jd9S0FAYc8ubI81ad7QDJsqEPbhvudztkGzlLbwuphCnAj97zxJWY%2B%2BkrY7ciNOr%2FeAxruW%2Bi6Cy6zmMO2mKR0jhn3Ictd0v8Z%2FhZQhRtyG9ubxruaX3IiCGwXoxKd3ffomyUypS%2FRSonI5uBkX55992%2BgB3MNTSgEcQ28GU6BnvbhzRLcyrTKBbUBMTQOXRYIJnN4krxSCz3X6nOmmzw6n7VwV8hn2ljsHtIunYgXxIYZtylpYpVbToPYVHqMBU1JCOKJNrOvBp810Lf1%2FC7Em%2BDbAxoN3fd6m6BXXvVJQmBTDXXNV9tOguvGtjRicncXDucaON0Kwx5bDAbG1lUxDkLCX3YD9uEAo1giknFp3aaEZMrUNqoHKZrksdGTMkjabYYnRL7TCCphlOIAz2706Lp9ijfKnotbeWZ%2FypJyzdTRu1jCGtUenzUDfsRcSLqDZ1%2BGPadk3547PTIIBx6UUi79Gjro7T7sdr3SWpZYduj4%2FiRFBqvbKtsd3ZVcavA73q0VlXtvv9Fa7Tw9kt%2Bn8%2F%2BH5Wux9yzpS5GMDy7aN8kRX%2BTOP5lXdqqaz2%2Bdyv7wRH%2Bs4qsPxer1X0HRvTLFHqZQi9T6GUK%2FbwpBP%2B%2FNFlwNiX2as%2FrHTneseP1b7pdv9vz3%2FTdwfFweDL4zfN8z7Ppc23WdT%2FBf7Dtf1%2F4ZFB8SdntnyLPmTwPFl%2BG%2ButkIC%2FywptcXpyK5R%2FsSvO%2F6JIGI7z6B1jCk1CWDwAA)
