### PR TITLE
add OneBookPlus, 2 templates

### DIFF
--- a/onebookplus.com.website-apex.json
+++ b/onebookplus.com.website-apex.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "onebookplus.com",
+  "providerName": "OneBookPlus",
+  "serviceId": "website-apex",
+  "serviceName": "OneBookPlus website (apex domain)",
+  "version": 2,
+  "syncPubKeyDomain": "onebookplus.com",
+  "syncRedirectDomain": "onebookplus.com.au",
+  "description": "Connects an apex/root domain to a OneBookPlus website: points the apex A record at the OneBookPlus edge and publishes the per-tenant ownership-verification TXT record the OneBookPlus domain wizard checks. Subdomain connects use the separate website template, so this apex A record is only ever applied when the customer explicitly connected their root domain.",
+  "variableDescription": "VERIFYTOKEN: per-tenant ownership token issued and shown by the OneBookPlus domain wizard.",
+  "shared": false,
+  "syncBlock": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_obp-site-verify",
+      "data": "obp-site-verify=%VERIFYTOKEN%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/onebookplus.com.website.json
+++ b/onebookplus.com.website.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "onebookplus.com",
+  "providerName": "OneBookPlus",
+  "serviceId": "website",
+  "serviceName": "OneBookPlus website (subdomain)",
+  "version": 3,
+  "syncPubKeyDomain": "onebookplus.com",
+  "syncRedirectDomain": "onebookplus.com.au",
+  "description": "Connects a subdomain (e.g. www) to a OneBookPlus website: CNAMEs the chosen host at the OneBookPlus edge and publishes the per-tenant ownership-verification TXT record the OneBookPlus domain wizard checks. Deliberately touches no apex records; apex connects use the separate website-apex template.",
+  "variableDescription": "VERIFYTOKEN: per-tenant ownership token issued and shown by the OneBookPlus domain wizard.",
+  "shared": false,
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.onebookplus.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_obp-site-verify",
+      "data": "obp-site-verify=%VERIFYTOKEN%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New provider: **OneBookPlus** (onebookplus.com / onebookplus.com.au), an Australian small-business platform with a website builder. Two templates connect a customer's domain to their OneBookPlus website:

- `onebookplus.com.website` (`hostRequired: true`) — CNAME for the connected subdomain host + a prefixed ownership-verification TXT.
- `onebookplus.com.website-apex` — apex A record + the same TXT.

They are deliberately split so a subdomain connect can never rewrite a customer's existing apex A records (Domain Connect replaces same-type records at the same host unconditionally). Record targets are hard-coded — the only variable is the per-tenant verification token, written with a fixed prefix.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — *N/A: no `logoUrl` used*

Both templates pass `dc-template-linter -loglevel error -tolerate info` with zero findings. The signing public key is published at `dck1.onebookplus.com` (two TXT fragments, `a=RS256,t=x509`) and verified end-to-end against the production signer.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — `All` on the verification TXT
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — verification TXT uses the fixed prefix `obp-site-verify=`
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description — no variables in any `host`
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — set on the verification TXT

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

- Subdomain test (`website`, `hostRequired: true` so apex test is not applicable): [Test onebookplus.com/website example.com.au/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANq7VGoC%2F%2B1Ua2vbMBT9K0IwaFns2XnXo7C%2BBn2XkI5tpQRZuolFHcm15KRuyX%2FflfNo2rTb1zH2JYl0z726556T%2B0QtjLOUWaDRE81yPZEC8mNBI6oVxFrfZWlhfK7HtLYKX7Axwumlgn0EXCEAgwbyieRQpU4hNhJLrm43M8gCQ7ZMEQs9ZlJtI34CuZFa0aiBuaXiV0V8CuVhFX%2BzJwfqgZA5cPsezGcFIgUYnsvMVuXpgVYKUwxhZNUA2QJ%2F5JPpdLpNrMbIG%2F1G5OBi7%2FzIEJsA4Yk2oAh%2BWsJsdbWeAmIEhClBsiJOpUlgnpVB7llQTFmipwoJJzLzkLgcSs5ce6T%2FvU%2BQkM7FRs1Fp1P5yDDKE%2BB3xieHkMoYcpQxLbH1gru3FFLI4GFRyXyen%2FiSeGGgqm4gYy5zydCrYEtb%2BE4UlksWp3D4YoLfjnrHX3%2F0L0%2BPLqI3OWEjdzgdaUwBopqDSTBI4vL3rNyTJmE5oJWGLDUwV3k%2F1fxudeNm3oP7QlYwmxd4tyBKo5snasvMOa4Si87hePziXKylsqav8cgV%2BtLfNJW1KTqwHQSz2qoSavJcZ6DjzKuGVelWOnsxy5z1XgZ2P6yN6cN6afz5YNGFw1Rye84sT6QanWvh3tpLU4SCQXNZydLqn7OXZWlJZ7ezGn3EjgfPZG%2Fx8aXz4YGhbvDs%2BkXD6Gk8jHJdZAO5zHK6j4374y%2Fzb14XuF1WuKlK4HGNj7tlYVznDdGE1rAddMJufafBmnGLU9eoHCmdw8DgN7NFDkuhxkVq5YBN2fOV4APmGCIvg1EsvSmimm%2BROZfFvP8oYY0OBHccpdtMTd7qDlm34%2FEw7HjNRmfo7bQbHa%2FNRdgVMWNho7626d5ZhG%2FvuhejXhdvL52y0tDZhpsWhF67yX%2FB8LWj3p3430V65djZbQ3N9l%2FNf0VN3AGGTUAMmIPWg3rbCzpe2OiHQVQPojDw262w3t75GARREDgeYOyc%2FRPuhPVtQEUix60j0Pzy4r48CM8mw%2BBs%2BPO4B92Ts%2BtENHsPlzibq08nvetdOvsFx1%2Bj3q0IAAA%3D)
- Subdomain test (`website-apex`, host `www`): [Test onebookplus.com/website-apex example.com.au/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIe9VGoC%2F%2B1UbWvbMBD%2BK0Iw2GicOU6aNIbC2m6je%2BnWtWFsKyXI8qUWtSVXkuO4Jf99J%2BfNSdt9HmPBEFv33Omee%2B7ugVrI8pRZoOEDzbWaihj0h5iGVEmIlLrN08K0ucpoa23%2BwjKE068SjhFwjgA0GtBTwaF2LSEywoLHcphtTI%2FdyBJIXjokiVXGhHyFHlPQRihJwwC9K8nPi%2BgTVG9r%2B5OpOdAFxEIDt8%2FB2qxAZAyGa5HbOjw9UVKiiyFMEpfDa62UXSZCrCKMPJFuSHIlJDrZBGovckTwYqVjwmx92HSC%2BAZRMiZ5EaXCJLDwy0F7FiSTlqhSIt9E5B7yFhPBmcuOjH6MVmF3Yy4TLMU9QytPgN%2BaNrksoqWBr2gVBmpnAznTqPK64ivZW8QoRAizQwQPlEwrApgSmvJUQEzKBGQdjhfGqgwtMEMLFxaRyzuhzlZo0qhk20nKtGBRCm%2B36v%2F93cWH9z9HXz%2B9%2BxI%2BWRIU4RYvFcYUGNmV0SRoJFH156K4K03CNGA%2FTlhqYNEjx6nit%2BuTRBl7AXeFaMIWBTA0vHqgtspdyx7RBRZf37g5qNUfKfwc9Nv4BB180GBtSsNu3%2FfnrbUvqrjxHqso9%2BrRqJWuXD8yy1yvbhsOXzQq86IZGl9nFtt2gnW3Z8zyRMibMxXXeaYpQsEYkFawtB62I9SuovPreYve40CMN%2FSu8fLVqMCMYT%2FAZkyWCZdliR83WhX5WKy8XCtlxi2Mlf%2FVboDrVYSrOgR%2BNvi4U9aJAt6Ne7A%2F6fuDzkEw7LJetM%2BpS1TcSKVhbPCf2UIjNasLlCYrUivGrGSbo5iPXXdWyMugFUNvyyYXS2fBY1nrZ0Rr0XHMHSvhdhhjURwNYeBNgqHv9Xow8aLI5x4MfbYf4O8Aho2d%2BMzK%2FMNW3KpwU7OjtGSVofNHTbTksttE7S1yu430bKH%2FQubrbp1ft7DR%2Fiv5LyiJs2%2FYFOIxc9DAD%2FqeP%2FA63VHHD4NB2Bm2g36v3x3s%2BX7o%2B44MGLsowQPuguYWoIOD2am5u%2FzMq%2FOsy36dnCWnB5mvj0%2FNSfDtfq93Of2%2B9%2FEuy5N7c0jnvwEfYcZS3QgAAA%3D%3D)
- Apex test (`website-apex`): [Test onebookplus.com/website-apex example.com.au/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI28VGoC%2F%2B1Ua2vbMBT9K0Iw2FicOXaWh2GwtOselLVdm42NUoIs38QijuRJchKv5L%2Fvynm5j5R93GBgiKJ7jnTPPffqllqY5RmzQKNbmms1FwnoTwmNqJIQKzXNs8I0uZrRxi58xmYIp%2BcSjhBwgQAMGtBzwaGiLiA2woLHcljuQw9pZAMkzx2SJGrGhHyBjDloI5SkUYDsUvKLIj6F8l0VfzQ1B7qERGjg9hCsyQpEJmC4FrmtjqfHSkqkGMIkcTm80krZTSLEKsLII%2BlGJFdCIsmmULHIgODFSieE2WqzToJkgiiZkLyIM2FSWPNy0J4FyaQlaiFRbypyD3WLseDMZUeG34fbY%2B%2BfuUlwIX4xjPIU%2BNQ0yVURbwJ8K6swUJEN5Eyjy7uKb21vEKMQIcw9IbihZFYSwJQwlGcCErJIQVbH8cJYNcMILDHChUXk5k6oshWa1CrZdJYyLVicwbs79f92cvnp%2FY%2Fh%2BenJWfRoSdCEKV4qjCnwZFdGk2KQxOXTRXFXmpRpwH4cs8zAukeOMsWnu51UGXsJPwtRh60LYGh0fUttmbuWHdA1Fpdv3RxU7g8V%2Fu12mvgFLfwwYG1Go7Dj%2B6vGjosu7tkjFedeNRqV06XrR2aZ69W7gTfPapV5Vj8al0uLbTvGutvPzPJUyMlnlVR5ZhlCwRiQVrCsGrYBelfS1c2qQX%2FhQIz28m7w8u2owJJhP8B%2BTDYJ42qiVZGPxJbi%2Bmhm3GuxJV%2FfZ99s6dfUrWtK3BZrxQEPkza8Hnf8bqsX9EPWjl9z6lIUE6k0jAz%2BMltoFGV1gabMisyKEVuw%2FVbCR64vS1RkMIpH3zVMrp%2Bbt%2FsaHzCrQUcJd4KEe7u67T7rh23wOt2w77Wh2%2FPYOBx7Ld7ttkII2m0OtbfwwFP5xGu4r2zdqEG2YKWhqweds5Hx551zsL5%2Fm%2BRdb65uGthZ%2F937V93DGTdsDsmIOVzgBx3P73qtcNjyoyCM%2FH6z1%2B6glpe%2BH%2Fm%2BUwLGrvXf4szXp50eTyYLPT%2FuXaXxxzITs14SZPHRWQ6n5mzydbr8cnR8boIPH0%2FK6Ru6%2Bg0m%2FeZkvwgAAA%3D%3D)
