### PR TITLE
Add plicklistings.com.website template

### DIFF
--- a/plicklistings.com.website.json
+++ b/plicklistings.com.website.json
@@ -1,0 +1,15 @@
+{
+  "providerId": "plicklistings.com",
+  "providerName": "Plick Listings",
+  "serviceId": "website",
+  "serviceName": "Plick Listings Website",
+  "version": 1,
+  "hostRequired": true,
+  "syncPubKeyDomain": "plicklistings.com",
+  "syncRedirectDomain": "plicklistings.com",
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "%SUBDOMAIN%.plicklistings.com", "ttl": 3600 },
+    { "type": "CNAME", "host": "www", "pointsTo": "%SUBDOMAIN%.plicklistings.com", "ttl": 3600 },
+    { "type": "TXT", "host": "%TXTHOST%", "data": "%TXTVALUE%", "ttl": 3600, "txtConflictMatchingMode": "All" }
+  ]
+}


### PR DESCRIPTION
# Description

New template connecting a customer's custom domain to their Plick Listings (plicklistings.com) site: apex + `www` CNAME to their Plick subdomain, plus a Cloudflare-for-SaaS ownership-verification TXT record.

A companion service, `plicklistings.com.website-email`, is being submitted separately (add-on records for custom-domain email sending) — split into two templates rather than one because they're applied independently and a single combined template would force every "just connect my site" applier to also receive DKIM/SPF/DMARC records they didn't ask for.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — done, see test link below (apex CNAME + www CNAME + TXT ownership record all verified with a `host` set, since `hostRequired: true`).
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` — n/a, this template doesn't set `logoUrl`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`plicklistings.com`) — **note:** the corresponding public key TXT record at `_dcpubkeyv1.plicklistings.com` is still being set up on our production DNS and isn't live yet; will confirm here once it is. The Online Editor test below used `ignore_signature` so this didn't block testing the template's records/variables themselves.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`plicklistings.com`) — this template uses `redirect_uri`
- [x] no TXT record contains SPF content — n/a, this template has no SPF-related record (see the companion `website-email` template for that)
- [x] `txtConflictMatchingMode` is set (`"All"`) on the ownership-verification TXT record
- [ ] no variable is used as a bare full record value — **not satisfied, with justification:** the TXT record's `data` is the bare variable `%TXTVALUE%`. This value is Cloudflare's own custom-hostname ownership-verification token (`ownership_verification.value` from their API) — we don't control its shape and can't safely wrap it in a fixed prefix without risking the verification no longer matching what Cloudflare expects.
- [ ] no bare variable is used as the full `host` label — **not satisfied, with justification:** same record, same reasoning — `host` is the bare variable `%TXTHOST%`, which is Cloudflare's own prescribed `ownership_verification.name` for this hostname. Cloudflare's SaaS product design (not ours) dictates this record's exact name; we can't add a fixed prefix without it no longer being what Cloudflare instructed the customer to publish.
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` on user-editable records — n/a, no record in this template is one an end user would need to modify/remove independently (unlike the companion template's DMARC record)

## Online Editor test results

**Editor test link(s):** [Test plicklistings.com/website example.com/sales](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJiVWWoC%2F%2B1UXW%2FaMBT9K5UlngbMCZSySJNGga3VCmVtoJMQikx8R60mcRY7pBniv%2B8awscY9GUPm6Y%2BJT6%2B9%2Fge33O9IBrCOGAaiLMgcSLngkNyzYlD4kD4T4FQWkQzVfVlSMrbgD4LMYEMTMjZTRGD%2BwqSufBhlZ%2FBVAnk3aJHk84etmFzSJSQEXGsMnmUSt%2FB91QkgFw6SQFp8sgfpNPPkHdkyER0okYTdgccM339YiAGyIQr4owXROexqa3db%2FW6ZH08Lj8YyVJEWrkSl6X74WXntte67peqxwi1DohTa1C6LJ9izLLszzndr%2B6OsYSrq9t7t4QQZ5oV0Kh1M%2ByW9gnw91m3ZfQNT9E9pv1HPKYnuWFsBQFZTpZl8kNG4O0uZoKcmyuEZ4ZOgaKu4nTFAjCNnyUyjT2xSYpZwkJlLLVJH%2F%2BSP9kQjAsGBLYXYVAOoTRgIe4AWokzmGXX6sTULWaRTMBT%2BGU6TWDjmTANtPBYxnYQ9z0Wx0GOMhXuIs3v%2FY%2FWVt2oK%2B7VVPByk8rE476RLcwEcApN7tNpxZ%2FazUqdwbQy5Q27wqFm4YK9o017b6hOTt3xqTroACgFkRYsWLUzY7kiyyM%2BLJShD6v%2Fkbr1RBTaVkIOxK2M8g9LmZRxbF59%2BOrDv%2B1DfGAVmwP3mIm1qd2o0IuKdeFS26k1HatRPbdos0HfUOpQaqSA0mtxC3yH919g8sWl8nKUJm9z9qlLw%2FaD7MihEPnVR7dt1cPBU9AJR%2Bd5BNnTe7L8CZEVCAeLCAAA)
