### PR TITLE
add Repliqo, Repliqo inbox domain

### DIFF
--- a/repliqo.app.inbox-domain.json
+++ b/repliqo.app.inbox-domain.json
@@ -1,0 +1,40 @@
+{
+  "providerId": "repliqo.app",
+  "providerName": "Repliqo",
+  "serviceId": "inbox-domain",
+  "serviceName": "Repliqo inbox domain",
+  "version": 1,
+  "logoUrl": "https://repliqo.app/repliqo.png",
+  "description": "Connects this domain to Repliqo shared inboxes: routes inbound mail to Repliqo's email infrastructure and authorizes it to send as the domain.",
+  "variableDescription": "%sesRegion%: AWS region of Repliqo's email infrastructure, e.g. us-east-1; %dkim%: base64 DKIM public key provisioned for this domain",
+  "syncPubKeyDomain": "repliqo.app",
+  "syncRedirectDomain": "repliqo.app",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound-smtp.%sesRegion%.amazonaws.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.%sesRegion%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template for **Repliqo** (https://repliqo.app), a shared team inbox product. The `inbox-domain` service connects a customer's domain (typically a dedicated subdomain, e.g. `inbox.example.com`) to Repliqo's email infrastructure (Resend / AWS SES): an apex MX for inbound routing, a send MX + SPF for the bounce/feedback subdomain, and a DKIM public key.

Variables are narrowly scoped per the quality guidelines: only the SES region (`%sesRegion%`, embedded in fixed SES hostnames) and the DKIM key material (`%dkim%`, embedded in a fixed `p=` prefix) vary per domain. SPF uses the `SPFM` record type. DMARC is intentionally not included so the template can never replace a customer's existing DMARC policy.

Apply URLs are signed; the public key is published at `_dck1.repliqo.app` (`syncPubKeyDomain: repliqo.app`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`dc-template-linter -loglevel error -tolerate info -logos` passes with exit 0 (also clean with `-cloudflare`).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Note on the last item: all four records are required for the service to function (inbound MX, send MX, SPF, DKIM); none are user-tunable, so the default `essential: Always` applies and no `OnApply` records exist. The template contains no DMARC record by design.

## Online Editor test results

**Editor test link(s):**

[Test repliqo.app/inbox-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACGOV2oC%2F%2B1WW2%2FiOBT%2BK5Glah8KNBBuk1WlCaRQWqVtgG5pqwo5yQl4CHFqO%2BFSdX%2F72kC5dDqz%2B7APs6s%2BxTlXn3O%2B78gvSMA0ibAAZL6ghNGMBMA6ATIRgyQiz7SAkwTltqorPJWmqLtWSgUHlhEfVi4k9ug8H9ApJvFOdeiirYy0rVEGjBMaI7OYQxEd0VsWSeOxEAk3T072LrE9J%2FFI%2BgXAfUYSsfJFTRrH4AuuiTHhm%2BCaoNpbUj7GDIJ1buCmxmgqgK%2F%2B0zjQpHm0Z%2F4b12AlInHIMBcs9UXKQMPSFKdiTBlZKm%2BhfDgoqcoMm8QFVRZmBHsR2AfXPOLAuzCSP0emZt31NLb60Wj4N6lzGhRGBS3leZDCfPF37SiYkKmM4mEO1bJmX3YcLUm9iPjaBBbaal6qsbLqkLL9vqjJLGL%2FJvUuYWGvRe%2FHrQy6EBAmm%2FoDE6miLODIfHxBYpGoETsDKR9TLuT5qwINJbHgfbqBhux0nk9FUthrQwFP8ZLGeMYLPp2ugEZke8VCAkLPISEkGoyqrr%2FmPsyimn%2BYKAQIPOxPfpRJCv5xpt5Ny%2FkuF0%2FCbhoBXxXlR2kA5mHkvQD9QX%2Fnz0BFKAzXU5BDUijGAktVcroeJ9q7hzzOhcR1KEcqHCz8MYlHDg1UXCuK0OvTaw7JtDDcTeJJRnybFsyxZDZsit3cQZ5GEvvJkLzZJ5jhKVfsf%2FN8PHB9evN9ROq87acSbOGoNKoAJXQ67dCx9Haz99zudTzDds8alntrWeX2lWU3G8S9bIzc5n1gjxtwfub%2BUYOKUY%2FsIpSXnVoR3zhOxQ1boi70h4tr%2Bya7TyF9COpXzty1G3fzfncK%2FfJ979nnzzabl%2BzWueG04tFd%2B%2Fjs7IEOLsvHE49%2FW7RbjZlXFdHtibgY1Nhy0LnJZkb92mVZcsmN%2B3nYuMWjpduOKa329cjp2Av3umK0s6vBXTNIL4rLyVLvn4ezjm25VgOpfpNRTBkMufxixUtkSoZCDk3TSJAhnuGdKPCHkijRQo6HS61szTuixOu9%2BHUHgwOSbJv7HUX2IHKI4WHgq0EStYtLFT3A5TrkPUMP82Xwq3nvS1jKF%2Bu%2BDgHoJcM39vb6Byv%2FJ5t9hybgEtSC4GiFyhlecPT6nqubQjf82dR6yNP3xe5Y%2Bh8qds32D6vNTuXaKGofLgztTyzpvKlUFvrr1%2FbTTfa%2F5f8BFn%2BVCT3l5BL%2FXCyfi%2BVzsXwuln91sajHHs4gGGJlVtJL1bxeyxcr%2FaJhlotmxShUarpeqxzruqnrqgjgYj2sF%2FlS2n8jIXwnnLKYZGX92pqXKK63T0bfotsebWVdzPRm9yxt1q3jWmnBT9HrX7gMBVaVDgAA)

[Test repliqo.app/inbox-domain example.com/inbox](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOCNV2oC%2F%2B1XbU%2FqSBT%2BK80kN%2FtBwGJ5sxuTBatYSdEKrqgxZNqewiylU2emQDHub9%2BZAgrovbvfdu%2FGT3TO65xznvO0vCAB0yTCApD5ghJGZyQAZgfIRAySiDzTEk4SVHhTdfFUmqKblVIqOLAZ8SF3IbFHF8WATjGJ31W7LlpupL0ZzYBxQmNklgsooiN6yyJpPBYi4ebh4dYl3p6TeCT9AuA%2BI4nIfdEpjWPwBdfEmPB1cE1QbZOUjzGDYJUbuKkxmgrg%2BTmNA02aR1vmv3ANchGJQ4a5YKkvUgYalqY4FWPKyFJ5C%2BXDQUlVZlgnLqmyMCPYi8DaueY3DvwGRvLwzdSadz2N5QeNhn%2BTuqBBaVTSUl4EKSyWf9W%2BBRMylVE8zKFW0ayO7WhJ6kXE1yaQafm8VGNl1SFl231Rk8li%2Fzr1OpBZK9H%2BuJXBDQSEyaZ%2Bx0SqKAs4Mh9fkMgSNWJnIOVjyoV8%2Fk2BhpJY8D5dQ0N2usinIilttaGEp3hJYzznJZ9Oc6AR2V6RSUDoBSSERINR0%2FXXwqdZVPN3E4UAgYf9yfcyScE%2FztS7Pnc%2B5OJJeJNGwPOi%2FCgNwNyNvBWgP%2Bi%2F%2BzNQEUrD1RTkkBSKscBSlZysxom27iEfF0LiOpQjFQ4W%2FpjEI4cGKm4zitDr02sBybQwfJ%2FEk4y4mRYssNxsWBe7vkO%2BAPI4kguQDMnGKcEMT7migI37447%2F0ybA4zrCk9rudWeV9A2YSqNKUULHbodOU2%2Bf9p7bPdszLPes1XRvm81Ku9u0TlvE7bRG7ul9YI1bcHHm%2Fl6HqtGIrDJUlna9jK8dp%2BqG56Ih9IfLK%2Bt6dp9C%2BhA0us7CtVp3i%2F7NFPqV%2B96zz58ttjiyzi8M5zwe3bUPzs4e6KBTOZh4%2FI%2Bsfd6aezUR3R6Ky0GdLQf29WxuNK5cNks63LhfhK1bPFq67ZjSWl%2BPHNvK3Kuq0Z51B3enQXpZXk6Wev8inNtW0222kOo8GcWUwZDLX6w2FJlyV6GApmkkyBDP8bso8IdyZaJMDopLrWzN3srEK4bcDGcNip2VeWvwh4XZAswuooeBryZKFDOHnmE0cD0o6o3jarFiHOtFr16Hou%2FrFXxcM%2FRK3dti%2BU9eAD%2Fg%2BT1sAZc4FwRHOVDnOOPodX991xXnC7FX9u4C79f9vr4%2FW90rLvhB4bMTSS1l7VNS0f7EcuXXRcuaf5IyP1Defs3Jyf%2BWJHYQ%2Bp8a1lNBcv4XBX1R0BcFfVHQv0RB6gMSzyAYYmV7pB%2FVinq9WK72y4ZZ0c1Ko1Qz6tVG5UDXTV1XlQAXq4m9yK%2Bv7e8u1L1K5J%2FMZ1zrTLp03EqFk1z0ew%2BD8dJKJtnkMLNnrQPqexPbPkGvfwHj9v%2FV8w4AAA%3D%3D)
