### PR TITLE
Add template tooldrop.app.website

### DIFF
--- a/tooldrop.app.website.json
+++ b/tooldrop.app.website.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "tooldrop.app",
+  "providerName": "Tooldrop",
+  "serviceId": "website",
+  "serviceName": "Tooldrop custom domain",
+  "version": 3,
+  "syncBlock": false,
+  "syncPubKeyDomain": "tooldrop.app",
+  "syncRedirectDomain": "tooldrop.app",
+  "description": "Serves a Tooldrop workspace from a hostname the customer owns.",
+  "variableDescription": "vctxt is the domain-ownership verification token shown in Tooldrop settings (the part after vc-domain-verify=).",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 300,
+      "groupId": "routing"
+    },
+    {
+      "type": "TXT",
+      "host": "_vercel",
+      "data": "vc-domain-verify=%vctxt%",
+      "ttl": 300,
+      "groupId": "ownership",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Tooldrop** (tooldrop.app), a workspace platform that serves customer workspaces from hostnames they own. The template has two records: an A record in the `routing` group pointing the connected FQDN at our edge, and an ownership-verification TXT (`vc-domain-verify=%vctxt%`) at `_vercel` in the `ownership` group, marked `essential: OnApply`. Apply URLs are always signed (`syncPubKeyDomain: tooldrop.app`, key published at `_dck1.tooldrop.app`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — *no `logoUrl` in this template*

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — *intentionally not set on the `_vercel` TXT: multiple `vc-domain-verify` tokens must be able to coexist at the same label (other services hosted on the same infrastructure keep their own tokens there), and the verifier tolerates multiple TXT records*
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — *the `vc-domain-verify=` prefix is fixed in the template; `%vctxt%` carries only the token*
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
[Test tooldrop.app/website dealmachine.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPTNT2oC%2F%2B1Va2vbMBT9K0Iw2FgcHCd1YkOh3doPI2zrttCtK8HI8nUjYktGUpImIf99V86zabuybxssGCzrvs45V7pZUgtlVTALNF7SSqupyEB%2FyGhMrVJFplXVZFVFGzvbJ1aiLx1srGgxoKeCQx00g9QITLbbPXInfGKsKkmmSiYkuk1BG6EkjdsYMpf8XaH4mMY5Kwysd64maR%2FmF%2BuAR7Ccx1fIhAZun%2FPJwHAtKlvXod8QGBjCyA7TTOmxqRgHkmvExshIGSsROLEj2CAGTdRMmqaDzLRgaQEXD9JOub23RJg6Zk3PwwikNxIVQZoiF5w5Z2LVGCQxIzQTIfc4DFgr5J0hr12OimlLWG6x8pR7m4x1nvnpG4cDKSudGRrfLqmdV07mc9x24HF55nqmhLRmoPCzGzbxCVr4oMHaAhX3%2FQa902pS1a3DhatOV41dusGPwT5hgrU5FE5PZlnN%2BAjVq1qDV8%2Fk34mBdjAGpBUMvehneV5VxZyuhqsGXSgJyZ7YEIttm5oBK0rGR0JCk6tyD4xuqiRiG4PSsdK4E72Nvn0UPtzG31K3rqE%2F4dfwj37UwRR3UmlIDL6ZnWjUyuoJntdyUliRsBnbb2U8YY4fsjJoxRIP2yXXF%2BRsr%2BtzrUoy7igJJ2aQtgPIeOCxkzz3Oq0o8KIwSL0sDXLeC096UQAHl%2FapC%2F30td1retij82LG5oauHp2NDfqXz8aLsv4lTHencTVs4FH636t%2Fo1d4gw2bQpYw5xf4Qej5Xc%2BPBq0wboex32l2e51eEL71%2FXhNAIxd81%2FW63pasAru3Xs74R%2BMkN8OoM34eHl6YFuomaTbpH9cy8llDgrW383jsj0IUt6OfP%2BknfMg6oSdyJV2taHAf0oUypHG%2BJoy7h%2FOMtpefLnsXMnFotO%2F%2BXkdXYr33XLctbNF%2F2PU7X7Xtj%2B6KUfBtWzNTunqFzYtI4hECAAA)
[Test tooldrop.app/website dealmachine.com/tools](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPbNT2oC%2F%2B1Va2vbMBT9K0ZQ2GicKi8nMRSWrYOVlrZ0YRRKMIp03YjalpGUpFnIf9%2BVYztt0nzotzEWDFZ0X%2BeceyWviYU0T5gFEq5JrtVCCtCXgoTEKpUIrfImy3PSqG03LEVfMi6taDGgF5JDEbSEqZGYrN7dc%2Ff43FiVekKlTGbotgBtpMpI2MGQVca%2FJoo%2FkzBmiYHtzt18egWri23AASzncQ9CauD2mI8Aw7XMbVGH%2FERgYDzm1ZiWSj%2BbnHHwYo3YmDdTxmYI3LMzKBGD9tQyM00HmWnJpglcvEm74PbFetIUMVt6PkYgvZnMPaQpY8mZc%2FaseobMMzM0ezLb4TBgrcyejPfJ5ciZth6LLVZecL%2FMWORZnX92OJCy0sKQ8HFN7Cp3Mo9w24HH5RfXMyUza8YK%2F%2FaDJj7tFj5osDZBxSltkCet5nnROly46mTTqNONH8a7hBHW5pA4PZllBeM9VCeFBidH8tdioB2MgcxKhl7kNhvlebIim8mmQX6rDKIdsQkWq5oqgCUp4zOZQZOrdAfMdduQslQkq0DUj6XGjXWV4vEgx6RK8lhmwY2CRL3T3AtpDKA95Z0hpb1OzNvDbtAdUuKgy6dMaYgMvpmda9TP6jnOcDpPrIzYku22BI%2BY44xMDVqx2NsWZttDUxEr9T7Wwkhwx1I6kUU8YDzoM78fi47fjeOhPxC07Ysp7bRYl%2FemMXt1mN876O8f5z2tXzdwlCzZypDNweCUNMrBae7RORifD%2Bj9N9Gv53czaeDc%2Fe%2Fkv9BJvAcMW4CImHNu03bg075Ph%2BNWEHaCkAZNOujRbueU0pAWLMDYrRzrYl1cPCyHF%2FeuvhhvbqPjFxqpL6F9nwbd%2B7leETOfVkk%2FXKvSoSr4gdZtitqQ4JcXhXKkMX6HBY2vL0Ny%2B3B9%2F%2BNhpAP2%2Fex0fHd1DZTf0Pjyl5BpOuuN07tvrez6cnR5tjwnmz8%2BCRoDmQgAAA%3D%3D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
