### PR TITLE
Add dnsdoctor.dev.domainverify template

### DIFF
--- a/dnsdoctor.dev.domainverify.json
+++ b/dnsdoctor.dev.domainverify.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "dnsdoctor.dev",
+  "providerName": "DNS Doctor",
+  "serviceId": "domainverify",
+  "serviceName": "DNS Doctor Domain Verification",
+  "version": 1,
+  "syncPubKeyDomain": "dnsdoctor.dev",
+  "description": "Proves domain ownership for DNS Doctor monitoring by adding a single TXT record.",
+  "variableDescription": "token is the per-domain ownership verification code DNS Doctor issues when you add a domain. Documentation only — never shown to the user.",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_dnsdoctor-challenge",
+      "data": "dnsdoctor-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "dnsdoctor-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `dnsdoctor.dev.domainverify.json` — a domain-ownership verification template for
DNS Doctor ([dnsdoctor.dev](https://dnsdoctor.dev)), an email & DNS health scanner with
optional monitoring. Before we start monitoring a domain we ask the owner to prove control
of it by publishing one TXT record; today that means copy-pasting the record into their DNS
host by hand, which is where a lot of people drop off. This template lets a supporting DNS
provider apply that record in one click instead.

It's a single TXT record — host `_dnsdoctor-challenge`, value `dnsdoctor-verify=%token%`,
where `%token%` is the per-domain code we issue when the user adds a domain. Nothing about
it is destructive: it's an inert proof record the user can delete once verification passes.

Requests are signed per the spec's digital-signature scheme: `syncPubKeyDomain` is set to
`dnsdoctor.dev`, the RS256 public key is published as TXT at `_dck1.dnsdoctor.dev`
(`p=1`/`p=2` chunks, reassembling to the SPKI), and our service signs each apply URL's
query string (`sig` + `key=_dck1`). `providerId` is `dnsdoctor.dev`, a zone we operate —
happy to complete any ownership check you need against it.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — "Check template" is clean; apex + subdomain apply tests below
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — `dnsdoctor.dev.domainverify.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: `logoUrl` is not set on this template

Also validated against `template.schema` (passes) and with [`dc-template-linter`](https://github.com/Domain-Connect/dc-template-linter): no warnings or errors, only info-level notes — `DCTL1021` on the custom `_dnsdoctor-challenge` label (expected for a verification host that isn't an IANA-registered underscore name), and under `-cloudflare`, `DCTL5008` noting Cloudflare ignores `txtConflictMatchingMode` (informational; the field is kept for providers that do honor it).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `dnsdoctor.dev`; public key TXT is live at `_dck1.dnsdoctor.dev`, every apply URL carries `sig` + `key=_dck1`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — correct, only `syncPubKeyDomain` is set
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A: our flow does not send `redirect_uri`, so it is intentionally omitted
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — correct, the only TXT carries a `dnsdoctor-verify=` ownership token, never SPF
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — set to `Prefix` with prefix `dnsdoctor-verify=`, so re-verifying a domain replaces the prior token instead of stacking duplicate records
- [x] no variable is used as a bare full record value — the record data is `dnsdoctor-verify=%token%`; the variable is only the token, anchored by the fixed `dnsdoctor-verify=` prefix, so it can't be repurposed into an arbitrary record
- [x] no bare variable is used as the full `host` label — the host is the fixed literal `_dnsdoctor-challenge`; no variable appears in it
- [x] no variable is used in the `host` field to create a subdomain — correct; the record targets a fixed host and relies on the standard `host` parameter for subdomain placement
- [x] `%host%` does not appear explicitly in any `host` attribute — confirmed clean
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — N/A: the template is a single inert proof record; there is no secondary/removable record whose loss would leave the template half-applied

## Online Editor test results

**Editor test link(s):**

- [Test dnsdoctor.dev/domainverify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEMdUmoC%2F%2BVT72%2FTMBD9VyxL%2B7SmSrr%2BSiQ%2BIIqAoY2NFYQ0qsixL423xI5sp12o%2Br9zbra1YxUSn%2FnkS%2B7e3XvP5w11UNUlc0CTDa2NXkkB5pOgCRXKCs2dNn0BK9p7Tl6yCovp7PKGzHZ5zFkwK8mhw%2BmKSbUCI%2FN2n3qFwsPXke%2B%2BUHLmpFZYjjjroyRCaKv4VZN9hrarPUJKgOVG1jtwQq%2BQIljSMSB6rbBZIWuS%2B3H7yZVWEk%2BpliRrCRPCR4xYPEog8x9zYoBrI%2FqeDzOSZSXMXgxy%2Bh4UkZa4AkgNJng1cnUgi3At4JCAtLZBnusCm7S68RRwftej74uaCpTrsFqVLfnZDMJoSBRgW2ILHEOc3g1v0F%2FPs2NsaXK7oa6tvdcoBBOFtg4%2F0mfnAl6wsgS1BO8fc%2BzQ1qC7tzcnO4UnWOFcSZOzcRhi%2BODeaZWXkrsL5niBfl2gsp3xkMsHerTkMXdkCN0utj36SytI9%2FQXvccNQgQ8MFxO6HNd7ZVgtDS6qVP5VF8zwyrrF%2FgJefsCunjC3lIf76T5DxZlA34mhjDKx2ySTamnI5dKG0gtnsw1BtU500CPVk3pZMrWbP9L8JTVddkie4tZbPmn%2Barb%2Bn80%2FxWvF7eQCu6lSv%2FWQsGHWTQQwTDO42DIwjyYDnkWjGKWZXHEWTYaHDzdo%2B%2F6L2937zhYixspGbKgb8s1ay3dbhc9dP8%2Fk4z7Y9kKRMp82SAcjINwEkTRPAqTs2kyivvReDgJ49MwTMLQywDrOtUb3K7DvaLh9T27G32YxudX%2FIso3n8crWeXtry7uSnm17m251%2F5t9Ppuj2fLPGt%2FAaNdupbqwUAAA%3D%3D)
- [Test dnsdoctor.dev/domainverify example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEUdUmoC%2F%2BVTbW%2FTMBD%2BK5alfaKpkqavkfiAOg2m0THYNECjihz72lokdrCdtlnV%2F8652daWFf4AX2I7d8%2Fd89zLhjooypw5oMmGlkYvpQBzKWhChbJCc6dNW8CStl6M16xAZ3p%2BfUvOd3a0WTBLyaHB6YJJtQQjZ%2FXe9AqFh%2Fcj995RcuakVuiOOOtvSYTQWvGbKruCuvE9QUqA5UaWO3BCb5AiWNIwIHqlMNhClmTm0%2B0zF1pJPKWak6wmTAh%2FY8TikQO5%2B3ZHDHBtRNvzYUayLIfzo0RO%2FwRFpCVuAaQEE7xKuTyQRbgWcEhAWlshz9UCg9S68hQwfxOj7Z2qApRrsFrlNflRdcKoSxRgWGIXmIY4vUteYX09z4axpcnDhrq69LVGIWhYaOvwkb5ULuALlueg5uDrxxw7LGvQ9O3t2U7hGXo4l9Mk7ochXtdurNUsl9xNmOMLrNcEle0KDzO5piddnmwnktDtdNuij1pBuqc%2FbT1NECJgzXA4oc11sVeC8kt8zY2uylQ%2BY0pmWGH9ED%2BjH47g02f8QxMA3zuJ%2FgeLsg6PRRd6sz4bZEPqacm50gZSiydzlUGVzlTQokWVO5myFdv%2FEjxlZZnXqMKiFUP%2B2QTVTP%2BpJrSf9PytE6%2FIHbUkFdxrln7xZp0eH3XFKOgMsl7QjXkcjAR%2B%2Br1eFvN%2BPIpCcbDHJ5f8H4t8XH6wFkdUMmRC3%2BUrVlu63U5b2Ir%2FVTtOlGVLECnzrp2w0w%2FCQRBFd1GYxKMkjNrD%2FqAT9d%2BEYRKGXgpY1yjf4LwdThpd%2F4oHs%2FdouxqPJ5MMwo%2BfvoyKrxfxh%2BveZzte3%2Bbry%2B%2BPy4v7%2ByFu0W%2FGbtH8xQUAAA%3D%3D)

The apex test applies `_dnsdoctor-challenge.example.com. TXT "dnsdoctor-verify=<token>"`; the
subdomain test (`host=shop`) applies `_dnsdoctor-challenge.shop.example.com. TXT "..."` — the
record follows the `host` parameter as expected.
