### PR TITLE
Add Mailname email template (mailname.top / email) 

### DIFF
--- a/mailname.top.email.json
+++ b/mailname.top.email.json
@@ -1,19 +1,18 @@
-{
-  "providerId": "mailname.top",
-  "providerName": "Mailname",
-  "serviceId": "email",
-  "serviceName": "Mailname 企业邮箱",
-  "version": 1,
-  "logoUrl": "https://mailname.top/logo.svg",
-  "description": "一键为你的域名配置 Mailname 邮箱（MX / SPF / DKIM / DMARC）",
-  "variableDescription": "邮箱子域、投递主机与签名密钥",
-  "syncBlock": false,
-  "warnPhishing": true,
-  "records": [
-    { "type": "MX",   "host": "%mailsub%",        "pointsTo": "%mailhost%", "priority": 10, "ttl": 3600 },
-    { "type": "SPFM", "host": "%mailsub%",        "spfRules": "mx include:%mailhost%",        "ttl": 3600 },
-    { "type": "TXT",  "host": "%dkimhost%",       "data": "%dkimval%",                        "ttl": 3600 },
-    { "type": "TXT",  "host": "_dmarc.%mailsub%", "data": "%dmarc%",                          "ttl": 3600 },
-    { "type": "TXT",  "host": "%mailsub%",        "data": "%verify%",                         "ttl": 3600 }
-  ]
-}
+{                                                                                                                                                                                                                                                                                                                 
+  "providerId": "mailname.top",                                                                                                                                                                                                                                                                                   
+  "providerName": "Mailname",                                                                                                                                                                                                                                                                                     
+  "serviceId": "email",                                                                                                                                                                                                                                                                                           
+  "serviceName": "Mailname Email",                                                                                                                                                                                                                                                                                
+  "version": 1,                                                                                                                                                                                                                                                                                                   
+  "logoUrl": "https://mailname.top/logo.svg",                                                                                                                                                                                                                                                                     
+  "description": "Set up Mailname email (MX, SPF, DKIM, DMARC) on your domain",                                                                                                                                                                                                                                   
+  "syncPubKeyDomain": "mailname.top",                                                                                                                                                                                                                                                                             
+  "syncRedirectDomain": "admin.mailname.top",                                                                                                                                                                                                                                                                     
+  "records": [                                                                                                                                                                                                                                                                                                    
+    { "type": "MX",   "host": "mail", "pointsTo": "mail.mailname.top", "priority": 10, "ttl": 3600 },                                                                                                                                                                                                             
+    { "type": "SPFM", "host": "mail", "spfRules": "mx include:mailname.top", "ttl": 3600 },                                                                                                                                                                                                                       
+    { "type": "TXT",  "host": "%dkimselector%._domainkey.mail", "data": "v=DKIM1; k=rsa; p=%dkimkey%", "ttl": 3600, "txtConflictMatchingMode": "All" },                                                                                                                                                           
+    { "type": "TXT",  "host": "_dmarc.mail", "data": "v=DMARC1; p=quarantine; rua=mailto:postmaster@%domain%", "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" },                                                                                                                           
+    { "type": "TXT",  "host": "mail", "data": "mailname-verify=%verifytoken%", "ttl": 3600, "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "mailname-verify=" }                                                                                                                                
+  ]                                                                                                                                                                                                                                                                                                               
+} 

--- a/mailname.top.email.json
+++ b/mailname.top.email.json
@@ -1,18 +1,19 @@
-{                                                                                                                                                                                                                                                                                                                 
-  "providerId": "mailname.top",                                                                                                                                                                                                                                                                                   
-  "providerName": "Mailname",                                                                                                                                                                                                                                                                                     
-  "serviceId": "email",                                                                                                                                                                                                                                                                                           
-  "serviceName": "Mailname Email",                                                                                                                                                                                                                                                                                
-  "version": 1,                                                                                                                                                                                                                                                                                                   
-  "logoUrl": "https://mailname.top/logo.svg",                                                                                                                                                                                                                                                                     
-  "description": "Set up Mailname email (MX, SPF, DKIM, DMARC) on your domain",                                                                                                                                                                                                                                   
-  "syncPubKeyDomain": "mailname.top",                                                                                                                                                                                                                                                                             
-  "syncRedirectDomain": "admin.mailname.top",                                                                                                                                                                                                                                                                     
-  "records": [                                                                                                                                                                                                                                                                                                    
-    { "type": "MX",   "host": "mail", "pointsTo": "mail.mailname.top", "priority": 10, "ttl": 3600 },                                                                                                                                                                                                             
-    { "type": "SPFM", "host": "mail", "spfRules": "mx include:mailname.top", "ttl": 3600 },                                                                                                                                                                                                                       
-    { "type": "TXT",  "host": "%dkimselector%._domainkey.mail", "data": "v=DKIM1; k=rsa; p=%dkimkey%", "ttl": 3600, "txtConflictMatchingMode": "All" },                                                                                                                                                           
-    { "type": "TXT",  "host": "_dmarc.mail", "data": "v=DMARC1; p=quarantine; rua=mailto:postmaster@%domain%", "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" },                                                                                                                           
-    { "type": "TXT",  "host": "mail", "data": "mailname-verify=%verifytoken%", "ttl": 3600, "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "mailname-verify=" }                                                                                                                                
-  ]                                                                                                                                                                                                                                                                                                               
-} 
+{
+  "providerId": "mailname.top",
+  "providerName": "Mailname",
+  "serviceId": "email",
+  "serviceName": "Mailname Email",
+  "version": 1,
+  "logoUrl": "https://mailname.top/logo.svg",
+  "description": "Set up Mailname email (MX, SPF, DKIM, DMARC) on your domain",
+  "syncPubKeyDomain": "mailname.top",
+  "syncRedirectDomain": "admin.mailname.top",
+  "hostRequired": true,
+  "records": [
+    { "type": "MX",   "host": "@", "pointsTo": "mail.mailname.top", "priority": 10, "ttl": 3600 },
+    { "type": "SPFM", "host": "@", "spfRules": "mx a", "ttl": 3600 },
+    { "type": "TXT",  "host": "%dkimselector%._domainkey", "data": "v=DKIM1; k=rsa; p=%dkimkey%", "ttl": 3600, "txtConflictMatchingMode": "All" },
+    { "type": "TXT",  "host": "_dmarc", "data": "v=DMARC1; p=quarantine; rua=mailto:postmaster@%domain%", "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" },
+    { "type": "TXT",  "host": "@", "data": "mailname-verify=%verifytoken%", "ttl": 3600, "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "mailname-verify=" }
+  ]
+}

--- a/mailname.top.email.json
+++ b/mailname.top.email.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "mailname.top",
+  "providerName": "Mailname",
+  "serviceId": "email",
+  "serviceName": "Mailname 企业邮箱",
+  "version": 1,
+  "logoUrl": "https://mailname.top/logo.svg",
+  "description": "一键为你的域名配置 Mailname 邮箱（MX / SPF / DKIM / DMARC）",
+  "variableDescription": "邮箱子域、投递主机与签名密钥",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "records": [
+    { "type": "MX",   "host": "%mailsub%",        "pointsTo": "%mailhost%", "priority": 10, "ttl": 3600 },
+    { "type": "SPFM", "host": "%mailsub%",        "spfRules": "mx include:%mailhost%",        "ttl": 3600 },
+    { "type": "TXT",  "host": "%dkimhost%",       "data": "%dkimval%",                        "ttl": 3600 },
+    { "type": "TXT",  "host": "_dmarc.%mailsub%", "data": "%dmarc%",                          "ttl": 3600 },
+    { "type": "TXT",  "host": "%mailsub%",        "data": "%verify%",                         "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
Add Mailname email template

# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
 [Test apply mail.example.com]https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABIuU2oC%2F%2B1Wa2%2FiOBT9K5GlSrvaQM2jFKiQGqBlGDYdXp1ht6qQSQx4SeLUdihp1f3te80zPEaa%2BbQdqV9I5HvPfZzce%2FArUtQPPaIoKr%2BiUPA5c6louqiMfMK8gPg0rXiIzK3tDo7Aaq%2BtYJFUzJlDlyCqUbuzA2fjZm2eUyEZD1A5YyKPT%2Fi98MBtqlQoy%2Bfnyczn2pyW8wmgXCodwUK1RKIeVUYUGtvYy9TGb%2FbANHrtW9Oot5o2%2FNpWt%2Fa7wQMj5pEwXA5egS4wDpx2NGrRuL46OmpYe3SpywR11NaHuD4L0geeUy5Vlz5F4AocKBFREwGKC1ei8sMrUnG4ZGGw9oX3a80oZ4GSfb5OnT4inHHBVAwkYRMpBQzlChi%2FmduA0Ka9H1KG427kUalDLgyCTuP6g%2F4OdubOmC%2BpB11ycZYerhia0VgTThQBl3lFc5m5MmYVIcmVEVaWIPA5S2aA14Wq8WDsMUfZRDlTFkxs7uqUlueh71UwdH0inL10%2BqNldKKniAgSKBbQK0NEpKI5UrwcAtInUlFxfbYq%2BKcqMRGVkkJYosfuS2CFoRd%2Ft77rXWmbT5SCAWbjuHK2eio%2Boz9eQVvQMVugky5r23Em9Pb4ZqIXHtDhbrQeobDNZNIFgUWmaYf7u9LX6zYRPAqHbIMJgVNf6oXfoB%2F24I8b%2FMMqgE6TGBJ9LjObUz0pcGA3G2Pbwo1a76nRa45y9c5N1ercW1a%2BcWfVa1XWaVUnnbqiUgEik83lLwqXxRImI8el48mU%2FTPz%2FICHT0KqaP68iF%2Bsaq1%2Bc9v41Pzc%2BtO%2B%2B9LudHv9%2B6%2FfBn%2F9jbfwZt3qWFVdSuJD6HIgLDhBZPBDmjk2CbigQwlPoiJBN3vqR55iQ%2FJMdkeuMyR6IIBoCVYId7DDwUrV1uQmRuNwhRPjsL%2FNQ9fR9DMtmc5oPKKFsZNycm4plc9gnBqVyDiVd7I4716WRtkRTejvKW0%2BpcD7E5Ccd8t7JrFEb0fzfrKveQVEJWNoOTH%2BJcvlSbT1rhuRmYScpQ%2FbOtS0%2F3WCfx1SV2p9zOZPSPa%2BVL2Xxrd%2FAz%2B2F4cCvac47%2FBzPpog%2FR9C9iFkH0L2IWS%2FtJDBbU%2BSOXWHRLtmcbaQwpepTLaPC2WcLV8U00VcyOfwHxiXMdYtwKSvmn2Fm2DyDoiaxRee%2FfRNNF%2Fwndf63JsPbhZF78LynH6uH93G7RLJhbX212nzHq7g%2FwHPBlXLLg8AAA%3D%3D
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
