### PR TITLE
Add skrybo.com email service template

### DIFF
--- a/skrybo.com.email.json
+++ b/skrybo.com.email.json
@@ -1,0 +1,55 @@
+{
+  "providerId": "skrybo.com",
+  "providerName": "Skrybo",
+  "serviceId": "email",
+  "serviceName": "Skrybo Email",
+  "version": 1,
+  "logoUrl": "https://skrybo.com/brand/skrybo-logo.svg",
+  "description": "Sending-domain setup for Skrybo: ownership, MX, SPF, DKIM, DMARC and bounce records.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "skrybo.com",
+  "syncRedirectDomain": "skrybo.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_skrybo",
+      "data": "skrybo-verification=%verifytoken%",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mailhost%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:%mailhost%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimkey%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:dmarc@%domain%",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    },
+    {
+      "type": "CNAME",
+      "host": "bounce",
+      "pointsTo": "%mailhost%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Skrybo** (skrybo.com), a self-hostable email platform. One-click sending-domain setup: ownership TXT, MX, SPF (via SPFM merge), DKIM, DMARC and a bounce CNAME. Signed synchronous flow only (`syncPubKeyDomain: skrybo.com`, public key published at `_dck1.skrybo.com`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Test apply: domain=example.com, apex (no host)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALOXVGoC%2F%2B1WW2%2FiOBT%2BK5ElnibQUG6dVEgNtN1FVTql7cx0VVWRiR3wEOzUdmiZiv3tewyBJAzareZlZiVeID7n%2BDv3L3lDms6SGGuK3DeUSDFnhMoBQS5SU7kYiVooZsjeaq7xDCzR3UoHckXlnIV0dYHOMItzWcnUusiUcyoVExy5dRvFYiw%2ByxiMJlonyj06yn0ejSTmJBNUjWVNzccAQKgKJUv0CgTdUU4YH1eJAHxuKarTxIqEtNZuXUu8cPA4YYlt%2BQ%2B2dXdzaVvnVwMffn3vtm%2BBE2skUh5SS9JQSKJqJoUFD3uxCKfIjXCs6Fpyk46u6OJ85Wq3QEZ%2FSwkDEL3fYiKUvqXPKZiQLWzmE7mPb0gvElOw%2B4f7zBoOgdpUmmCNt5BVKCOLWIhNGbqV1WmhxZTyCphqDTVttB1naW9R%2FYcc9Mw0VDCu1b2AY8W0xqgqq0YzIZleQIOc%2FUhQQr%2BMpZLoNo0pZIEYD%2BOUULeEuQ%2BllGWFTNlM0RhqJ2SlFqy7OaWLPO9513StfmpNu1LhUyvpri6Bzbs8BGSGZViCM%2B2vGyAuOD21ZIq7Jmgt3JXtWWUdRQneRlQpyjXDZmo%2FcS9JYhOkftV9waOYhdrHOpzASPqCmChuJI3Y636TTJdHgwrh9689%2FyJPYD2j%2F9K4vARPSxt9h5yCfLieIPHNUNJXDBtPC1MJQngaS5EmAdvYJ1jimTKssLn5WLr6tLn7iMxzYQSNSFOlV4f6ccOoN5EanXmuFVbDBFfovzHJpj7TmEEAoT8Y9AbfvOveePo8mbI%2FPr44PW94cel5n%2Fre8MQz%2Bv74Cp4vPON%2FODj3hl4PmXqwMReSBgr%2BsU4lFFjLFPZvlsaaBfgF5yISBti0FcqnQAued3eTr5ntXbtZKkRpkgISmuoyQ51RHbdb0UenGpF2u9oMT5zqSStqVkedUZuAeb1x0iqw8I%2F8vI%2BH89YWh9aLX%2FBCoeUuN2RJneXp7PapFH2ZJ36fXEodOisuPLBU3drw005u1t84jn%2FX9pRSymDfR5E%2FuzH%2Fh0L8BKOXme%2FXp7h5fyz30H6W5Zb237OTv7pTTza8OA5keSDLA1keyPJAlv9BlvBxq%2FCckgAbs2PnuF11OtV6497puM2W22rVWk6z1el8cBzXcUzwMHTrzN7gi7b4LYu0F81v%2Fvr23B91juaDL%2Fpy9rktBqxxp77%2BOejw%2BIMaN%2FWXoUi16KLlP%2Bf3ejH1DwAA)
- [Test apply: domain=example.com, host=sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOmXVGoC%2F%2B1WXW%2FiOhD9K5Elni7Q8FHYpkLaQD%2BEekNbyq7QVigysQEvwc7aDpStuL%2F9jhNoCIt2V1f3oSvxArFnPDPnzPgkr0jTRRRiTZHziiIploxQ2SXIQWou12NRDsQCFd8sPbwAT%2FSU2GBfUblkAU0O0AVmYbaXc7Wut8YllYoJjpxKEYViKj7JEJxmWkfKOTvLcp6NJeZku1EynmW1nEIAQlUgWaSTIOiJcsL4tEQExOeWojqOrImQVprWscSKQ8YZi4qWNyxaTw83RevqruvBr%2Bf2OxYkscYi5gG1JA2EJKpsIKx50A5FMEfOBIeKpjsP8fiOrq%2BSVIcEGXufEgZB9HGPmVC6T7%2FF4ELewm5zIuf5Fel1ZAgbDAdbb1j4asc0wRq%2FhSwBjWzCAmxoaBWS1VqLOeUFcNUaOK01bHtTfIvqDbOgH01DBeNaDQQsC6Y1xlRIGs2EZHoNDbKPRwIKvXwsFU36cUgBBWI8CGNCnVzMY1FyKAtkzhaKhsCdkIWyn3ZzTtcZ7mXLdK1yac1bUuFLK2olh8DntzL4ZIFlkAtn2l8xgbjg9NKSMW6ZorVwEt%2BPhbSKXPgiokpRrhk2U3vP3SgKTZH6RXcEn4Qs0B7WwQxG0hPEVPEg6YS9HHfZ2rJq0F75nZ7rXWcA0hn9SeMyCkabIvoOmPxsuEYAfDeU9AXDjad7U2nGKh7DYipFHPlsdyTCEi%2BUEYbd4efc6dHu%2BHNyfpTc7t0gml1NlU4WlWrNmHf1Gpt5Lu9dEFPi3hQkQdPZ31rMOMCm1%2B22u1%2FdXns6%2Fzabs9uLld12H69vXPe%2B4z5%2BcI29M72D52vX5H%2FsXrmPbhsZVtiUC0l9Bf9YxxJo1jKGW7iIQ818vMLZFgl8bJoLJCqwQubDG8pTfdve0HLK4E9uaY6M3Ez5JDAkMyOidWxfNOrjWqlhV4NSfdIMSuMPE7tUaYzJ%2Bbh5Tii29%2FT4R6U%2Bpsi5Ju9PsBuu8FqhzaFQbLHlMB02LAchLxvvClCuWzlEyxYoV8XaadYBQOsfHIbvuFF5XGnkTDnLB0gP1fO%2FXqM%2FhI9U738g4Vean9fGd4F095LZHHk3bMGm74by79%2FWd9C3URHeMCdJPUnqSVJPknqS1P9FUuFDWeElJT42nlW72ijZzVKlNrCbTr3h1C%2FKtdp5o9H8y7Yd21RgpjAF9wpfx%2Fvfxai3WParq%2Fv191u3R1iP9zufb%2F%2BuDQexu8T92LW%2FvJz1r268amO4aqHNv99DN1tHEAAA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
