### PR TITLE
add Hoversite, Hoversite Hosting

### DIFF
--- a/hoversite.build.hosting.json
+++ b/hoversite.build.hosting.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "hoversite.build",
+  "providerName": "Hoversite",
+  "serviceId": "hosting",
+  "serviceName": "Hoversite Hosting",
+  "version": 1,
+  "logoUrl": "https://assets.hoversite.build/logo.svg",
+  "description": "Points a domain at Hoversite's hosting edge. TLS certificates are issued automatically once DNS resolves.",
+  "syncRedirectDomain": "hoversite.build",
+  "syncPubKeyDomain": "hoversite.build",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "178.105.196.17",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "178.105.196.17",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Hoversite (https://hoversite.ai), a website agent with managed hosting on `hoversite.build`. The template points a customer domain (apex + `www`) at Hoversite's hosting edge; TLS certificates are issued automatically via on-demand ACME once DNS resolves. The template is fully static — fixed A records, no variables — by design.

Apply URLs are signed per the spec's digital signature scheme: `syncPubKeyDomain` is set to `hoversite.build`, the RS256 public key is published as TXT at `_dck1.hoversite.build` (`p=1`/`p=2` chunks), and our service signs every apply URL's query string (`sig` + `key=_dck1`). *(Added in review — thanks @pawel-kow for the pointer that some providers won't take unsigned templates.)*

`providerId` is `hoversite.build`, a zone we operate (the hosting edge's own base domain). Happy to complete any ownership verification you need against that zone.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://assets.hoversite.build/logo.svg returns 200 `image/svg+xml` (also verified via `dc-template-linter -logos`)

Also validated locally with `dc-template-linter`: exits 0 with no notes. Signature verification was additionally exercised end-to-end in our test suite (sign the query string, strip `sig`/`key`, verify against the published public key), and the `_dck1.hoversite.build` TXT records are live and reassemble to the exact SPKI.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `hoversite.build`; public key TXT at `_dck1.hoversite.build`, all apply URLs carry `sig` + `key`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — correct, only `syncPubKeyDomain` is set
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — `syncRedirectDomain: hoversite.build` is set; our current flow does not send `redirect_uri` yet, this future-proofs it
- [x] no TXT record contains SPF content — no TXT records in the template
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A, no TXT records
- [x] no variable is used as a bare full record value — no variables
- [x] no bare variable is used as the full `host` label — no variables
- [x] no variable is used in the `host` field to create a subdomain — no variables
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not applicable: both records are the service itself; removing either breaks hosting for that name

## Online Editor test results

**Editor test link(s):**

- [Test hoversite.build/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABqKUGoC%2F%2B1T247aMBD9FcsvfSAEBwiXSJW66lYC7WpFWSq1Qigy9kCthti1nbAB8e%2B1WS67iK762Ep9iuM5Z3zmzMwWW1ipjFrAyRYrLUvBQQ85TvB3WYI2wkI4L0TGcXAKP9CVg%2BPBEeBCBnQpGByIxop8eb69xKPBCbG%2FkTlOogBncim%2F6MxnsFaZpNGgxoA14YWShgeGpvR8DoZpoew%2BBx5JkVuDKOJyRUWOqEWnR98ZdBCGgC8hRJP7R8RAW7EQzNXvaBqQMKYAjmhhXQbrAllWIZkzQLcPj0iDkVkJJvS1VTkbAxcamL3dP3fVMw8bFfM7qN4AuRxSc4OT6RbbSnmzbty11%2BuOH7z1%2B8om0v1G3V4YkTiM%2Bp0w6rqYtc6zFiG74Bp7vV7%2FKX%2B2C%2FBG5pCe9cycxUfd8ETdqEDI5Oqc3p2WWhYqFUe8opqujB%2BnI3P6ijo7cqcY%2BxfFMpcaUuO%2B1Bbaybe6gACvisyKlK7p%2BYqzlCqVVU6gcVGX4rVh%2BfOgecM4tfStYgOccuZFCj%2BybcLjNpvH9QVQUm%2B3o3Z9zjpRPaIx6XVJfx7x%2BMUC%2FGY%2Fri%2FB2Shw45xbQf2I32RrWhm8u2jaoYLnpv0zNcwC1%2Fj%2FrfgrWuHWy9ASeEo9rEmanTrp1iMyIXES95KYhHGzF7f6NUISQnwJYOxzeVu3jS%2F3EA834%2BU3Fik17o7u24NNrcN74gf9qb6qRQvuhuPq80cgtW45%2BfQe734B5RgjCUwGAAA%3D)
- [Test hoversite.build/hosting example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACeKUGoC%2F%2B1T227aQBD9ldW%2B9CHGrAFzsVSpaRM1UauINkmlCiFr8U5gVeO1dscmFPHvnYUQAqJRH1upT%2FbOzJk5Zy4rjjAvc4nAkxUvram1AnuteMJnpgbrNEI4qXSuePDsvpFzCudXuwByObC1zuAJ6FAX0731OJ5dPUdsLKbgSRTw3EzNvc19BsTSJc2mdA7QhUdMmj4wdLXHK3CZ1SVucvCh0QU6Jpkyc6kLJpE9F33j2BMxBmoKIbv7fMsysKgfdEb6CWaBaecqUExWSBmQHHm%2BZKbIgF3c3DILzuQ1uNBrWxbZV1DaQoYXm3Ine%2BbDhtXkEyxfCaIcxirHk9GK47L0zTons%2BdLv%2B986zfK7gw9o14%2FjEQcRoNuGPXIh0g9awuxDk6hF4vFn%2BLH64D%2FNAWkez5javGONzxKWhUIMzPfp3fVhB5Ta6oy1TtIKa2cO79RO%2FDoAD3ewUcbvK%2Brp4WxkDr6SqwsiUBbQcDnVY46lQu5N6kslWWZL4mmIy9lOWxbsV23LTMlUb4mOuCpyjxT7Ve3JVpRp93PGlk7hkYHWv1Gv6MeGr140lWTQdRXUefFIfzmTk4fw0HDgDa7QC39tp%2FnC7l0fH00vycZNL%2Fw35MyDmgP%2Fo%2FlrxsLXZ6TNahU4pZMtyF6jUjciTiJB4loh53eoNeKzoRIhPAqwOFW4Yqu9OV98o9ddyHE%2B1l%2B3fmA%2Fe%2FD%2B1rJ%2BEdr2Lr88u12UsscZmdxHYumvXzL178AsdeG92oGAAA%3D)

Both tests apply cleanly: apex test produces `example.com. A 300` + `www.example.com. A 300`; subdomain test produces `sub.example.com. A 300` + `www.sub.example.com. A 300`.
