### PR TITLE
Add franchisesystems.ai email-sending template

### DIFF
--- a/franchisesystems.ai.email-sending.json
+++ b/franchisesystems.ai.email-sending.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "franchisesystems.ai",
+  "providerName": "Franchise Systems AI",
+  "serviceId": "email-sending",
+  "serviceName": "Franchise Systems AI email sending",
+  "version": 1,
+  "syncPubKeyDomain": "franchisesystems.ai",
+  "syncRedirectDomain": "app.franchisesystems.ai",
+  "logoUrl": "https://franchisesystems.ai/logo.svg",
+  "description": "Configures the DNS records required to send email from your domain via Franchise Systems AI.",
+  "variableDescription": "%mx% is the return-path MX target for the send subdomain; %dkim% is the DKIM public key TXT value.",
+  "records": [
+    {
+      "groupId": "return-path",
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "%mx%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "%dkim%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/franchisesystems.ai.email-sending.json
+++ b/franchisesystems.ai.email-sending.json
@@ -6,9 +6,9 @@
   "version": 1,
   "syncPubKeyDomain": "franchisesystems.ai",
   "syncRedirectDomain": "app.franchisesystems.ai",
-  "logoUrl": "https://franchisesystems.ai/logo.svg",
+  "logoUrl": "https://app.franchisesystems.ai/logo.svg",
   "description": "Configures the DNS records required to send email from your domain via Franchise Systems AI.",
-  "variableDescription": "%mx% is the return-path MX target for the send subdomain; %dkim% is the DKIM public key TXT value.",
+  "variableDescription": "%mx% is the return-path MX target for the send subdomain; %dkim% is the DKIM public key material (base64, without the p= prefix \u2014 the template adds it).",
   "records": [
     {
       "groupId": "return-path",
@@ -22,8 +22,9 @@
       "groupId": "dkim",
       "type": "TXT",
       "host": "resend._domainkey",
-      "data": "%dkim%",
-      "ttl": 3600
+      "data": "p=%dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
     },
     {
       "groupId": "spf",
@@ -31,6 +32,16 @@
       "host": "send",
       "spfRules": "include:amazonses.com",
       "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
     }
   ]
 }


### PR DESCRIPTION
# Description

New template for **Franchise Systems AI** [franchisesystems.ai](https://www.franchisesystems.ai/)- a SaaS platform for franchise management. Our customers (mostly US small-business franchise brands) connect their own domains to send email from our platform (Resend / Amazon SES-backed). The template configures the return-path MX + SPF on the `send` subdomain, one DKIM TXT, and an optional DMARC baseline record.

Notes for review:

- **Sync flow only, signed requests** (RSA-SHA256); public key published at `_dck1.franchisesystems.ai`.
- Records are split into four groups (`return-path`, `dkim`, `spf`, `dmarc`). Our service currently requests `groupId=return-path,dkim,spf`; the `dmarc` group is applied selectively per domain (only where no DMARC policy exists yet).
- Customers frequently use subdomains as sending domains, so the `host`-set case is a first-class path for us (second editor test below).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the synchronous flow uses `redirect_uri`)
- [x] no TXT record contains SPF content — SPF is delivered via the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix: the DKIM TXT uses `All` (a selector must hold exactly one key — re-applying after key rotation replaces the stale key), the DMARC TXT uses `Prefix` on `v=DMARC1`
- [x] no variable is used as a bare full record value — the DKIM record data is `p=%dkim%`
- [x] no bare variable is used as the full `host` label — all hosts are fixed (`send`, `resend._domainkey`, `_dmarc`)
- [x] no variable is used in the `host` field to create a subdomain — subdomain sending domains use the `host` request parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record (users may strengthen or remove their DMARC policy without breaking the template)

## Online Editor test results

**Editor test link(s):**

[Test franchisesystems.ai/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABcAUWoC%2F%2B1WXW%2FqOBD9K1akSndFgYSGj1L1IUBvb0RDodCK226FnMQBlyQOthOgVfe37ySEArttd9%2F2Q32KhY9n5sw5Y%2FOiSBJEPpZEab4oEWcJdQk3XaWpeByHzowKItYCQKKEqXL8BunhAI4o37cgNNygkGECShCeUIdkcUiAqV8UJHRpON3tfRIAZUfQ7khCuKAsVJoaHF%2BHTj%2B2u2TdYQALP6w0Bd4Ql3LiyDcojqLS%2B3CfTdkt9wEzkzISzXL5A2w5RZZEkhbmEuFwGsmsOKXNQo9OY04EkjOCOr0hguSMuwK%2BixgqcZFkGa%2BcosdZgNYs5sjNKkQJxei9lpTSLmBOse2TzkHSo2B1hOgmIycy5mExwnKGrDGSmE%2BJRB7j2W6WV8T2JtUZOnLnNHg72%2BmaFopi26cOmpM1CsATkM9H32wsSE0%2FRksqZyyWGTo6RxEnHl2hX%2BOKqunZj1srIewCZSp%2FSavOO6A0H16UKWdxlJlir1LAyHWUesEaw3rGhIR1WmxqN0ZDKUYsJ5oZkDJO5RrMoMJJCYqd1FT19Xg%2FfMpsF3c0Hu0CgzoQujTZdAGYpjJiiWErOt%2B0RNmLC8uVTIWFvkgLSxAmnFrMTeMavq8c5hWRt0s77H%2B3%2FkQIEDexT6AfCg0dP3ZJEwf4mYVgsZLDAuVjTgHmzgekJtvNnEly3rGMm7Z2BkKFLCRnh5SIgGokiAvQ69CIIj%2FtwsdE%2B5nU70PyvV1O5fXx9VgBRmSy0%2F4RStvOIFlh8AnJ2eYMYJVRndAM%2FweD5Hqm7YVIEeY4EOmFtY35cBD0cRv1QUnXWdy%2FihmsUoRHiGtjZ14UgYxKsSgSLGRRKx1K9JgfhgOWeelZhnrZHi4uh6Z90hlctIzBrWHolz2j027RQbc1HXSo1%2BDti5t6I7YLIxLoT0N81SKkTfvRif783V1Z3Qa7XizLoyvdGd6vn5e9xTpuqe7TVZefmkOLBNy%2B7S3wD3w%2Fakf6ygyc1fBudn9XKyeQ845XL8pjXRcmuSMttU6Ta6%2FXM51oXrh5ahTUtvpTr6x%2Bkovr9knoR%2F4iIePTRb1aVwtT1Vs1KO8%2Fjf1edVkbmB1jYLSUVEM6DRknEwFfDJ0DJ0geE%2BhV7Es6wUu8%2B8l1Jji1EUguYBdaA%2BO%2BP9bh5rrPpyC36d9r94F1D8d%2F4jqpDWg6H7ZLnFrNqRTd06pe1PXTShF7jZOig%2BtVXavX1EZN3XvAPnnjPnu9dnbdHyLDX%2BK1UF7TiT2Yz5z2p5fO%2F9ZDB8L9V6Q6dGhyDveDht69qtFvGB6AfzfJx2O4er9G8WsUv0bxHx9F%2BNsgcELcCU5hFbVSK6r1oqaONL1ZqTS1aklrVCuqWlDVpprWI4mQG%2FIv8Brvv8OKhucLLKyuVhDY1%2Bx%2BOxmw3umyPjdtPUpmfq3d6lbv6j8YMc%2BV198Bnpv8FeYNAAA%3D)

[Test franchisesystems.ai/email-sending example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFgAUWoC%2F%2B1WbU%2FqSBT%2BK5MmJrtBoEAFxPChgHpZLfKm4eoSMrRTGG07w8y0gMb97XtaisC96u7HvRvDhxbmOS%2FPOc85w4umiM89rIhWe9G4YBF1iGg7Wk1zBQ7sOZVEriWAZA5T7fgN0sE%2BmGgXWxAabFDIbANKEhFRmyR%2BiI%2Bpl5UkcGgw25194gAlJmhnEhEhKQu0WgHM14HdDadXZN1iAAs%2BzDQG9olDBbHVGxRznnsf7rEZuxUeYOZKcVnL5z%2FA5mNkTkZxYg6RtqBcJclpTRa4dBYKIpGaE9TqDBAEZ8KR8FyEkImDFEt4pRRdwXy0ZqFATpIhiihG75UkF1cBC4qnHmkdBD3yV0eIbiIKokIRZDlWc2SNkMJiRhRymUhOk7gynG5CnaEj54n6b7atq7aFeDj1qI2eyBr5oAmI56HfpliSsnGMllTNWagSNK8jLohLV%2BjPsKgXjOTHrZQQdoAyVb%2FHWacV0GoPL9pMsJAnotjLFDBqzWMtWCN4nzOp4D1ONpYbo4GSQ5YSTQRImaBqDWLQwVJBx0plXX893ncfM9v5HY6GO8fQHXCdm2yqAEzjNmKF4YjXNyXR9vzC60rFjYW6KAsraEwws5gT%2BzU9TzuMK7m7CzvoXlg%2FEQJEP%2FQI1EOjge2FDqlhHz%2BzACSWs5mvfczJx8L%2BgNRke5gyieoty%2Bw3C2fQqIAF5OyQEpGQjYLmAvQmMDn34ip8TLSbtPp9SHq2i6m9jl%2BPNWBEJrvejyG17QySFQadkJRtyiAeB%2FiW0J3QxOYHkaQ9jUsM3jgW2Jfx0tr6fThwPN56fti4Hqe%2B%2F8mvv4oRLiHOFNtPWekrngtllmCpsoXcYavGqTEYWO1L1zL1y%2BZgcTloT0ut3nnD7N2apnHZMVvNBu1dNWa9FnWronner1TDaWZIfONxgK8bhDRpl5eM5wtnZV1V2c1imR9eG%2Fbgfv287CzWYUN3Hq%2BvxGl7YBFfTG87C%2FwN3w%2Bb3Fi1fXs1uJvf35XzEcS8Eyfn%2BZFhyDa5Iw29QqMbt9Np2%2Fwp03%2BsZvSm%2Ft0orr6T85tmKfC4t4jI6HRROanomZnurqpUdB9HXudkWe61W2bPbGhxL%2BksYIJMJDwxVA4UoURIoFahp%2BgEL%2FHuJ8ee4FhO0HoJp1AaGPv98Q42az%2BZwbTnqWb%2FXc0PdHy4CyaOHeuBJpdXET52EWdJeepkjbJLstNSVc8Su%2BRWHDioEnfvNvvkwvvsKjvU7v5Umd4Sr6X2Go%2FwwcCm%2FH%2FaQj8Ug9f%2Ft4o66OCv1LN3NBvVYW0U0LubHP2FPe8XYDs%2Bhu38NaVfU%2Fo1pf%2FlKYU%2FGxJHxJngGFrUi%2BWsXskW9GHBqBVLtaKeK53oVeM0o%2Bs1XY8ZEak2BXiBO3z%2F9tZU0wvO%2B35kLR1qtnl4%2BQcbWJl%2BN%2BPrI3%2BxDG4L34LWyL4c3N%2FWtde%2FAXaHIY8kDgAA%3D%3D)

[Test franchisesystems.ai/email-sending example.com/@ — all groups incl. dmarc](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJcAUWoC%2F%2B1WbU%2FqSBT%2BK5MmJvcGgQIVEOOHAuoSBUHQRV1Dpu0UBvsyzEwLaNjfvmdKEdir5u6HTfZuTJp00nnmnPOc85wzfdUk8ZmHJdFqrxrjYUwdwluOVtNcjgN7QgURSwEgkcNUO3yDdLAPR7TzDQj11yhktgAlCI%2BpTRI7xMfUywoSODQYb%2Fc%2BMYCSI2h7JCZc0DDQagU4vgzsbmRdkmUzBFjwYaQKeEMcyokt36CYsdz7cC8ch7fcA8xESiZq%2BfwH2LxC5kSsAnOIsDllMglOa4SBS8cRJwLJCUHNTh%2BB85A7At6zCCJxkAwTXilFl4c%2BWoYRR04SIYopRu%2BlJKeygDnFlkeae04P%2FMUBomuPnMiIB1mG5QS1h0hiPiYSuSFPdhO%2FIrLWrk7QgfNM%2FbezzctWG7HI8qiNnskS%2BaAJ8OehbxYWpGwcojmVkzCSCZqdIsaJSxfoj6ioF4zk40ZKCDtAmcrvKuo0A1rt8VUb8zBiiSh2IgWMXDKlhfYQ1pNQSFirYJXcQhpIMQhTookAacipXIIYdDgpoWKlsq6vDnfNK2Zbu4PhYGsYqgOmc6N1FoCpKiOWGLbY6Tol2o5dWC6kKizkRbaxhMIE43boKLum52n7fgVzt2773fP2D4QAcRN5BPKh0cD2IofUsI9fwgAklrNDX%2FuYk4%2B5%2FQGp0WYzZRKfNtvmTaNwAoUKwoCc7FMiAqKRUFyAXgcmY57KwsdEu0mp34eke1uf2uppdagBIzLa1v4JQtv0IFlg0AlJ2aYMYJVQHdEE%2FzeBpPVcp3fNFSwyzLEv1ODa2H7cM%2F60sf6oqXVi%2F2dt%2BwuFdAlxLGw%2FZ4UvWS4SWYKFzBZy%2ByV7So3AgXbrwm2b%2BkWjP7vot6xSs3dWN3u3pmlcdMxmo057l%2FVxr0ndKm%2Bc3VSqkZUZEN%2BY9vFVnZAG7bKS8XLuLNqX1fB6Ns8Prgy7%2F7B8mXdmy6iuO9OrS37c6reJz63bzgz%2Fhh8GDWYsWr696N9NHu7K%2BRh83vGjs%2FzQMESL3JG6XqHxtdvptGz2nLmZVjN6Q783iot7cnbdKAUe82YxGR7PKkcVPTPW3UWV8u506HWO5uVeq2n2zLqmakrHQcjJSMAbQwZBGZJHBHIVeZKO8BxvPzn2CCtZgQQE7EJqoP132zxYj%2F%2B0K1LZ%2Fly696S8Pw5Gjq3kQFW%2FHFUrxWpVt7PHhmtkDdsoZK0CPsoWjaJeKleL5XK1snOhfXLnfXabbeW721SmN8dLoa1UB%2B%2F1a0r70yH0v9XQXuF%2BlVLtKzQ%2BhTlRQO%2BObvQnhgvhlyT5D%2B%2BP%2Fwqtzd21Wj0dwhXzNWK%2BRszXiPkaMf%2FSiIHfPIFj4oywwhX1YjmrV7IFfVAwakV4SjmI0yhWMrpe03VFhwi5ZvsKf0%2B7%2F02aPrVY9%2Ff%2BVWNWvp8Ksx7fnVuTB0NQ8zwjngfRyyyQw%2BmLvG2cnWqrvwA86tWlpg8AAA%3D%3D)
