### PR TITLE
add Apex Insights, Website

### DIFF
--- a/getapexinsights.com.website.json
+++ b/getapexinsights.com.website.json
@@ -6,8 +6,8 @@
     "version": 1,
     "description": "Connect your domain to your website hosted by Apex Insights.",
     "syncBlock": false,
+    "syncPubKeyDomain": "getapexinsights.com",
     "syncRedirectDomain": "getapexinsights.com",
-    "warnPhishing": true,
     "records": [
         {
             "type": "A",

--- a/getapexinsights.com.website.json
+++ b/getapexinsights.com.website.json
@@ -1,0 +1,25 @@
+{
+    "providerId": "getapexinsights.com",
+    "providerName": "Apex Insights",
+    "serviceId": "website",
+    "serviceName": "Website",
+    "version": 1,
+    "description": "Connect your domain to your website hosted by Apex Insights.",
+    "syncBlock": false,
+    "syncRedirectDomain": "getapexinsights.com",
+    "warnPhishing": true,
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "136.110.150.120",
+            "ttl": 3600
+        },
+        {
+            "type": "A",
+            "host": "www",
+            "pointsTo": "136.110.150.120",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **Apex Insights** (`getapexinsights.com`), a hospitality website platform. The template connects a customer's domain to their Apex Insights-hosted website: two static A records (apex + www) pointing at our Google Cloud HTTPS load balancer (`136.110.150.120`). No variables.

The template uses the **signed synchronous flow**: `syncPubKeyDomain: getapexinsights.com` — our platform RS256-signs every apply URL server-side, and the public key is published per the spec key-publication format (`p=N,a=RS256,d=…`) in TXT records at `_dcpubkeyv1.getapexinsights.com` (the `key` parameter our apply URLs send is `_dcpubkeyv1`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver *(N/A — this template sets no `logoUrl`)*

Also validated with `dc-template-linter -loglevel error -tolerate info -logos` (exit 0, no findings).

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together *(warnPhishing is not set)*
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead *(no TXT records in this template)*
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) *(N/A — no TXT records)*
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description *(no variables)*
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description *(no variables)*
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) *(N/A — both A records are the service's core records; changing them independently breaks the connection by definition)*

## Online Editor test results

**Editor test link(s):**
[Test getapexinsights.com/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABTuSmoC%2F%2B1TYWvbMBD9K0ZfY6eyEzuNYbC2Y1BGS1cCWQnBKPYlFbElVZLjuiH%2FvefESZrRdfu4wT4YrNO7u%2FfendbEQqFyZoHEa6K0XPEM9HVGYrIAyxQ8c2H44tGabioL4h4gt6zAFHKBCOe6heC1Ab3iKWwLVDAzHAsfom3O%2BBBfgTZcChL7LsnApJoruz2TKykEpNapZamdTBaMC8fK3bGt6zxKYyFzZrVzwqLbNKxFepnLdEniOcsN7CJ35ewb1F%2B21X4psAHeQ8Y1tv8NFCFSZ4bEkzWxtdr6geGGF%2F5%2BbtySXFgzknj0e1HX92nXD%2FELKF5am5O4F1G6cd%2FLr6rqzytMNy55kQKSI6cperrnD88Mpwwt77YB%2Fi20LFXC93jFNCtMswn7zMlJ6nSfOyGk6cgXQmpI0BTBbKlRgNUlml2UueUJq9gxlKUJUyqvkaDBWyxxaprY7UZjWsYs%2B1iuS5IsbWjyZs9mIQtnbB56QMPQ6%2Ff6Pe88mKdeSodsGEVRGEThm839YLnf396jXWAMCMtZ3pDOK1YbsvlpeK2O3fD%2BMSVTF5fg%2F1j%2BurHgszNsBVnCGlhAg8ijA4%2BGo6AXh37cP%2B8OhsMBHXQojelWBxi7E7nGV%2Fr2fZIf30c39xdX0c1YqHHBwv4ZXT6pUvsPT3DbOWNfVXV3tuy85JcPn8jmFTJ2QwkfBgAA)
[Test getapexinsights.com/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABXuSmoC%2F%2B1TXWvbMBT9K0avtY1sJ85iGGxLRtsF2nQURhuCUaSbRMSWjCTHcUP%2Be%2BXESZvRdXvcYA8G349z7rkf2iIDeZERAyjZokLJNWegrhlK0AIMKWDDheaLpdE%2BlTlyTyk3JLcQ9NlmONdtig1rUGtOYU9QwUxzS3zytpgfJ%2F8alOZSoCRwEQNNFS%2FM3kYDKQRQ49SyVA6TOeHCMfJgtrzOUmoDzJnVzpkKvylYC%2Folk3SFkjnJNBw843I2gnq4Z%2Ftlg03id2Bc2fK%2FSbUpUjGNkskWmbrYz8O6G13291MzLcmF0ffSmkEU%2B0GA%2FaBrvxDboDEZSqIY4537Fr6qqj9nmO5c9CQFpC%2BapnamR%2F2wIXbL0OpuC%2BilLKy1ULIsUn7EFESRXDfXcERPzuDTI35yIGgq84WQClI7HEFMqWwjRpV26HmZGZ6Siry4GE1JUWS1Fapt1NKcD08cbqTVxogh73fuopTRRi1vTq4bx7QXh8zrQ9D3OpRij0Rz6vUJ7kVzTGjEwldH%2FM6dv33I55MDrUEYTrJGe1aRWqPdT7ts27G79P%2FdlqauPYz%2Fa%2Frr12SfpiZrYClpUkMcxh7uebh7H0ZJN0g6fT%2FG8YdeeIFxgve9gDaHRrf2Fb9%2Bv%2BjhajO%2BHAwfb%2Bpvxe2wMw5XEF2svvYGT3d5d3hLrm6D0fry4XF0hz%2Bi3TP0ThMDRwYAAA%3D%3D)
