### PR TITLE
Add auridigital.com.hostname.json (website/funnel CNAME)

### DIFF
--- a/auridigital.com.hostname.json
+++ b/auridigital.com.hostname.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://auridigital.com/logo.png",
   "description": "Points your domain at your Auri Digital website or funnel. SSL is issued automatically once connected.",
-  "variableDescription": "No variables \u2014 the record target is fixed. The host parameter selects the subdomain to connect.",
+  "variableDescription": "No variables - the record target is fixed. The host parameter selects the subdomain to connect.",
   "syncRedirectDomain": "crm.auridigital.com",
   "syncBlock": false,
   "records": [

--- a/auridigital.com.hostname.json
+++ b/auridigital.com.hostname.json
@@ -8,6 +8,7 @@
   "description": "Points your domain at your Auri Digital website or funnel. SSL is issued automatically once connected.",
   "variableDescription": "No variables - the record target is fixed. The host parameter selects the subdomain to connect.",
   "syncRedirectDomain": "crm.auridigital.com",
+  "syncPubKeyDomain": "dcsig.aurisend.com",
   "syncBlock": false,
   "records": [
     {

--- a/auridigital.com.hostname.json
+++ b/auridigital.com.hostname.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "auridigital.com",
+  "providerName": "Auri Digital",
+  "serviceId": "hostname",
+  "serviceName": "Auri Digital Website",
+  "version": 1,
+  "logoUrl": "https://auridigital.com/logo.png",
+  "description": "Points your domain at your Auri Digital website or funnel. SSL is issued automatically once connected.",
+  "variableDescription": "No variables \u2014 the record target is fixed. The host parameter selects the subdomain to connect.",
+  "syncRedirectDomain": "crm.auridigital.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "sites.aurisend.com",
+      "ttl": 3600
+    }
+  ],
+  "hostRequired": true
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **Auri Digital** website/funnel domains. Auri Digital is a multi-tenant marketing/CRM platform; customers serve their websites and funnels on their own (sub)domains via a single CNAME to our edge (`sites.aurisend.com`), with SSL issued automatically on connection. Companion to the already-submitted email template (#1370).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **justification for omitting**: the template is fully static (no variables; fixed CNAME target `sites.aurisend.com`) and `syncRedirectDomain` is set, which per the signing guidance means signatures are not required — there is nothing an attacker could substitute.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the synchronous flow uses `redirect_uri`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [x] no variable is used as a bare full record value — the CNAME target is a fixed constant
- [x] no bare variable is used as the full `host` label — the only record host is `@`
- [x] no variable is used in the `host` field to create a subdomain — `hostRequired: true`; the subdomain rides the `host` apply parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — n/a; the single CNAME **is** the service and removing it disconnects it

## Online Editor test results

**Editor test link(s):**

- Subdomain (host=go; hostRequired=true so no apex test applies): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAItgU2oC%2F91TXU%2FbMBT9K5Zf17RJ2tI20qTxsaFpUKECQhpCkWvfBg%2FXDrZTyKr%2B910nFAoM7X1SH%2Brcc%2B45Pvd6TT0sS8U80GxNS2tWUoD9LmhGWWWlkIX0THW5WdLOc3nKlgin%2BwggRy0Cqw7sSnJouLfGeR1Qz5%2F%2FwiFXMHfSB9AKrJNG0yzpUGUKc2lV6OJ96bJe742TXkB0S10gUYDjVpa%2BIdMzI7V3pDaVJcIsmdSE%2Bfb4SvihFSbGkkWlNaguOT8%2FIdLhz1UgCKs80r3kTKmaGM2BcINA7kF0g19mJZsrOHolPzVkW3AkIv4WiAVurCCe2QJ8EFjIR2xBLrAWQiIls5iMB0scKOzvGpqr5k%2F%2BvdkqB11Xaz4DIbGtP2oAKMvtsvt%2BWAF6Vs1%2FQP0MFNzJooE60GIHd6AMv6PZgikHHdp6djS7XlNfl2Fsh9P9068IDpbx%2BCUsQ5P1hcFjyNK97es9jrC%2FF8ebm5Y3g%2FsKjeN6eFvBpkN%2FGw35ixjCxNYpPDLcSnhq9aRaGPxfWFOVudwymvhc2N0t9%2FoV%2BWbLvg70G1SVhTYWckxCM19ZaO106LJSXubsgb18EjxnZalqNOmwik3eJ6LbvW68CebZP%2BPo0FzwYFiGhzKP%2B2yYjljUH6YQDSbjNJoIlkYxDId7o2SUDIZs5%2BV98DA%2FeHq7uYFDM16y8K721QOrHd3gZDDD%2F%2B1OOHLHViByFoBpnO5F8ShK0ot4kvXHWTLpjiejSZx8iuMsjsM1wPn2mmvcj93NoCvpeoPTYZr2Dx8PR6PZTB2f3Ir7xfjApFd2ME34t0slf5a%2Fju8%2B080fQpLPPk0FAAA%3D

