### PR TITLE
Add advancedsending templates: cname + domain-authentication

### DIFF
--- a/advancedsending.com.cname.json
+++ b/advancedsending.com.cname.json
@@ -8,7 +8,6 @@
   "description": "Points a subdomain at a hostname via a CNAME record — for custom domains, branded links, open/click tracking, CDNs and similar.",
   "variableDescription": "%target%: the hostname the subdomain should point to. The subdomain label is supplied via the host parameter (hostRequired).",
   "syncBlock": false,
-  "warnPhishing": false,
   "hostRequired": true,
   "sharedProviderName": true,
   "sharedServiceName": true,

--- a/advancedsending.com.cname.json
+++ b/advancedsending.com.cname.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "advancedsending.com",
+  "providerName": "Advanced Sending Connect",
+  "serviceId": "cname",
+  "serviceName": "Custom domain (CNAME)",
+  "version": 1,
+  "logoUrl": "https://connect.advancedsending.com/static/logo.svg",
+  "description": "Points a subdomain at a hostname via a CNAME record — for custom domains, branded links, open/click tracking, CDNs and similar.",
+  "variableDescription": "%target%: the hostname the subdomain should point to. The subdomain label is supplied via the host parameter (hostRequired).",
+  "syncBlock": false,
+  "warnPhishing": false,
+  "hostRequired": true,
+  "sharedProviderName": true,
+  "sharedServiceName": true,
+  "syncRedirectDomain": "advancedsending.com",
+  "syncPubKeyDomain": "connect.advancedsending.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/advancedsending.com.domain-authentication.json
+++ b/advancedsending.com.domain-authentication.json
@@ -1,0 +1,50 @@
+{
+  "providerId": "advancedsending.com",
+  "providerName": "Advanced Sending Connect",
+  "serviceId": "domain-authentication",
+  "serviceName": "Domain authentication (verification + SPF + DKIM + DMARC)",
+  "version": 1,
+  "logoUrl": "https://connect.advancedsending.com/static/logo.svg",
+  "description": "One click to fully authenticate a sending domain — an ownership TXT, SPF, DKIM and DMARC. Apply all of it, or any subset via the groupId parameter (verify, spf, dkim, dmarc).",
+  "variableDescription": "%verifyValue%: domain-ownership TXT value; %spfInclude%: SPF include host (e.g. _spf.advancedsending.com); %dkimSelector%: DKIM selector label; %dkimTarget%: DKIM CNAME target host; %dmarcPolicy%: none|quarantine|reject; %dmarcRua%: mailbox for DMARC aggregate reports",
+  "syncBlock": false,
+  "sharedProviderName": true,
+  "sharedServiceName": true,
+  "syncRedirectDomain": "advancedsending.com",
+  "syncPubKeyDomain": "connect.advancedsending.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "%verifyValue%",
+      "ttl": 3600,
+      "groupId": "verify",
+      "essential": "OnApply"
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:%spfInclude%",
+      "groupId": "spf",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkimSelector%._domainkey",
+      "pointsTo": "%dkimTarget%",
+      "ttl": 3600,
+      "groupId": "dkim",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=%dmarcPolicy%; rua=mailto:%dmarcRua%",
+      "ttl": 3600,
+      "groupId": "dmarc",
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This PR adds **two** generic, signed, shared templates for **Advanced Sending Connect**, a Domain Connect Service Provider operated by **Ideal Web Construct SRL** (`advancedsending.com`). Both are signed with our published key and are reusable by many SaaS customers, who pass their brand via the `providerName` parameter (`sharedProviderName`) and their values via `%variables%`.

- **`advancedsending.com.cname.json`** — points a customer's subdomain at our service (custom domains, branded links, open/click tracking, SMS short-links, CDNs). The subdomain label is supplied via the standard **`host` parameter** (`hostRequired: true`), not a variable; the only variable is the CNAME target `%target%`.
- **`advancedsending.com.domain-authentication.json`** — one click to fully authenticate a sending domain: an ownership **TXT**, **SPF** (via `SPFM`), **DKIM** (CNAME) and **DMARC** (TXT). Records are bucketed into groups (`verify`/`spf`/`dkim`/`dmarc`) so a caller can apply all of it or any subset via the `groupId` parameter.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — test links below (apex + subdomain per file)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`advancedsending.com.cname.json`, `advancedsending.com.domain-authentication.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://connect.advancedsending.com/static/logo.svg` → HTTP 200, `image/svg+xml`)

# Checklist of common problems

Both templates satisfy each item:

- [x] `syncPubKeyDomain` is set — `connect.advancedsending.com`; the public key is published as TXT at `_dcpubkeyv1.connect.advancedsending.com`
- [x] `warnPhishing` is **not** present in either template
- [x] `syncRedirectDomain` is set — `advancedsending.com`
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type (domain-authentication); cname has no TXT records
- [x] `txtConflictMatchingMode` is set on unique TXT records — set on the DMARC TXT (`Prefix` / `v=DMARC1`); the ownership TXT is intentionally multi-value (no unique constraint)
- [x] no variable is used as a bare full record value — cname's only variable is the CNAME `pointsTo` (`%target%`, a hostname); domain-authentication's DMARC and SPFM values are prefixed. The single bare value is the ownership TXT `%verifyValue%`, a platform-prescribed and self-prefixed token (e.g. `as-verify=…`) — a fixed prefix would double-prefix it, so bare is necessary; the template is signed, so only platform-authorised values ever apply
- [x] no bare variable is used as the full `host` label — cname's record `host` is `@`; domain-authentication fixes the DKIM suffix (`%dkimSelector%._domainkey`)
- [x] no variable is used in the `host` field to create a subdomain — the subdomain is supplied via the `host` parameter; all record hosts are fixed (`@`, `%dkimSelector%._domainkey`, `_dmarc`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on every record in both templates

## Online Editor test results

**Editor test link(s):**

`advancedsending.com.cname.json` — with `hostRequired: true` the apex test is exempt (per the template note); subdomain test (`host=link`, `target=sms.advancedsending.com` → `CNAME link.example.com → sms.advancedsending.com`):
[Test advancedsending.com/cname example.com/link](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF9AUGoC%2F91U224aMRD9FctSpUTlsgsE6EqVSiBK00uCQvpQpQh57QlY7Nob27spRfx7xyxXleQD%2BrQ69pmZc2bGu6QO0ixhDmi0pJnRhRRgbgSNKBMFUxyEBSWkmta4TmllR7llKYbQ3oZERiWL9LVSwB0yLZhCcljn4srTd2eb4H5unU6J0CmTipz1b3vfr86RVYCxUisahRWa6Kn%2BYRJkz5zLbFSv87JC7YS%2BunXMSV73QTVbTDGXAMuNzNw6Hx1qqZwljNg83pRlDuFMW%2BclkkIyhGslxADXRpBfeSMIW%2BRJG8IPBdsKiQ1TAs0nUs0R6gxUnSeSz4kzjM9RVYX0B7dYUAliZSoTZmreIDOSxQkMjsS9c8xMwb2LiJvBXpIHe7l2pvNEkMwbIU7XyMPRdcJiSIi0eJRliURt3tE2H8mYwZQODDnz%2BB6ec2lAnHtRdqH4ZaL5nEZPLLFQoYcUGjmT45mdMUTDoy04vBkdTnhzgYnvQWAW7gZrma9ul6cO8%2FgrLHbEN8aNAeWMLI0el9QtsvVW%2BeHRUj3CT35p12N%2F0AdNxlPncK2a7SCoULCY1knm9%2BxO9bB1C7oaryr0j1Yw2RcZ40JthcFvhi8HNkI21fwmIJoanWcTuY1Zt936F7aNfjwKH2%2FjH8sEiEuZ%2FsSm9qR5L09OlTYwsfhlLje7lqd54uSEvbD9keAT5n2hG4u3mPnflqnyXW5MCOYYotfqHzVwIri3J%2F1j7zZE8KHTDavdGKDa6kC3GoedoNoKYmg3Oxex6MDBn%2BSNn82pX8hxo08ObjWuYNf%2FY3u4H5YVICbMcxtBo10NOtUweAiCqNWKwota0Gw32t33iIPAWwHrSr9L3JrDfaH2C%2Bjn69C6obAq5brlPo8Gd4urb6b5ch%2F%2B1M8vvVFxeT26XNx8pKu%2FXhajBDAGAAA%3D)

`advancedsending.com.domain-authentication.json` — apex and subdomain:
[Test advancedsending.com/domain-authentication example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO%2F0VGoC%2F%2B1Wa2%2FbNhT9KwSBAA0iO1JsJ40CA82SDkgLd27idY8sMGjxSmYtixpJKXaz7LfvUg%2Fbaux0XwPkiy1dHh7ex7mXeqAG5mnMDFD%2FgaZK5oKDuuLUp4znLAmAa0i4SKJ2IOfUWUE%2BsTluoecViNyUKHIhkwQCg0gNKhcBFFxczplIWiwzU0iMCJgRMlljKrLLAkWaKPImByXC%2Bu2A3Ax%2Fxt%2FLj1cD%2Bzc4v77YRyYEacvpew6NZSR%2FVTEyTo1JtX94GJRetbfEdKgNMgeHdlNb5xFycdCBEmnho09%2FSYAEsQhmxEgSZnG83PQQCCMVGymjJH9lR67XJSwh8j5Bt6YiJaPfR4713CkdZwkvXW%2BT8zS1jHFMZEiEcYhUuLwkOptoMCQXjOBhJFIyS684SZnCZBlQVV6WDtFp6BA%2BE3P8nTMV7LdtPpgSbBLDZSOWvXLPFxZnsOdXDrcabpLcLp6RPaS9SoI44xZpky7KNzKV2pA30I7aZIygbUndx%2F3WoxuIMe1SIUMRt67eScwmEFegEVMRmBpy8el88J6YwlYcZVE2rKHEIiwRlsgE%2Fvk7w0RgCfBRwVckrWHXGUMMxhVP5IKEeFaRaMKiSEFkC6YglcpoK79lEvwUy2BG%2FZDFGtAyZQr4sCFyo7LVys2mYKsFJLkGLhQ6USp4Z%2FNY6DCbfITlCviMMnEDckrFNfVvH6hZprZJsES4YBODL%2B%2BsWplh35cWzcZgA3SOXdehlXYQVGJwFbS2AmZxIfBCg%2FTRWR2C5R40T8FCX2cxoCu00oG%2FqRC6eQraf3xEUef1GU25tMelNGdgnU2lSIweyRpWCWZXkBby4%2FMbeRwX0lknM%2B8XovHOSNpvqO%2BMqIz1rbqM9NeC2%2BlKRbvNF9yyMDguQyQ2A2aCKdZ9ILl1bqggFIvtkGpt7SR9vHt06DfsivFaL3dONXQRCAuGMx4qTVUh1xUbixpfjBZt74F6521j612995ba5w29WRPTrdLS5zCXLSNnkFjYWiQWtWtgWOSmAkpGrzaXFa%2BMbWvZSbIuloXbWbEyY6WsrXh%2B14gM8yeiRCoYa%2FxnJlOr9p5nsRFjds%2FWJh6MmS0hplvjKnJ%2B355JeaFttOfW9DRUM%2BaBzb2wugnCTtDjPWid8BOv1T31Oi3mhb1Wj5%2F2vBAmYSfkG5fxM%2Ff1%2F7mF14rY2jNPmuZpdHkf6%2BrVN4S%2Fq8rkX7zn6qgx6BcSdT2qqritBBvzaVXiZ6T5skv93Hy0LdYYi0%2F764UEf%2BfgGHxt5ddWfm3lF9%2FK9suD5cDHzOKO3KPjlnvS8jojr%2Bsfdfxup33cfeuddg9c13ddGxZoU6bkAb8GNr8DqHwbZaNpcP%2Feu%2Fojv%2FjzszroAZt9cS%2B%2FHn0YLWa5e3%2BeumK%2B%2BO1w1qeP%2FwFFbk0HUw8AAA%3D%3D)
[Test advancedsending.com/domain-authentication example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEz1VGoC%2F%2B1WbU8jNxD%2BK5YlpENslk2AlFsU6Ti4qikXGpFQVaIocnYniRvH3treQErpb%2B94X7JZLuH6lYov2ez48eN5eWa8T9TCIhHMAg2faKLVkseguzENKYuXTEYQG5Axl1M%2FUgvqrSHXbIFb6HkBIoMcRS6UlBBZRBrQSx5BxhWrBeOywVI7A2l5xCxXssIUZJcZitRR5MMSNJ%2BUbwdk0P8Rfy%2Bvuj336J3fXOwjE4KM4wybHhVqqm61QMaZtYkJDw%2Bj3Ct%2FS0yHxiJzdOg2%2BWY5Ra4YTKR5kvkY0l8kkEjwaE6sIpNUiNWmh0AYKdhIHiX5PW0FzWPCJFEPEt2a8YQMfxt6znMvd5zJOHfdJ%2BdJ4hiFIGpCuPWI0ri8IiYdG7BkyRnBw8hUqzTpxiRhGpNlQRd5WXnEJBOPxHO%2BwN8F09G%2B7%2FLBNGdjAZe1WPbyPb8ykcJeWDjcqLlJlm7xjOwhbVdGIo0d0iWd529kpowlH8Cf%2BmSEoG1J3cf9zqMBCEy70siQxW2KdyLYGEQBGjI9BVtCLq7Pe1%2BIzWzZUQ7lwuorLMIKYVJJ%2BPvPFBOBJcC%2FGv5A0hJ2kzLEYFxirB7JBM%2FKEk3YdKph6gqmIVHaGie%2FlYw%2BCxXNaThhwgBaZkxD3K%2BJ3Op0vTLYFGyxgCQ3EHONTuQK3tk8DtpPx1ewWgNfUSZuQE6lY0PDuydqV4lrEiwRLrjE4Msnp1Zm2cvSotlabICjdhB4tNAOgnIMroIxTsBMZALPNEifvfUhWO5e%2FRQs9E0qAF2hhQ7CTYXQzVPQ%2Fv0jsjpXZ9Tl4o9yac7BOZsoLq0ZqhJWCGZXkA7y%2FfNreRxl0qmSuexkommekaRTU98Z0SnrOHVZFVaC2%2BlKQbvNF9zyaHFcTpDY9piNZlj3noqdc30NE%2F64HVKsVU7S5%2Ftnj%2F6FXTGq9HLvFUMXgfDIcMZDoakiZBdDWbURL%2Fdk48W4u6DcfVfbfl%2Fuv8sJ7j26oTtnZqaRWzoxLFTDqjlIB6vE4lC7BodDbiohZ2yW5rzyhdF3lp0kVdEc3M2MtRkr5mzZ%2F0%2B16DCPfCqVhpHBJ7OpXrf5IhWWj9gDq0xxNGKulJh2g6vI%2BbJNZX6xFbkuxLU1QzUBjeLIlYBnEoJTgGYQNVrNCWscn8aswVrHR402TNqnraMo%2BMhONu7lV67u%2F3Ih18WxtYW%2B6aGtQS47WOFmeWeEu%2BpN%2FsGbrwweY39DwZcDrAjfCbKaWv7Lkr%2Bi1rdf%2Bnx8%2Bi8VUM1Q13610flt772hLNx7OCrfW%2F291d9b%2FX%2Ff6u7LhS0hHjGHbQWtdiP4odE8GjaPw9ZJ2Gz7RycnGMhBEIRB4EIDY%2FO0POHXxOZ3BA2k%2Ffrl4%2Fz85id2a5JB%2B%2BSAy1PZ11x%2BvrpetC5X0P1ZjL8ubvlDhz7%2FC0XQ77qbDwAA)
