### PR TITLE
Add Pie AI Website template (getpie.com / aiwebsite)

### DIFF
--- a/getpie.com.aiwebsite.json
+++ b/getpie.com.aiwebsite.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "getpie.com",
+  "providerName": "Pie",
+  "serviceId": "aiwebsite",
+  "serviceName": "Pie AI Website",
+  "version": 1,
+  "logoUrl": "https://ai.getpie.info/logo.png",
+  "description": "Points ai.<yourdomain> at your Pie AI website so AI search engines can find and recommend your business.",
+  "variableDescription": "target = your Pie AI website host (assigned by Pie)",
+  "syncPubKeyDomain": "getpie.com",
+  "syncRedirectDomain": "app.getpie.co",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "ai",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Pie** (`getpie.com`) — "Pie AI Website". Adds a single CNAME
(`ai.<domain>` → the merchant's Pie-assigned AI-website host) so a business's
Pie-hosted, machine-readable AI website is reachable as a first-party alias on
their own domain. TLS on the alias is issued via HTTP DCV once the CNAME
resolves, so no validation record is needed — the template is exactly one record.
Multi-location businesses apply the same template with the protocol `host`
parameter (`host=<location>` → `ai.<location>.<domain>`); no variables in `host`.

Rule-6 note: `pointsTo` uses `%target%` as the full value because the target is a
**Pie-assigned, per-merchant hostname** on Pie's serving domain; the apply URL is
RS256-signed (`syncPubKeyDomain: getpie.com`), so the value cannot be tampered
with in transit.

Domains referenced here — `getpie.com` (provider identity + signing key),
`getpie.co` (`syncRedirectDomain`, our app / apply-return host), and `getpie.info`
(Pie's serving domain, where `%target%` resolves and the logo is hosted) — are
**all operated by Pie**.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — schema check passes; apex + `host=<location>` applies verified (links below)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://ai.getpie.info/logo.png` live since 2026-07-14 (200 `image/png`, official brand wordmark)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `getpie.com` (key TXT at `_dck1.getpie.com`, live before provider onboarding)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.getpie.co`) — the sync flow uses `redirect_uri`
- [x] no TXT record contains SPF content — n/a, single CNAME
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [x] bare `%target%` used **by design** (Pie-assigned per-merchant hostname; apply URL is RS256-signed) — justified in the Description above per rule 6
- [x] no bare variable is used as the full `host` label — `host` is the fixed literal `"ai"`
- [x] no variable is used in the `host` field to create a subdomain — subdomain use goes through the protocol `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — n/a; the single CNAME *is* the service (removing it is disconnection, not a tweak)

## Online Editor test results

Captured from the signed-in editor 2026-07-15 (Copy-Markdown links), against the submitted template (logoUrl `ai.getpie.info`).

- **Apex apply** (`example.com`, no `host`) → `ai.example.com. CNAME 3600 examplemerchant.getpie.info`:
  [Test getpie.com/aiwebsite example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEWSV2oC%2F91Tf2vbMBD9KkJQ2GiSOnGdpmYdhLbQsq50I2OFEszZuiRituRKclIv5Lvv5Pzs2n2B%2FSGQ7t7p3r27W3KHRZmDQx4veWn0XAo0t4LHfIqulNjJdMFbO889FITkDxLJaNHMZYYNGuQCUyvdgX2PZcNb9nPnnqOxUised1s811P9w%2BQEmzlX2vjkBGRnk1mqiT7xgE6pphQn0GZGlq6J5Q9aKmcZwT%2FVujJCFyDVZwaO%2BSfbZN2QYlb7l0Uw2YyhmkqFlmWg2EQqwYCOQaq0QLo18WllPcZ2PGEwEtIcr14RcGCIKLt4N99MW8c%2BgLVyqlCwtPaAj16bWmUPVfoF66uG8d9Ce%2F93FJLouB0CyrKzQxHIczXC8vhpyV1depUv74dfr8nlEzft8E1rJBppeh%2Bt2R6R1TmSO%2BwHwWq8avHfWmGy%2F29MMm%2Bz4gvQaGyJbT6m29ToqkzkFl%2BCgcL68dlGPr0KHW9jn7i%2Fr4kcgAqknoByh23nnhpJpw0mXkJwlaEqnamwxYsqdzKBBexNIktIo7ymSix56fe3yqj1ODbKCHCwr%2FBdBgdCtXgiMl%2Bg9JM%2BEEF6FvYmbQzwvH16GkXtFE%2BhHWHYnfQgxSgdHGzM213619rsFaa5Q%2BUk%2BL0Y5guoLV%2Btxi1S%2Bz8si2bCwhxFAh7WC3r9dnDW7kajbhhH53EYdsIoGvTOjoMgDgJfAFq3rnRJU3I4H%2Fxu9Hijh91%2BfXlb%2Fur109njTY2L55co1NW5rtzz8aUN6%2BOX6PrbBV%2F9AW%2BC5VX9BAAA)
- **Franchise apply** (`example.com`, `host=halcyon`) → `ai.halcyon.example.com. CNAME 3600 examplemerchant-halcyon.getpie.info`:
  [Test getpie.com/aiwebsite example.com/halcyon](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHCSV2oC%2F%2BVTf2vbMBD9KkJQ2Kid2nHipGYdlDWwUlpC6dhGCOZsXxIxWzKSnNYL%2Be475XfXbV9gfxisu6e7957uVtxiVZdgkScrXmu1FAXq24InfI62FtjJVcW9Q%2BYBKkLysUAKGtRLkeMGDeIZMyPsSfyIZde37OshvURthJI8CT1eqrn6okuCLaytTXJxAaKz6yzkTF04QKeWc7pXoMm1qO3mLh8rIa1hBP%2FQqkYXqgIhPzKwzB3ZruuOFDPKnQyCzhcM5VxINCwHyWZCFgzo00hKK6S%2Fzf2sMQ5jOo4waAFZiTevCFjQRJRd%2FbHfQhnL3oExYi6xYFnrAO%2BdN63Mx012h%2B3NhvHvRrv8IxaC6NgDAuq6c0ARyHHVheHJZMVtWzuXPz1c348o5RpvnsM92saiJ0Xnsy3bM4paS3ZHcRCsp2uP%2F1QS02O9Kdm874ovQKOxJ7YrvIAyb0m%2Fx%2BdaNXUq9tdq0FAZN0X7ApNXFab7EpNDDQptaZ1gK6QXAmn9Heh0GLgjTIYqjakzFmyjSbvVDXq8akorUniGY6jIU3KubEmfoSx1eeuX3A4pjdFRWQEWjvr%2FyejETo%2BnRe70C7cP2TDECC8DH%2Frxpd8b9kP%2FMg9nPg7iYR50ESDun%2BzV243723K9eQcaUpRWgFui6%2FIZWsPX66lHb%2FL%2FqKVJMrDEIgWH7gbd2A8Gfth%2FCntJECRh3ImjMIq653QIAqcDjd0KX9FMnU4TH57f2M9x97ELD4Pvd%2Be93jAKZ3px1xuF36JiFGXhOHx8ui%2FN6McVX%2F8CyB3ZhEEFAAA%3D)

> Sample `target` values (`…getpie.info`) are illustrative — `%target%` is a merchant-facing variable the apply flow sets at runtime (`<slug>.getpie.info`). `pointsTo` stays bare `%target%`, so no re-run unless the `pointsTo` form itself changes.
