### PR TITLE
add MailLogic, Email Forwarding

### DIFF
--- a/maillogic.io.email-forwarding.json
+++ b/maillogic.io.email-forwarding.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "maillogic.io",
+  "providerName": "MailLogic",
+  "serviceId": "email-forwarding",
+  "serviceName": "Email Forwarding",
+  "version": 1,
+  "logoUrl": "https://maillogic.io/static/images/mail-orbit-logo.svg",
+  "description": "Configures inbound email delivery through MailLogic.",
+  "syncPubKeyDomain": "keys.maillogic.io",
+  "syncRedirectDomain": "dc-lab.maillogic.io",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.maillogic.io",
+      "ttl": 300,
+      "priority": 10
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx2.maillogic.io",
+      "ttl": 300,
+      "priority": 10
+    }
+  ]
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
[Test maillogic.io/email-forwarding example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANOqWWoC%2F%2B1VbU%2FbMBD%2BK5G%2FkqROW1oaadLQNvYCjGkq0gaqIse%2BpoYkjmy3kFX97zsH%2BkLKNPYRaZ9q5Z473z3P%2BemSWCiqnFkg8ZJUWi2kAP1ZkJgUTOa5yiQPpSL%2BJvaVFYgl5xg9c1EMGdALyaHJApcWTJW%2BY1rIMtuGHxM%2FOIB3sgtYgDZSlSSOfII3qkudI3BmbWXiTme3j46xzErekQXLwDShQOlU2sDlhWbhygkwXMvKNiXJO1VOZTbXYDxZpmpeCq%2Fp0ROQS7y59uxMq3k28zYjha7puuTf5ukp1O8Vwl2lW6hN2GLFwb6DkBq43QAFD3KWtqEIUVoYEl8via2rhsQf%2BH2mjMXzW8exkqU1Y%2BXYv4%2FaBaxFWnqUOi2k0tLWyBhd%2BS8r131hucnKJ79UCcm23wlyup4N7hnuC4RcFdvL8JQhh1Ui1%2FiKaVYYt1PrzOsnqZN17jUh7kaZlUpDYvCXWRSLxFbPwSfFPLcyYbgrm0%2BCJ6yq8hobNBjFEi1Cy4dFcwwIZtm%2FkOmTRHDXtXS7TFNB%2B4OBCDiDadAf8FEwSvvTYDQdDgSDNKWQ7ryM517NX57Glj8wBkormdv84%2FyO1Yas2tI%2BN1j3VQ428XFJ%2Fsv26mTDZ2vYAkTCHKxLu4OADoNoOKb9mB7Fh1E4GPZG%2FaMDSmNK3Vhg7MPQy%2BbcWMJuT%2BFeFwhYMC1ZmsMTA2lZT2M4zmxWzlqdE%2Bxb6yPzO4nhE6of5Yiot7dqfxDxRaVa4qKlrhzzOf5HIHWOhpYw%2ByRgwq4Zkour6Opm3Is%2BHo9Gn6zunp3cXtj6S2%2BsT887l7w%2B7B9kN8Xx%2FRB%2BviGr3wVsEyTWBwAA)

[Test maillogic.io/email-forwarding example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOyqWWoC%2F%2B1VbW%2BbMBD%2BK5G%2FFohDGpoiTdq0F6nq2lVVKm2rImTwlbgDjGwDZVH%2B%2B860eSOd2n2stE8h3POc757nfCyJgbzMmAESLkmpZC04qDNOQpIzkWUyFYknJHE2sUuWI5ZcYPSrjWJIg6pFAh0LLM29k6phiosi3YafiJ8tYPBlF1CD0kIWJBw5BE%2BUNypD4MKYUofD4W4dQ22YEclQ5CwF3YVcqWJhXMvzdG3TcdCJEqXpUpKPsrgTaaVAD0QRy6rgg67GAYdM4MntwCyUrNLFYNOSZ4tui%2BSqis%2Bh%2FSQRbjP9glZ7PVUs7Bq4UJCYDZAnbsbiPhQhUnFNwtslMW3Zifgd3y%2BkNvj83mosRWH0TFr1H0b9BMagLGNKrRdCKmFaVIyunNel81%2BZbr5yyG9ZQLStd46arnuDB4bzAl4i8%2B1hTdPgnxRlLCOxppRMsVzbsVqTb%2FfY8zX9tuPbc0VaSAWRxl9m0DISGlWBQ%2FIqMyJiODGbVzyJWFlmLZapMYpZerIWj%2BP2WBpnhv2LqA6JeGJLF3amA59NAQLmTikP3GM2DdzT43HijhNKExqfBtM7tnNDnrs9L1yRPR1BayiMYPYSfMga1mqy6rv8fHf%2BW%2B1u7uDE%2FDfwDRuIt1mzGnjELNKnfuDSE3d0MqPHIT0NR4E38acTf3xEaUip7Qy0eex72T13m2K3LO%2BgEATUTAkWZ7C3V15cSnYhrewGtqvicANvvfB2Mnl78j9ZNKKDgxn8u7WvS9czHTfwyjqS4ScF9bTa9Aw7VAYJu1uTBM3VfRFXJfxMs0na3h%2FFl9f8fnZz0lx8oz8mZX1O6bjN%2FKo9e0dWfwDVuPtpBQgAAA%3D%3D)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
