### PR TITLE
Add templates: qrticket.app (tickets-apex, tickets-subdomain)

### DIFF
--- a/qrticket.app.tickets-apex.json
+++ b/qrticket.app.tickets-apex.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "qrticket.app",
+  "providerName": "qrTicket",
+  "serviceId": "tickets-apex",
+  "serviceName": "qrTicket — Entradas (dominio raíz)",
+  "version": 1,
+  "logoUrl": "https://qrticket.app/icon.svg",
+  "description": "Conecta un dominio raíz (ej: tumarca.com) a tu cartelera de qrTicket.",
+  "variableDescription": "%ip%: the IPv4 target qrTicket requests for this domain.",
+  "syncPubKeyDomain": "qrticket.app",
+  "syncRedirectDomain": "qrticket.app",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 600
+    }
+  ]
+}

--- a/qrticket.app.tickets-subdomain.json
+++ b/qrticket.app.tickets-subdomain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "qrticket.app",
+  "providerName": "qrTicket",
+  "serviceId": "tickets-subdomain",
+  "serviceName": "qrTicket — Entradas (subdominio)",
+  "version": 1,
+  "logoUrl": "https://qrticket.app/icon.svg",
+  "description": "Conecta un subdominio (ej: entradas.tumarca.com) a tu cartelera de qrTicket.",
+  "variableDescription": "%cname%: the CNAME target qrTicket requests for this hostname.",
+  "syncPubKeyDomain": "qrticket.app",
+  "syncRedirectDomain": "qrticket.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two new templates for **qrTicket** (`qrticket.app`), an event ticketing platform. They let an event organizer connect their own domain to their qrTicket page, which is served from Vercel.

Two templates rather than one because `hostRequired` is a template-level flag and the two cases need different record types:

| File | Case | Record |
| --- | --- | --- |
| `qrticket.app.tickets-apex.json` | root domain (`tumarca.com`) | `A @ → %ip%` |
| `qrticket.app.tickets-subdomain.json` | subdomain (`entradas.tumarca.com`) | `CNAME @ → %cname%` (`hostRequired: true`) |

The target is not hardcoded because Vercel returns a per-domain value, so it is passed as a variable at apply time.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Notes on the checklist

- **Bare variables as record values (rule 6).** `%ip%` and `%cname%` are bare by necessity: an `A` record value is an IPv4 address and a `CNAME` value is a hostname, so neither can carry a fixed prefix. Both are scoped to a single record of a fixed type, and the value is chosen by qrTicket (not the end user) from what Vercel returns for that specific domain. This matches the existing `theqrcode.co.vercel-qr-a` / `theqrcode.co.vercel-qr-cname` templates.
- **`txtConflictMatchingMode` / SPF (rules 4, 5).** No TXT records in either template, so both are trivially satisfied.
- **`essential` (rule 10).** Not set: each template contains exactly one record, which is the whole point of the template — if the user removes it the connection simply stops working, and there is nothing for them to legitimately edit.

## Online Editor test results

**Editor test link(s):**
[Test qrticket.app/tickets-apex qrticket.app/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMmjVmoC%2F9VTf0%2FbMBD9KpYlJNCa1klLYJEmDcE0wX4hxEAbVNHVPopHEqe2UwhVv%2FvOhdIyxv6fZCmXO7%2B7e893M%2B6xrAvwyLMZr62ZaoX2UPGMT6zX8gZ9F%2Bqad55iX6HERfR0EaWIQzvVEhegB4iLoMa7VegPDLtsEhEP2IfKW1Dg2KYypa60YRYuGyFQ3W8ReIrWaVPxLO7wwozNd1tQkmvva5f1euvt9bQ0VddNx4RS6KTVtV8g%2Bb6pUHpgTcVe1GCb%2BCtjvinBSuhKU24xoF8mwXos0AJTyJY9d0NDYDWMCjx4VmJD1xuU5hrZ4fF0wDzYMVF84mpx0qDzjl0ZS7e0C42ArkJC11byuBl9wvZg4XuperhxgkpbYvHaHYoZqxzPLmbct3VQeo%2Fc18Z5Mt%2BHtzO68u7UPHZLHu9Jy1SI%2BXDe4fckUr7KMiQRXyn1mJOssTVNnesloAYLpQsztIRePMcOl%2BALHmxdB2sn7dJJYjo8NKLHlbGYO%2FqCbywx8bbBDi%2BbwuscbmHlUjKntEVLfTuKUrbn7KuHkQvsFXggc73YSoAOz5UMfeswvqgQRuJKRGpbQDTob%2B9Go3SURKNdmhjsy%2B1UDNZ24W978o9tWKmHzmHlNYSB3ituoXV8Ph92SMn%2FnwW9roMpqhzCtUQkaSR2onhwmsSZSDIRd9N%2BfzeN3wiRCRFI0Ho8sJvRDKy%2FPu%2FLn%2FHRnjhrj85PPorky%2Be7tgTo3Zy0YwffJvHZ%2BdudH6N9kU7kOz7%2FDe9Dq%2FrNBAAA)


[Test qrticket.app/tickets-subdomain qrticket.app/entradas](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABakVmoC%2F%2BVT227bMAz9FUHAgBaLE9vNpTEwYL1hGLYVaZc9bF0QMBKbqLUtV5JdpEH%2BfZTT1OnabR%2Bwp8QkzyHPEbniDrMiBYc8WfHC6EpJNB8lT%2FidcUrcomtDUfDWU%2B4cMqyz4zpLGYumUgJr0AZiA1vOpM5A5U3%2BNyD7WcZh1GVnuTMgwbK9DUblSu8TqkJjlc55ErV4quf6m0kJvXCusEmnsztcRwmdt201J5REK4wqXI3kJzpH4YCVOWvI2R7eJAwf27ZdmYER0BY622fAXMkEGIcpGmAS2Xbcth8JjIJZiqfPmrwROSl7kzC3QHZyfvTljDkwc1L4JNXgXYnWWXatDZUpyxbaOg%2FztHaZi1E5%2B4TL041lL7z3FZcolSE1f6rxjJfUh4roIZwpscWpXhtpeXK14m5ZePvrAR%2FL6fO9f1mtcmfHutFCQefI7n4YrifrFn8gH6cN2YR8%2FssUFN26S5G50WUxVVtgAQYy65dtS3H1nGOyJblqWChWD%2BaD9Z82bYfANJC59Q%2FH%2FZBqnmuDU0u%2F4EqDWxOyMnVqCvfQhKSYUqt0SZosZYn2pUGbfrtKJDigyKsDNIa1%2BFQKr0%2F5exj0%2BuHwOhoEMR4Og%2B5g0AtAxCI46MsZRD3Z6wHsHNdrh%2Fev83ppOVpLXwr8wRyl97C0fL2etMj%2B%2F0Am7YqFCuUUfHkcxv0gHARRdxxHSXiQRIftbm8YH3TfhmEShl4RXeZG84q2aHd%2F%2BLIafRg%2BxKPb0XEHL6KL8%2BKrXJzMyvJzZ3E5D0fVzb3Ko%2BMfi%2FH3d3z9C5YmNZVMBQAA)


[Test qrticket.app/tickets-apex qrticket.app/entradas](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOGkVmoC%2F91Tf0%2FbMBD9KpalSaA1rRNKWiJNGgz%2BKGgbGrBJgyq62tdilsTBdgql6nffuVBaxtgHmGQp8f14d%2B%2F5bs49lnUBHnk257U1U63QDhTP%2BK31Wv5C34a65q1n3xcocek9X3rJ49BOtcRl0mOKi6DG%2B7Xrjxx21SQi7rKjyltQ4NiWMqWutGEWrhohUD1sU%2FIUrdOm4lnc4oWZmAtbEMi197XLOp3N9jpamqrtphPKUuik1bVfZvJPpkLpgTUVe1WDbeFNxnxTgpXQlqbcZkBXJsF6LNACU8hWPbdDQ2A1jAo8fFHina7fEcw1ssHptMs82AlRfOZq8bZB5x0bG0tR2oVGQFcB0M0qedqMTnB2uLS9Vj1EfEOlLbF4K4Z8xirHs8s597M6KL1P5mvjPP1%2BDG9ndOXduXnqlizek5apEIvhosUfSKR8jTIkEd8o9YSJTw9Hlok1TZ3rVWINFkoXZmkFcfkSY7gCuVyjkE3XwdJL23SSmA4PjelJZSzmjr7gG0vMvG2wxcum8DqHO1iblMwJvpgRD0deQnupRvU4ghudK%2FBAls2aa11aPFcy0NBhquO0n6R7ozja3cFR1AU5jkDuyGin3x8jxN1kLOKNFfnb%2BvxjSV6Lis7RTUOY9%2F3iDmaOLxbDFgn835Git3cwRZVDCE9EkkaiF8Xd8yTORJp143acdHupeC9EJkQgQ8v0yHJOE7I5G%2FxEDc4%2BX9wcHO%2F2D7RXx0eo0%2Fu9r4PJ9%2FFPP%2BjBj31zdrNXdpw8%2BsAXvwExAu5G%2BwQAAA%3D%3D)