### PR TITLE
Add Vane rewards and email onboarding template

### DIFF
--- a/vane.promo.onboarding.json
+++ b/vane.promo.onboarding.json
@@ -37,7 +37,7 @@
       "groupId": "vercel-verification",
       "type": "TXT",
       "host": "_vercel",
-      "data": "vc-domain-verify=rewards.%domain%,%vercelVerificationToken%",
+      "data": "vc-domain-verify=rewards.%fqdn%,%vercelVerificationToken%",
       "ttl": 600,
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "vc-domain-verify=rewards.",

--- a/vane.promo.onboarding.json
+++ b/vane.promo.onboarding.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "vane.promo",
+  "providerName": "Vane",
+  "serviceId": "onboarding",
+  "serviceName": "Vane Rewards and Email",
+  "version": 1,
+  "logoUrl": "https://vane.promo/favicon.ico",
+  "description": "Connects rewards.<customer-domain> to Vane and authenticates the customer domain for email sent through Vane.",
+  "variableDescription": "%postmarkDkimSelector%: Postmark DKIM selector; %postmarkDkimPublicKey%: Postmark RSA public key without the k=rsa;p= prefix; %vercelCnameTarget%: project-specific CNAME target returned by Vercel; %vercelVerificationToken%: optional Vercel ownership token without the rewards.<customer-domain>, prefix.",
+  "syncPubKeyDomain": "vane.promo",
+  "syncRedirectDomain": "vane.promo",
+  "records": [
+    {
+      "groupId": "postmark",
+      "type": "TXT",
+      "host": "%postmarkDkimSelector%._domainkey",
+      "data": "k=rsa;p=%postmarkDkimPublicKey%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "k=rsa;p="
+    },
+    {
+      "groupId": "postmark",
+      "type": "CNAME",
+      "host": "pm-bounces",
+      "pointsTo": "pm.mtasv.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "vercel-routing",
+      "type": "CNAME",
+      "host": "rewards",
+      "pointsTo": "%vercelCnameTarget%",
+      "ttl": 600
+    },
+    {
+      "groupId": "vercel-verification",
+      "type": "TXT",
+      "host": "_vercel",
+      "data": "vc-domain-verify=rewards.%domain%,%vercelVerificationToken%",
+      "ttl": 600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "vc-domain-verify=rewards.",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a signed synchronous template for Vane customer onboarding.

The template configures:

- Postmark DKIM and Return-Path records.
- The fixed `rewards` subdomain CNAME for Vercel.
- An optional Vercel ownership-verification TXT record.

The synchronous signing public key is published at `_dcpubkeyv1.vane.promo` and has been verified against the private key used by the Vane API.

Validated with the official `dc-template-linter`, including live logo reachability, and with the Online Editor using both apex and subdomain test cases.

# Description

A self-service onboarding procedure for Vane clients.

The template allows Vane's onboarding API to configure the DNS records required for the customer's `rewards.<customer-domain>` site and Postmark email authentication through a supported Domain Connect provider.

# Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [X] Resource URL provided with `logoUrl` is actually served by a webserver

Additional validation:

- `dc-template-linter -loglevel error -tolerate info -logos vane.promo.onboarding.json` exits successfully.
- `https://vane.promo/favicon.ico` resolves successfully and serves an image.
- The signing public key published at `_dcpubkeyv1.vane.promo` matches the Vane API signing key.
- Apex and subdomain application results were checked in the Online Editor.

# Checklist of common problems

- [X] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [X] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [X] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [X] No TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [X] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [X] No variable is used as a bare full record value
- [X] No bare variable is used as the full `host` label
- [X] No variable is used in the `host` field to create a customer-controlled subdomain
- [X] `%host%` does not appear explicitly in any `host` attribute
- [X] `essential` is set to `OnApply` on the optional Vercel verification record, which may be removed after ownership verification

# Online Editor test results

**Editor test links:**

[Test vane.promo/onboarding example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA1kWGoC%2F%2B1WbU%2FjOBD%2BK5YlPl1TkpS2tHucFFqEEFuOl%2B4eK4Qqx3ZaL4mdtd1CQfz3G6cpTaFdrfa%2BcBJfIMk8npln5plxn7DlWZ4Sy3H3CedazQTj%2BoThLp4RyevwJVO49mI5Ixkg8VewwVfD9UxQXsCVjBXRTMjxylBBo0t%2BD2aDiGToKCMiBdiMayOUxN2ghlM1Vl90CvCJtbnp7u6uEthNCLhTsg5%2F4BjjhmqR2%2BIo7ikpObUG6UWE%2Bp90aqzKuPaYgkDyL2QVKnJwscnUTri0ggJng%2BAZLeFoAUeJ0oi7DJEBIEC0mo4nhYe6S5poQeKU99ey2MmVsRnRd%2F07kV3xFDJSeqeLzsvPqH96MgCHC8MntIY%2Fn8apoKd8Xj1weRWhvDCgOz5H98JO1NQWGd8daEM%2B5Qco1zwRD%2BANKkl52pNQ8CHRY27BE5TuO0TzTM6pSMBN7ywaHCFb2KFadqolZyieo6%2FF6Rc38OrwxFEbqjsuwZkqiJK0xCJ1L6F5E5FDcQGxlt7WRtTKhF0ZzVxS4A2k%2B4XxteKc%2FZIzoYHCZgRYFITB3ZsnPIYe5YUOl3UFgJ3nTn7D6yG8TOD71j7VR4sModBOX8QSgC6rvKVVLoAFvTZavg%2BPDxaEmIDNDoilE5iDgWIu%2FHlBGW%2BElLZVLPxc%2BzmZoocrOnnmxWoqKTduSJWQ1gxV8b2eWWJmdcltNdF194t2e%2FBuF3O7OUjZz%2FUIGyS3DLQtzqyiqy3tGS2gqybMaCmexen5wVJcO8kPJndqWyVbSeY%2Fd2drEnCOG7clBHGb628Z5Xk6x8%2B3zzX8qCQfrTR6C5SWMuYPBJYur1OVrajDU1GxkSjw1d6%2F6dOmgkKAnGiSGbfJl6Fu1mLdLoPdYPdchPvdUBvGyLkK%2FbDlt%2FwgDAN%2FL8iz19iX%2BXHgwclxMoj8497Vj%2BOrk7jRvzg6jC6%2BRNHe8VnU7x2Ki9PD8UVvyI2FEyf96CI6dA7fSM85a9B9QkNKkriZ%2BB3aqJeZM2k8P2gvC7BFL85DEjYYp0EziEngt1nMGq0Yu1aKsVSajwz8J7A1QTdWT3kNZ9PUihEBLbx8YnREnAag8was4Ba205rS5eJSfF2on66g3yrU2n4aMep0Idw4Bp2402gGTS9psYa3FwYNr0PD2AsZcG7vd3zSblXu%2FLe%2FBrbe%2ByspV8ciSu%2FJ3OBntxRebZiyGGtrrOS%2BbYW9dy6rbVkS%2BRVhVpfVO6O3ptpf38%2BVvVPbOFjvhfLL0n6%2BrcGW%2FhjXj3H9GNf%2FxbjCbW7IjLMRseWEen7bC1pDf6%2Fb3Os22vX9%2FdZ%2BM%2FzD97u%2B7xjAwC0K8QS3evU%2BxwkLv4vraMBY1HmYPcb0cXj4PY%2FSb6dnZ9ef%2F9m90uKcDvrfovYR%2FEj%2FF8TrSnc3DwAA)

[Test vane.promo/onboarding example.com/club](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA9kWGoC%2F%2B1WXU%2FjOBT9K1YknqYJSVrK0FlWSluEWFSG0sLsCKHKcZzW28QOsVPoIv77XicpTUqzWs2%2BzK54AeJ7fD%2FPPfjFUDROIqyo0XsxklSsWEDTi8DoGSvMqQUnsTBab5YrHAPSuAMbnEqarhihOVxwX%2BA0YHy%2BNVTQ6IY%2BgVkizAN0FmMWAWxFU8kEN3pOy4jEXNymEcAXSiWyd3i4TeAwxOBOcAt%2BwLWASpKyROVXjYHgnBIlUVpEsH4hmVQipqkZCAjEf0VKoDwHHRtnakG5YgRqlgj%2BRhs4KuAoFCmiOkMkAQiQVGTzRe7B0knjlGE%2FosNaFgeJkCrG6XK4ZPGERpCRSA966Lo8RsPLixE4LAxfUA1%2FnfkRI5d0Xb1wM%2FFQkhvQkq7RE1MLkak84%2BVpKvGX5BQlKQ3ZM3iDThIaDTg0fIrTOVXgCVr3B0QzZUIJC8HN4MobnSGV26FbKks5DZC%2FRnf57Tc38KnxWJc2FUvKwZnIC8VRiUXiicPwFiyB5gKill7jIFplwrqNcs0J1A1FD3PjLuO0%2FYYGLIUS9iPAIiCM0bt%2FMeYwoyTn4aavAFDrRNNv%2BvsUPhZw3jgna1ZkCI3W%2FMIKA3TT5YZR6QAK%2BNru2jb8%2BayAiCHY1AgrsoA9GIlAh7%2FOSzb2QkrbNpbx2vr7YvIZbstJYtMXGSdU6iUVjCs5Ffm5FSssVxanqppo3X0xbhO%2BVbG3%2B4OU86xH2EO5TaCmOKsKrxrGMyug2yGsSEme4vb6dEOug%2FAx4AetRspWkvnX02lMAu5RqVWCYa1cX7mXJNHaeH14bRl%2FCk5nW44%2BQEkbGtNnDKJLLSLibekkynz4yrs2Y%2Fmd6vzfzWpfUyFIglMcS63mm3D3tXgPm4D3RcSHMuSPhtuzTtqVa7tdu2s7ruvYHSeJd7Fve6TBo4vzcOTZ54PJ4%2Fnkwm8Px2d9b3zreZ3zK2846LPxZX8%2BHkypVHDjYuiNvb52%2BI6C2lmbfMbEJTj0j0L7hLStMvOAS9N2jjdNaOCN9hC67YAS58jxsWMfB37Q7kKfYKRszkVKZxJ%2BY1BP4I9KM9oy4ixSbIaBE29HAZlhzQVggAQruAWVqjGeF%2F8cdxtVkSKrpMSOHv1Qt2piNQuIJgjTu9k5cbo%2Btj%2BbgRvaZic48U3fDrsmdZ3jkBLXP3I7lQfA%2B6dB4yOgzuvqnnjRE15L41WrxI7klF3Z6tpOE5qE7b9Q1EY16hX9E75WtewnrLNG6FLCd6pslFANsyoC1dq7fT9TA95U%2FvWhBbL%2Bsdcfe%2F2x1%2F%2BvvYb3gcQrGsywKlfZtI9Npzu1O72jTq99Ytld12nbn2y7Z9u6CljKoiMv8E6ovhCM78fBGHfv%2Bpcni1F4%2BDh01t8mYyImw3gquqvfluO7aRZ%2B78dXh7fw%2FP8LCyPg25EPAAA%3D)