### PR TITLE
add Game Axiom, Domain Verification

### DIFF
--- a/gameaxiom.com.domain-verification.json
+++ b/gameaxiom.com.domain-verification.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "gameaxiom.com",
+  "providerName": "Game Axiom",
+  "serviceId": "domain-verification",
+  "serviceName": "Domain Verification",
+  "version": 1,
+  "logoUrl": "https://www.gameaxiom.com/icon.svg",
+  "description": "Verify domain ownership in Game Axiom by publishing the Cloudflare custom hostname ownership TXT record.",
+  "variableDescription": "ownership: the per-domain Cloudflare custom hostname ownership verification token issued by Game Axiom.",
+  "syncPubKeyDomain": "gameaxiom.com",
+  "syncRedirectDomain": "gameaxiom.com,www.gameaxiom.com,admin.gameaxiom.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Game Axiom Domain Connect template for domain ownership verification. The template publishes the Cloudflare custom hostname ownership TXT record at `_cf-custom-hostname` using the standard Domain Connect `host` parameter for apex and subdomain verification.

The TXT record value is intentionally a bare variable because Cloudflare Custom Hostnames provides the complete ownership verification token and Game Axiom must publish that exact value for verification to succeed.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Additional local validation: `dc-template-linter -cloudflare -loglevel error -tolerate info -logos gameaxiom.com.domain-verification.json`

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

`essential` is not set because this is a provider-issued ownership verification token and should remain managed by the Game Axiom verification flow rather than independently edited by the end user.

## Online Editor test results

**Editor test link(s):**

- [Test gameaxiom.com/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACAnVWoC%2F%2BVUXWvbMBT9K0bQp9mpYzcfNeyhbVgpo83YurWsBKPIN4moLHmSbNcN%2Be%2B7ynfWsO59YLCse%2B7VOedea04s5IWgFkgyJ4VWFc9A32QkIVOaA33hKm8xlRN%2FG7zDfQxf48u7cHGMGdAVZ7DMy1ROuQwq0HzCGbVcyR1inTxYYrwfhxhMMW6VtH0i1FR91wKxM2sLk5ye1nXdOuB0ypmSLVNNMTUDwzQvloUSsqzbeCsmnqolFp7xwsOPHW1v3HhFORYcQ3Lq2Rl4V0KV2URQDR4rjUXMTBkrXcquyP3jvaeBKZ21HGeqOR0LGBwQ2KKTZd0CdLAm809H7HvnWfUM0uPGlJA5zjsF7nzTSPalHH%2BGZuXpkcY5yFfIOJK2x0H%2BG299muVcto6VuhSKPZNkQoUBn6ycMCR5mhPbFK65aBBCnSz8SNkkWAkNNkJdu6ilGDzZSj7BTWux3XEY4urFXik5EZzZW2qZ68%2BtylztCyHIYrTwyauSkO4OH%2FnruUMMvFAcaVhTXvPA1VSrskj5Bl9QTXPjxn6T%2BXSQOtrkPhG33lJ1G29FBcs2BesCxFHkU6k0pAbf1JYa6VtdomV5KSxPaU13WxlLaVGIBhUZjOIRf9opVz%2FOX%2B18l9W%2Bx2nGnHbuftl%2Bu8ei8zYN4m7cDc5oZxycn7f7QZ%2ByOOzFZwBxZ%2B8GOHo9vH8F7DoBxoC0nIplR2vaGLJYjHzsyn8oG2fL0AqylDpYFEbdIOwF7fi%2B3Us6%2BEStKAw7ce9DGCZh6MSAsSvpc5yy%2Ffki1%2FLX1TB67D7Ya6jveJVJNfz2ejkddKvup%2BEkYg%2BXN8%2FDwaT%2B2f9IFr8ByEtrJf0FAAA%3D)
- [Test gameaxiom.com/domain-verification example.com/league](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPQmVWoC%2F%2BVUXW%2BbMBT9K8hSnwYEmgQapD10jTRVU7sPZVO1KkIONsSqwcw2EBLlv%2B%2BakK82Uve%2BJ%2BDec4%2FPPffiDdI0LznWFEUbVEpRM0LlPUERynBO8YqJ3E1EjuxD8hHikP4MD%2BvW5CGnqKxZQrs6InLMCqemkqUswZqJ4ojoi6cdxvp1joESZd4i30ZcZOKn5IBdal2qaDBomsY90zRgiShcVWdQSqhKJCs7ogh1vK21U2KJpgDiJSst%2BDjKthatVVYLziBVZJZeUuuOi4qkHEtqJZXSgFkKpQtTciSZPc0sSRMhiWs0Y8nwgtPpmYADOup4SyqdXsw%2FHXHqnaXFCy0splRFidF87MCcr9oi%2BVYtvtB25%2BmFwRnID0oYiNaXQfYbb21Mcla4l6g%2BcZG8oCjFXFEb7ZxQKHreIN2WZrhgEEBNW%2FARJ6mza9TZN2rGhTWG5NWh5SsIag3jHnoevK30nShSzhL9gHVi5vMgiOG%2B5Rxt51sbrUVB4%2BPhc7vfO8DQFYaVpr3kXgenOKvM0ZkUVRmzfVWJJc6VWf59%2FfMZwXzP8LyngMhBtgm%2FbdDpRub0NMjIZVkhJI0VPLGuJLSiZQX25RXXLMYNPoZIEuOy5C10pyALR7y2ttj9RBesdQ9t9g6%2FK%2B7U9pgkxghm%2FuJwMiSpR4aOP%2FIDZxTQwJmMF9gZpyEZ4iCYjEbXJ5fCxRvj%2FVvh9XCoUrTQDPNu1A1uFdpu5zYM6n%2F3ALZO4ZqSGBvwtXcdOF7o%2BMOZH0bjMPJu3OFkfOPffPC8yPNMS1TpnQEb2L%2FTzUNfye%2BxUovx7KlZT%2B%2FDP2w9Dct0ubpbPwbZqK79lyp7akaP39fNR7T9C8%2FW64QjBgAA)
