### PR TITLE
Add Convertly Image CDN template

### DIFF
--- a/convertly.sh.image-cdn.json
+++ b/convertly.sh.image-cdn.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "convertly.sh",
+  "providerName": "Convertly",
+  "serviceId": "image-cdn",
+  "serviceName": "Convertly Image CDN",
+  "version": 1,
+  "logoUrl": "https://convertly.sh/logomark-color.png",
+  "description": "Connects a custom domain to Convertly Image CDN.",
+  "variableDescription": "cnameTarget is the Convertly CDN target. verificationToken proves ownership of the custom hostname.",
+  "syncPubKeyDomain": "domainconnect.convertly.sh",
+  "syncRedirectDomain": "convertly.sh",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "cdn",
+      "host": "@",
+      "pointsTo": "%cnameTarget%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "verification",
+      "host": "_convertly-verify",
+      "data": "convertly-domain-verify=%verificationToken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "convertly-domain-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Convertly Image CDN Domain Connect template so customers can connect a custom CDN hostname through supported DNS providers.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template

No `essential` records are required for this template. Removing either record disconnects the CDN hostname or ownership verification.

## Online Editor test results

**Editor test link(s):**

[Test convertly.sh/image-cdn kliio.app/images](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADUxUWoC%2F%2B1V247aMBD9lcjSPpVkQ4AsRKrUvVZVC7tdUbXVCkVex0ksgp3aBpYi%2Fr3jkEDC5b2q%2BgTxzDmeOWcyWSNNZ3mGNUXBGuVSLFhE5acIBYgIvqBSZytHpai1i43wDHLRbRWFkKJywQgtUGyGE2qTiO%2FPDxHWJ5Nj3d6NIAeOFBMcBe0WykQivskMclOtcxVcXtZruDThGZZTm4hMSCfnCeAjqohkuS44zB2cEq0sbJG50mJmRQBh3NLCOnG%2FYwrAkuHXjN41iAiHosdYJlRbTFk6pTU8IC1dxBwLjljMCDa4sZhSbhmhqLLEkkNrKcstERf4sqBUKG3Izd1qxcnT%2FPUzXd0VZcLF23rJtg%2FnwAOT%2F0wjJiG2Q5zIuckEmaIgxpmiLWRufKa%2F5gADh7ScwxkwCBkpFLyskV7lhT%2Bj6%2BE9ECRSzPPtBBQuGjg8fDAzIBjXaizg8aKm0AWEtAbfOr7rblo7xvGPcYOvrtWeONw1YBcJZqIirHG9NXsrS5nw%2FuJI9UYJ8PdNg11xxogeYk1SxpOhiExNT5LG7A2dTClj5%2B9Fm8mmhX4LTsO9gJNWaRoApxljwsF5vm%2BveCFUpUPICkwpbUMQ4MmxxDNl3sSK8aVGOak4XyrSScl6nrHmUpnUnKlJE1JoaRI1VbrtdZDplyVcSBoq%2BMV6Lmk1Q7N5plmIl3h%2FFJEQKs1WII%2BCKDAdzxffroOdLpXXh6U1DA0jYmRhZoyiAfX7Xq9r%2B732wO56ft%2FG%2FmvX7vhd0unH%2FZgOOrWFdWqZndtYh55RpSjXDJuddJ0t8UqhzdGAlw0dzbFz1OKZsarE%2Fms7nrRgyv87%2BS84CS%2B8wgsahdgke67n2%2B6V3XbH7aug1w66A6fXG%2Fj93jvXDVzXNAItbbtewy6obwHk5dNH%2BCI8roj%2B6g4eHqSXjnL%2F%2FtmLvgwX%2FaH3%2FefHTuq7N9PbJazOPyfY8rtrCAAA)