### PR TITLE
Add nanimail.com.email.json (new template)

### DIFF
--- a/nanimail.com.email.json
+++ b/nanimail.com.email.json
@@ -1,0 +1,61 @@
+{
+  "providerId": "nanimail.com",
+  "providerName": "nanimail",
+  "serviceId": "email",
+  "serviceName": "Email",
+  "version": 1,
+  "syncPubKeyDomain": "nanimail.com",
+  "syncRedirectDomain": "app.nanimail.com",
+  "logoUrl": "https://nanimail.com/brand/wordmark.png",
+  "description": "Email on your own domain with nanimail: receiving (MX), authenticated sending (DKIM, SPF, Return-Path) and domain ownership verification.",
+  "variableDescription": "verification = domain ownership token issued by nanimail; dkimselector and dkimkey = per-domain DKIM values issued when the domain is connected",
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "@",
+      "data": "nanimail-verification=%verification%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "nanimail-verification=",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "receiving",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound.postmarkapp.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "sending",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:spf.mtasv.net"
+    },
+    {
+      "groupId": "sending",
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "k=rsa; p=%dkimkey%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "sending",
+      "type": "CNAME",
+      "host": "pm-bounces",
+      "pointsTo": "pm.mtasv.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:dmarc@nanimail.com",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for nanimail (https://nanimail.com), an email hosting service for custom
domains. The template sets up mail receiving (MX), authenticated sending (DKIM TXT,
SPF via SPFM, Return-Path CNAME) and domain ownership verification (prefixed TXT).

Variables: `verification` (ownership token issued by nanimail), `dkimselector` and
`dkimkey` (per-domain DKIM selector and public key material issued by our email
infrastructure at connect time). The DKIM host keeps a fixed `._domainkey` suffix and
the DKIM data keeps a fixed `k=rsa; p=` prefix, per the template quality guidelines.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — SPFM is used
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (verification TXT uses Prefix matching; DMARC uses All)
- [x] no variable is used as a bare full record value (verification TXT uses the fixed prefix `nanimail-verification=`; DKIM data uses the fixed prefix `k=rsa; p=`)
- [x] no bare variable is used as the full `host` label (DKIM host is `%dkimselector%._domainkey` with the fixed `._domainkey` suffix)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (DMARC and the ownership verification TXT)

## Online Editor test results

**Editor test link(s):**

[Test nanimail.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEEIVGoC%2F%2B1XbU%2FjOBD%2BK1EkpFvRlqQvKXRVadMWSmHTpVB2u6xQ5SZu621im9hJCYj77TcOLU1YetxJJx2641MSz3ieeXlm7NzrEgfcRxLrjXudhywmHg57nt7QKaIkQMQvuSzQC0%2ByPgpwRgoSgcOYuDjdhPNrK%2BXD1WqMQ0EY1RsmaCTUPYsmpzjpMBDTXxGVxjn2SIhd%2BaSDOC890%2FPZjF2GPgjnUnLR2NvLKuxNQkS9vSULvQCFixKnM9jjYeGGhMvUm0f%2FNEa1hEWhxpZU81I8bUnkXFtba2jgCSYxoTPtN2f0oaChSM4xlcSF%2FHmawNRLZZ3TnlPQLs6OCto5llFIi2dIzj9o4MfaMGBALuaEa5ATMlUWwJWSyhEKCZr4uJPzMKulNX%2B1ItkCU40IEYEjk%2BTJ54%2BatyCBwD7kkIWPHsDCAidgheOwuLKkXNZi5EdYrK0sITQN4luDEaG5jFIwhD3wE3IBKRV648e9PgtZxNP6Z%2F0EJZlwVf%2FhaAgfcyYkfHxS6UcSZQpezG5r7mS%2FdpQVCcWtWIYBr7eyzejUJ650kHTnkG%2BHeQrjLMRTcqu%2FqLKSbQOETVgIVUikWPSF2pz7if5QyEb2VPtNWM4oHxVnhEoxZPBJ6IRF1CtxkCraKdqu%2B4iwkMgEmsDIhJYHW1FpAwVkcvJggk%2FPIx%2BLFMz1Iw83YKkUSCTiEsVSf8ViriY7WZbslMaPJQeWbGq1aIYCfdR4c2dFoFxlXgFr923ncAPHg6JKjwve57LGg4z%2FW62rPna3BDJeC1dex82OY5%2B3TeU4ZRR%2F1MIINRUFJGukup%2BeTZO%2FRDbb97eR5vqhoN8B0njTINfgznp%2B4VsE8xavwFZew1sa3pik%2Bs%2B7KEu9TWofIwXbHIUoEGp%2Br1F%2B5GCu1zg%2FdPWeIv19lJw27BYpwNfM6lDNILNcsSfuKLlTe7KsUnvKRtkyrPIBPOtmnQdrHUU0EDu97tSxjW774qZ70ZtUOoPDlj24tO1qt2932i0yOG3NBu3T3dG8v6SdWuvueH5qzaIb6htXZcMhtCIGxpKftfypHU9vhUW6gV%2B5ElZyeTc6nnW%2B1W8ttrsU3rTL5wk3zYU8PBl9Oz2cxnJwMTQ7g5bXO5fV1nc7%2Fu62wvO2Q456g59fu4F92A1n1vKie3UbiaN6TUSsl1zWrGOxTztfJrtTOsVHdb89463Pi%2BrQ4LUTMV32OvbAbumKE2RGWYjHAp4IzgRgkQwjXNCDyJdkjJZos%2BS5Y6TIBBQSIIXUwIzNsZ0%2BnquvjtJXi5Tj%2B9hzFYuIajKrvm%2B5Vg0Xy%2FseKlbrdaO4f%2BCiondQdaum6Zlu2czcCl66Mbx0L9gQ%2FsXmUY2eHa6%2Fxrl9sGYCyc%2FYfy0s21%2BiROSi2la%2BuAnD29RenOTa7ygdN2mAEN9bDul5h%2F%2F5UfKfbfi30VYvFGt9EK%2FKlTuIV9XZdgi%2FYdb9o6f%2BG5iC1wW4M7zP%2FPeZ%2Fz7z32f%2B%2B8z%2Ff8x8%2BBcSKMbeGMlVUxWNetEsD8tmo1Jp1Col86Bi1a1dw2gYhvIfC%2FkY%2FD38X2T%2FLPToxBF9%2F3jWxeRA7MfRyRWzdvs%2F9y9u7Jt6zXOOPTTv%2Bv0ZOq429Yc%2FAD440xgFFAAA)

[Test nanimail.com/email example.com/correo](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ8JVGoC%2F%2B1XbW%2FiOBD%2BK1GkSrcq0PAWtqyQNkBLaTfd0tJdtqsKmcQBH4nt2g6QVnu%2F%2Fca8lKQtu7e6D1ed%2Bglsj%2BeZl2dmnAdT4YiHSGGz%2FmBywWbEx6Lrm3WTIkoiRMKCxyIz93h2jiKcOoUTicWMeHh5CWf31sJH690ZFpIwataLIJFQ7yIeneGkzeCYPkfUEpfYJwJ76lEGcV54IheyMbsWIRxOlOKyfnCQFjgYCUT9gzkTfoTEtMDpGO74WHqCcLW0ZmWfwaiRsFgYbE4Nf4lnzImaGBttdQMswWRG6Nj4wx28yxkoVhNMFfEgfr4hMfWXZ%2B2zrpszri6Oc8YlVrGg%2BQukJu8MsGOjGDAgFhPCDYgJCbQGMKWgY4QEQaMQtzMWpqWMxnMtik0xNYiUMRgySh5t%2FmD4UxJJHEIMmVhZABtTnIAWjkV%2BrUmbbMxQGGO50TIH1wzwbwNGpOExSkER9sFOiAWEVJr17w%2FmWLCYL%2FOfthOEVMJ1%2FvuDPiwmTCpYfNThRwqlEp5PX2vspVd7WouC5JZty4K%2FC9ViNAiJp1ykvAnE22W%2BxrgQOCAL80WR9dkuQLiEpdSJRJpFn6nDeZiYP3Jpzx5zv3XLHWS94oxQJfsMloSOWEz9AodTTTtN200dESaISqAIrJRrWbA1lbZQQCY3CyZ5cBmHWC7BvDD2cR22CpFCclagWJm%2F0JjJyV6aJXuF4SrlwJJtrqYNIdEHgzf21gTKZOYXYK1zxz3awvEor8PjgfWZqPEoZf9O7bqOvR2ODDeHa6tnjbbrXLaK2nDKKP5giBg1NAUUqy9lPz7pJv%2BIbE4Y7iLN7Y%2BceQ9Iw22B3II5m%2F6FFwj6LV6Dra0GQYEZrJdODsny1tNaShNwG%2BCVv4DAkUCR1F18g%2FU9A3a7Qfu%2Bgbtd4%2F0%2BVkYabsslzJfUbl%2F3o2Kp7Iy8QXKv76QZpu%2BUrJJt2aVD%2BK0VazzayGjSwbHb7QSuY3VaV3edq%2B6o3O4dNZ3eteNUOudOu9UkvbPmuNc62x9Mzue0XW3en0zO7HF8R0PrpmS5hJZlz5rzi2YYOLNgIW3SicLyjbST6%2FvBybj9tbaw2f5c%2BkGHTxJeLE7V0eng69lRMFO9q36x3Wv63UtVaX5zZt%2B8prhsueS42%2FvzSydyjjpibM%2BvOjeLWB7XqjJm3eS6ap%2FI97T9ebQf0AAf18LWmDc%2FTSt9i1dPZTDvtp2e0zQ1P8iYMoGHEn4RzAdglBIxzplRHCoyRHO03fK9IdLEAjpJOIXQQL%2FNMJ%2BuZuwjh37aW3%2BZqUwBDH1PE4roqrMPPcsqvi%2Fna6PDIF%2Bp2SiPymiUL1Zr74tV2674h5XUM%2BGlJ8RLD4WnFfBiTen6T%2FfcHS7vbropn7L99z%2F20AnnKJEZB3%2Ba1FkDenzReLHhG3%2BhZVda%2Bgquvn7vnraA1NwpPPX8cfz8bxvDa6q8FzK3GeHr3G1H%2BLNU7Zrir56Pq8dD4XnR%2FYs3xKtpobc5eIe8zY632fE2O95mx9vseJsdvzM74NtMohn2h0itay9v1fLFUr9UrJcP65VyoWpZVdvat6y6ZWkvsFSrEDzA9076S8f8hEOX3whrIS%2FuK6c3%2FqI8IMfJ9XV5fDI4bbZKpeDOO6ndnB7Oug3zx98HmVp0oRQAAA%3D%3D)
