### PR TITLE
Add template: xonark.com.aeoapex (Xona AEO — apex/root-domain connects, APEXCNAME)

### DIFF
--- a/xonark.com.aeoapex.json
+++ b/xonark.com.aeoapex.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "xonark.com",
+  "providerName": "Xonark",
+  "serviceId": "aeoapex",
+  "serviceName": "Xona AEO (root domain)",
+  "version": 1,
+  "logoUrl": "https://aeo.xonark.com/logo.png",
+  "description": "Serves your existing website through the Xona AEO edge so AI assistants (ChatGPT, Perplexity, Google AI) can read and recommend your business. Points the root domain (@) at the Xona edge with a flattened apex alias (APEXCNAME) — for DNS providers that support CNAME flattening (ALIAS/ANAME) at the apex. Your site keeps working exactly as before, fail-open.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "xonark.com",
+  "syncRedirectDomain": "aeo.xonark.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "APEXCNAME",
+      "host": "@",
+      "pointsTo": "cname.xonark.com",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}

--- a/xonark.com.aeoapex.json
+++ b/xonark.com.aeoapex.json
@@ -5,7 +5,7 @@
   "serviceName": "Xona AEO (root domain)",
   "version": 1,
   "logoUrl": "https://aeo.xonark.com/logo.png",
-  "description": "Serves your existing website through the Xona AEO edge so AI assistants (ChatGPT, Perplexity, Google AI) can read and recommend your business. Points the root domain (@) at the Xona edge with a flattened apex alias (APEXCNAME) — for DNS providers that support CNAME flattening (ALIAS/ANAME) at the apex. Your site keeps working exactly as before, fail-open.",
+  "description": "Serves your existing website through the Xona AEO edge so AI assistants (ChatGPT, Perplexity, Google AI) can read and recommend your business. Points the root domain (@) at the Xona edge with a flattened apex alias (APEXCNAME) for DNS providers that support CNAME flattening (ALIAS/ANAME) at the apex. Your site keeps working exactly as before, fail-open.",
   "syncBlock": false,
   "syncPubKeyDomain": "xonark.com",
   "syncRedirectDomain": "aeo.xonark.com",


### PR DESCRIPTION
# Description

New Service Provider template for **Xona AEO** (https://aeo.xonark.com) — companion to the merged `xonark.com.aeo.json` (#1318). That template is `hostRequired` (single CNAME on a subdomain host), so root-domain connects can't use it: this template covers **apex connects** with an `APEXCNAME` record, for DNS providers that support CNAME flattening (ALIAS/ANAME) at the zone apex. Owners connecting a bare domain (e.g. `clinic.com`) get the same one-click synchronous flow.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://aeo.xonark.com/logo.png → 200, image/png)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published at `_dck1.xonark.com` (TXT, `p=N,a=RS256,d=…`), same key as the merged `xonark.com.aeo` template
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the service uses `redirect_uri` in the synchronous flow)
- [x] no TXT record contains SPF content (template has no TXT records)
- [x] `txtConflictMatchingMode` — n/a (no TXT records)
- [x] no variable is used as a bare full record value (template has no variables)
- [x] no bare variable is used as the full `host` label (host is the fixed apex label `@`; `hostRequired: false` — the record always targets the zone apex, which is the template's purpose)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — the single APEXCNAME is the service's core record, set to `Always` (removing it disconnects the service entirely)

## Online Editor test results

**Editor test link(s):**

[Test xonark.com/aeoapex xonaauto.ai/www (with host)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEUcUGoC%2F91U224aMRD9FctPoHJZbiFZqVIIRBFqk5BbmyiK0LAewGKxN7YX2Eb8e8dLuKSN1Pc%2Brdc%2B58zMmbHfuMN5EoNDHr7xxOiFFGj6god8pRWYWSXSc17anVzBnJD8MT%2BjfYtmISPMCYAaElztdw%2FArHN%2BzQpGa8eEnoNURYIt0FipFQ9rJR7riX4wMcGnziU2rFZJrrLPoeoBlURNiCfQRkYmLufyOwqGlmU6NQxX0jqpJmyJIysdMjc1Op1M6YtslweKCTKrWafPwFpigHKWFbpTcBeD%2BxIboEliknJZiV1oPYmRoEUWgWIGQTBQghaU1BxplQcepVYqtLbCBlp6NR%2FwoFxWOC0ycPs88hyW0k0ZsDH571AhKZN%2FDGIJlE5ncP7YvepcnhfZWBvWu7pj2y54eRKzaZJo41iO2qr46gud7%2F3OXbWzYb%2BH9doV9uSzza2ZISaWLbWZeQquIHJxRoawEVI8LLExyLisE1QV39JMRWexjmY8HENscbMzSEffMOvlJf45Mv78FoUkp9wO8bGphJpq627xNSWY2El7c42wPHx%2B4y5L%2FBDt3Hjn0Napn8vc7XtNv5Gicfso7hwNVOMoCEqceoPKSfAT1omXkFm%2BflmX%2BC%2BtcLiP90LTdVgNpE5XQO6DLpdL%2BpnQVCVDuaUkYGBu%2FQ3akp8%2FsF%2B29Oec7%2BPKiSKTh5a%2B4FJDJTqTUunzNHZyCEvYb4loCEkSZ5SmpVNS%2BdwWtblu3hYBDv5pyVBEPmXp726reVwbQatVbohGvdxs0gqOG1BGqLejNh6Lk1bz4Bn4%2B4H4%2FCH4YNpnLVi%2FlMjA%2F6ke6rWFBYoheGQ9qB%2BVg3Y5OLmv18NaENYalaPj9kmt%2BSUIwiDwFaB1m%2FreaC4OJ4I3nvqvD91Ve7CYL7JWv107s99%2FNHpV83izED%2FNCle97uXF9ao5u%2FnK178BvxvshswFAAA%3D)

[Test xonark.com/aeoapex xonaauto.ai/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGgaUGoC%2F91U224aMRD9FctPQeGyXAJlpUrZJJCmTVKUEJUoQmjYHcBlsbe2l0sQ%2F97xEi5pI%2FW9T%2Bsdnzlz5njsNbc4S2KwyP01T7Saiwj1TcR9vlQS9LQYqhnP73fuYUZI3sv2KG5Qz0WIWQKgggSXh%2BgRmAWt7%2BxEK2VZpGYgZI5gc9RGKMn9cp7HaqyedEzwibWJ8UsloiseNJQcoJjIMeVFaEItEpvl8kcqhoatVKoZLoWxQo7ZAodGWGR2olU6ntAX2V4HRmNkRrHghoExlAHSGnZyOQF73enmWQd1EhOVXeXZtVLjGAmaYyFIphEiBjKiBYmaIa2ywsPUCInGFFlHCcfmCh61y07OcwzsQUemYSHshAEbkf8WJRIz%2BccgFkBygk6rd3kf3LVybKQ0u7p%2FZLtTcPREZtIkUdqyDLVjcd2fBLc3wWMp2Ga%2FlXXcRfbs1GbWTBETwxZKT10KLiG08YoMYUOkephnIxBxQSUoi%2B5IVzK8iFU45f4IYoPbSCcdfsPVVdbinyPj9h8wEuSU3SPeHyqhJsrYB%2FyVEizaUztzdWS4%2F7LmdpW4Idq78ZZDoXM3l5nbXUW%2FoaRxe09uLQ1Ute55eU5ng9IKcBMWxAtYGb7pb%2FL8VUkcHOr1abqOu4HUqiKIQ1FajWmkkoHY4RPQMDPu%2BuwyX96l9ne5L5y7imIsyd6BoS%2FYVFNzVqfU9CyNrRjAAg6hKBxAksQrEmholyg%2BNkRuL5ozJAIL%2FzRjEIVOr3C3Nhx65WG1gYVmpVEt1Mp1LIAXlgtQPiNsOaqN6vWjB%2BDvp%2BHjJ%2BBg10fOb%2Fp5su6%2FaYaO2MAcowE4WMWr1Ateo%2BA1u5WK71X8cr1Ya9ab5U%2Bnnud7npOPxm6bW9NEHM8Cb7QD8%2FrTxJeq3X44%2B9r68lwN2720Ojs7ve2lQyxdKFHr3vwQd0%2Bf%2BeY3ZH7YssAFAAA%3D)
