### PR TITLE
add MyStdio, MyStdio Client Portal

### DIFF
--- a/mystdio.com.portal.json
+++ b/mystdio.com.portal.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "mystdio.com",
+  "providerName": "MyStdio",
+  "serviceId": "portal",
+  "serviceName": "MyStdio Client Portal",
+  "version": 1,
+  "logoUrl": "https://mystdio.com/mystudio-logo.png",
+  "description": "Connects your branded client portal subdomain (for example portal.yourcompany.com) to your MyStdio account.",
+  "syncPubKeyDomain": "dc.mystdio.com",
+  "syncRedirectDomain": "mystdio.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "mystdio.com",
+      "ttl": "3600"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **MyStdio** (`mystdio.com` / `portal`). MyStdio is a SaaS platform that gives video production studios a branded client portal. This template lets a customer connect their portal subdomain (for example `portal.theircompany.com`) to their MyStdio account by adding a single CNAME record.

The template is intentionally minimal and static: one signed `CNAME` record on the host-parameter subdomain pointing to `mystdio.com`, with `hostRequired: true` so it can only be applied to a subdomain (never the apex). It contains no variables.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`mystdio.com.portal.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://mystdio.com/mystudio-logo.png` returns HTTP 200 `image/png`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`dc.mystdio.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`mystdio.com`) for use with `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — the template has no TXT records
- [x] `txtConflictMatchingMode` — N/A, the template has no TXT records
- [x] no variable is used as a bare full record value — the template has no variables
- [x] no bare variable is used as the full `host` label — the template has no variables
- [x] no variable is used in the `host` field to create a subdomain — the template uses `hostRequired` plus the `host` parameter; the record `host` is `@`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — N/A, the single CNAME is the service's own record (not a user-managed record such as DMARC)

## Online Editor test results

**Editor test link(s):**
[Test mystdio.com/portal example.com/portal](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMY8TmoC%2F91TXW%2FaMBT9K5GfNhHSEFiASJPW0j1UW6GjTOuGUGTsW2otsTPboU0R%2F33XQPhY%2BQV7SuJ77rnnHp%2BsiIW8yKgFkqxIodVScNA3nCQkr4zlQgVM5cTfl4Y0Ryi5re5dEQsG9FIw2LQUSluaHQ5Pwd4gEyCtd1ejlqCNUJIkLZ9kaqG%2B6wzRT9YWJrm4OJq%2FeS%2Fxo%2BlgQSEX2M3BMC0Ku2EgAyUlMGu8SpXam2sqOXCPbSdudXmmnHOVUyG9d49Ke%2FBCcXXYVQPXiLMKKis3871n1Zaslk8ZU6W0gduvkuyunH%2BB6npDiAI4C04dc5gxcKFR1h51CnlSxo7hT4kYtM%2FqEnyCcKW5Icl0RWxVOP8Gw8vbzzs4fn5y16GEtGai3lBa6zxsx2FI1rO1T16VhPTAOUPfai27%2FY%2B0HF%2FhQquySEXdVVBNc%2BNCUvdPTwhmNcO0pnDTxUIqDanBJ7WlhnrJvMysSOkzPRxxltKiyCoUa7CKRG8NkNs87TVyaul5B5wBPkk5c4qFy2Y3fuyFLGbNLmvzZqcTdptzaIVNiKNeNI%2BjKPrQP8r5mV%2FgbNL%2FtQ2MwcQJ6m7hMnumlSHr9cxHC%2F%2BjdfCyDV0CT6kDR2EUN3F%2B2Ju0oiTsJFEUtDqdOGo3wjDBIOISgJM3260wFcd5IL9uzKRxNfoxeBhF%2FRGI9vhadhq2%2F9D9HX%2F9eSVe4nv9Tb4OJ5x9JOu%2F2NsptLAEAAA%3D)

Subdomain test (`example.com` / host `portal`) resolves to `portal.example.com. CNAME mystdio.com` TTL 3600 with no errors. An apex test is not required because `hostRequired: true`.
