### PR TITLE
add Ploro, App hosting

### DIFF
--- a/ploro.dev.hosting.json
+++ b/ploro.dev.hosting.json
@@ -7,7 +7,7 @@
 	"logoUrl": "https://ploro.dev/favicon.ico",
 	"description": "Connects a domain to an app built on Ploro: routes traffic to the app and pre-validates its HTTPS certificate.",
 	"variableDescription": "target: the Cloudflare-for-SaaS routing hostname the CNAME points to. owntxt: the custom-hostname ownership token. dcv1/dcv2: the ACME (DCV) certificate-validation tokens. All four values are issued per hostname by Ploro and passed on the apply URL.",
-	"warnPhishing": true,
+	"syncPubKeyDomain": "ploro.dev",
 	"syncBlock": false,
 	"syncRedirectDomain": "ploro.dev",
 	"hostRequired": true,

--- a/ploro.dev.hosting.json
+++ b/ploro.dev.hosting.json
@@ -1,0 +1,20 @@
+{
+	"providerId": "ploro.dev",
+	"providerName": "Ploro",
+	"serviceId": "hosting",
+	"serviceName": "App hosting",
+	"version": 1,
+	"logoUrl": "https://ploro.dev/favicon.ico",
+	"description": "Connects a domain to an app built on Ploro: routes traffic to the app and pre-validates its HTTPS certificate.",
+	"variableDescription": "target: the Cloudflare-for-SaaS routing hostname the CNAME points to. owntxt: the custom-hostname ownership token. dcv1/dcv2: the ACME (DCV) certificate-validation tokens. All four values are issued per hostname by Ploro and passed on the apply URL.",
+	"warnPhishing": true,
+	"syncBlock": false,
+	"syncRedirectDomain": "ploro.dev",
+	"hostRequired": true,
+	"records": [
+		{ "type": "CNAME", "host": "@", "pointsTo": "%target%", "ttl": 3600 },
+		{ "type": "TXT", "host": "_cf-custom-hostname", "data": "%owntxt%", "ttl": 600, "txtConflictMatchingMode": "All" },
+		{ "type": "TXT", "host": "_acme-challenge", "data": "%dcv1%", "ttl": 600, "txtConflictMatchingMode": "All" },
+		{ "type": "TXT", "host": "_acme-challenge", "data": "%dcv2%", "ttl": 600, "txtConflictMatchingMode": "All" }
+	]
+}


### PR DESCRIPTION
# Description

New template `ploro.dev.hosting.json` for **Ploro** (`ploro.dev`), a multi-tenant
app-hosting platform. It connects an operator's external subdomain to their Ploro
app in one click: a routing **CNAME** to the Cloudflare-for-SaaS custom-hostname
target, plus the custom-hostname ownership TXT (`_cf-custom-hostname`) and the ACME
DCV TXTs (`_acme-challenge`) that pre-validate the HTTPS certificate. All four
values are issued per hostname and passed as template variables on the apply URL.

`hostRequired` is `true` because the routing record is a CNAME, which cannot live at
a zone apex — the flow is offered for subdomains only.

Synchronous apply requests are **signed**: the template sets
`syncPubKeyDomain: ploro.dev`, every apply URL carries `sig` (RS256 over the full
query string excluding `sig`/`key`) and `key=_dck1`, and the public key is
published as TXT records at `_dck1.ploro.dev` in the spec's multi-record format.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

> Note: the template also passes the official `dc-template-linter`
> (`-tolerate warn`, exit 0); the only remaining message is one `info`-level
> note — `DCTL1021` (`_cf-custom-hostname` is a Cloudflare-specific underscore TXT
> host, not in the IANA list). `logoUrl` (`https://ploro.dev/favicon.ico`) returns
> 200 `image/svg+xml`.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `ploro.dev`. Apply URLs are signed (RS256)
  and the verification key is served from `_dck1.ploro.dev` TXT records.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — `warnPhishing` is not set.
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — set to `ploro.dev`.
- [x] no TXT record contains SPF content — none present.
- [x] `txtConflictMatchingMode` is set on TXT records that must be unique — set to `All` on all three TXT records.
- [x] no variable is used as a bare full record value **unless necessary** — **justified:** `%owntxt%`, `%dcv1%` and `%dcv2%` are opaque tokens whose exact value is dictated verbatim by Cloudflare-for-SaaS ownership verification and by the ACME (DCV) challenge respectively; no fixed prefix is permitted by those protocols.
- [x] no bare variable is used as the full `host` label — all TXT hosts are fixed (`_cf-custom-hostname`, `_acme-challenge`); the CNAME host is `@`.
- [x] no variable is used in the `host` field to create a subdomain — the subdomain is carried via the `host` apply parameter (`hostRequired: true`).
- [x] `%host%` does not appear explicitly in any `host` attribute.
- [x] `essential` is set on records the user may need to modify — N/A; every record is required for the connection to function, none is safe to remove.

## Online Editor test results

**Editor test link(s):**

[Test ploro.dev/hosting example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEusUGoC%2F%2B1V227bOBD9FYJAgRZrybJyawQsUNtZtMVugiBxr0FgjEjKZkORKkk5cYP8e4eSr02ywD5sURR5kS3OmduZM9Qt9aKsFHhBs1taWTOTXNi3nGa0UsaamIsZ7awMJ1AikJ4GEx47YWeSiQY%2BNc5LPVmfLrD9qiJr20xYJ42mWa9DlZmYd1YFX%2B8rl3W7q5TdAjCE0TE%2B0IsLx6ysfONJh0ZrwbwjQLgpQWriDQFNADPltVSeGE2aEjNiTe2FI95CUUgWgH4qGiRoTiorohkoySGAJIZ8MxqdnhMmrJeIx%2BM4FA1WQq7E0VYZHuxE%2BKwJOFSm5oUCjFcYG50DnDepsemmeY1ctMCT%2FvFfpDJSYzJvYmKutb9ZRGG186aMVg5oQ7qmskLkldAx4WzW6%2BIjbfH9IcZ6fjR8%2F2Kz4mVHWGXr52LSV4oUprYEbTW2ioUS6VwtkANh1yXm85a4lh1wDgEhTMuZmpN3Z%2F8ERtxcs9M6%2F1vMj5oJ%2FCCXYB4ow65oVoByoj05E1xaHNyDLqGEM%2FG1RgSqydsanRBsLHc0u7ilfl4FNTX8LeD4%2BiposyFzZPD1WTuTZ3jqPQprZz9J7jor59HH0dp1zIroB8KD0sBDCNSOZRUI4%2BC%2FG4%2FSK5Rk%2Fhg8m%2BJwjw1vNK4UfTQPsFJEbApKCT3ZzBGm%2Bb9nSP9Thsu7Dv1mtBivqb%2FEcMuBiRvAy0LEzJTr9G5qKnyboN6rsVz6VGChdOFSWXpfbLlfLv0v2gD43g4vnKBoVA7sKl4rBO3tTIIdNQLMCx6tNiRqlB7hGvsADdRuAfFgAekt7Okj9pQGEuREGyvGDn%2FB11YsJVnWyssxXMP6iLNxsxvImUMrhr0vV93ehQuqFuN5oMsN3XbomLPAn%2BQNdjfnxV4e7RzAQbQrsGRIe0WUM5739ouXHJK9jXv63gX%2B8E29PUGB6669BNWo4Rrmjt7d09yikwe2J97u7t9ntKnJX7rP7d16rMdNef22raW%2FXmuXHbxrntbtad2e1u2nrBt%2BOh3MBB9DgKZJuh8lB1EvGSUvs3Q3292Jk8N073D%2FjyTJkiQ0gOprW7zFr%2Brm95QefTjs5l%2FfToWAvbQ4OTBXMBSDKZP9wac35eD1afX5m8zl%2B8GX4z%2Fp3XdOSaIoqQwAAA%3D%3D)
