### PR TITLE
add Meep, Meep Website

### DIFF
--- a/usemeep.com.site.json
+++ b/usemeep.com.site.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "usemeep.com",
+  "providerName": "Meep",
+  "serviceId": "site",
+  "serviceName": "Meep Website",
+  "version": 1,
+  "logoUrl": "https://usemeep.com/favicon.svg",
+  "description": "Points your domain's website record at your Meep site. Email and other records are not touched.",
+  "variableDescription": "host is the subdomain (e.g. www) that will serve the Meep site.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "dc.usemeep.com",
+  "syncRedirectDomain": "usemeep.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "meep-sites.pages.dev",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the `usemeep.com.site.json` template for [Meep](https://usemeep.com), a small-business website + CRM platform. It connects a customer's custom domain to their Meep-hosted website by adding a single CNAME (at the passed `host`, e.g. `www`) pointing at our Cloudflare Pages deployment. No other records are touched.

- **providerId / serviceId:** `usemeep.com` / `site`
- Synchronous flow, signed (`syncPubKeyDomain`: `dc.usemeep.com`)
- One `CNAME` record, `hostRequired: true`
- Passes `dc-template-linter -loglevel error -tolerate info -logos` (exit 0)

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead _(n/a — no TXT records)_
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) _(n/a — no TXT records)_
- [x] no variable is used as a bare full record value _(n/a — no variables in record values)_
- [x] no bare variable is used as the full `host` label _(n/a — host is `@`)_
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template _(n/a — the single CNAME is essential to the service)_

## Online Editor test results

Tested in the Online Editor with **host set** (`hostRequired: true`, so an apex test is not required): domain `example.com`, host `www`. "Check template" passes; "Test apply template" produces the expected `CNAME www.example.com → meep-sites.pages.dev`.

**Editor test link(s):**

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMLZTWoC%2F91T30%2FbMBD%2BVyy%2FbNOaNE3ahkSatDKYxCYYY2xDoCpy46M1JHGwnYZQ9X%2FfOWmh1XjY814S%2Be777r77taIG8jJjBmi8oqWSS8FBnXAa00pDDlC6qcxp79l1xnKE0lP0oFWDWooUWrwWGOTZtIMjv2G2cS5BaSELGg96NJNz%2BVNlCFoYU%2Bq439%2FJ2L9lGEUWrl7OkcdBp0qUpuXScykKo0kjK0W4zJko3mhSd0mIglQqTpjp%2FK0A63DJMSIzwgpOpFmA2iA1YQpIIQ0xskoXwF2rkynBZhkc7eVdSG2I0ATZRFezLjV5C%2B7cJXVdv0MHpq1FlhHbBWiBLwJsc5oiPcxkek%2FjW5Zp6Czn1ewrNEdtOEzDU3e%2F9xZzAVygYPOM2odYaRfwUCEGZ2FUhaE39dH4ZkVNU9pxfDqbnB5v4Pj8aAfbNvNS4tPGc6xU7ZZsjl8OS0QYg0MKxp63nq579EkWkLyEnuJwtpLgkeEuwY4kNGJj8DFXsioTsaWUTLFc25Xbkm%2F22NMt%2Fabl27xiXkgFicY%2FM5WCbZV5lRmRsJq9mHiasLLMGpSp0YtR%2Fu5A0e1np44zw%2F6h%2Fh5NeGpFC7vvwIehPwoDJwjCyBkG3tiZ%2BePUGR5EtwwOBgPg3s7hvHJTr1zPXtNAayiMYPZGJlnNGk3X62kPG%2Fg%2F1YOz1mwJPGEW6Xv%2B2PFCxzu49EaxN4hHQzeIRlEUvPe82LMKsB7TVbjCvdjdCNp%2FvL67u4%2Beav9qPDn80b82E%2BlfqO%2B%2FwuY4u4r056OTU%2FgS%2BuG3%2Bw90%2FQez6UgP%2FQQAAA%3D%3D
