### PR TITLE
add VibeHost, VibeHost Custom Domain

### DIFF
--- a/vibehost.vn.hosting.json
+++ b/vibehost.vn.hosting.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "vibehost.vn",
+    "providerName": "VibeHost",
+    "serviceId": "hosting",
+    "serviceName": "VibeHost Custom Domain",
+    "version": 1,
+    "logoUrl": "https://vibehost.vn/image.png",
+    "description": "Trỏ tên miền của bạn về máy chủ hosting VibeHost",
+    "variableDescription": "%ip%: IPv4 của máy chủ hosting VibeHost mà tên miền cần trỏ về",
+    "syncBlock": false,
+    "syncPubKeyDomain": "vibehost.vn",
+    "syncRedirectDomain": "vibehost.vn",
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip%",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for VibeHost (vibehost.vn) — a Vietnamese web-hosting provider.
The template adds a single A record pointing the customer's domain (apex or
subdomain via the `host` parameter) to the IPv4 address of their VibeHost
hosting node (`%ip%`). Used by the "Custom Domain" feature so customers can
connect their own domain with one click instead of editing DNS manually.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, template has no TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — `%ip%` as A-record `pointsTo` is the standard pattern for custom-domain hosting templates (each hosting node has its own IPv4), same as e.g. `approximated.app.arecord.json`
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description — host is fixed `@`
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — N/A, the single A record IS the service; users manage it through VibeHost

## Online Editor test results

**Editor test link(s):**
[Test vibehost.vn/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF0xUmoC%2F9VTbW%2FaMBD%2BK5GlfioEhwQCkSatK1pX9WXVRDtNFEWX5ACLxE5tJ4wi%2FvtsXgZUrfZ5n3y6e%2B78PPeyIhqLMgeNJFqRUoqaZSivMxKRmiU4E0q7NSeNv6F7KAyUPJngNxM0EYWyZiluciye8enB%2BwbuXFZKi8IZiAKYLVujVExwEnkNkoupeJS5LaN1qaJW64hCixUwRbfcFM9QpZKVepNJhvK58jCdOPq5ohSBOwXbeDzupNbAEJzEGmA89TbkFBuwt3TS2Rbj7Mg7R9pqkAySHAcnH56x8ixyrh%2Fq4FD%2F3%2BV2EPohTQi5o%2FdadjRtJ5c8%2FZKLdE6iCeQKt56HKrnB5a6Pb4dlAT8wYxJT%2FQHEhITMFIlGK6KXpR3ShXFbgDE%2F24kLxrUaip1g49HaDMfvUroerxvkVXCMD2XGZiz7r%2FA3mKVCNxXFoaaxplJUZcz2%2BBIkFMou3j5zdJI63ueOiLVZaa029V3qep7vhsTSYFMuJMbKvKAraYRoWZkmFVWuWQwLOLiyNIayzJeGtTJRU%2B1UPN8uqxWfgQZjHn92pL9B4iy1vJld%2BoTSSegHSbMd9mkz6PdoM%2Blm2ExoG5IEen4Hu0cX9M5xvX9Ch76hUsg1A3sbF%2FkCloqs1%2BOG6eF%2FLcDMVEGNWQx6Q7XdbdKw6XlDrx3RIAo6rt9v94PwnNKIUssfld4KW5nJH8%2BcvPBB7%2Fv9z7l399Rht1eL%2FsucBYvw5vxqVs2%2F9l78sPilbsPLV%2FH4iaz%2FAFxfVij3BAAA)

[Test vibehost.vn/hosting example.com/bot](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF4xUmoC%2F9VTXU%2FbMBT9K5ElntYGpwnpiDRp3ZDWCjYKYzwMqugmuWkt4jiynZRQ9b%2FPTtu1RaA978n2vecen%2Fu1Ihp5VYBGEq1IJUXDMpSTjESkYQkuhNJuU5LeX9cP4AZK7o1zbJzGo1A2LMUuxuJZOd9bX8Gdr7XSgjsXggOztA1KxURJIq9HCjEXv2RhabSuVHR6eiDhlHGYo1t15BmqVLJKd5HkTj7WHqa5ox9rShFKh7PO4pVOai84BCexFzCWZuNyeAf2WiddbDDOVrxzkFsDkkFS4MXRhyesOomcybQJ9vz%2FpttC6LsyYVg6epfLVqatZFumXwqRPpEoh0LhxjKtk0tst3V83SwLuMWMSUz1OxDjEjJTJHpYEd1WtkkjY7YAc%2F1sOy5YqdWd2CZsLFqb5vghpevZukdeRInxnmZm2rL7Cp%2FBDBW6qeB7zkTYis6lqKuY7UIqkMCVnb1d8MNR9GwX%2FtDFmyer7GNAfZe6nue7Q2LFsHkpJMbKnKBradLRsjal4nWhWQxL2JuyNIaqKlqjXRmvYTsuQbkZ2Y3cDDSYx%2BF3B3XokThLrXhmhz%2BgGZxlgd9PkjDoB8Nzvw%2B%2BR%2Ft5muc%2BpR8xPPcPNumNJXt7lY7qh0phqRnYNRkVS2gVWa9nPVPL%2Fz8L010FDWYx6E7tIOzTYd%2Fz7rxBRIMoCN2Bb6ScfaA0otSmgEpvcluZGTjsPpHi6pY%2F3YZjHd5cLq8ng2cUcnH%2F%2FTqvx%2Fz8quW%2Fx6OXbz%2Fz6c3kE1n%2FATu0g88HBQAA)
