### PR TITLE
New template: seekpages.com.customdomain (SeekPages)

### DIFF
--- a/seekpages.com.customdomain.json
+++ b/seekpages.com.customdomain.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "seekpages.com",
+  "providerName": "SeekPages",
+  "serviceId": "customdomain",
+  "serviceName": "SeekPages Custom Domain",
+  "version": 1,
+  "description": "Connects your domain to your SeekPages site: www points at SeekPages and the root domain forwards to www.",
+  "logoUrl": "https://app.seekpages.com/logo-full.svg",
+  "syncPubKeyDomain": "seekpages.com",
+  "syncRedirectDomain": "app.seekpages.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "sites.seekpages.com",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "REDIR301",
+      "host": "@",
+      "target": "https://www.%domain%"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for SeekPages (https://seekpages.com), a website builder. Connects a
customer-owned domain to their SeekPages site: `www` CNAMEs to our serving hostname
(`sites.seekpages.com`) and the apex 301-forwards to `www`. Records are fully static —
no template variables — and apply URLs are RS256-signed (`syncPubKeyDomain`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published at `_dcpubkeyv1.seekpages.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (template has no TXT records)
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [x] no variable is used as a bare full record value (template has no variables)
- [x] no bare variable is used as the full `host` label (hosts are the literal `www` and `@`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the `www` CNAME so users can later edit or remove it without breaking the template

## Online Editor test results

**Editor test link(s):**
[Test seekpages.com/customdomain serialprogress.io/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMITTWoC%2F%2B1VXW%2FaMBT9K5GlPjUEh5YCkSaVfjx0W1nL2n0IociNb4O1xI5sB0YR%2F33XMEg6ULVHHgpIEO69595zro%2B8IBbyImMWSLQghVZTwUHfcBIRA%2FCrYCmYIFE58bfBAcsxmXzF8J0LY8iAnooEVmVJaazKucqZkFXo3yLvcpXmXW3ypqCNUJJEoU84mESLwq6eyaWSEhJrvLkqtbcG9qxaP1aARliIvNls5hVKSExnthZlknt2Ap5Wym4wnpWeMc2NA8O6AKfIVKoedYZdJ9YWJmo2WVEEr5RoupzGc5llgZmmjuFcJnfl0yeY%2FyWzK51LGQIXGnlsk3aQMRETFE5EotGC2HnhJLsc9G%2BvMTRRxuIjDup2saL4oFwv5G12gKxFEidnlPoEjAFpBXOsvsh%2BUWRzsvS3%2BMPrq5vhCQ2rFueunukUbE0HJ9DRWrgjshwvffKiJMTVwGPcW8VfYz88MKnG7oFQFTj%2BSrUqi1hsqgqmWW7c8dvUj%2FYAjDcII0Jcd5FKpSE2%2BM1sqZGJ1SX4JC8zK2KGi93%2BxZOYOdY4rMEoQuyqK9fnc60uZ5b9j7IxT9zYwh370zZvU96BBuVhr3HKgDV67bDb6DLOWtCDp167UzPRXoe9YaNKvb3rrO2zX7E5r7iErU5A8R1uGBwGgX42Y3Pzen587aUQRYc%2FfM1MuwTqVtrnkMMhNPbRmO8meTfJu0neMAleSYZNgcfMpbVo66xBO%2Fh5CE%2BjdieiZ0FIQ9qjx5RGlLq1gLFrmgu8wep3F0mGafd60vo2FM3PWXd284M19fFt%2F%2BLj5EU%2Bf%2B89Dn52k98X91dTe%2F%2BBLP8AHnBjLbYJAAA%3D)
[Test seekpages.com/customdomain serialprogress.io/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAIUTWoC%2F%2B2VbWvbMBDHv4oR9FWdRHYemhoGC21hoV0fsnZQSjCqpDjqbEtIcjIv5LvvlDSxs2Rj7FUHTQJGudNf97vTHy%2BQ5ZlKieUoWiCl5UwwrocMRchw%2Fk2RhJsmlRnyt8FrkkEy%2BgLhWxeGkOF6JihfbaOFsTJjMiMir0K%2FbvLOVmne%2BSZvxrURMkdR4CPGDdVC2dUanck859Qar5SF9tbCnpXrZSVohOWRN5%2FPPSVFDunE1qIkZ56dck9LaTcaE6nnRDPjxGBfE6pIZSIfdAqnTq1VJmq1iFLNnU60XE5jUqRp08wSR1jm9LZ4vuTlK8x%2B61zKiDOhgWObtKcMiZAgoSIUPS2QLZVr2dn14PMFhKbSWFhCoW4WK8R76c4CbrMnZC1AtHsY%2B4gbw3MriKO6yQdKpSVa%2Blv90cX5cNTGQXXER7ef6ITbWh9cg47WjTtCy%2FHSRz9kzuOq4DHMreLXcB5cmETD6U0hK3EzlQpWiZaFisVmpyKaZMZdwY3G0wGR8UblaS3jqhBJLjWPDTyJLTQQWV1wH2VFakVMYMDbvxiNiaOHog1EQWa%2Fy%2Fn6njra10oZseRv2hwz6uoXzgMT2usHp7jTmASYNTqkyxp9TlkjxPiUt2lIeyysOeqg3f7gqd1WHpxvbcCDCmsXKQhPmhi%2BwQbk7XAM0jkpzS4GfH5HEkX%2FB0PNawc56mY75KG3xTX2wbrvFnq30LuF%2FtlC8EozZMZZTFxqiMNeA5%2FA7z7oRN1%2BFMDlCk%2Fa3c4xxhHGbkLc2DXqAt5%2B9fceOh7O%2BzrFo5vL%2FjRtXT0%2B3oXDy5u71kv26dm8dB6O9bT82u1d0e%2FmA1r%2BBEpw%2F2v6CQAA)