### PR TITLE
Add clarflow.com.funnels template

### DIFF
--- a/clarflow.com.funnels.json
+++ b/clarflow.com.funnels.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "clarflow.com",
+  "providerName": "Clarflow",
+  "serviceId": "funnels",
+  "serviceName": "Funnel hosting",
+  "version": 1,
+  "logoUrl": "https://cdn.prd.clarflow.com/email/clarflow-logo-square.png",
+  "description": "Serve your Clarflow funnels from your own subdomain over HTTPS.",
+  "variableDescription": "%acmtoken%: label of the AWS Certificate Manager DNS validation record, without its leading underscore; %acmtarget%: ACM validation target, without the fixed .acm-validations.aws suffix; %cftarget%: Amazon CloudFront distribution name, without the fixed .cloudfront.net suffix",
+  "syncPubKeyDomain": "clarflow.com",
+  "syncRedirectDomain": "clarflow.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "ssl",
+      "type": "CNAME",
+      "host": "_%acmtoken%",
+      "pointsTo": "%acmtarget%.acm-validations.aws",
+      "ttl": 3600
+    },
+    {
+      "groupId": "routing",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cftarget%.cloudfront.net",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template for **Clarflow** (<https://clarflow.com>), a funnel builder. The
template points a customer's subdomain at the Clarflow funnel hosting stack — an Amazon
CloudFront distribution fronted by an AWS Certificate Manager certificate.

Two records, in two groups, because they become available at different times:

- **`ssl`** — the ACM DNS validation CNAME. Applied as soon as the certificate is
  requested; ACM cannot issue until it resolves.
- **`routing`** — the CNAME pointing the customer's subdomain at their CloudFront
  distribution. That distribution cannot be created until the certificate is issued, so
  this record's value does not exist at the time the `ssl` group is applied.

Hence one template applied twice by group, rather than two templates.

`hostRequired` is set: the service is only offered on a subdomain. The `routing` record is
a CNAME at the applied host, which is not valid at a zone apex.

The template is signed (`syncPubKeyDomain`), and `syncRedirectDomain` lists our production
domain only.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Notes on the unchecked / not-applicable items

**Rule 7 (bare variable as `host` label)** — the `ssl` record's host is `_%acmtoken%`. The
label is an opaque token minted by AWS Certificate Manager (e.g.
`_3639ac514e785e898d2646601fa951d5`); ACM dictates it in full and there is no fixed suffix
we can pin it against, so the exception in rule 7 applies. We have narrowed it as far as
the format allows: the leading `_` is fixed in the template rather than carried in the
variable, so the variable cannot escape the underscore-prefixed namespace that DNS reserves
for this kind of record.

**Rules 4 and 5 (SPF / TXT)** — the template contains no TXT records at all, so both are
vacuously satisfied.

**Rule 10 (`essential`)** — both records are required for the service to function: removing
either takes the customer's site offline or breaks certificate renewal. Neither is
user-tunable, so the default `Always` is the correct treatment and `OnApply` would be wrong
here.

**Rule 6 (bare variable as full record value)** — satisfied. Both `pointsTo` values pin
their fixed suffix in the template (`%acmtarget%.acm-validations.aws`,
`%cftarget%.cloudfront.net`) so the variables carry only the account-specific portion and
cannot redirect the record to an arbitrary host.

## Online Editor test results

All runs use `domain=example.com`, `host=funnels`. No apex run: `hostRequired` is `true`.

The two groups are applied at different moments in our flow, so each is tested in isolation
as well as together.

**Editor test link(s):**

1. **Both groups** — [Test clarflow.com/funnels example.com/funnels](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANu0WGoC%2F%2B1UbW%2FbOAz%2BK4KAfWri2nHivBwGXNGu2zC0K9YOu0MRGLJEp1ptyZHkpFnR%2F36UEzdJm21fD7jLlyQi%2BZB8%2BJCP1EFZFcwBnTzSyuiFFGA%2BCjqhvGAmL%2FQy4LqknWfbJSvRl55urGixYBaSQxOU10pBYbevG%2Ffz5p3caeukmqF5AcZKregk6tBCz%2FRXU6DbnXOVnRwfc6GCyohgt4ZjKJksjtunro%2Fq2nnNDARVgynAciMr1%2BDSaywAyErXhrTFkk15JDe6XJv0UhFbZ0IjuCIayyIfbm6urgNfIzOSZQWc7eG%2BYbx0%2Bh7UmwkpWIZd6Zy4OyAn367JKRgnc8mRUHLBFJsh3tnlNVmwQgrmEYgBro3okKV0d7p2RDpLCmACeSG1QoYt2uEP0uRhZgYOE52cXuxirN%2B3GD59Lh9AkACjultPG7ClxQZztCIkz7eIJfuBSKeFrsW50coRIa0zMqubDArndhCf%2B4DcBwQK3Abaz3ul%2BFWdfYLVWcPlawV5jy8gJBLgfubjBfIF5jU6oZycqaFD14RZOrl9pDOj66pRmrUF%2BrtV1ajx8uTi3SYc%2F6bbGXnlaqmcvdHt7NYMHCLKAzrUYZyE4VNnNxv%2B2Aj3cMY%2FX%2BR5JvoFX3sZpk8dijOAdNvhFFXcUgMPDFcTdpjZW7CmuFQ2YRs22ioRpWKGldYvdYt3uwc4bRFvnyGnG8yDeC2h3hgn8ZjxQdSH4WgAo%2FFI9JJ%2BkoRRzsaDSAxa%2F4YBH5DyhMV5BL2sLwaBy8uZUD%2Fc%2FN47tkx5PxE1H5ZxAfmIen7kTOE2pBa%2FmasNtKIo68LJlC3Z9knwlFVVsUI6LVoREAXzYlxqfY7S37UQbHlGfTAf8pMefqejDk0F93OQXke9YZxlYpB1%2BSCJuv14lHcznuXdQRjyfhjHSZSHO8f20CE%2BfG5fyQOsBeUk82f1pFiylaVPXtOHCXnV7v4ofqHif1V%2F0w5u0P9T%2F69NHc%2BIZQsQKfPevbCXdMNhN0puonASjye9OBiM434yPgrDSegrcWDduuVHvDG714Uu8od76H07%2Bvvjd20f7PyT%2BKzeZ%2BxoMQc%2B%2FJBEf1Xi6nvv%2Fnw4%2F%2FqWPv0D2MIfnEAJAAA%3D) — applies both records:
   ```
   _3639ac514e785e898d2646601fa951d5.funnels.example.com.  CNAME  3600  _c6a3f1e2b4d5.tfmgdnztqk.acm-validations.aws
   funnels.example.com.                                    CNAME  3600  d111111abcdef8.cloudfront.net
   ```

2. **`ssl` group only** — [Test clarflow.com/funnels example.com/funnels](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEm1WGoC%2F%2B1UYY%2FaOBD9K5alfjqSTQgESFWpiL3V3VWsVmXb6rRCkRNPWG8TO2s7ULriv3ccyMJuqfoHyhdg5s2bmednP1ELVV0yCzR5orVWa8FB%2F8tpQvOS6aJUGz9XFe09565ZhVg6O2QxY0CvRQ5tUdFICaU5Rg%2FwqzZO7pWxQq4wvQZthJI0CXu0VCv1SZcIu7e2NsnFRc6lX2vun85wARUT5UUX8lyVZx4bpsGvW04OJteiti0vXeAAQLaq0aQblhzGI4VW1T6lNpKYJuMKySVROBb55%2Fb2ZuG7GZkWLCvh8gXvG5ZXVn0F%2BSYhJctwK1UQew9k%2BmVBZqCtKESOgpI5k2yFfJfXC7JmpeDMMRANudK8RzbC3qvGEmENKYFx1IU0EhU2mIe3pO3D9AosNprO5qcc%2B%2FiRw7UvxDfgxMcq74g0PtsYXLDALFLmxZGxYt%2BRaVaqhl9pJS3hwlgtsqbtIPHczvLnrqBwBb4Ee6B2572V%2BU2TfYDtZavlzw5yiI%2FABQpgf4VxBvkIjw2C0E5WN9Cje8EMTe6e6Eqrpm6dZkyJeLutWzdeT%2Bd%2FH8rxb3o8I%2BdcJaQ1t6o7u70C54RyhBZ9GMVBsOuddsMfB%2BOe7%2Fj%2BVZ9noV%2Fp9aLDctejeAaQHjdcoos7aeAbw6sJJ8q8uGDtcKloy1o1sLZmmlXGXeWO5e4FzbLjuXsmWh6YTlg68VwoiqMJy4fhAEbjIYwnY96PB3EchAWbDEM%2B7PDttq4gzWMWFSH0swEf%2BraoVlx%2Bt49fHbBTxeF42H5YlnMoxtRpIVYSnZ8a%2FGa20dAZoGpKK1K2YccQz1NW1%2BUWpTOYRUI0x6ujkfunJ%2F3dCv5RU%2FQCcyW%2F2OF3nunRlOdOfeE8M4rH4xHvF17BeeENxiz2smgcelkQFJOsGAYjlp88rOce3fNP609WAGNAWsHcEzotN2xr6G637KGb%2FqjyWhW0oWFr4Clz6H7Qj71g5IXxbRgkgzAJIz%2FsB9Ew%2BisIkiBwe4CxewWe0KOn7qTj%2Fx4eZlI2N5NJtY6jqI4%2BD%2BRqHtcfpo9BdTWcPQTh4st0OP8%2Ff0d3PwB%2BoJk%2BbAcAAA%3D%3D) — applies only the ACM validation record:
   ```
   _3639ac514e785e898d2646601fa951d5.funnels.example.com.  CNAME  3600  _c6a3f1e2b4d5.tfmgdnztqk.acm-validations.aws
   ```

3. **`routing` group only** — [Test clarflow.com/funnels example.com/funnels](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJK1WGoC%2F91U227bOBD9FYJAn2or8k2xVSywRtJig2zSInG6zQaGQJEjmahEKiRl1w387zuUrdhOvfsB6xfbczkzc%2BZwXqiDsiqYAxq%2F0MropRRgrgSNKS%2BYyQq9CrguaefVd8tKjKUXOy96LJil5NAkZbVSUNi9dRf%2BqbGThbZOqhzdSzBWakXjXocWOtcPpsCwhXOVjc%2FOuFBBZURw2MMZlEwWZ62p67O69rlmBoKqwRRguZGVa3DpPTYAZK1rQ9pmya49khldbl16pYitU6ERXBGNbZE%2FZrMv94HvkRnJ0gIuj3DfMV46%2FR3Uu5gULMWpdEbcAsj0r3tyAcbJTHIklNwwxXLEu7y9J0tWSME8AjHAtREdspJuoWtHpLOkACaQF1IrZNiiHz6Qpg4zOTgsNL24OcTY2vcYvnwmf4AgAWZ195E2YCuLA2boRUie7RFL9hORLgpdi09GK0eEtM7ItG4qKNzbSXzuEzKfEChwO2i%2F77XiX%2Br0GtaXDZe%2FKshH3IGQSID7txgvkDt4rjEI5eRMDR26JczS%2BOmF5kbXVaM0awuMd%2BuqUePt9ObjLh3%2FJvsdeeVqqZyd6XZ3WwZOEeUBHepwEIXhpnNYDX%2FshHu64u9v6rwS%2FYavowrzTYfiDiDZTzhHFbfUwA%2BGTxMOmDl6YE1ziWzSXvvD%2FIoZVlr%2FnFukpyOoeYv19Ao236G9QWpJ9OZBNJgwPuoN4Xw8gvFkLPrRMIrCXsYmo54YtfHN1D4h4REbZD3op0MxClxW5kL9dM%2FffWDLjo8TvebDUi4gG1PPicwVvoDE4jdztYFWCGVdOJmwFdubBE9YVRVrpNCiFwFRJG9WpLYnaM8cbpyh4bjyfyyqQxPBPaHSS2E0FpwN%2B1E3TMeD7nAciW7a72XdQTqaQD8S0blgB%2Ffy1C09fTF%2F2TBYC8pJ5i%2FjtFixtaWbzbyDIvnfD4kisWwJImE%2Buh%2F6Ts67vWjWC%2BNhP%2B5HwXgyiIbj92EYh6GfA6zbjvyCCjrUDr38fAuKRVf8Zj2dXf%2B5mrhH%2B7B4uPuaP37729rR14jX7%2FPrj%2FLx6je6%2BQdweW1aEgcAAA%3D%3D) — applies only the CloudFront record:
   ```
   funnels.example.com.  CNAME  3600  d111111abcdef8.cloudfront.net
   ```
