### PR TITLE
Add cnames.dev Domain Connect templates

### DIFF
--- a/cnames.dev.apex-only.json
+++ b/cnames.dev.apex-only.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "cnames.dev",
+  "providerName": "cnames.dev",
+  "serviceId": "apex-only",
+  "serviceName": "Connect a root domain (no www)",
+  "version": 1,
+  "logoUrl": "https://cnames.dev/logo.png",
+  "description": "Point a root/apex domain (example.com) at cnames.dev without also setting www",
+  "syncBlock": false,
+  "shared": false,
+  "syncPubKeyDomain": "cnames.dev",
+  "syncRedirectDomain": "app.cnames.dev",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip1%",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip2%",
+      "ttl": 300
+    }
+  ]
+}

--- a/cnames.dev.apex.json
+++ b/cnames.dev.apex.json
@@ -1,0 +1,33 @@
+{
+  "providerId": "cnames.dev",
+  "providerName": "cnames.dev",
+  "serviceId": "apex",
+  "serviceName": "Connect a root domain",
+  "version": 1,
+  "logoUrl": "https://cnames.dev/logo.png",
+  "description": "Point a root/apex domain (example.com + www) at cnames.dev",
+  "syncBlock": false,
+  "shared": false,
+  "syncPubKeyDomain": "cnames.dev",
+  "syncRedirectDomain": "app.cnames.dev",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip1%",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip2%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%edge%",
+      "ttl": 300
+    }
+  ]
+}

--- a/cnames.dev.custom-domain.json
+++ b/cnames.dev.custom-domain.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "cnames.dev",
+  "providerName": "cnames.dev",
+  "serviceId": "custom-domain",
+  "serviceName": "Connect a custom domain",
+  "version": 1,
+  "logoUrl": "https://cnames.dev/logo.png",
+  "description": "Point a subdomain (e.g. app.example.com) at cnames.dev",
+  "syncBlock": false,
+  "shared": false,
+  "syncPubKeyDomain": "cnames.dev",
+  "syncRedirectDomain": "app.cnames.dev",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%edge%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Domain Connect templates for [cnames.dev](https://cnames.dev) — a developer-first custom
domain API for SaaS: one API call gives every customer their own domain, with SSL, edge routing,
and per-tenant isolation included. These 3 templates cover connecting a subdomain
(`app.example.com`), a root/apex domain with `www`, and a root/apex domain without `www`. A
wildcard zone template (`*.zone.example.com`) for whitelabel/multi-tenant use cases will follow
in a later submission.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — see test links below
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter) — clean, zero warnings/errors on all 3 files
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://cnames.dev/logo.png`, verified live)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
- [x] digital signatures are used and `syncPubKeyDomain` specified — all 3 templates set `syncPubKeyDomain: "cnames.dev"`; requests are signed RSA-SHA256 server-side when `DOMAIN_CONNECT_PRIVATE_KEY` is configured (see `signApplyParams()` in `../control-plane/src/lib/domainconnect.ts` and "Signing synchronous requests" in `./README.md`). The public key is published as `_dcpubkeyv1.cnames.dev` TXT records.
- [x] `syncRedirectDomain` is specified when intended to use `redirect_uri` parameter in the synchronous flow — all 3 templates set `syncRedirectDomain: "app.cnames.dev"`.
- [x] no TXT record with SPF content (i.e. `"v=spf1 ..."`) instead of using SPFM record type on APEX — n/a, none of our templates touch email/SPF.
- [x] `txtConflictMatchingMode` is set on TXT records which shall be unique on a label — n/a, our templates carry no TXT records (`custom-domain`, `apex`, `apex-only` are CNAME/A only; our domain-ownership proof is out-of-band via `points_to_us` detection, not a template-applied TXT).
- [x] variables are set to the smallest scope needed (i.e. limit possibility to be misused to set any arbitrary record and conflict with other template) — every variable (`%edge%`, `%ip1%`, `%ip2%`) is the *entire* value of its field, never a prefix/suffix inside a larger string, and none appear in a record's `host`/`name` field.
- [x] no variables as a host name to apply template on subdomain instead of standard `host` parameter — the control-plane (`connect.ts`) splits every hostname into the registrable base (`domain` param) and the subdomain label (`host` param) before calling the DNS Provider; it never folds the subdomain into `domain` or duplicates it into template vars.
- [x] no explicit usage of `%host%` variable in `host` attribute — confirmed clean; no template record's `host`/`name` field contains `%host%`, `%domain%`, or `%fqdn%`.
- [x] `essential` setting is used on records, which the user shall be able to change or remove manually later without dropping the whole template — n/a, none of our records are the kind of secondary/removable record (like DMARC) this applies to; all records in each template are core to the service and intended to stay `essential: "Always"` (the default).

## Online Editor test results

**Editor test link(s):**

> Note: the CI's per-template coverage check only reads the top-level `domain`/`host` fields of
> a token, which reflect whichever domain/host combination was **selected** at the moment
> "Copy Markdown" was clicked — not every case run in that session. `apex.json` and
> `apex-only.json` (no `hostRequired`) therefore need two separate links each: one copied right
> after testing with Host set, one copied right after testing with Host left blank. Re-test with
> Host blank last (or re-run + re-copy) before pasting so the selected state is the blank-host
> case. `custom-domain.json` (`hostRequired: true`) only needs the with-host link.

[Test cnames.dev/apex-only cnames.dev/domain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABrjT2oC%2F%2B1VUWvbMBD%2BK0ZQWKnt2E6aOobBuo2OsDLK2sFKCUaxromoLRlJieuF%2FPednCZO0ox1bA992JOtO313%2Bj7dnRbEQFHm1ABJFqRUcs4ZqCEjCckELUD7DObE3Xi%2BoG3fp0HNeQYNiJbw6EmR1639CfJBCgGZcaijpDQOkwXlwnkjpFNV1TFun4PSXAqShC7J5UR%2BUznCpsaUOul02owd6%2FRLMUEMA50pXpoGR64kF%2BsEHXuSTRZ4pMgS%2FEwWxw41ThvNqbiZyhnCci0dDcZwMbFHsgRqkb3PZfZAknt0A1qmVAFrl7jhajb%2BDPXHJtEzZdD%2FFRhXSHyzg5alv7MLvVIxTZK7BTF1acU6R%2FNUaoO%2F76z6lpi%2Bkbg84mV4hCZjUJ1uECzdl4GiHdBo6ZIfUkDa5h6hmgdJPIV8crpkouSsTPkaVFJFC22rZw2%2F28aP1gHu1n60IAdrCAeRH%2FZjP%2FTDlTXatUbEnpNPhFSQavxSM1PI1KgZil%2FMcsNTWtHWxLIU1c1rpKXRi9F2JRWrUtxQYdRQXG%2BfoxXJJSnLLC9uCzumcQbdCLwI4lOvxxjzxnAK3iDu9cKQRXSQjbf65HkH%2FapL9uUFrUEYTm3xn%2BcVrTVZ7l3yb2lEr5TGyMWK%2BX8lr%2BpKsPE0nQNLqd0cBVHfC868YHATxknQT8LYj8JeP%2BqeBEESBJYFaLOit2j%2Bm963ee13ThWn4xwaY9Pme1fZNPmeLofnTjNn7IxZ2hFp%2B%2FnZiBT7r5G%2Fo%2FKBWjp8bS8OEJFmdK4P%2FE%2F5HpyzL%2BK%2Fgvh%2FLcOfxmnUWNoCzPGBwxKy5dBSQM%2F21CZDll9el8NJeXFye9Y9%2BX5TFcOoui0u6k%2BPqncfDHK4vhg%2B5Ho8fEuWPwFpIGp3mggAAA%3D%3D)
[Test cnames.dev/apex-only cnames.dev/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMHzT2oC%2F%2B1VUU%2FbMBD%2BK5ElpCGaNAm0oZEmDYYmAWMwBi%2BgKnJs03pL7Mh2GrKq%2F33ntCVt6SbQJm0Pe8rl7j7f3ee78xQZlhcZNgzFU1QoOeGUqVOKYkQEzpn2KJugzpPlE%2Bg2bZqpCSesAeGCPbpSZHWrX0DeSyEYMQ52lJTGoTLHXDhvhHSqqtoF9wlTmkuB4qCDMjmStyoD2NiYQsfdbhuxa41eIUaAoUwTxQvT4NCV5GIZoGszeYrCHjFUyTwi810HG6c9zam4GcsSYJmWjmbGcDGyKdkCakGOM0m%2BofgBzAw0Y6wYbX%2FB4apMz1l90gR6xgzYrxnlCgp%2F8sBF4a15gVUqqlF8P0WmLixZR6AeS21AfGfZt4XpGwm%2FO7wIdkBlDLCz7%2FuzzstA4RpoOOug71KwpI09BDa3FrE4EqSRkmWR8KV7gRXOte2bJfB%2BFTlcQu%2BRlSFvKwaD0Av6h17gBXNtuK4Nkc2Nj4RULNHwxaZUUJ1RJRCel5nhCa5wq6IkAUazGkrRYIXT1mkU8%2FazjFBsMIirKbScdFBCiS2G2z4OKI4GvYi4xH8YuAchPnTxftp3CRsQ1n9IIz%2FdXxmL5wPzs6Fo2WRaM2E4tl1%2BlFW41mi2cZu%2Fyj3853IfdqAr%2FpP%2Fl8iHYdJ4wmiCrVvoh33Xj1x%2FcBMM4iCKw8CLeocHkb%2Fn%2B7Hv2%2FyZNvPCpo3cTLKNaL8TrDhOM9Yom9HduLlmcDcY2b4%2Fmq1hN8bMrjo7o89Wndh8Vbw1fre0zva7evEBIWpW4DLhP1rv4qIWxtfUP4d4v03Da89p2JjZ1svgoYIWsu2waD8IgVb3MLrc01dpnZ1z%2BuH22KQ9fVfg2zN8dPH18uLz9Z0q8%2FSkOj89%2B%2Fjl4C2a%2FQBkCtxQYAgAAA%3D%3D)
[Test cnames.dev/apex cnames.dev/domain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGbjT2oC%2F%2B1Wa2vbMBT9K0ZQ2Gji2I7zqGGwru1gKytdH4OuBKNat6mYbbmS4jQN%2Be%2B7ch5OXG%2FN2Bj90E%2B278s6R%2Bfqako0JFlMNZBgSjIpcs5AfmIkIFFKE1A2g5w0Vp4TtFV9CmTOIyiSaAYPpWkRfSDSFCJtUUsKoS0mEspTjMpBKi5SErgNEouhuJQxRt9pnamg1Sr%2F0TJOO0uHmMNARZJnusgjp4Kny7ot8%2B9FcesNPFDEBXYkEmvXGo%2FHby2qrc11T9LoQyyiHyS4pbECtNxRCaz8xIDT0c0xTA7nS64CR%2F8ZMC4R3CqCZpm9EYVeIZkiwfWU6ElmCNlH851QGl%2FfG3INCnUh8HOHZ%2B4OmrRGKtqOM2tsl%2BT9IungZP%2FLUZmIPFRSgQ1hI3cwa5BHkUJYrnuAtNcSsKi62tChFKMs5MukjEqaKCOsZfr1ev5gWeB66UcL4jcGd8%2Bz3W7fdm13bvU2rZ6xmrUbs3muc24g8GEqJIQKn1SPJMZpOcI9TUax5iEd09LEohA3LZ4gYoVerLi5U%2BlcxSuUjGqK3%2BtLLPlrkJBFBjI37eC3e50OdKHZoU6%2F6d9Q1ux3e72mF0WR1%2B52%2Bszx17rrad%2FV9FaVdFAKUs2p6Z39eEwniswqsnkWgfeSESw1vECBGrarSKoKeHFoBg1siFdZvcrqH8sKT0FFc2AhNcGe43WbTq%2Fp7F24%2FcDpBW3f3us4vufvOk7gOAYAKD1HNy3ei%2BO5%2BCU%2Bcyo5vYmhMBYncUWOxTlc2eD5KVzDVf3MKGaEmQ8zMxrNgftkNKbVS4a9wXxNo9QLc%2BsCHvm9Lp4pVIVezNAl%2Bv%2FDau0k3orleYr912T%2FaZ3nON%2BuXg31M9NOMV7JsCuMwkta0LN%2BISCj%2FPN5en512%2Fa7j%2B3Dj%2F37o7iT6Kuz7%2FeTY7jKdnvHl%2F7pt%2FtP8HX8jsx%2BAmjQ4O4rCwAA)
[Test cnames.dev/apex cnames.dev/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOLzT2oC%2F%2B1WbWvbMBD%2BK0ZQ2Gji%2BC1NYhisbxvb%2Bra2o7ASjGypqZhjuZLiNAv57zvZcZ24XpsyGP3QTz6f7k53j547aY4UHacxVhT5c5QKnjFCxReCfBQleEylSWiGWg8rJ6Crr0kqMhbR3Amn9L5SLa33eZLQSBnYEJwrg%2FAxZglYZVRIxhPk2y0U8xH%2FIWKwvlUqlX6nU%2B3R0YtmmozAh1AZCZaq3A%2BdcZaUcTt672Vw4x29x1AXNSM%2BNraN6XT63sDKWM97lkR7MY9%2BIf8Gx5KC5hYLSqpfMDibhN%2Fo7KBIuV44rJ9TwgQU92CB09Rcs4JVLohE%2FvUcqVmqAdkF9S2XCsSPGlxdhbzk8LvFUnsLVEoBFK5lLVqbOTl%2Fcdo%2F2T0%2BrBwBh5orJSO65jtctNBvntCgynsIsDcCsIwK0kjwSRqw0jzFAo%2BlplTpeL3qOSxdr5GWoWYt2gPHtHf6pm3ahdZZ1zpaq%2FPVav1dxVmnzUYJFzSQ8MVqIsBOiQmc43gSKxbgKa5UJArgoOIZVClhFSKun05SMFcDTbDCIK5mV8HVQgGJdJ1Ms5%2B6ttsPcdjGPddpe1G318ZO6LY91%2FNI1w77mIYrzfS4zRpaqcKYSkkTxbBukt14imcSLWr8eCpt53WmXTJ0mXrB0GXy9UN%2BRQUMW8DzN868ceYlnIH5JXFGSYC1mWM5O22r17YGl%2FbAt3t%2B1zN7%2FZ1uz9q2LN%2BydOpUqqKueS7nIzXfDL4ZFgyHMc2V%2BQytES6foLXTLOZnA0rNEz6f63qmL%2FRFpkflo4ssqT8JzDXMG1qhmYAbB3DQk1QwnwlULz2%2F8crq%2Fw%2BqS548PIQ2R7lwMf8Z7JfGeQ7zzeI1QL%2FQjRTDAwq6QjO8bCbQr17kyL6%2FGmTnR58d78vpd3Vz9WlvZOG7n6dHB19PXXXnXV7cnB0ehwcXU%2FkBLf4A3wvGPNcKAAA%3D)
[Test cnames.dev/custom-domain cnames.dev/domain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN%2FkT2oC%2F91Ua2%2FaMBT9K5GlSptKQgLlFWnSSoe0al3F2u4hIRQ58QW8JnFqO2kZyn%2FfNQEClE3a131yfN%2Fn%2BNysiIYki6kG4q9IJkXBGchrRnwSpTQB5TAoSGPnuUXbsU%2BBLHgEVVKutEhsJhLK09q3SbsSaQqRtqhVxVm7uAKk4iIlvtcgsZiLrzLG%2BIXWmfKbzbpd0zidLJ1jDgMVSZ7pdR4ZC56ayioPq6rWG3DmjkWzzIEXiiDBiUTy1qLaOhx%2FmUbDWESPxJ%2FRWAFaFlQCq68YMM7DT7D8UI17jB%2F9d8C4RGi7CNP2IGohlL6Dp5yvS2uZY2XMEJIp4k9WRC%2BzNUW3l59Hm3C8vjfcG2TqQeD1DNgcztCmNfLTdt1yWjbIL5FCUNeaIjUnB93U3JE%2BlyLPAr5NyqikiTI62KZP9vOn2wKTrR8tZh5jMec%2BXjMWn6dCQqDwpDqXsEWd5LHmAX2mtYlFARIWLxGFQi9WfM1IWmloNz2jmuL9uHPNTYMELDJwuFHmrMdY1PU8m%2FXDjn3Rph170I1mtse6vW6v1Yee19oT%2BusV%2BJvMj5kFpSDVnBoRX8bPdKlIWU4byPL%2FiAt1oGgBLKAmuOW2urbbs93Bg9f3vbbf8RzX7bc77XPX9V3XIAGlK5ir9feB6FakoJLTMIa1uVLYCTr%2BQeNG36VZNyOuk%2Bt28Ah7fZwD3v%2FwNLiEpeExxh8AsmAQ1SOgZ38FyOAC1IyPej%2F1aBjefGHff3zMn4aLx28ejMfh9Uw%2Fvdyf3191hovRO1L%2BBnmtltugBQAA)