### PR TITLE
Add stowlane.com facility-page template

### DIFF
--- a/stowlane.com.facility-page.json
+++ b/stowlane.com.facility-page.json
@@ -1,0 +1,17 @@
+{
+  "providerId": "stowlane.com",
+  "providerName": "Stowlane",
+  "serviceId": "facility-page",
+  "serviceName": "Stowlane facility page",
+  "version": 1,
+  "logoUrl": "https://stowlane.com/icon.png",
+  "description": "Point your domain at your Stowlane storage rental page.",
+  "variableDescription": "Your Stowlane facility page",
+  "syncPubKeyDomain": "stowlane.com",
+  "syncRedirectDomain": "stowlane.com",
+  "hostRequired": false,
+  "records": [
+    { "type": "A", "host": "@", "pointsTo": "%edgeip%", "ttl": 600 },
+    { "type": "CNAME", "host": "www", "pointsTo": "edge.stowlane.com", "ttl": 600 }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Stowlane**. It points an operator's domain at their Stowlane self-storage rental page: apex `A` → the Stowlane edge IP (passed as the `%edgeip%` template variable) and `www` `CNAME` → the stable edge hostname `edge.stowlane.com`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — n/a (template has no TXT records)
- [x] `txtConflictMatchingMode` set on unique TXT records — n/a (no TXT records)
- [x] no variable used as a bare full record value — n/a
- [x] no bare variable used as the full `host` label — hosts are fixed (`@`, `www`)
- [x] no variable used in the `host` field to create a subdomain — correct
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` OnApply on user-modifiable records — n/a (both records are essential to the service)

## Online Editor test results

**Editor test link(s):**
- [Apex — example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABtZUGoC%2F%2B1TTW%2FbMAz9K4GAnmo7duzEqYEBS9sdgmJFkbVAtyAwFItJBdiWJslx3SD%2FfVS%2Bk3U997CTZfE9ke%2BRXBIDhcypAZIsiVRiwRmoISMJ0UbUOS3By0RBnH3snhaIJT%2B2UYxoUAuewZo0oxnPuWlcSedHsTNSawdrbWELUJqLkiSBQ3IxF08qR%2FiLMVIn7fZxJW2eidKT5RxZDHSmuDRrJnkQvDStRlSqxURBedmi2999WnxIYcKWgtLQfJ3cs9mp4nSaw%2B3Jez9PqOcV66bMHqrpHTS362R%2FG2YRI2BcQWb%2BhXkR2ozgd4UgdG9Gcw0OQYJQTJNkvCSmkda4wRaLx6%2B2F1aqfhT4ewFsDlxe4K0xaFrP91fOnndzP%2Fj%2B7cCt6%2FqUbcneWU37ZyYrh7yJEtJDQRM0fScFXilOzrESvMTTXIlKpnyHl1TRQtvp2jHHJ9TJjjsm9ryRY%2F%2BCKPI6fsfrRF7sE1sMn5dCQarxS02lUKBRFRpWVLnhKa3p4YplKZUyb7B2jVF879TMcjOQ1kxGDcXjabqDDQ5JWWbL53a%2Br2a9mM76oRt3w74bAQvdfpBFLgvjgIUwnXZZcLQs7y3SR%2BtycBG0xiHl1O7BIK9po8nqncZudWwau1XyUVM%2Fk5qJg%2FPxvy2fri24hZougKXUwtD8nuvHbuA%2F%2Bp2kc5VEsReFfhz2L30%2F8dc9AW02Ipe4pcf7SQY3v0aPd8N6VD2x7OZ5qF4Ff25fqWnZu%2B4M80xeFrNQB93udfSFrP4AMS%2FPrY4GAAA%3D)
- [Subdomain — sub.example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANVZUGoC%2F%2B1TTW%2FbMAz9K4GAnmY7tpvGsYEBM5ph6IYFRZet6IrAYCwlVedYqiQn8YL891H5dtf13MNONkU%2Bku%2BRXBHDZrIAw0iyIlKJOadMXVGSEG3EooCSebmYEefgG8AMY8m3nRc9mqk5z9kGNIGcF9zUroTpie8ZqLUPa%2B3C5kxpLkqSBA4pxFR8VwWGPxgjddJun3bS5rkoPVlOEUWZzhWXZoMk14KXplWLSrWomAEvW7AzD2UxkcKCLcVKA8WmuGerg%2BIwLli%2Fke%2BuAX3esa7L%2FLoaf2F1f1Psb8FsxA2jXLHc%2FCvmQWhzw54qDEL1JlBo5hAECEU1Se5XxNTSCpfuYvH3g52FpaqHAs0zRqeMyzN8NQZF6%2Fr%2B2jngLgfp149H7GKxaKIt2HvW0yHNaO2Q36Jk2bGhEYq%2Bp8KWgJtzysTyq8ZoTJWoZMb3EAkKZtou2B5830CP9vD7DR7NLSn7EHQ6XuiHXtjxIp%2FYlvi0FIplGr9gKoU0japQtllVGJ7BAo5PNM9AyqJGBhq9mK8pabldy23TFAyg0Sx4lMMhGc0tB273PMrji5AFsQthL3Y70aTr9uJu140nQOl4HETjXnByNC8d1Gtn01CTaY37ysGeRFosoNZk%2FcKMd2Rwxl6D0GszfmOkRg6uy%2F8RvekR4XVqmDOagY3EMXRdP3IDf%2BiHyXmYXJx7F1EcdLrvfD%2FxN9Nh2mx5rvB6T%2B%2BWXKWDVEdy%2BXT7uHzIQyn60W0YfL7M765%2Bsv7w8tPgV%2FyD1ql8TN%2BT9R9kz6%2BgrAYAAA%3D%3D)
