### PR TITLE
add Swivu, Swivu Site

### DIFF
--- a/swivu.site.json
+++ b/swivu.site.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "swivu",
+  "providerName": "Swivu",
+  "serviceId": "site",
+  "serviceName": "Swivu Site",
+  "version": 1,
+  "logoUrl": "https://documents.swivu.com/favicon.png",
+  "description": "Connect a custom domain to a published Swivu marketing site. Creates AWS ACM DNS validation and a routing CNAME to Swivu hosting. The subdomain label (e.g. www) is specified via the host parameter in the apply URL.",
+  "variableDescription": "cname_target: Swivu custom-domain CDN hostname (e.g. custom.swivu.site); acm_validation_host_0: ACM DNS validation record label token from AWS (hash prefix only, without the site domain suffix); acm_validation_value_0: ACM DNS validation CNAME target token from AWS (hash prefix only, without .acm-validations.aws suffix)",
+  "syncPubKeyDomain": "domaintemplate.swivu.com",
+  "syncRedirectDomain": "api.swivu.com,api.dev.swivu.com,admin.swivu.com,admin.dev.swivu.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%acm_validation_host_0%",
+      "pointsTo": "%acm_validation_value_0%.acm-validations.aws.",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cname_target%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Domain Connect template for Swivu custom-domain hosting (`providerId`: `swivu`, `serviceId`: `site`).

When a board owner connects a subdomain (e.g. `www.example.com`) to a published Swivu site, this template creates:

1. **ACM validation CNAME** — `%acm_validation_host_0%` → `%acm_validation_value_0%.acm-validations.aws.` (token values from AWS ACM, passed on apply)
2. **Routing CNAME** — on the requested subdomain (`host` apply parameter + `@` record) → `%cname_target%` (Swivu custom-domain CDN hostname)

Matches the apply URL built by swivu-server `CustomDomainService._build_domain_connect_url`.

**Note:** Staging/dev publishes the same template at `domaintemplate.dev.swivu.com`; production uses `domaintemplate.swivu.com` (`syncPubKeyDomain`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A (no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — ACM validation `pointsTo` uses `%acm_validation_value_0%.acm-validations.aws.` with the token-only variable; the `.acm-validations.aws.` suffix is fixed in the template (same pattern as `buckt.dev.acm-validation`, `kitkaton.com.storefront`)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description — `%acm_validation_host_0%` is bare because AWS ACM prescribes the validation record label token; the site domain suffix is supplied by the apply `host` + `domain` parameters (`hostRequired`)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead — routing uses `@` with `hostRequired`; subdomain comes from apply `host` param
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — N/A

## Online Editor test results

**Editor test link(s):**

[Test swivu/site example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFmgT2oC%2F%2B1U227bOBD9FYJAgBaVFdlqfNFigXWdBTZom7axjaINAoESxzJRSVRJyooS5N87lOTYrl0s9q0P%2ByRxeOZyznDmkRrIipQZoMEjLZTcCA7qitOA6kpsSuo8G69ZhiA678wa1EbE0EIF%2Bj%2Bb9oFk3l5tQGkhcxr0HZrKRC5VipC1MYUOzs%2B5jMsMcqPdJqkby%2Bx8xTCWzN0iT9Cfg46VKEwTg85knkNsCCNxqY3MCJcZEzkxEk1FGaVCr4GTtoKMqW9gRJ4QW6ZLZgqQribTz3Mynb0nl9dzsmGp4MxGJyznGETJsnGZXU%2Ff%2F23jtrHWUluzSxZrILqMurwpiyAlL8DFm6qqXhKhiS4gFiuBZWwEIwbx1pkUTKE8BhSx9aKVFUVak%2BXNO9fKxJRgUQqXB3TjHF1Cw1QCJugqaYn3ugJml9dNeAvs6mgBnaCW%2Bcs%2FCIuzcEc1tB6hF5xSQUEsFe%2BIGfkNcrJSKLQV7cWa6TUpFKzEPZF5WjukEmaNijWEbK5tQ3S5QtBxZvwt4RepO8kbtv8htYspersw2mWV3ua3b7PO449l9Bbqy6Y0lLWtcfv%2Bd0%2BvQ98AFyiDecazQuxAjj1x2OxbeCbyo%2FMBBkNb0W%2Fge4mxcXSMKsGhrdqaBreP1NSFnZ5GhQ6Ox7OTrTuz4ymRg17IE6BO5bNT0tjXZgwOoe95T86v0v71U4L9l3i2H%2BHuyaEPModwR%2BXO6RRGR7hnqDLsSYBGnBQ8JDhqRSi2Ls18aLuMts63B953W%2Ffbxh%2BPJ5Wx9yGL4v7AP4HphGlA9%2FXDaDyxoH1y9upogqhlKZJcKgg1fpkpFWx7mJWpESGr2M7E47CZbhRF4y3GPO5v3i7Lrla31QTLZNbY1vZv7XNoyGOrmLC7OOr7wxEfT3r%2BiEHv9Soa99gFXPRee%2BBPfD%2Fmw0m0t9UPVv2JnX7QK9Aat7RgdndP04rVmj6deDwdpwMux2L%2BNgTuHHx4%2F3fmd%2BwMTqVmG%2BAhs8iBNxj2vFHPmyz6fjDoB4OJO%2FT747H3yvMCz7OFgzYtr0ec1f0ppct09GVxdXGepPX8KvGzJS%2BSr%2FrN8kZ%2F%2Blp9uH%2B3uKqHD6PPOvtn%2Bid9%2BgFfM2BFGQkAAA%3D%3D)

Subdomain test (`domain=example.com`, `host=www`) produces:
- `_abc123.www.example.com` CNAME → `_xyz789.acm-validations.aws.`
- `www.example.com` CNAME → `custom.swivu.site`