### PR TITLE
add Customdomain, Custom domain

### DIFF
--- a/customdomain.ai.customdomain.json
+++ b/customdomain.ai.customdomain.json
@@ -1,22 +1,20 @@
 {
-  "providerId": "customdomain.ai",
-  "providerName": "justeasy",
-  "serviceId": "customdomain",
-  "serviceName": "Custom Domain Connect",
-  "version": 1,
-  "logoUrl": "https://customdomain.ai/logos/customdomain.svg",
-  "description": "Point this host at the justeasy edge so your custom domain serves the connected application with automatic SSL.",
-  "syncPubKeyDomain": "customdomain.ai",
-  "syncRedirectDomain": "customdomain.ai",
-  "sharedProviderName": true,
-  "hostRequired": true,
-  "records": [
-    {
-      "type": "CNAME",
-      "host": "@",
-      "pointsTo": "edge.customdomain.ai",
-      "ttl": 3600,
-      "groupId": "a1"
-    }
-  ]
+    "providerId": "customdomain.ai",
+    "providerName": "Customdomain",
+    "serviceId": "customdomain",
+    "serviceName": "Custom domain",
+    "version": 1,
+    "logoUrl": "https://customdomain.ai/logo.svg",
+    "description": "Points this host at the Customdomain edge so the custom domain serves the connected application with automatic SSL",
+    "syncPubKeyDomain": "customdomain.ai",
+    "syncRedirectDomain": "api.customdomain.ai,app.customdomain.ai,customdomain.ai",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "edge.customdomain.ai",
+            "ttl": 3600
+        }
+    ]
 }

--- a/customdomain.ai.customdomain.json
+++ b/customdomain.ai.customdomain.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "customdomain.ai",
+  "providerName": "justeasy",
+  "serviceId": "customdomain",
+  "serviceName": "Custom Domain Connect",
+  "version": 1,
+  "logoUrl": "https://customdomain.ai/logos/customdomain.svg",
+  "description": "Point this host at the justeasy edge so your custom domain serves the connected application with automatic SSL.",
+  "syncPubKeyDomain": "customdomain.ai",
+  "syncRedirectDomain": "customdomain.ai",
+  "sharedProviderName": true,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "edge.customdomain.ai",
+      "ttl": 3600,
+      "groupId": "a1"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Customdomain "Custom domain" template. Customdomain (https://customdomain.ai) is an open-source custom-domain onboarding service; this is the subdomain variant of the service (the apex "Website" variant is #1323): it points a single host at the Customdomain edge with one CNAME, with automatic TLS issued at the edge after DNS applies. `hostRequired` is set — the template always applies under the protocol-level `host` parameter. The record value is fixed (no variables). Synchronous flow requests are signed (`syncPubKeyDomain` published at `_dck1.customdomain.ai`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — n/a: the template contains no TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — n/a: no variables used
- [x] no bare variable is used as the full `host` label — n/a: the only record's host is `@`, applied under the `host` parameter (`hostRequired: true`)
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — n/a: the single CNAME is integral to the service

## Online Editor test results

**Editor test link(s):**

- Subdomain (host=shop): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANF7TWoC%2F91TbW%2FaMBD%2BK5G%2FNtAQGiiRJg21SJu6vgy67qVC0WFfg7UkzmwHyhD%2FfWdoeCnbtM%2BTIsV399z5nsd3S2YxLzOwyOIlK7WaSYH6vWAx45WxKhcqB1k0QTJ%2FG76BnODsYg9AUYN6Jjke5e5CB3neNjpDbaQqWNzyWaZS9UlnhJpaW5r49PRVG6cO0TSzlBIFGq5ladfJ7E7JwhrPTqXxpspYDywZ6O236aFI0TNqHeD7fXiuRzSbgCoK5BaFB2WZSQ7uBm8u7dSDilLI5t5o9MExWxT8rppc4eJyQ%2Bd3ujnQEIXUVHQLg1I2X0F9uu7Id1zOkRvij4rqkdZWV%2BgzKq20MCx%2BXDK7KNcy3%2FSvBy9wMt%2B6B1xLdK%2FIdEI0j2tbS9q3O0GwGq989lMVmOxKj0nyun18BpobKqHy3R1mqkqyUq2qMpF1TgkacuPmq85%2BPEgf1%2FmPmwJkgzPcwVST%2BsgLGp8a6Bz2eXvMn7dO0Cm%2B%2BImBTAulMTH0B1tprPXKq8zKBOawcwmeuOdeEGFDUSpxrGWxmeAXngIs%2FIOUPksEd%2FSlW42nHo86najVCIBj46yHT41Jt91phKIXTtqtbicSZ3u79odV%2FMuyHb4FGoOFleBWqp%2FNYWHYajX26V3%2BX3ZubmCGIgEHDYOw0wi69N2HYRy24iBqnp%2B3o173JAjiIHBk0NgN3SXNzP60sNvs4WsaXV2AKofmaXDS1oMwGvWn15%2Ff6d73yZfbahQMLofFt4ePb9jqF2Xmu4xPBQAA

Verified apply output (host=shop): `shop.example.com. CNAME 3600 edge.customdomain.ai`.
