### PR TITLE
Add spidee.ai.custom-domain template

### DIFF
--- a/spidee.ai.custom-domain.json
+++ b/spidee.ai.custom-domain.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "spidee.ai",
+  "providerName": "Spidee",
+  "serviceId": "custom-domain",
+  "serviceName": "Connect your domain to your Spidee site",
+  "version": 1,
+  "logoUrl": "https://spidee.ai/logo.png",
+  "description": "Points your domain at your Spidee website by adding two A records. Your email and everything else on your domain stay exactly as they are.",
+  "syncPubKeyDomain": "spidee.ai",
+  "syncRedirectDomain": "spidee.ai",
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "75.2.60.5",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "75.2.60.5",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **Spidee** (https://spidee.ai), a website builder.
`spidee.ai / custom-domain` connects a customer's domain to their Spidee site by
adding two static A records (`@` and `www` → `75.2.60.5`, the Netlify load balancer
that serves Spidee sites). Non-destructive: it only adds the two web records and
touches nothing else in the zone (email/MX preserved).

## Type of change

- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using the Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`  (spidee.ai.custom-domain.json)
- [x] resource URL provided with `logoUrl` is actually served by a webserver  (https://spidee.ai/logo.png returns 200 image/png)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set  (spidee.ai; public key published at _dcpubkeyv1.spidee.ai)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`  (warnPhishing not set)
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`  (set to spidee.ai)
- [x] no TXT record contains SPF content  (no TXT records)
- [x] `txtConflictMatchingMode` set on TXT records that must be unique  (no TXT records)
- [x] no variable used as a bare full record value  (no variables at all — both A records hard-code the IP)
- [x] no bare variable used as the full `host` label  (hosts are literal @ and www)
- [x] no variable used in `host` to create a subdomain  (n/a)
- [x] `%host%` does not appear in any `host` attribute  (n/a)
- [x] `essential` set to `OnApply` where the user may modify/remove records  (n/a — both records essential to the service)

## Online Editor test results

**Editor test link(s):**

- [Test spidee.ai/custom-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH4nWGoC%2F%2B1T32%2FTMBD%2BVyy%2F0qRJlrQ0EhLdxgOCwX4xBFMVOfEttUjsyHYaQtX%2FnXOzriswxBtC4sn23X13n7%2B7W1MLdVMxCzRd00arleCgX3OaUtPgFXwm6OjB8Y7VGEivti60G9ArUcA2vmiNVbXHVc2E3PvuISdKSigs6VWryRBDrBqeQzpihHU5V6CNUJKm4YhWqlQfdIX4pbWNScfjB1Zj5%2FMbWSKEgym0aOwWRs%2BVkNYcVGL2oFIHuStG8p4wzoUsie0UmRMNhdLc%2BOSTCwaEVoRJTgA59XbpAqEyQJQ8yG4s6wl8ZYWtMKEhdgl4avCdCr0sztv8DfSngzCHwjr3JXCBle2TAceVKr7Q9I5hbbQsMTV%2FeN5zpuntmtq%2BcVrPEbdUxuL1pWveVo9rhc9p4kf%2BJPATNFuLuh5NgmAz%2BhWy67o%2FwS42I%2FpNScj2PBbYkN1XUBUcL%2FALVe9T463Uqm0ysYtvmGa1cSO4Q94eQBc77C2lrqIopdKQGTyZbTVSt7pFMeq2siJjHdubeJGxpql6JGjQiykOhZLDfDqhOLPsqY%2BOaMYLR1C4WWdRnjzPj5g3mwWxF7M48PIgLrzobhJHScIgnN49Wpuf9ul3e7MXCYwBaQVz8z%2BvOtYbuvmhWffsh2b9E%2FwXI2z4%2Fxb81RbgOhm2Ap4xFxYF0cQLpl44uQ4CZJqGsR9NwjCJnuE7CNwfwNjha2vcvsd7R%2FObtzIOx1efp%2BXpyfFZfjErWWLe56cXr4rj60t2Nv%2FYyun0ph2rF3TzHS3tn1ZwBgAA)
- [Test spidee.ai/custom-domain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKsnWGoC%2F%2B1UbW%2FTMBD%2BK5a%2FrknTZGloJCTK9gE0CU1bEZSpitz42lokdrCdZqHqf%2BfcrOsyGOIjSHyK7%2BW5l%2BfusqMWyqpgFmi6o5VWW8FBv%2Bc0pabCJ%2FhM0MGj4QMr0ZHeHkyoN6C3IoeDf14bq0qPq5IJebI9QC6UlJBb0qpak86HWNWJXThihHUxt6CNUJKmowEt1Fp91AXiN9ZWJh0OH6saOptfyTVCOJhci8oeYPRaCWlNLxOzvUwNLF0ysmwJ41zINbGNIlOiIVeaG5%2FMnTMgtCBMcgJYU2s3zhEKA0TJXnRjWUvgnuW2wICG2A3gV4PvWGhlfl0vr6C97IjpE%2BvMN8AFZrYvOrwtVP6VpiuGuVGzwdD8UXyomaZ3O2rbynE9RdxGGYvPN254Bz5mCsUk9kN%2FHPgxqq1FXqNxEOwHv0I2TfMn2MV%2BQL8rCdmpjgUO5NgKsoLrBX6uyueh11rVVSaOkIppVhq3hUfwXQ%2B9OMLvDniXV6yl0pAZ%2FDJba2zA6hopKevCiow17KTiecaqqmixTINWjNKnS3Zb2lXGmWUvNTygGc9dlcLtfJKsVhBNmDeKWeidnzPuTfLVyoviPMqXAQsno8mT8%2Fnprn53Pz2ywBiQVjB3CtOiYa2h%2B2dzO7Xg%2F1ttLAY4%2F%2F%2Fj%2BGvGgZdm2BZ4xpxnGIRjL0i80XgWBFhsGk%2F8MI6TMDlDOQhcG2Bs190Or%2FLpPdL2Ys6Xy6C1%2BIscRnX5qWU3V7eTs8tvyew%2B%2BjJPpq%2FeRXEy%2FxwGr%2Bn%2BB5v67vWOBgAA)
