### PR TITLE
Add jently.io email template

### DIFF
--- a/jently.io.email.json
+++ b/jently.io.email.json
@@ -1,0 +1,32 @@
+{
+    "providerId": "jently.io",
+    "providerName": "Jently",
+    "serviceId": "email",
+    "serviceName": "Jently E-mail Sending",
+    "version": 1,
+    "logoUrl": "https://jently.io/brand/icon-gradient.svg",
+    "description": "Sets up white-label transactional e-mail sending (MX and SPF on the dedicated send subdomain, plus the DKIM public key) for Jently platform customers.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "jently.io",
+    "records": [
+        {
+            "type": "MX",
+            "host": "send",
+            "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "type": "SPFM",
+            "host": "send",
+            "spfRules": "include:amazonses.com"
+        },
+        {
+            "type": "TXT",
+            "host": "resend._domainkey",
+            "data": "p=%dkim%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a new template for **Jently** (`jently.io`), a voice-AI agent platform.

The `email` service configures white-label transactional e-mail sending for a
customer's domain:

- `MX` + `SPFM` on the dedicated `send` subdomain (Return-Path / bounce
  handling — does not touch the customer's existing apex SPF or mailboxes)
- the DKIM public key as TXT at the fixed label `resend._domainkey`, with a
  fixed `p=` prefix and a single variable (`%dkim%`) for the key material

Signed synchronous flow only: `syncPubKeyDomain` is set to `jently.io`
(public key published at `_dck1.jently.io`). The template does not use
`redirect_uri` (our app polls for completion), hence no `syncRedirectDomain`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `jently.io`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A: the template/flow does not use `redirect_uri`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — SPF is expressed via the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — set to `All` on the DKIM TXT (a re-issued key must replace the old one)
- [x] no variable is used as a bare full record value — the DKIM TXT value has the fixed prefix `p=` (`"p=%dkim%"`)
- [x] no bare variable is used as the full `host` label — all hosts are fixed strings (`send`, `resend._domainkey`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A: all three records are required for the service to function

## Online Editor test results

**Editor test link(s):**

[Test jently.io/email jently.io/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMSaTWoC%2F%2B1UbU%2FbMBD%2BK5alSZto0pS%2BR%2BLDBkxAVcagk5AQqlz72no4sWU7gQ51v33nFGiBato39oFPudzrc8%2Fd%2BZ56yIxiHmh6T43VpRRgjwVN6U%2FIvVrEUtPak%2BGUZehITyoT6h3YUnKo%2FCFjUq11z1zJYRSs5AJyIfMZepVgndQ5TRs1qvRM%2F7AKvefeG5fW60%2B16xPLclGXXOfRzDIh0RC7MmQQ4LiVxldZ6AV4RwpDbufSQ6TYBBTxGOsYDx5MEVhBcCsI5OPwkmBqcnH2leic%2BDkQAUJypEJUTsQVE6ExJq8RowpXuRwMjofEFBMlObmBxScy1ZY89BhoxN%2BM8MJ5nWGDcaBjkfMvSvMbmk6ZcrDSnBWTASwOqvQvuLbAtRWOplf31C9MIHF4ifq5dh7lAC1MRMvcu5FGzRRATBi%2FiVzmTVy4CJjzUSNmGfulcwcu5jqrhii1lX6BnCc16j0S3uwkybL2VAe5GL6q5Mz0vFCAgKjMuSoEpM8zbyQYXY7W8RZChni8IhHZCkNjnqHJ7H0QNzL7QDdwoHjn93U%2BRW79kHk%2BxzENtQh5PytFl9fLGsWyMF4zdI0Zt3H4gAClmdWFGctHb8Msy1zY9ce4q43A68fIKxrkAHElY2U5y7WFscMv84VFVN4WOM2sUF6O2S1bqwQfM2PUAoE6tGKKF6PMV7fxQPADJ%2F86xg3Cnk90LHhoTIZj5N12M2m0OpFo9ztRa8p51BP9btTnDTHtt1izudvbuOtXB7%2FtsNekgkPoXjJVjeaWLRxdvtqCrU2We7hODbJ1kchvptRjg9jff9vSXxf7%2BYTeuIHrGi79%2B%2FK9L9%2BbLB8%2BoY6VIMYsuO0mu50o6UZJb5QkabOZJr241U3avfYO%2FidJwA7Or3q5xxd3862lJhl8H%2BwUJ6bcyfrto%2FLoFDrDyVnzXCcj8e3kYP%2BgcQeNZuvs8HiPLv8AjQbLUdcIAAA%3D)

[Test jently.io/email jently.io/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPybTWoC%2F%2B1UW2%2FaMBT%2BK5alSZtGQriWRuKh670dU7UyqVpVIWMfwMWJM9uhZBX77TsO0ELppD32oU%2BJz83f951z%2FEgdJJliDmj8SDOjZ1KAORc0pveQOlWEUtPKk%2BMbSzCQXpQutFswM8mhjIeESfVs2wolx4H3kmtIhUzHGDUDY6VOaVyrUKXH%2BodRGD1xLrNxtfp0d3VoWCqqkus0GBsmJDpCO%2FMVBFhuZObKKvQanCV5Rh4m0kGg2BAUcZhrGfcRTBFYQrBLCORj74ZgaXJ9dUJ0StwEiAAhOUohyiBi86HQmJNWSKZyW4YcXZ73SJYPleRkCsUnMtKGrDh6GfGYEJ5bpxMkGHo5ipR%2FUZpPaTxiysLScpUPL6E4Ksu%2F0NoA10ZYGt8%2BUldkXsTeDdon2jr899B8R7RMne1rtIwAxJDxaWATl4W5DYBZF9RClrDfOrVgQ66TsolSG%2BkK1DyqUOdQ8EY7ihaVp3tQi97OTTYbfc8VICAqU65yAfF25Y0C%2FZv%2Bc74BXyEcLEVEtXzTmGPoyrofxFQmH%2BgGDvydu0OdjlBb12OOT7BNPS183QOl6OJuUaF4LQyeFbrDiq9puEKwmsix0Xk2kOuMjBmWWD%2Fv69zbjeS7dfbtMt1fgVD9mXoEcpxqAwOLX%2BZyg%2BicybGrSa6cHLAH9mwSfMCyTBUI2KIXS7xoabrckVKmFdaVQP%2Fb0w31tts7ENwzlH4z29BucdiPgg6vtYJmY08EnUYLgnqjWeO1JougNtpY8p3tf23LtxUGixycZKrs1QMrLF3sjMW%2F2c66OGQ18up4kT9MqTVTJPqmue2M%2FAuiWXe7Z2%2BAyV0Fd%2BJ9Lt%2Fn8q3NJT68ls1ADJgPrUf1dhDtBVGnH0VxoxPXo7DTbtf3O5%2FxHEUeP1i35POI7%2FTmC02bh79a4uBsfMp68%2F37QzlRvdOTzv7JqHoxnbPm8c%2Bq%2BgqFPmvNm126%2BAuubbE%2FFQkAAA%3D%3D)