### PR TITLE
Add seobrothers.com.whitelabel template

### DIFF
--- a/seobrothers.com.whitelabel.json
+++ b/seobrothers.com.whitelabel.json
@@ -1,0 +1,21 @@
+{
+	"providerId": "seobrothers.com",
+	"providerName": "SEO Brothers",
+	"serviceId": "whitelabel",
+	"serviceName": "White-label client portal",
+	"version": 1,
+	"logoUrl": "https://platform.seobrothers.com/favicon.svg",
+	"description": "Connects a subdomain (like app.youragency.com) to your white-label SEO client portal.",
+	"syncBlock": false,
+	"hostRequired": true,
+	"syncPubKeyDomain": "seobrothers.com",
+	"syncRedirectDomain": "platform.seobrothers.com",
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "@",
+			"pointsTo": "connect.seobrothers.co",
+			"ttl": 3600
+		}
+	]
+}


### PR DESCRIPTION
# Description

New template for **SEO Brothers** (seobrothers.com): connects a partner's subdomain (e.g. `app.youragency.com`) to their white-label SEO client portal. The service uses Cloudflare for SaaS custom hostnames, so the template is a single static CNAME to our fallback origin — certificate issuance and renewal happen automatically over that CNAME (HTTP DCV), no TXT records or variables needed.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — link below
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `seobrothers.com`; signing keys published as TXT at `_dck1.seobrothers.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`platform.seobrothers.com`) — the sync flow uses `redirect_uri`
- [x] no TXT record contains SPF content — *no TXT records in this template*
- [x] `txtConflictMatchingMode` — *n/a, no TXT records*
- [x] no variable is used as a bare full record value — *no variables at all; the single CNAME target is static*
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute — record host is `@`
- [x] `essential` — *n/a; the single CNAME is the whole service*

## Online Editor test results

**Editor test link(s):**

[Test seobrothers.com/whitelabel adambate.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL6gTWoC%2F91TXW%2FaMBT9K5GfNpWEAOWjkSat7Vppm9YPyjRpFYoc%2BwJWHTuzndAU8d93TaCFbpX2vCfk3HOOzz0cr4iDvJDUAUlWpDC6EhzMZ04SYkFnRrsFGBsxnZPW8%2FiK5ggndxfXwdkWgVMLphIMNtzlQjiQNAP5MtiyfvhRuJkFTApQLii0cdQjK1QSWpGk0yJSz%2FV3I5GxcK6wSbvtbc60yaNXztozivpaRbaaowgHy4wo3EaInGulgDkb0MCWGdc5FSp4J8UDBLQoolqXhs5BsdorvQ%2BcDvynYLnn0u954DTyS9WKnUnNHkgyo9JCiyy0dWP4VQoDGIEzJTSomzL7CvWnzc1%2FjdWDxsCRx9wz7K1lEY84bbglyf2KuLrwoZ5fnX67II0HPH70f5YWytmJxiNrMnglhRjnMN%2FeII7X03WLPGkF6Yv4FKPcuaGc5hmWZOtgew0GiIe50WWRih2noIbm1rdpx74%2FpE93%2FPuNgL9ZzJU2kFr8pa40sIsvL6UTKV3Sl0%2BcpciSNRq1OEWVP1NQTdMae5w6%2Bk8ZtEjKmfctfIP73YwOZ%2FFxyI85hMcZ4%2BEoG3VCznt82MmGvf5ouPck3ngxb76JgwTBWiyXoL7sp3JJa0vW62kL0%2Fxfd8MOWFoBT6lHduPuIIyHYTyaxHHSHyW9UTTsnQw6%2FSM8x7HfBKxrtl1hX%2FabQm4n7Z%2BP1W1HMXMCtW7zqns9e8y%2BXF7ePR3dMDHol3X%2F6nEwlvoDWf8GDC2c0vEEAAA%3D)



