### PR TITLE
Add plicklistings.com.website-email template

### DIFF
--- a/plicklistings.com.website-email.json
+++ b/plicklistings.com.website-email.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "plicklistings.com",
+  "providerName": "Plick Listings",
+  "serviceId": "website-email",
+  "serviceName": "Plick Listings Email Sending",
+  "version": 1,
+  "hostRequired": true,
+  "syncPubKeyDomain": "plicklistings.com",
+  "syncRedirectDomain": "plicklistings.com",
+  "records": [
+    { "type": "CNAME", "host": "%SESDKIMTOKEN1%._domainkey", "pointsTo": "%SESDKIMTOKEN1%.dkim.amazonses.com", "ttl": 3600 },
+    { "type": "CNAME", "host": "%SESDKIMTOKEN2%._domainkey", "pointsTo": "%SESDKIMTOKEN2%.dkim.amazonses.com", "ttl": 3600 },
+    { "type": "CNAME", "host": "%SESDKIMTOKEN3%._domainkey", "pointsTo": "%SESDKIMTOKEN3%.dkim.amazonses.com", "ttl": 3600 },
+
+    { "type": "SPFM", "host": "@", "spfRules": "include:_spf.plicklistings.com", "ttl": 3600 },
+    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@plicklistings.com", "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" }
+  ]
+}


### PR DESCRIPTION
# Description

Companion to the `plicklistings.com.website` template submitted separately — a pure add-on for custom-domain campaign email sending on a domain that's already connected via `website`: Amazon SES's 3 Easy DKIM CNAME records, an SPF-merge record, and a DMARC record. Applied independently and later than `website`, only for customers who opt in to sending campaign email from their own domain (most of our customers already have existing mail elsewhere — Google Workspace etc. — this only ever adds records, never touches or replaces MX/existing mail setup).

Deliberately does **not** repeat `website`'s apex CNAME record: DNS disallows a CNAME coexisting with any other record type at the same host, and this template needs an SPFM record at the apex — confirmed via `dc-template-linter` (`DCTL1011`) when both were combined into one template during development. Splitting them resolves this cleanly.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — done, see test link below (3 DKIM CNAMEs + SPFM + DMARC all verified with a `host` set, since `hostRequired: true`).
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` — n/a, this template doesn't set `logoUrl`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`plicklistings.com`) — **note:** the corresponding public key TXT record at `_dcpubkeyv1.plicklistings.com` is still being set up on our production DNS and isn't live yet; will confirm here once it is. Same key as the companion `website` template. The Online Editor test below used `ignore_signature` so this didn't block testing the template's records/variables themselves.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`plicklistings.com`) — this template uses `redirect_uri`
- [x] no TXT record contains SPF content — SPF is handled entirely via the `SPFM` record (`spfRules: "include:_spf.plicklistings.com"`), not a raw TXT
- [x] `txtConflictMatchingMode` is set (`"All"`) on the DMARC TXT record
- [x] no variable is used as a bare full record value — the 3 DKIM CNAME `pointsTo` values embed the variable in a fixed pattern (`%SESDKIMTOKEN1-3%.dkim.amazonses.com`), never bare
- [x] no bare variable is used as the full `host` label — the 3 DKIM CNAME records use `%SESDKIMTOKEN1-3%._domainkey` (fixed `._domainkey` suffix, only the selector varies), matching the recommended pattern directly
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC TXT record — customers commonly tighten `p=quarantine` to `p=reject` over time, and this record should be editable independently without the rest of the template being treated as broken

## Online Editor test results

**Editor test link(s):** [Test plicklistings.com/website-email example.com/sales](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGiVWWoC%2F%2B1Wa08iMRT9K6SJn3hkHjADY0hEYbPqoiyQqDFkUqYFK%2FNi2hlEwv72veUhiAhuYjbrhk%2FQ6T339J7ennaCBPVCFwuKrAkKoyBhhEbnBFkodJkzcBkXzO%2FznBN4KPMScIU9AKCGDEn9WMTAPKdRwhw6w49olzNBs9TDzF3NbYWmajIo1aI%2BgSEEJzTiLPCRpWbQQ8BFkw5jFlHIK6KYQrKx7zTi7iUdVwOA%2Bu%2BsV4Y1KQGkI3YGQkAQEY6s%2BwkS41Cu8OyqUq%2BhOT0Mj1q1VvXyvN6%2BvqxdqUc5m8zyDehY6hIwX%2FB2sCWODJiXwx5%2BDnxOl3RCuMjSDUWZZj7Ep32QT%2FskPv2DfPof8LUa3%2BoruhO5O2GvGbsUVEfMd9yYUMuGb7ltG7QtY%2Fu2vUpoEw9HDowJFhjGSblarzTP1ONUWB7GOMI%2BpKPHqSjGZdlsIrBmiJOdbPD3SZwFfg%2BCRB0L5wGi6gGR9BVXtjXlnEJqDAB07VfC0B2jaWeaQSAItVd91YGVLTuQPmE4dHRBtiiAYylFBvWjIA5ttgSFsHSPy9O5hN%2B%2FwneWCe4XGeDDqxaUM1jtao5O8rTQM%2FrmQ5GVHpWB6mqe7ueDQmhsgjQJGppRkZeEEquJNtKf8uPCs4HNbtEpEYWqPW0TpEtQX3%2FIs8KjMTDdolfylUANtaEe5XlBGLGZFJGUhvX9IKI2h18s4oguT7UXu4LZeIRXn4hjY6kpKMlhFijenlB%2Fbin7ilxr6dxS7EWz7IXu7vIMdJ8jt4hJ43M07ORNU8%2FqPYKz%2BUJezeJS18wWnGJJV52eVuxqa176rtnuMtONnllvwoo7wmOOpluO%2BkKofRu7Q6i90P9KqH3NvEOovdCvLdTcehcybZSelMHE1dRuS0%2F9wjP7%2FJoVzy%2Bb3JvCP%2BfK%2BYeEeLnRpp0M3EYH7z1478F7D9578N6%2F673w0uY4ocTGMlhTNCOrmFnVbCuapZuWVswZuqkapbSiWIoiK6JczJWZwHt7%2FaWNtNOLRq%2Fq3tz1%2BvVkWE9fFIjSukkbjbRvfj%2B9G49wk1RweFu6%2FVlG09%2F9WeDPIRAAAA%3D%3D)
