### PR TITLE
add template: vProxy Cloud Game Cloud

### DIFF
--- a/vproxy.cloud.gamecloud-bedrock.json
+++ b/vproxy.cloud.gamecloud-bedrock.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "vproxy.cloud",
+  "providerName": "AtomRoute Global Network",
+  "serviceId": "gamecloud-bedrock",
+  "serviceName": "Minecraft Game Server (Bedrock / CNAME)",
+  "version": 1,
+  "logoUrl": "https://vproxy.cloud/vProxyCloud-Logo.png",
+  "description": "Point a subdomain to your vProxy Cloud gamecloud (CNAME record).",
+  "variableDescription": "target = game server hostname",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "v1.domainconnect.vproxy.cloud",
+  "syncRedirectDomain": "cocodigit.com,vproxy.cloud,atomroute.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300,
+      "essential": "Always"
+    }
+  ]
+}

--- a/vproxy.cloud.gamecloud-java.json
+++ b/vproxy.cloud.gamecloud-java.json
@@ -15,7 +15,7 @@
       "type": "SRV",
       "service": "_minecraft",
       "protocol": "_tcp",
-      "name": "",
+      "name": "@",
       "priority": 0,
       "weight": 0,
       "port": "%port%",

--- a/vproxy.cloud.gamecloud-java.json
+++ b/vproxy.cloud.gamecloud-java.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "vproxy.cloud",
+  "providerName": "AtomRoute Global Network",
+  "serviceId": "gamecloud-java",
+  "serviceName": "Minecraft Game Server (Java Edition)",
+  "version": 1,
+  "logoUrl": "https://vproxy.cloud/vProxyCloud-Logo.png",
+  "description": "Connect your domain to your vProxy Cloud gamecloud (Minecraft Java Edition, SRV record).",
+  "variableDescription": "target = game server hostname, port = game server port",
+  "syncBlock": false,
+  "syncPubKeyDomain": "v1.domainconnect.vproxy.cloud",
+  "syncRedirectDomain": "cocodigit.com,vproxy.cloud,atomroute.com",
+  "records": [
+    {
+      "type": "SRV",
+      "service": "_minecraft",
+      "protocol": "_tcp",
+      "name": "",
+      "priority": 0,
+      "weight": 0,
+      "port": "%port%",
+      "target": "%target%",
+      "ttl": 300,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

Two new templates for AtomRoute Global Network (vproxy.cloud) game server hosting, letting customers point their own domain at their game server:
- `vproxy.cloud.gamecloud-java.json` — a single SRV record (`_minecraft._tcp`) for Minecraft Java Edition, carrying the server hostname and port.
- `vproxy.cloud.gamecloud-bedrock.json` — a single CNAME record for clients that do not support SRV lookups (`hostRequired` is set since CNAME cannot live at the apex).

They are intentionally split into two templates (instead of one template with groups) because the CNAME and SRV records must never be applied together.

Justification for bare variables in record values: `%target%` (SRV target / CNAME pointsTo) and `%port%` (SRV port) are provisioned server-side by our panel and point to per-server node hostnames under our own infrastructure (e.g. `xxxxxxxx.tw.vproxy.cloud`); each customer server has a unique hostname/port allocation, so fixed prefixes are not applicable. The apply URLs are always signed (`syncPubKeyDomain` is set), so the variable values cannot be tampered with.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

  gamecloud-java (subdomain): [Test vproxy.cloud/gamecloud-java example.com/a](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANhIT2oC%2F%2B1Ui2rbMBT9FSEotMx2FC8Px1BY145u7VJKuw62EIwiqY5W2zKSktQJ%2Bfdd2U3jlq5fMDBY96l7zrn2BluRlxm1AscbXGq1lFzobxzHeAnWYxWwTC049p5jVzSHXHxiVX6jFlag80zNaIauhF0p%2FQCZRuilZKJukkJ23cH%2FQ5d0H3zqMpaFYJreW3QODnQLQaHR4QXkoi9cWqmKIygCp4EjjrsezlSq7nQGxXNrSxN3Ou1BO8trZ5zWV36H1KAsUujAhWFalrbugk9VAfdaVKmFRlzlVBbIqsZsGqC6A3oeHx3uR21P56Hbm59IC6Y0PwrcqFRLOsvE2YsLLdWpsOi4bohMA3OujC3A9lCp9Ougczm6qoJ9zhR7wPE9zYxoPNeL2aWozurBnVLdoAHBGlzBK%2BlcyY3gEsa0z0VMMcVlKm3AVO61KzwK2mqnrQtBfQPP4HiywbYqnXCAei8m2Em%2Bo6dZFQvdnUaJZSV4ikbuT3VQKi1thWPi4ZWQ6dzWxxpwjA%2Fc%2BwDyGsqcpznVPgs9PxLIFsaIwkrq7jjJVrQyeDvdenitCpHs552C8jvA4pHCpu8wOfLB6VYyBaxlIncFJdU0N%2B5z2JVOXtROd8UTqJ7uBwVzxrgI7Ool%2F9MdtgkO%2B%2F3BALs5ZVooLRIDb2oXGsixegHq5ovMyoSu6N7FWULLMqsAloEo9HktwxO7Dgunlrrjm5O0CWxp1Ej0Ty3fk6sG5OGEM8eXdF98NCKj%2FmjE%2FB4ZEL8netyPemHXjwhn4A8pHc5av5O3fjXv%2FkBawr21BNupByL%2BZ%2Bg9hmAjDV0KnlCXF5Jw4JOhT0Y%2FyDAmETwBGZJwFH0gJCbEkSKMbXjbwO62txb%2FGmZzfnXZDXu363Um0vOvxUMeFRennc7dethXZtw5G%2F9WURT2jvH2L%2BqTHNNvBgAA)
  gamecloud-bedrock (subdomain, hostRequired): [Test vproxy.cloud/gamecloud-bedrock example.com/a](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABBJT2oC%2F91Tf0sjMRD9KiEgKLfdpj3p2gXh6g%2FEU2upPdCTUrLJuAa3mzXJtu6Vfveb7Fqtd8L9f1DoTmbe5L03kxV1MC8y7oDGK1oYvVASzLmkMV1g9FKFItOlpMFbbsjnWEsHTs%2FHunRAzjKd8IwMwS21ecJKC2ahBNRNUqyuO7QSkEaLrfxroyuVgzD8wZEzPCA3mARDdo%2BactImx8PB1eke4vDcKp3TuBPQTKf6h8kQ%2F%2BhcYeN2e5tuezHywXF98SWWhkWeYgcJVhhVuLoLHWmVO8KJLROp51zlxGlS6dKQBk5qPHmTQHZrKsSA0EbuhZ4SN4onGZx8aOy4ScGRwxpKbKPoUVuXe8loQJWLo8ybET%2FwzEJAfXIMz6UygK45U0JTNSqTC6hOanZ%2BJJ2wYSp0jq658I8ZecgYJHYR7g0ktNBSpcqFQs%2BDbUTAcYjGD9GnEN8oszS%2BX1FXFX48tWTaMMTwm98E75udaAx3Gqk7eOocTuMrYwEFayF3ivvpDLIlryxdT9cB%2FaVzmL1fMcV5bDjCC8ct3NB4vYvjZ4r0ipnaAApu%2BNz6Vd1A7z9gpxvwPaIxaOjVYSIkhG750TJPS6W5NjCz%2BM9daWDj%2F7zMnJrxJX8%2FkmLGiyKrUIXFLPb926i8WWtPXnLH%2FeenV287NpPCa1L%2BxRxE%2FaSf9DqtpBcdtPaTbqfFu72k1Yl6B%2Fjj%2FQfR33qOnz3Vfz3ALX8%2Fm9V6GqDX%2F6cy3AnLFyBn3Nd1WbfXYlGL9Scsilk%2FZvthj0WdiH1hLGbMSwHrGrUr3JXtLaH8OpW3k8XPSfEMN9V4csFTeJK3p%2B54dNNnV5Ynd8NxNLi%2B%2B35%2BSNe%2FAa7dPY1qBQAA)
  
 Note on the missing apex test for gamecloud-java: the Online Editor rejects any apex apply of this template with `Invalid data for SRV host: __tcp.@` (tried with both `"name": ""` and `"name": "@"`)