### PR TITLE
Update VibeHost template logo and TTL

### DIFF
--- a/vibehost.vn.hosting.json
+++ b/vibehost.vn.hosting.json
@@ -4,7 +4,7 @@
     "serviceId": "hosting",
     "serviceName": "VibeHost Custom Domain",
     "version": 1,
-    "logoUrl": "https://vibehost.vn/image.png",
+    "logoUrl": "https://vibehost.vn/image.svg",
     "description": "Trỏ tên miền của bạn về máy chủ hosting VibeHost",
     "variableDescription": "%ip%: IPv4 của máy chủ hosting VibeHost mà tên miền cần trỏ về",
     "syncBlock": false,
@@ -15,7 +15,7 @@
             "type": "A",
             "host": "@",
             "pointsTo": "%ip%",
-            "ttl": 3600
+            "ttl": 300
         }
     ]
 }

--- a/vibehost.vn.hosting.json
+++ b/vibehost.vn.hosting.json
@@ -3,7 +3,7 @@
     "providerName": "VibeHost",
     "serviceId": "hosting",
     "serviceName": "VibeHost Custom Domain",
-    "version": 1,
+    "version": 2,
     "logoUrl": "https://vibehost.vn/image.svg",
     "description": "Trỏ tên miền của bạn về máy chủ hosting VibeHost",
     "variableDescription": "%ip%: IPv4 của máy chủ hosting VibeHost mà tên miền cần trỏ về",

--- a/vibehost.vn.hosting.json
+++ b/vibehost.vn.hosting.json
@@ -6,7 +6,7 @@
     "version": 2,
     "logoUrl": "https://vibehost.vn/image.svg",
     "description": "Trỏ tên miền của bạn về máy chủ hosting VibeHost",
-    "variableDescription": "%ip%: IPv4 của máy chủ hosting VibeHost mà tên miền cần trỏ về",
+    "variableDescription": "%ip%: IPv4 của máy chủ hosting VibeHost mà tên miền cần trỏ về; %ttl%: TTL cho bản ghi DNS, khuyến nghị 300 giây",
     "syncBlock": false,
     "syncPubKeyDomain": "vibehost.vn",
     "syncRedirectDomain": "vibehost.vn",
@@ -15,7 +15,7 @@
             "type": "A",
             "host": "@",
             "pointsTo": "%ip%",
-            "ttl": 300
+            "ttl": "%ttl%"
         }
     ]
 }


### PR DESCRIPTION
# Description

Updates the VibeHost Domain Connect template to match the final Cloudflare onboarding configuration.

Changes:
- Switches `logoUrl` from PNG to SVG: `https://vibehost.vn/image.svg`
- Changes the A record TTL from a fixed value to the `%ttl%` variable so VibeHost can keep the recommended TTL configurable from the apply request
- Uses `ttl=300` in the Online Editor tests, matching the Cloudflare recommended Auto TTL equivalent
- Bumps the template version to `2`

Cloudflare has already enabled proxying for this onboarded template. This PR keeps the source template aligned with the current requested configuration.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

The template creates a single A record intended to remain managed by the hosting setup; no optional TXT/MX/DMARC-style records are included.

## Online Editor test results

**Editor test link(s):**

- [Test vibehost.vn/hosting sang0023.io.vn/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALyvWGoC%2F9VTbW%2BbMBD%2BK5alflpCDaQhZZq0vq7T1qpa02laGqEDHOIWbGQbUhrlv88mZEmjVvu8Txx3z7089%2FiWWNOizEFTHC5xKUXNUiq%2FpjjENYvpXCjt1Bz3%2FoZuoDBQ%2FNMEr0zQRBSVNUtom2PxjGdb7x4cnVVKiwKdiwKYLVtTqZjgOPR6OBeZuJe5LaN1qcLDw50RDlkBGXVUbYunVCWSlbrNxGP5ULk0mSH9UBFCgaOCtR6Xo8QaNAAUWwOMp16HUNGC3QYl8zUGdcOjHW41SAZxTs9fNTxg5UGIvt7Wg239f5frIOTdMSHgSG%2B4dGN%2BRAda56bbePzdlBYdD5%2BjbM7Q%2Bc1dDz3Nq8Y64xlHPGu7JzHyCUEZazt5jdWj4clpLpInHM4gV3Ttua3ib7Tp1NiX3AJ%2B0JRJmuh3ICYkZKpwOFli3ZRW6hPjtgBjfrbvRjCu1Vh0azMew8f%2BWFp4NV318IvgNNpWmhp9N90U8IwQz3eYWDfsKhsrk6IqI7ZJKUFCoewj3iRP9rOnm%2FQJtjYrreUOieMeu84ocDxvYP3tfBNsFojtdCzjQtJImS%2FoShqKWlZmfUWVaxbBArauNImgLPPGkFEmaqq8XgtfH4NdSwoajLnXvWtuWvdwlCaWDbNnRVOAmM7S%2FpDEcX%2FgB6P%2BaHYE%2FUEwhNgH30sGwc6NvnG%2Bbx%2FpdptUKco1AyvNSb6ARuHVatozm%2F3PKRhBFdQ0jcDCPOIN%2ByTou8OxS0I3CH3PcYd%2BMBh9ICQ0ipvxqdJrakuj%2Fq7u%2BGVxVmWjI37Hjx8f6cmvq6fyOVcXF5f15fXva2i%2BkJE41ffPi6uLT3j1B5DilAFbBQAA)
- [Test vibehost.vn/hosting sang0023.io.vn/test1](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMuvWGoC%2F91TXW%2FaMBT9K5alPi2A81FSMk1aOyZRsaJqY10niiLHMcFqYme2kzZD%2FPfZIQyKWu19T7HPPTn3nnt9N1DTosyxpjDawFKKmqVUXqcwgjVL6Foo3a85dP6GZrgwVHhnghMTNBFFZc0Ibf%2BxfMazA3pCB58qpUUBxqLAzMrWVComOIw8B%2BYiE99lbmW0LlU0GByVMGAFzmhf1VY8pYpIVur2TziXD5VLyQrohwohijkoWIu4HBB7oCEGiT1gg9S7EChastsAst5xQFc8OPJWY8lwktPxi4RnrDyLwPVtHRz0%2Fy3XUdCbZeKQA7330pX5HpxpnZts8%2FkXIy06Hz4H2ZqB8eybAx7XVWPBZMUBz9rsJAE%2BQiBjbSavsfNoOLnKBXmE0Qrniu6Q2yqZ0qabxunILeErTZmkRL9BMSEhUwWjxQbqprSjvjSwJZjjR%2FtuBONazUXXNoMYP%2FZibcHtcuvA34LT%2BKC0NPPdZ1OYZwh5fp%2BJXcJOWVOlXXPNpKjKmO3%2FK7HEhbIvea%2BwOJVY7jUWnYgBWGmv7hD13ZHbvwj7nhdYvK10AU0roa2TZVxIGivzxbqSxqyWlWlkUeWaxfgJH6CUxLgs88bYUiZqVF42iO%2FWYm8jxRqb60kFXQEmvQPjlFhbzC7Zyj8no3MX9dKUhL0gDC96SRKOeh4JAoLOw%2BAiGB1t7CvL%2FPrKnvSWKkW5ZthO6zJ%2Fwo2C2%2B3SMX3%2BX7yYEStc0zTGlushb9hDYc8dzl0UuWEUhP0A%2BS4K3iEUmTfgtHI7fxvzHo5fAhyE5Y0%2FJz%2Buw%2FBmcln%2BHE6T6ep%2BOvGvfgVyVszumvRejp9vJ0%2BfP8DtH1sK7JF3BQAA)
