### PR TITLE
Add Nouncify brand profile template

### DIFF
--- a/nouncify.brand-profile.json
+++ b/nouncify.brand-profile.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "nouncify",
+    "providerName": "Nouncify",
+    "serviceId": "brand-profile",
+    "serviceName": "Nouncify Brand Profile",
+    "version": 1,
+    "description": "Connect your custom subdomain to your Nouncify Brand Profile.",
+    "variableDescription": "Configure the subdomain to point to Nouncify.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "nouncify.com",
+    "syncRedirectDomain": "nouncify.com",
+    "warnMessage": "This will change the DNS settings for your subdomain to point to Nouncify.",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "custom.nouncify.com",
+            "ttl": 3600
+        }
+    ]
+}

--- a/nouncify.brand-profile.json
+++ b/nouncify.brand-profile.json
@@ -10,6 +10,7 @@
     "syncPubKeyDomain": "nouncify.com",
     "syncRedirectDomain": "nouncify.com",
     "warnMessage": "This will change the DNS settings for your subdomain to point to Nouncify.",
+    "hostRequired": true,
     "records": [
         {
             "type": "CNAME",

--- a/nouncify.brand-profile.json
+++ b/nouncify.brand-profile.json
@@ -1,22 +1,22 @@
 {
-    "providerId": "nouncify",
-    "providerName": "Nouncify",
-    "serviceId": "brand-profile",
-    "serviceName": "Nouncify Brand Profile",
-    "version": 1,
-    "description": "Connect your custom subdomain to your Nouncify Brand Profile.",
-    "variableDescription": "Configure the subdomain to point to Nouncify.",
-    "syncBlock": false,
-    "syncPubKeyDomain": "nouncify.com",
-    "syncRedirectDomain": "nouncify.com",
-    "warnMessage": "This will change the DNS settings for your subdomain to point to Nouncify.",
-    "hostRequired": true,
-    "records": [
-        {
-            "type": "CNAME",
-            "host": "@",
-            "pointsTo": "custom.nouncify.com",
-            "ttl": 3600
-        }
-    ]
+  "providerId": "nouncify",
+  "providerName": "Nouncify",
+  "serviceId": "brand-profile",
+  "serviceName": "Nouncify Brand Profile",
+  "version": 1,
+  "description": "Connect your custom subdomain to your Nouncify Brand Profile.",
+  "variableDescription": "Configure the subdomain to point to Nouncify.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "nouncify.com",
+  "syncRedirectDomain": "nouncify.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "custom.nouncify.com",
+      "ttl": 3600
+    }
+  ],
+  "logoUrl": "https://nouncify.com/logo.png"
 }


### PR DESCRIPTION
# Description

Adding the Nouncify brand profile template to allow our users to easily map custom sub-domains to their public brand profiles.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test nouncify/brand-profile example.com/custom](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACUST2oC%2F91T72%2FaMBD9VyJ%2FHQFDICmRJq20RdoqUEXLpA2hyImPYDWxM9sBAuJ%2Fnw0NUPbr%2Bz4ld%2Ffu%2BfndeYc05EVGNKBwhwopVoyC%2FExRiLgoecIWFWqc8mOSGxwanysK5IolcGiIJeHUNdgFy%2BBcu2pyBhbmPJ1gK5CKCY7CdgNRUIlkhT7E6E5wDol2KlFKJymVFrmjypiKnDDuaHEs%2FJ64aZmJZCTO4P6adcHSUoKjl%2FCerxCMa%2FtTc1oWVfFkkInkFYULkik4Zp7K%2BBGq%2B0PrhVnNRORvPROgTBr5f8IshdIT%2BFEakHFPy9IwG7yQVKFwtkO6Kqxvd%2BPb0cMb3ISf7DisTPUiTHh0pXlFrXWGQs%2FHeD9voEykYipNAi21LlTYal2iW7bcLHiK9g20FRyiswbTTGvxsCFmT%2BBC%2B%2Bl0E6dSlEXE6q6CSJIru1F1%2F%2BwdwbxmmNUUc3M6S7mQECnzJdrMpzYlLzPNIrIm5xRNIlIUWWXEKlM1RL8axo97d9JIiSb%2FdqyBIppY5cyuNPVIp%2B35vkvjJHC79AZc4nuB27%2Fx%2FCCmPdIPvIv3cf1u%2FvY6ri0EpYBrRuygbrM1qRTam%2FEZO%2F%2FTq5klUGQFNCIW3MEd38WBi%2Fsv2Avb3bDba%2BJePwiCDxiHGNuLgNLHm%2B7MtlzuCcoftl5ru%2Fk6Kkds%2BNzF60FaTfvLie58CYajIXv9tnkUg%2Bl33l5%2FRPufkr2fVPUEAAA%3D)
