### PR TITLE
Add nexusbuild.ai hosting template

### DIFF
--- a/nexusbuild.ai.hosting.json
+++ b/nexusbuild.ai.hosting.json
@@ -6,9 +6,8 @@
   "version": 1,
   "logoUrl": "https://nexusbuild.ai/apple-icon.png",
   "description": "Points your domain (and www) at your website hosted on NexusBuild.",
-  "syncBlock": false,
+  "syncPubKeyDomain": "nexusbuild.ai",
   "syncRedirectDomain": "nexusbuild.ai",
-  "warnPhishing": true,
   "shared": false,
   "records": [
     {

--- a/nexusbuild.ai.hosting.json
+++ b/nexusbuild.ai.hosting.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "nexusbuild.ai",
+  "providerName": "NexusBuild",
+  "serviceId": "hosting",
+  "serviceName": "NexusBuild website hosting",
+  "version": 1,
+  "logoUrl": "https://nexusbuild.ai/apple-icon.png",
+  "description": "Points your domain (and www) at your website hosted on NexusBuild.",
+  "syncBlock": false,
+  "syncRedirectDomain": "nexusbuild.ai",
+  "warnPhishing": true,
+  "shared": false,
+  "records": [
+    {
+      "groupId": "hosting",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "16.58.11.126",
+      "ttl": 600
+    },
+    {
+      "groupId": "hosting",
+      "type": "A",
+      "host": "www",
+      "pointsTo": "16.58.11.126",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New service template `nexusbuild.ai.hosting` for NexusBuild (https://nexusbuild.ai), a website migration + hosting service for small businesses. It points a customer's domain (apex + www) at their site hosted on NexusBuild, so a non-technical owner can connect their domain with one click instead of hand-editing DNS.

Applies two records to our stable hosting Elastic IP:
- `A @ -> 16.58.11.126`
- `A www -> 16.58.11.126`

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `nexusbuild.ai`; our RSA public key is published as TXT records at `_dck1.nexusbuild.ai` (chunked `p=1/p=2,a=RS256,d=...`) and the synchronous apply requests are signed (`sig`/`key=_dck1`).
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — removed.
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — set to `nexusbuild.ai`.
- [x] no TXT record contains SPF content — N/A, the template has no TXT records (two A records only).
- [x] `txtConflictMatchingMode` set on TXT records that must be unique — N/A, no TXT records.
- [x] no variable used as a bare full record value — N/A, the template uses no variables (the IP is fixed).
- [x] no bare variable used as the full `host` label — N/A, no variables; hosts are the fixed labels `@` and `www`.
- [x] no variable used in `host` to create a subdomain — N/A, no variables.
- [x] `%host%` does not appear explicitly in any `host` attribute — confirmed.
- [x] `essential` set to `OnApply` where the user may modify records — N/A; both records are the A records that point the site at NexusBuild (the purpose of the template), with nothing the user should remove.

## Online Editor test results

**Editor test link(s):**
- Apex (domain, no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIpjUmoC%2F%2B1T72vbMBD9V4w%2Bbcx2ZNd2EsNgLYP96NqFLR1bQzCydXFUbMlIclI35H%2BflJA5W1PotzHYJ8u6d0%2Fv3t1tkIa6qYgGlG5QI8WKUZAfKEoRh%2FtW5S2rqE8Ycn8Fr0ltwOjahi9s2MQUyBUrYJe3FEozXva3jxKcNeSKaXB66AqkYoKjNHBRJUpxIytLpXWj0sHgNykD0jQVeKwQ3G92yRRUIVmjdwRoIhjXyulEKx0qasK484Jw8%2Bh6%2FdIheh84VgDUEdzp5flWeseLSZtfQvd2R3HCDwv5ApRJKPTToCWRYFxZkEqBiwxWSKpQOtugUoq2%2BcMx3TXWqnNztJfm%2BMY6v6toKsxvkPjxyA8CPwgTi9fGpgTjrftcPuPC8xjnWxc9CA5Zr3lurD4Umlct5ExSD%2B6JGSDwC1H3r5jTTk7GDokNkaRWdsgOFLPTHPMDyQwhq4GVXEjIlPkS3UpTjpatsbJuK80ysib9FS0yOxudkaxM1FAYm48s4PtBtJZSosnTxbsoo4XVyqydeU6C0XgM3pguxl5Ew9jLz3Do4UWQFCOAHMfh0X6cXJ7TC9K7BUoB14zYqT%2Bv1qRTaGub%2Blj9voH%2FhP65azr%2FvwV%2FtQVmnRRZAc2IhYU4TDw89IJgGsTp2SiNsR8FyTgavcI4xdgWAErvS9uY7TveO9RFV18vgLO76IbeTm4%2Fxe%2Fwtx%2Ff9d3lZ5iOurFalupjORxG7x%2Bi12j7E5jl6DBbBgAA
- Subdomain (host=shop): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI5jUmoC%2F%2B1TYWvbMBD9K0afNmo7dhI7jmEwjzHoytJSksEIwSjWLdGwJUWSk7oh%2F32Ss8zpmkI%2FbrBPlnV3T%2B%2Fe3dsjDZUosQaU7pGQfEsJyGuCUsTgoVbLmpbExxS5v4MTXJlkNLHhDzZsYgrklhbQ1q250pStuttnBc4OlopqcLrULUhFOUNp6KKSr%2FhMlhZKa6HSXu8JlR4WogSPFpz5oi0moApJhW4B0B2nTCun4bV0CK8wZc4bzMyju91bB%2Btj4JwBEIczp6PnW%2BoNK%2B7q5Q00H1uIC3rYlHsgVEKhX05aYwlGle%2B4VOAik8slUSid79FK8lr8oZhuhJUqM0d7aY7vrfJtR1NufsPYjxI%2FDP2wH9t8bWSKg%2BDgvhbPqPA6xMXBRY%2BcQd5xXhipT40uyxqWVBIPHrBZIPALXnWvqDUX5q%2BllNNTscASV8ou2glmfhlncQKaH5EsF7piXEKuzBfrWpq2tKyNpFVdaprjHe6uSJHbHWkMdWWiBsbIfSYFOy7kL5IEa%2FyyDi7KSWEpU6tsEI3DkESFN8BF4g2jYuAl4wK8OB7FCU4iMh70z6xy0UeXvfJUOFAKmKbYmiArd7hR6GBn%2FLwJM0%2F%2FX2tk4Zpt%2BD%2BSv2okxnIKb4Hk2Kb2g37sBSMvDKdhlA6SNBr6STAKx4OrIEiDwDYBSh%2Fb2xt3nvsS3d9ebcafsgmbQjwY4s3Xmywj5AdsPn8LHzMhh7Nr%2BNIjma5m79DhJ7Vr%2BXiDBgAA
