### PR TITLE
add Ermaz, Ermaz Website

### DIFF
--- a/ermaz.app.website.json
+++ b/ermaz.app.website.json
@@ -1,0 +1,24 @@
+{
+    "providerId": "ermaz.app",
+    "providerName": "Ermaz",
+    "serviceId": "website",
+    "serviceName": "Ermaz Website",
+    "version": 1,
+    "description": "Connects your domain to the website Ermaz built and deployed for you, with automatic HTTPS.",
+    "variableDescription": "sitehost is the hostname of the customer's deployed Ermaz site",
+    "syncPubKeyDomain": "ermaz.app",
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "75.2.60.5",
+            "ttl": 600
+        },
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "%sitehost%",
+            "ttl": 600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **Ermaz** (https://ermaz.app), an AI website builder that deploys customer sites with automatic HTTPS. The template connects a customer's domain to their deployed site: one apex A record to the hosting edge and a `www` CNAME to the customer's per-site hostname (passed as the `%sitehost%` variable).

Requests are signed (RS256); the public key is published at `dck1.ermaz.app` per the spec's `dc-pubkey-record` format.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (no `logoUrl` used)

`dc-template-linter -loglevel error -tolerate info ermaz.app.website.json` passes with exit 0.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (we do not use `redirect_uri`)
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (no TXT records in template)
- [x] no variable is used as a bare full record value — the only variable, `%sitehost%`, is the CNAME target for `www`, which is the standard pattern for per-customer site hostnames (same shape as other website-builder templates)
- [x] no bare variable is used as the full `host` label — hosts are fixed (`@`, `www`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (both records are required for the service to function)

## Online Editor test results

**Editor test link(s):**
- [Test ermaz.app/website example.com/@ (apex)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANgmUGoC%2F%2B1T227bMAz9FUFAsYfZruomTmJgwLpesKFbVyDBBrQIDFliEq225ElyXDfIv09KmtvWYa992JMkkoc8PBQX2EJZFdQCThe40mouOOhPHKcYdEmfIlpVONg6bmjpAvGldzmzAT0XDFbhDeRGuDRb634s%2Br71zkEboSROTwLMwTAtKrt643MlJTBrUKtqjbgqqZDIKmRngJ6zo3W2vBaFRVRyxKEqVAscTZT2uAA1ws4Qra2DW8HQx9Hodhj5ulQLmhdwcVDTJ50pY5Ewqzr%2BLh1xpCarN6uNywT6jdmVWnPYNNtKdlvn19BerAj%2FJpwGpjQ3OL1fYNtWXpAzZ%2FZl3PW9l1YJac1IuWevG8VRQqKuM1tb4DQhZBlsgec3Z18ud%2BCmaQ7hR5tmjvbx42WAn5SEbEdl7JTfkn2kbv4QMVXuUrvbVKu6ysQmvqKalsb%2FkQ3y%2FgA63mDvsb9vmPj3VBUcZJjT%2FIGGcZL0XZsSbCEm7UokT1BMpdKQGXdSW2vXrdU1BLisCysy2tCdibPMoYrW9WOc11U4lFauv52XllNL%2FyJrgDPOfDvC%2F11GYzYhvBfSAYWww5JJ2O%2BcnoT9AWf90y6LO3C6twV%2FrMfLe7ATE4wBaQUtPMeioa3ByxcG%2B0x9Pdhn8v9S71W1NA7cX%2Fk%2FjlczDr%2BJdA48oz4sJnESkl5IBqM4TrvdNCbR4KTT6yRvCUkJ8eTB2HWnC7eV%2B%2FuIr%2BKH2Ww4NE%2Bj%2FhV5%2FHrMvv0c9vMPxfE1uWh%2BnN1dP9RVfjed1J%2Bbd3j5C0OJepFYBgAA)
- [Test ermaz.app/website example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAksUGoC%2F%2B1TyW7bMBD9FYJA0EMkgZZtORZQoEESNE2brXGRtoEhUOLYZiORAklZUQz%2Fe0jvblP0mkNP0ixvZt4bzgwbKMqcGsDxDJdKTjkD9YnhGIMq6HNAyxJ7m8AVLWwiPnMh69agpjyDRXoNqea2zMa7m4vuN9EpKM2lwHHLwwx0pnhpFjY%2BkUJAZjRqZKUQkwXlAhmJzATQqjpaVksrnhtEBUMMylw2wNBIKofzUM3NBNHKWLjhGTofDG7uAteXKk7THE73erqiE6kN4nrRx%2F0LOziSo4WdVdpWAvVOb1stZ1iTbUR2U6WfoTldDPybcAoyqZjG8cMMm6Z0ghxbt2tjfz84aSUXRg%2BkNXvdIAwiEnSt25gcxxEhc28DPLk6vjzbguu63ocfrMkc7OKHcw8%2FSwHJdpShVX4z7BO1%2B4cgk8W2dJrLsbXGSlZlwteYkipaaPdO1uiHPfhwjX9YFrD2eiLnG8ucgfBTmj5SP4yiI0tXgMn5qFmI5QblYyEVJNp%2BqamUZW1UBR4uqtzwhNZ062JZYlF5Y3lpG7Ud9iUWy%2Be3osKooX9R2MMJyxwr7p5xOwtbQLpdn5Cjjt%2FpMuKnKQU%2FbTM4Iqw9Yll%2F5yD%2BuJTXT2JfV9AahOE0d6PmNW00nr%2By5xUDu%2Bdgn8W%2FlHxz3IaefT%2F%2F1%2FNm1%2BMulU6BJdSlhiSMfNLzSX8QtuNWLw77QdTpRC1ySEhMiCMA2izZzuzV7t4rvv148eNOPOlLfa5%2FpZOf36%2FCynz5dnHLD6eUldfq6%2F31Y3ldjp7O3uP5C7x7IBqABgAA)

