### PR TITLE
add Modulora, Modulora domain verification

### DIFF
--- a/modulora.dev.domain-verification.json
+++ b/modulora.dev.domain-verification.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "modulora.dev",
+  "providerName": "Modulora",
+  "serviceId": "domain-verification",
+  "serviceName": "Modulora domain verification",
+  "version": 1,
+  "logoUrl": "https://modulora.dev/logo.png",
+  "description": "Adds the TXT record that proves you control this domain for your Modulora creator profile.",
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_modulora",
+      "data": "modulora-verify=%code%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "modulora-verify="
+    }
+  ],
+  "syncPubKeyDomain": "modulora.dev"
+}


### PR DESCRIPTION
# Description

New template for Modulora (modulora.dev), a UI component registry. It writes a single ownership-proof TXT record (`_modulora` → `modulora-verify=%code%`) used to verify that a creator controls a domain before it backs their profile and seller features.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`dc-template-linter -loglevel error -tolerate info -logos` passes with exit 0.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes:
- `syncRedirectDomain`: not set because the template does not use `redirect_uri` in the synchronous flow.
- `essential`: not set because the single verification TXT is not a record end users need to modify independently; replacing it is handled by `txtConflictMatchingMode: Prefix`.
- Signing public key is published at `_dck1.modulora.dev` (TXT, `a=RS256,t=y,p=…`).

## Online Editor test results

**Editor test link(s):**
[Test modulora.dev/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC7fVGoC%2F%2BVT227aQBD9FWulPDUG22BwLPWBXCq1EVHUUqkViqxhdwyr2F53d01wUP69sxAuoZHa9z55Lues58xlzSyWdQEWWbpmtVZLKVB%2FFixlpRJNoTR0BC7Z%2BT53ByVh2fg1SxmDeik5bkhClSArf4la5pKDlao6IE6o3hbsnYDJNc5Kw3NWqLn6rgsiLaytTdrtHlfVdelOXc2JJdBwLevNGykbCWE8u0Bv8mPiaeRKC3LBek4FGq9VjcdVZbUqKC7NrpRcaZfT3r5GrhEsRYmYywI7Tk1b8ctC8UeW5lAYpMgCNIq9u%2F2hYel0zWxbO81UBzEXylhysvLQPAEWjpq97Vz78YwrgWeUt5bU9wZBQObKXqkqLyS3Y7B8Ias5lelev9eYyxV7F%2FKa%2B%2FMX7OVhq%2BW%2Bmd1ie73pwOncX87Zs6owO0gikthBcQW0PNjhqjyoI2uuVVNncoevQUNp3ILtmNM31Icdd8qczTeipsyqRx%2FCWcR7oo8xe6Ba5LxSGjNDX7CNJpjVDXW8bAorM3iCQ0jwDOq6aKl0Q1l68HQa1XYd%2F2EaJ5W8mUomuFMm3fbPeJLkYRL6OMi53wcA%2FyLqx%2F4A4ou8F8ziIEqOTum9M%2Fv7MR3ajMZgZSW4%2BxgVT9Aa9kJDpZb%2FJ1LdAsMSRQYOFgXRwA%2BGftibhFEaB2nc7yRJPxlGH4IgDQInBo3dCl%2FTNh3vEfs1%2FnZb3lzehUuAq%2BsvXRENZyO%2B%2BprPb8LqKb6dPH7Kf3YDbcsxnc5vzpDnADgFAAA%3D)
[Test modulora.dev/domain-verification example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANLkVGoC%2F%2BVTyW7bMBD9FYFATrFsyZI3AT2kC9AtrdO6RVsjEMbk2CYiiSpJOVaN%2FHuHVrw2RT%2BgJ2mWN3xvlg2zmJcZWGTJhpVaraRA%2FUawhOVKVJnS0Ba4Yq197APklMuuH6MUMahXkuMWJFQOsvBXqOVccrBSFYeMM6jXJHtnyWQa95eELZaphfqiMwItrS1N0ukcs%2Bq4cLssFoQSaLiW5bZGwq6EMJ5dojf5NvE0cqUFmWA9pwKNV6vK46qwWmXkl2ZHZa60i2lvz5FrBEteAs5lhm2npi7480zxO5bMITNIniVoFHuzedCwZLphti6dZuJByKUylow0PzRPgIWjZjedq59dcCXwguLWkvqoHwT0u7YvVDHPJLfXYPlSFgui6aqPNc7lmj2Z8hj78wn2cNtoGVezd1i%2F3HbgfO4PLfZLFZgeJBFI7FJxDbQ82OYqP6iDsiRjoVVVpnIHKUFDbtyO7cDTE%2FTtDj7d4snkW2lTZtWdD%2BGsyyMRY4%2FdEiO5KJTG1NAXbKUpzeqK%2Bp5XmZUp3MPBJXhK9bKaBBiKUsHzmRTNUu5n0m74%2F2UuZ2xO5pMK7gRKdwfDUTQYxlHoiwgHfjzDmT%2FsjoTfjwWf9QIe9yE4OqqnDu7fZ3XScDQGCyvBHctVdg%2B1YQ80YWr%2B%2F6XYLTWsUKTgMrtBt%2B8HAz%2BMJmGUhHHSG7bDQW8Ux5dBkASOkUVjG%2B0b2q3jrWKvTXwTmEn%2BKp%2Fx97I3%2Btr7GOlw%2FP2y8%2FnHpFD9n2t4uy7G9ubTPZ3Tb0NRkpRMBQAA)