### PR TITLE
Add and update NextuneSolutions cloud template

### DIFF
--- a/nextunesolutions.com.cloud-application-domain.json
+++ b/nextunesolutions.com.cloud-application-domain.json
@@ -3,46 +3,30 @@
   "providerName": "Nextune Solutions",
   "serviceId": "cloud-application-domain",
   "serviceName": "Nextune Cloud Application Domain",
-  "version": 2,
+  "version": 3,
   "logoUrl": "https://www.nextunesolutions.com/logo.png",
   "description": "Connect a custom domain to a Nextune Cloud application.",
-  "variableDescription": "target: CNAME endpoint. loadBalancerIp: apex A record IP. verifyHost: relative TXT host (e.g. _nextuneapps-verification or _nextuneapps-verification.www). verification: ownership token. Apply ONE group only: routing_a (apex) OR cname (subdomain) — never both.",
+  "variableDescription": "target is the CNAME endpoint. verifyHost is the TXT record host for ownership verification. verification is the verification token.",
   "syncBlock": false,
   "syncPubKeyDomain": "nextunesolutions.com",
   "syncRedirectDomain": "www.nextunesolutions.com",
   "hostRequired": true,
   "records": [
     {
-      "type": "TXT",
-      "groupId": "routing_a",
-      "host": "%verifyHost%",
-      "ttl": 3600,
-      "data": "nextuneapps-txt-verification=%verification%",
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "nextuneapps-txt-verification="
-    },
-    {
-      "type": "A",
-      "groupId": "routing_a",
-      "host": "@",
-      "pointsTo": "%loadBalancerIp%",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "groupId": "cname",
-      "host": "%verifyHost%",
-      "ttl": 3600,
-      "data": "nextuneapps-txt-verification=%verification%",
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "nextuneapps-txt-verification="
-    },
-    {
       "type": "CNAME",
       "groupId": "cname",
       "host": "@",
       "pointsTo": "%target%",
       "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "verification",
+      "host": "%verifyHost%",
+      "ttl": 3600,
+      "data": "nextuneapps-txt-verification=%verification%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "nextuneapps-txt-verification="
     }
   ]
 }

--- a/nextunesolutions.com.cloud-application-domain.json
+++ b/nextunesolutions.com.cloud-application-domain.json
@@ -1,0 +1,48 @@
+{
+  "providerId": "nextunesolutions.com",
+  "providerName": "Nextune Solutions",
+  "serviceId": "cloud-application-domain",
+  "serviceName": "Nextune Cloud Application Domain",
+  "version": 2,
+  "logoUrl": "https://www.nextunesolutions.com/logo.png",
+  "description": "Connect a custom domain to a Nextune Cloud application.",
+  "variableDescription": "target: CNAME endpoint. loadBalancerIp: apex A record IP. verifyHost: relative TXT host (e.g. _nextuneapps-verification or _nextuneapps-verification.www). verification: ownership token. Apply ONE group only: routing_a (apex) OR cname (subdomain) — never both.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "nextunesolutions.com",
+  "syncRedirectDomain": "www.nextunesolutions.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "TXT",
+      "groupId": "routing_a",
+      "host": "%verifyHost%",
+      "ttl": 3600,
+      "data": "nextuneapps-txt-verification=%verification%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "nextuneapps-txt-verification="
+    },
+    {
+      "type": "A",
+      "groupId": "routing_a",
+      "host": "@",
+      "pointsTo": "%loadBalancerIp%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "cname",
+      "host": "%verifyHost%",
+      "ttl": 3600,
+      "data": "nextuneapps-txt-verification=%verification%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "nextuneapps-txt-verification="
+    },
+    {
+      "type": "CNAME",
+      "groupId": "cname",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds **Nextune Cloud Application Domain** template for [Nextune Solutions](https://www.nextunesolutions.com) — one-click custom domain connect for hosted applications (Railway-style flow).

When a user connects a custom domain on Cloudflare, the template applies:

1. **CNAME** — routes the selected host to the Nextune Cloud edge endpoint (`%target%`)
2. **TXT** — domain ownership verification at `%verifyHost%` with prefix `nextuneapps-txt-verification=`

**Template file:** `nextunesolutions.com.cloud-application-domain.json`  
**Provider:** `nextunesolutions.com`  
**Service:** `cloud-application-domain`  
**Version:** 3 (CNAME + TXT only; no A record — Cloudflare apex flattening handles `@`)

Public signing key is published at `_dck1._domainconnect.nextunesolutions.com` on `nextunesolutions.com`.

We will request Cloudflare onboarding with **proxied: true** default for CNAME routing after this PR is merged.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description  
  **Comment:** TXT uses fixed prefix `nextuneapps-txt-verification=%verification%` (same pattern as `railway.com.custom.json`).
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description  
  **Comment:** `%verifyHost%` is supplied by our backend as a fixed label (`_nextuneapps-verification` or `_nextuneapps-verification.{host}`), not a user-controlled subdomain. Same approach as Railway’s `%verifyHost%` in `railway.com.custom.json`.
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead  
  **Comment:** `%verifyHost%` is the verification record name only; the user-facing subdomain comes from the standard Domain Connect `host` parameter (`hostRequired: true`).
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)  
  **Comment:** N/A — both records are required for domain connect; neither is optional post-apply configuration like DMARC.

## Online Editor test results

**Editor test link(s):**

- **Subdomain test** (`hostRequired: true` — primary flow):  
  https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJjeU2oC%2F%2B1WXW%2FTMBT9K5GhTzRZkmahq4TEYONDaBOUwhCjilzHbc1SO9hO0zL1v3OdNEuydR3whsRTm5tzj6%2FPPb7xNdJ0kSZYUzS4RqkUSxZT%2BTZGA8TpSmecKpFkmgmuHCIWqHuDOccLyEHnJcr6WMEAoqhcMkILFpKILLZxmiaMYAOwY7HAjNewW0QvTYJ1XCdYJ1XCkkoFATTodVEiZuKTTCBxrnWqBgcHeZ47u2o%2BMFAn5TNgiKkikqW6YEEvBeeUaAtbJFNaLKyyNEsLCLXraWzAMZVgyfAkoSctPo3ljGqLKUvPIfH8%2BOzUojxOBePasaB6Nl2%2FEeoGMfoysiQlQsbW3ISnQloi57DLOUtLfLVm66nKb8W0uKJFbWrNyYtEkCs0mOJE0TLyPpu8o%2ButlPc21yCHNGZQlb7B3ics4E3ZQ%2FojgwRotpYZrFbuSKHB5TXS69T0tpAC4DMpsrS0BTddLwng8bkxlpFJjQQ8dkolOxDVGnrcC113072hA91aZE0das5OLXiLCFyANa41gNYqW6%2B03aR51mk%2BFfkrDX6Zggv0GdZkzvjsTMSmnPeSTtlqN2T77oHF0Ga86aKfgtOoVm8MhVYtoCsMp5Q2VC%2F7UskQsSLlthKlykCUYokXyhzxivKyxTmuSC8L1vGWdh9lra5BRc39tZy75WvRQEJM8%2Fj04nR4MRw%2BfvS482j4StJ8SnM5zQv6ROD4BU4wJzCOikK8I9%2Fxwr7jOp4BlBYxL4jnFFPGadRQ7gpEZTMuJI0U%2FGKdSVq5dJElmkU4x3UoJpE55mvogYK3QH3XwbwcVqX0Wx%2Fdu37LdFFMjP7MGBYfesFhfzKxj3q9wA6CGNv9wD%2B0w9APwiMaBiT0G6N23zj%2BzVnbsgxVinLNsJmex0mO1wpt7hyv7U73NtZp6bDX4nv7%2FU8JNe7C0fzvjP%2FOuOsMGEsKL2kcYYP0XT%2B03ae254%2B8Pmxh4PadoHfo98InrjtwXbM5qnSp0XXxvxjRO8uEeHXpKEDN8fvA9L09fNEDit8eva3JWw%2Fefe7%2B7Q%2FXji8MhDV8OSNczO9yFrduE3%2FmQqdRgrPzHvDt7%2F35DaHG8ThujYGHF27qCjeAjbFiAjcvMJAxw32OBVzze4bo1zcXyy%2FB98WVJ19%2F%2F%2BAT9mok89dX%2FteTNR3OdfouS88m8WfivYWbxi9coMR18gsAAA%3D%3D

**Test values used (v3, 2026-07-12):**

| Field | Value |
|-------|--------|
| Domain | `example.com` |
| Host | `www` |
| Groups | `cname`, `verification` |
| target | `c1.cloud.nextuneapps.com` |
| verifyHost | `_nextuneapps-verification` |
| verification | *(sample token)* |

**Expected records:**

- `www.example.com` CNAME → `c1.cloud.nextuneapps.com`
- `_nextuneapps-verification.www.example.com` TXT → `nextuneapps-txt-verification=<token>`

> Editor session saved at 2026-07-12T18:36:08Z — template v3 CNAME + TXT.

> **Note:** `hostRequired: true` — apex-only test is not required per guidelines. If maintainers want an apex test anyway, groups `cname` + `verification` with empty host and `verifyHost` = `_nextuneapps-verification` also applies cleanly on v3.
