### PR TITLE
Add templates: quizdek.com (hosting, email)

### DIFF
--- a/quizdek.com.email.json
+++ b/quizdek.com.email.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "quizdek.com",
+  "providerName": "Quizdek",
+  "serviceId": "email",
+  "serviceName": "Quizdek Email Link Tracking",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "quizdek.com",
+  "syncRedirectDomain": "quizdek.com,builder.betterly.academy",
+  "description": "Enables branded email link tracking for your Quizdek funnel emails.",
+  "variableDescription": "tracktarget is the email link-tracking endpoint host your Quizdek workspace uses.",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "links",
+      "pointsTo": "%tracktarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/quizdek.com.hosting.json
+++ b/quizdek.com.hosting.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "quizdek.com",
+  "providerName": "Quizdek",
+  "serviceId": "hosting",
+  "serviceName": "Quizdek Quiz Hosting",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "quizdek.com",
+  "syncRedirectDomain": "quizdek.com,builder.betterly.academy",
+  "description": "Connects your domain to your Quizdek quiz funnel: the quiz host plus the first-party tracking gateways.",
+  "variableDescription": "ip is the IPv4 address of the Quizdek origin serving the quiz and tracking gateways.",
+  "records": [
+    {
+      "type": "A",
+      "host": "quiz",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "conversions",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "t",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for **Quizdek** (quiz-funnel SaaS platform):

- `quizdek.com.hosting.json` — connects a customer domain to their Quizdek quiz funnel: A records for the quiz host (`quiz`) and the two first-party tracking gateways (`conversions`, `t`), all pointing to the Quizdek origin IP passed as `%ip%`.
- `quizdek.com.email.json` — branded email link tracking: a single CNAME (`links`) pointing to the link-tracking endpoint passed as `%tracktarget%`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: `logoUrl` is not set in these templates

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in these templates)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, no TXT records
- [x] no variable is used as a bare full record value — `%ip%` is the full `pointsTo` of the A records and `%tracktarget%` the full `pointsTo` of the CNAME: both are service-operated endpoints (origin IP / link-tracking host) that vary per deployment and region, analogous to existing hosting/email templates; hosts are fixed labels so the records cannot be repointed at arbitrary names
- [x] no bare variable is used as the full `host` label — all host labels are fixed (`quiz`, `conversions`, `t`, `links`)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A: all records are integral to the service; none are user-editable extras

## Online Editor test results

**Editor test link(s):**

- [Test quizdek.com/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJRhUGoC%2F%2B1UUWvbMBD%2BK0bQp8VGThwnMexhXcdaCltXOkopwciSnIrKlirJ7tyQ%2F75TnDRNFxiMvRT6JOl03%2Bm7u%2B%2B0RI5XWhLHUbZE2qhWMG7OGMrQQyOeGL%2BPqKrQ4PnqG6nAFf3oL%2BHCctMKyteQO2WdqBc767534Nfg9Nmp5cYKVaMsBkBX02Op6D3KSiIt7y0XTXHOuxNVEVH%2FQck7XHImDKfukMugaIQEylHBneNGdhGhhPGqAyzjlhqh3fp59FnVNQSxQacaE7B1rMCp%2Frgl7yMHZQOeMgvcHe8NPuVAy8auTaUw1oWaGNcFzhB6D4kGC6juI%2Bls5FMmRpBC8pO994UORB%2Fg7KJNAsKY4dYGqlzbtgSUEQvgtS4thH2mQGp2%2BDEojDLMoux2iVynfSc%2BgdlT3lTKN1aJ2tkrBZYjoY%2FA4pxE2SjFeDU4hKOq3jTO%2Fgvc%2FQU0Xw3Qk6p5vmM%2Fh35t%2B8t%2FEdAr30hgExN2C6ManYutP7SAVNZreou83YPOt9hb5PdC%2B12cTqJ4MoyGwySKxzPkqYhFrQzPLazENQaScaYBdVaNdCInj2RnYjQnWssOmFu4hYj7da%2F7YdjUnRFH4PT6zRelGKCcUZ%2BC8LOVkrJgeDwNhzGdhklJZ2EximdhMirSssSUJyx5MacHRvjwpO5KCJLjtRNEer7SiwitXvVwk8K%2BBN5yJu7t8J8PQNjvinpX1P9TFPx8lrSc5cS7DfEwDfEkjPEVHmV4nI3TaBon01H8AeMMY8%2BfW9cnt4S%2F8eWviMT37qc4x2nHb%2BLr6%2FjEfWknd6cP5EY%2FHpvz63R8eXGmm%2BZru7j5iFa%2FAesK6Vh4CAAA)
- [Test quizdek.com/hosting example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEVjUGoC%2F%2B1UUWvbMBD%2BK0bQpyWu7ThJa9jDtrK1LIxulEFXgpGlc6pFtjxJduuG%2FPed7KRNusBgsIeNPgl9uu%2F03d0nrYiFopLUAklWpNKqERz0BScJ%2BVGLBw5Ln6mCDB6PPtECQ8nn%2FhAPDOhGMOgot8pYUS6e0P1oz63e%2BWNQA9oIVZIkREJbsrdSsSVJcioN9MhlnX2E9kwVVJS%2FSHIBX4ALDcweChlktZAo2c%2FAWtCy9SmjHIoWuRwM06Ky3fXknSpLTGK8VtXa410uz6p%2BuxXvMnt5jZEy8ewt9IAr2atkbTooF9rYYUW1bT2rKVtiod4Cu3tHW%2BO7kqkWNJNwtne%2FqDzRJ7i4bGKPcq7BGE%2FlHbYVoLRYoK6utZj2UQIt%2BeHLsDFKc0OSmxWxbeUm8QZhJ3nTKTdYJUprrhQiR6I6QsRaSZLRJAjWg0M8psrN4Myf0O1vSPP1gDyoEtIn9XOc13a%2BcE%2FRr7CxwCanqTPcLLSqq1RsKTgFWhhn6y35Zo8939JvOj5uReU24WTqh9PIj6LYD8enxAkSi1JpSA2u1NYaS7K6Ro8WtbQipXf0CeIspVUlW9Rv8BQz7ne%2F7J%2BE677f6%2BbUUkSe37vTlAFJOXOVCPfKKGNRlgXT4SQ6yYcx0HxIx1M2PB2HcZDH4xhOsp0Xe%2BAxH36ze81E%2F0FpBZVOtnSOIutnA91UsuOH%2F6Mg%2B8%2BVMR%2Bg4V9s9mKzv2wz%2FCMNbYCn1EVGQTQZoo4wuApGSThKglN%2FPIpOgvhVECRB4EoAY%2Fv6VviL7v6fZHY2K%2Fk55Oq4zuX78Pz6rpnJJv5aHV99MNejGZPfvuvLpVkw9ZqsfwKm4NVWqAgAAA%3D%3D)
- [Test quizdek.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGFiUGoC%2F91TXW8aMRD8KydLeSpQA02Ak%2FqQj3uo0qRtSlu1ETot9gIuPvtq%2B0gOxH%2FvGkIAJf0Dfbo778zsztx6xQIWpYaALF2x0tmFkug%2BSJayP5VaSpy3hC1Y47l0CwVB2ZdtkQoe3UIJ3FCwAKX3Z8fYJIvV5KMy82ToQMyVmRJ2gc4ra1jaJl5txIW2Ys7SCWiP25PP1fga6ytLdPNirgi4Q6kcivAapDGulKa5W2MMAZ2uWyBAYlETV6IXTpVh055lBsYafTJ2YCTKZGMm0XHc8DRuMrEuqW3lkp2nSWUM6i3Wt6IdcCrqXB1pbwQCuCmGRPkkzPBAvvksj0aWVpmQzKwPx40erJv7EgQmlcdNJ3JsnfQsvV%2BxUJcx6cvb85uMSpFOn1Hcx38XNf3Q0tHJwSQnVApBs7R7xvl6tG6wpTWY73VHFNEuUnwE2hN8Sv2pAb1Nna3KXO3wJTgofNylHfP%2BiDrace9ZfD%2BYZoOkKOivVT7YAp2KCnpLo%2BHU1FiHuacnhMqR3%2BAqWpGi0kHl8AD7IylyKEtdkxdPVZJ%2BmZHZLucuIwkBos1%2FTXAQVYPlUkSLKu58H9ooxrLX7J92zprvxKDdHA8m3SbvCn7aH2B3MuAH9%2BeVq%2FXaDdoHjN6jCQqoOTvXD1B7tl6PGhT2%2F%2BaJ9sHDAmUOEdbh1Jr3mm0%2B5N2UD9JOu9Xpn%2FV6vTecpzz2D%2BjD1uOK9uNwM5gpHrNZxrPscvHntr388VZcwc3SfcKLn3cTd7789e3i9%2Fevs7vrYf89W%2F8FjOx%2FfQYFAAA%3D)
- [Test quizdek.com/email example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG5kUGoC%2F91Ty27bMBD8FYFATrUdKnb8ENBD2rht6ibNq5cGhkCRK4cwRaok5UQx%2FO9dSnFiI%2BkP9CSQuzO7MxquiYeiVMwDSdaktGYlBdgzQRLyp5JPApY9bgrSeSldsAJbyVVbxIIDu5IcGggUTKrXu%2F3eaBqq0Q%2Bpl9GtZXwp9QJ7V2CdNJokMeJqzT8pw5ckyZly0N5cVtkM6lODcP1mr9BwDUJa4P69lk5WSYV79zLwHqyqe4wzAUWNWAGOW1n6ZjyZapYpcFFmmRYgokZMpMK6%2FnndKDc2qk1lo62mvNIaVNvrekEOszLwnO5xNwSe2QX4SLrI38MOffeFHrQojdQ%2BujfO7w96MHbpSsYhqhw0k1CxscKR5G5NfF0Gpz9fnJxPsRTgeAzkLvy7wOluDV4d7GxygCXvFUn6Q0o3802HPBkN6SvvHC3aWgqPDHMCz64%2FD3BVhoeFNVWZyi2kZJYVLsRpC77bQ8%2B38LsGj8ednZpmNAT%2FXeW8KcDKQKJaJK4oF9pYSB1%2Bma8sqva2wqAUlfIyZQ%2Fs9UrwlJWlqlGRwypSv3VKtxFtnOq1cgTzLAj%2B1xY7pnVIKnhQKkP6%2BTEf88GYdvM8i7uDPMu7k2GcdwWFSX98PBqOId95Se88svfe0p7V4BxoLxnOJyfqgdWObDbzDtr%2Bn0rDdDi2ApGy0HlEj4ZdOurG9Jb2k3ic0GFv1I8HdPCB0oTSIACcb2WuMS27OSGHg9Pl2fnk0EwuZ9nl1fdv%2FPrGf2W%2Ffo5%2Bxzerx%2BJpMDub3UyqL3L6kWz%2BAvZEIKIaBQAA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
