### PR TITLE
add Emergeo, Emergeo Content Hub

### DIFF
--- a/emergeo.ai.bloghub.json
+++ b/emergeo.ai.bloghub.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "emergeo.ai",
+  "providerName": "Emergeo",
+  "serviceId": "bloghub",
+  "serviceName": "Emergeo Content Hub",
+  "version": 1,
+  "logoUrl": "https://emergeo.ai/icon-mark.png",
+  "description": "Connects your domain to your Emergeo AI-visibility content hub, published at blog.<yourdomain> so AI search engines cite your own domain.",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "blog",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for **Emergeo** (`emergeo.ai` / `bloghub`). It applies a single fixed CNAME (`blog` → `cname.vercel-dns.com`) that connects a customer's domain to their Emergeo AI-visibility content hub at `blog.<domain>`. The template has **no variables**.

**Note on `syncPubKeyDomain` (intentionally omitted):** this template contains only a single fixed CNAME with no user-supplied variables, so there is no request payload to cryptographically sign. `warnPhishing: true` is set instead, following the established pattern used by other variable-free templates (e.g. `animacontent.hosting`, `crevado.com.portfolio`, `domainconnect.org.dynamicdns`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [ ] `syncPubKeyDomain` is set — **intentionally omitted; justified in the Description above** (single fixed CNAME, no variables; `warnPhishing` used instead)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A (no `redirect_uri`)
- [x] no TXT record contains SPF content — N/A (no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A (no TXT records)
- [x] no variable is used as a bare full record value — N/A (no variables)
- [x] no bare variable is used as the full `host` label — N/A (no variables)
- [x] no variable is used in the `host` field to create a subdomain — N/A (no variables)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set on records the end user may need to modify — N/A (single required CNAME)

## Online Editor test results

**Editor test link(s):**

- [Test emergeo.ai/bloghub example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFVeUGoC%2F91SXU%2FbMBT9K5ZfSdKkX0C0TSod0kBbhRATQqiKHPvSeiS2azstXdX%2FvuumpSD2sOc9Nb33nHvvOT4b6qE2FfNA8w01Vi%2BlAHslaE6hBjsDnTBJo9fOhNWIpJdtDxsO7FJy2DHKSs%2FmTXmsvkeTsVYelCffdpglWCe1onkWUSTqn7ZC7Nx74%2FJO57i9I7lWcc3sc2LUDIkCHLfS%2BB2Z4lAF3Duy1o0lQtdMKuJ1%2B%2FeweXQVL6WTpaykXxO%2BvwNvjYhpykq6OQjCPAkKkk%2BB2g76QlwgEwfM8jkBNZMKHOHSQ7tAr9R%2BZxJkrxW%2FqDR%2FpvkTqxxEdMWsupnjfImn5942WJtr529h0UgL4hVogWsrHM0fN9SvTbBtPBn9uKQtfu9ueAktlXd3Gitcob8J%2BsihioVyCdc1IrxHI3vDNN1OtxH9rRUUx%2BlT9G93b3jhF4ZvD3vafg1%2BzaxuTCEPeMMsq13Ix4H5%2BI46PXAfKQ0b5UxpC4XDX%2BYbCwfddVN5WTC05LUkeMGMqdZ4oMMujvgoX7Uh2ssXzLN%2FkB7RQvBwsgzBPON90T97Oo97vOzF%2FUF6GpeZSONzyFhPPJVZlvXehPxj%2FP%2Be8qNj4BwGSrKQ4FG1YmtHt9tphO79T3rwoR1bgihYgHXT7jDGzVl6l3bzQTdPB0nvbJidZidpmqdpOB%2BcbwVuMBdvE0FXil33J6Nb13y%2FP5cPD%2Frmq1mKEzm45YtyYu674196caIuutf6M93%2BAbC7nx%2BnBAAA)
- [Test emergeo.ai/bloghub example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAtfUGoC%2F91Ty27bMBD8FYLXSrIkv2qhLZAEBppD0saNUQSGIdDk2iYskSpJ%2BVHD%2F96lZOeB9NBzT4a4M7uzs%2BMjdVBWBXNAsyOtjN5KAeZW0IxCCWYFOmKSBs%2BVe1Yiko7bGhYsmK3k0DAWhV6t68XL61s0udHKgXLka4PZgrFSK5olAUWinpoCsWvnKpt1Oi%2FTO5JrFZbMbKJKrZAowHIjK9eQKTZVwJ0lB10bInTJpCJOt5%2BXyVe34VZauZCFdAfCzzpQa0CqelFIuwZBmCN%2Bg%2BiTp7aNvhDrycQCM3xNQK2kAku4dNAO0Dt1nhn5tQ%2BKXxeab2i2ZIWFgO6YUd%2FX2F%2Bi9MyZGt%2FW2roJ%2FKqlAfEMNMC1EZZmsyN1h8rbdnN%2FdTemLf7srr%2BElsrZR40vXKG%2FEfrIoQiFshHXJSKcQyO7gzg%2BzU8B%2Fa0V5C%2Fd5%2Bhfo9dfeM%2Fw9nCmncfY5jgro%2BsqlxdKxQwrrY%2FIhTx7w55f6LOG7%2BfKldIGcou%2FzNUGLtuXdeFkztCY5yfBc1ZVxQFlWqxil%2FcmqDZKzYFaiYI59g8mBDQX3CuXTURFyhMYxqEQ%2FY9hj42G4SjpihCW%2FYT1Fv3hEuJXcX%2F%2FR%2Fh73t94B9ZiuiTzcb4qduxg6ek0D9DH%2F3AtvLxlWxA588g0TgdhPAyT%2BDFOs34%2Fi4dRPx2kSfohjrPYa3BgXbvjEVPyOh%2B0kCORjK%2B%2FjfbL7s8ujPc%2FnthwoG93%2B6f9Q9KZTHvsYbpMtpPN3Wd6%2BgMT11RnuwQAAA%3D%3D)
