### PR TITLE
Add CatalogHub, CatalogHub Custom Domain

### DIFF
--- a/cataloghub.in.customdomain.json
+++ b/cataloghub.in.customdomain.json
@@ -1,0 +1,42 @@
+{
+  "providerId": "cataloghub.in",
+  "providerName": "CatalogHub",
+  "serviceId": "customdomain",
+  "serviceName": "CatalogHub Custom Domain",
+  "version": 1,
+  "logoUrl": "https://cataloghub.in/lovable-uploads/b3316a01-8a3e-471d-a288-212bef5dccd6.png",
+  "description": "Connects a seller's apex domain or chosen subdomain to their CatalogHub store. Points the applied hostname through Cloudflare, which terminates and auto-renews TLS at the edge and proxies to the store; verifies the seller's ownership of the hostname for the Cloudflare custom hostname; and delegates ACME validation to Cloudflare so the certificate renews automatically without any further DNS changes.",
+  "variableDescription": "token = the per-hostname ownership-verification value CatalogHub obtains from Cloudflare when it creates the custom hostname (proves the seller controls it). host (built-in, optional) = the chosen subdomain label; omit it to connect the apex. fqdn (built-in) = the complete hostname being connected; used to build the Cloudflare DCV-delegation CNAME for automatic certificate issuance and renewal.",
+  "syncPubKeyDomain": "domainconnect.cataloghub.in",
+  "records": [
+    {
+      "type": "A",
+      "groupId": "customdomain",
+      "host": "@",
+      "pointsTo": "104.21.12.49",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "groupId": "customdomain",
+      "host": "@",
+      "pointsTo": "172.67.193.171",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "customdomain",
+      "host": "_cf-custom-hostname",
+      "data": "%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "CNAME",
+      "groupId": "customdomain",
+      "host": "_acme-challenge",
+      "pointsTo": "%fqdn%.23c1c60ae5862988.dcv.cloudflare.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description
New template for CatalogHub (SaaS store builder). It connects a seller's own
apex domain or chosen subdomain to their CatalogHub store via Cloudflare for
SaaS. Two A records on the applied hostname proxy it through Cloudflare (edge
TLS, auto-renewed), one TXT (`_cf-custom-hostname`) proves ownership for the
Cloudflare custom hostname, and one CNAME (`_acme-challenge`) delegates ACME
validation to Cloudflare so the certificate renews automatically with no further
DNS changes.
 
The same template supports both modes using Domain Connect's optional `host`
apply parameter. With `domain=example.com` and no `host`, `@` resolves to the
apex. With `domain=example.com&host=shop`, all relative record names are scoped
to `shop.example.com`, while `%fqdn%` resolves to `shop.example.com`.
 
## Type of change
- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
 
# How Has This Been Tested?
- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is actually served by a webserver
 
# Checklist of common problems
- [x] `syncPubKeyDomain` is set (`domainconnect.cataloghub.in`)
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` — N/A, the synchronous flow uses no `redirect_uri`
- [x] No TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the TXT record (`All`) so a re-verification replaces rather than stacks the ownership token
- [ ] The `_cf-custom-hostname` TXT value is a bare `%token%` variable by necessity: it is the exact ownership-verification value Cloudflare generates per custom hostname and matches verbatim, so no fixed prefix can be added
- [x] No bare variable is used as a full `host` label
- [x] No variable is used in `host` to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` — all records are `Always`; each is required for the hostname and its SSL to function
 
## Online Editor test results
 
**Apex:**
[Test cataloghub.in/customdomain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB2oV2oC%2F%2B1V%2B2%2FbNhD%2BVwgBwVrEkiX57aBAU3vAijVpsTrbsCAwKPJks6FFlaTseEH%2B9x4l%2BZVH12HAkB8CBIjM4z2%2B%2B7473noWFrmkFrzhrZdrtRQc9HvuDT1GLZVqNi%2BSQGReY2s8pwu87I0q8y9FgjYDeikYVH6FsWrB1YKWbrXpgRcZlffIeHNxCdoIlXnDqOHhFXWhJTrMrc3NsNk8qKYp1ZImEvwil4py00xarahLw8jv0xb47V7EfRr3%2B34cxQmkHc4Y7wZ5NsM0HAzTIrdlKm%2BksgyYNYQSA1KC%2Fgk%2Fc7ghVf1EacLmykBGTJHUZ1YROwehyR4YhKIhIJ%2BUyDAYmjFKLgVwgt42Q%2FB4qFUxm5ORVAVPJdXQIKu5YHNiQS9Ehhxg7owTWljla8hgZcjkw2dCbRkQ%2BAxKOxJxI%2FBuVUeV%2BoRg%2B0RaHruzDRa1yrCtc5ETlZaWbTkpQnMHu3JIxdz2ykmZjYOEWVnb6ejsZ7KkUnDquufy7zmbqhoG2mIdSBeQGoPDs0AXRqVck5Wwc1VYjL0maaHRR5Px%2BWdsM81mYAKnBKqFo3d8QJVV10jDmzJLDtrfItli9KsesKo8rLSAfY5UYpE%2BQ1KNIPcqX80xrrCEaShxljAOW0FeOfUfNJcwlVmtpEHX10F5k7xKCiGtL7IGUWXZVL6uK36gIkkTkCdELTAz%2FmEzWaXFWj1wE5D0K892QbehFE4s2D0uExDZbOMP%2FIQUBpWHIZ0rv0%2FzePS7X7Pq%2BjQ6P0VenRy2RB2wKIwpaMYq7ZWUUulYMuuMfSqSX2Fdj%2FDQq6DVdQT3F4gGpjQ33vDy1rPr3K2DUzye4Vjkj20OBw9P37rdU87VROHPKGwHcRREcdAeoMVa3BKtbhjeNf5T1F4cdHtBNGgFUS96Iu7kz8kPRJ6y1K8sW4m6tYPNQONRqeKj%2FQT4eWNxD6VSMHtGLZsjmWeKl0ik9PYKKKn6kRIoW4CPE4VCxaE6hHrkVHUUxC0WsW5IodPvxoN%2BP%2BBsGbCtSgJU2UEbru4a3t8qg%2BmOxqtGzThGhRvqVFm71XVsSp2Kzf2carow7q3ZeF4euF5tfC899112y%2F3AubT%2BTlD%2BbuarK646MctwE04N%2Fqe20NgwqwtoeItCWjGlK7o74mzq9vMawRi0YoZDTWbVa%2FV2R9xTsmt4U84cHuHoSFi%2F126xvp92w47fpoOOT8Nu6vfbcRy2%2Bsmgl7T2ntJH39nvvKW7toLBbWIFlaVIVnRtvLt7E%2FAIhidF%2FjxRVPNW4%2FjuWP2TPJ491M1kb8A%2BGOAa6N6s%2FNsJfk7Arxq4DF5G7mXkXkbufxs5fE4NXQKfUnctDuOuH%2Fb8qDOJOsNWPGx3grAT9trd4zAchqGDgQxXPbjF13X%2FXfWK99f5X%2BbjtRi%2FE%2BtBW4svF%2F0PneVFc%2FLbeDY47nzpvWs3%2F2g1u8fmjXf3DbtsS%2BtlDgAA)
 
**Subdomain:**
[Test cataloghub.in/customdomain example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACypV2oC%2F%2B1V%2B2vcOBD%2BV4QhXEvXju19ZkPhwm7vQZukR9K7QgiLLI3XolrLJ8n7aMj%2FfiPb%2B3Ca3PW4X3IQCGSt0Ty%2B%2Bb4Z3XkWFoWkFrzxnVdotRQc9K%2FcG3uMWirVPCuTQOReZ2e8oAu87E1q8y9lgjYDeikY1H6lsWrB1YJWbo3pGy8yqe6R6fbiErQRKvfGUcfDK%2BqTluiQWVuY8fFxq5pjqZY0keCXhVSUm%2BOk240GNIz8Ee2C3xtG3KfxaOTHUZxA2ueM8UFQ5HNMw8EwLQpbpfImKs%2BBWUMoMSAl6B%2FwZwFrUtdPlCYsUwZyYsqkObOK2AyEJgdgEIqGgHxUIsdgaMYohRTACXrbHMHjoVblPCMTqUqeSqqhQ1aZYBmxoBciRw4wd84JLa3yNeSwMuT6wxWhtgoIfA6VHYlYC7xb11GnPiXYPpFWx%2B5si0WtcmxrJgqi0sqyKydFaO5gXw6pmdtdOa2ycZAwr2o7m5y%2FI0sqBaeuey7%2FgbOpq2GgLdaBdAFpMDg8C3RhVMoNWQmbqdJi7A1JS40%2BmkwvrrDNNJ%2BDCZwSqBaO3mmLKqu%2BIA1vqywFaH%2BHZIfRr3vA6vKw0hIOOVKJRfoMSTWCPKh8lWFcYQnTUOGsYLRbQV459beaS5jKrVbSoOvroLpJXiWlkNYXeYeoqmwqXzcVf6MiSROQp0QtMDP%2BYTNZrcVGPbAOSPonz%2FdBd6EUTizYAy4TEPl86w%2F8lJQGlYchnSt%2FSPN08rvfsOr6NLk4Q16dHHZEtVgUxpQ0Z7X2KkqpdCyZTc4%2Blsl72DQjPPZqaE0dwcMFooEpzY03vrnz7KZw6%2BAMj%2Bc4FsVjm8PBw9Mf3e6p5upa4WcU9oI4CqI46J2gxVrcEt1BGN53%2FlPUYRwMhkF00g2iYfRE3OvP198RecZSv7bsJOrWDjYDjUeVio8OE%2BDPtcU9lErB7Dm1LEMyzxWvkEjpHRRQUfU9JVC2AB8nCoWKQ9WGeuRUdRTEXRaxQUihPxrEJ6NRwNkyYDuVBKiyVhtu7zveV5XDbE%2FjbadhHKPCmjpVNm5NHSZTxbbcmdj6FFTThXHvzdb7puV%2Bu%2FW%2FqQPgd9U1d4Dzaf29sPz97NdXXJVinuNGnBn8T22psXFWl9DxFqW0YkZXdH%2FE2czt6Q2CMmjFDG1t5vWr1eBoOHxKgR1vxpmDJRwzcTIKGecDnyYhPkl8GPujZDj007QXD9N02OuN%2Bgev6qNP7t88q%2B0Og8HlYgWVlWZWdGO8%2BwcD8TiUJ2X%2FfMHUU9jAeWTYgjbEf1LM%2FwLzdvC3qNvz%2FQCx%2BwoOBurfjvpza8NtB7fGy1y%2BzOXLXD6vucSH2dAl8Bl1V%2BMwHvjh0I%2F611F%2F3B2Oo0Fw0ot6cfdNGI7D0EFBzutm3OE7ffhCe%2Bd2Kj8tLwfT6Wjyx0%2FnYV789vPll4ldh2f0%2FYfsapJ8ji4v35xdfX331rv%2FC4XTJfC3DgAA)
 