### PR TITLE
Add DoDomain templates (dodomain.io): custom-subdomain-cname and domain-verification

### DIFF
--- a/dodomain.io.custom-subdomain-cname.json
+++ b/dodomain.io.custom-subdomain-cname.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "dodomain.io",
+  "providerName": "DoDomain",
+  "serviceId": "custom-subdomain-cname",
+  "serviceName": "Custom domain (CNAME)",
+  "version": 1,
+  "description": "Points one subdomain at a SaaS product via a single CNAME. Used by DoDomain (domain-connect-as-a-service) on behalf of its integrator applications; the CNAME target is the only variable.",
+  "variableDescription": "target = the CNAME destination host provided by the integrator application (e.g. cname.integrator-app.com).",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "_dckeys.dodomain.io",
+  "syncRedirectDomain": "app.dodomain.io",
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "connect",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/dodomain.io.domain-verification.json
+++ b/dodomain.io.domain-verification.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "dodomain.io",
+  "providerName": "DoDomain",
+  "serviceId": "domain-verification",
+  "serviceName": "Domain ownership verification (TXT)",
+  "version": 1,
+  "description": "Proves domain ownership to a SaaS product with a single constrained TXT record at a fixed host. The value is always prefixed dodomain-verify=; only the token is variable.",
+  "variableDescription": "token = the opaque verification token minted by DoDomain for this connect session.",
+  "syncBlock": false,
+  "hostRequired": false,
+  "syncPubKeyDomain": "_dckeys.dodomain.io",
+  "syncRedirectDomain": "app.dodomain.io",
+  "records": [
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_dodomain-challenge",
+      "data": "dodomain-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "dodomain-verify="
+    }
+  ]
+}


### PR DESCRIPTION
Hello Domain Connect maintainers,

This PR adds two constrained templates for **DoDomain** (dodomain.io), a domain-connect-as-a-service API/SDK that SaaS products embed so their end users can attach custom domains.

**Templates**

- `dodomain.io.custom-subdomain-cname.json` — one CNAME at the requested host; the only variable is the CNAME target (`%target%`). `hostRequired: true`.
- `dodomain.io.domain-verification.json` — one ownership TXT at the fixed host `_dodomain-challenge`, value always prefixed `dodomain-verify=` with `txtConflictMatchingMode: Prefix`; the only variable is the token.

**Signing**

Both templates set `syncPubKeyDomain: _dckeys.dodomain.io`; all synchronous applies are signed (RSA-SHA256, `sig` last, `key` present). The public key TXT is already published and resolving at `_dck1._dckeys.dodomain.io`.

Both set `syncBlock: false` and `syncRedirectDomain: app.dodomain.io`. Happy to adjust anything to fit review feedback.

Thank you!