### PR TITLE
Maillogic email sending

### DIFF
--- a/maillogic.io.email-sending.json
+++ b/maillogic.io.email-sending.json
@@ -1,0 +1,40 @@
+{
+  "providerId": "maillogic.io",
+  "providerName": "MailLogic",
+  "serviceId": "email-sending",
+  "serviceName": "Email Sending",
+  "version": 1,
+  "logoUrl": "https://maillogic.io/static/images/mail-orbit-logo.svg",
+  "description": "Configures DKIM, SPF, and DMARC records used to authenticate email sent through MailLogic.",
+  "syncPubKeyDomain": "keys.maillogic.io",
+  "syncRedirectDomain": "dc-lab.maillogic.io",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "smtp1._domainkey",
+      "pointsTo": "smtp1._domainkey.%fqdn%.maillogic.io",
+      "ttl": 300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "smtp2._domainkey",
+      "pointsTo": "smtp2._domainkey.%fqdn%.maillogic.io",
+      "ttl": 300
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:smtp.maillogic.io"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 300
+    }
+  ]
+}

--- a/maillogic.io.email-sending.json
+++ b/maillogic.io.email-sending.json
@@ -34,7 +34,8 @@
       "type": "TXT",
       "host": "_dmarc",
       "data": "v=DMARC1; p=none;",
-      "ttl": 300
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
     }
   ]
 }


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->

[Test maillogic.io/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFLOWWoC%2F%2B1XXU%2FbMBT9K5Elnpq0SYCUBSFRPiYQlKHSSZugqtzYaT2SONhOoVTdb991%2BpG2tFD2xCaeSLjX99xzfY7jDpGicRphRZE%2FRKngfUaoOCfIRzFmUcS7LCgzjsxZ7ArHkIvqEL3UUQhJKvosoPkqqpdZkiaEJd0iNll1qqPGzSzap0IyniDfMRFg8e8igqyeUqn0K5X5DipSYcWCCotxl8o8ZHHRYcrS68qyr8sRKgPBUpWXRMc8CVk3E1QaJxfnddO4uf5qGjghxkm91jg2BA24INLIJCWG4gbOVI8mAALTMHIeBvBQhuoJnnV7xoxyWfMaJMF11rmggxMOqRrvng5keWlqOq1BCQMsNUskgRXhznLqpB3k3w5RFxDTfJ7knsUQVINUz%2B%2F4qlY%2FhdcelwpeZaxSp9wmeWGA19vEWaJkk6%2BIlrfCB5JsLeMqBTPftu2R%2BS5c91Vc929xZRoWsLBh9QL1UM8zDRtZRGFKiCVBlBHqa7jF2ktMYiyCombzR7Mo2Z4GCVYY3vsHuTScfSM9SHhC9%2Bf6hKcnpTUVsUDVsQp6oOE6J7poLYrQqDUy0TMsahc72YLK012nTxicRssBj4sG4CnvtM3y%2FOnYx1MYNwc1UixwLLVDp9VuF8q1pvVukX7OK66rBk2ybsIFbUv4ixX4A%2FlKZNREcRYp1saPuPgXCdo4TaMBcJIQhaKgziVRJGNvrxDjZKovhDjX%2BzpVmLA3gWbM9B56IcGkanuWs7frWDvU3rY61Aut3ZC41CM7oY2rc2fUqvPrtUOq2AwqteUZjvJNfcQDiUZaTuspu2spu%2F8F5bFfJoQP560CsnKMtS40fmMwxYSdZ%2F8T9N53HHwcOi0TTppPY34a89OYH8yY8DWWuE9JG%2Bs013Y9y65aTrVpe%2F6O7Tt7ZfeL7e56Jdv2bVuzoFKNSQ7z5%2FyrP9%2BQtdgCRPtYMNzJL0XDddeNt64E48%2F7%2BPK52SmyYJyF8b%2F7cNncxxuBuu8FXZDaKoSxSyYQd5s57A6h19X8Jpe7lzLXRVvgEtBkBL8oQFdaI0uSXVIIZM9f9dBNxr2zRql6FIrns2bt0nlgR7UM06tSt%2Bfxb7%2BqkZBxacAvz34eoNEfoIFvVSEOAAA%3D) 

[Test maillogic.io/email-sending example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGLOWWoC%2F%2B1XbU%2FiQBD%2BK80mfrq2tBURa0zO18RojUFMvCghS3eBPdtub3db5Aj322%2B2BYGq%2BPLpvPiJlpmdZ56ZeYZlghSN0wgrivwJSgXPGaHilCAfxZhFER%2Bw0GYcmY%2B2CxyDLwrAeq6tYJJU5CykxSmqj1mSJoQlg4VtdupYW42rR2tOhWQ8Qb5rIsDi1yICr6FSqfRrteUMalJhxcIai%2FGAysJkcdFjytLnbJnrcITKULBUFSHRIU%2F6bJAJKo2js9PANK4uT0wDJ8Q4CvZbh4agIRdEGpmkxFDcwJka0gRAoBpGwcMAHspQQ8GzwdB4pGxrXuMkvMx6Z3R8xMFV493TsbQrVdNuLUoYYKlHRxJaEe5VXWfpIP92ggaAmBb1JPcsBqMap7p%2Bhxf7wTG8DrlU8Cpjlbp2lxSBAV63ibNEyTZ%2Fxmpv9H%2BRZKOKqxTUfNNxpua7cL21uN5HcWXaX8BCw4IF6nddz7TfyiIKVUIsCaOMUF%2FDrcauMImxCBcx2zftRcju3EiwwvCe7xWj4e4a6V7CE7q7lCc8PSg9UxELVYBVOIQZDjjRQfejCE07UxP9hkPdRSc7EHnedfqAQWnUDnm8SGA0GsFLkWyXFUfmlS8LUeYHYVIscCy1SOcBb1ciduYhb4uYnVnQlwJCqmyQcEG7Ej6xApUgX4mMmijOIsW6eIQXX5Gwi9M0GgMzCVYICjNaGY2kVPiToSsZzur7nNVeovHSjJjQqVCTZ7qjuO42sbuDrXodN616o%2BlaO03cs7x%2BuEW8XmO7vuMtbaznttm6lbXSGir1DmA4Kro8wmOJpnq%2BXmbvrWXv%2FU%2FsSy3NuK9Qzfdg3FzjRY0afzBIZkax4XwWjuW%2BsCtU1%2B2Mf4pVx4SN9CXdL%2Bl%2BSffTSRd%2B0SXOKeli7ek5XsNyti13u%2B00%2FLrjb9btrSZk0fzmOL7jaCJUqpLnpHguLg%2FLOVmrWYA1x4LhXnG9mrz94rLmjlHeF8o77duXzoqwVlryoV30Ps2%2FCdz7CHhVcs8ilYKaQd29TYx3CL0%2B9a%2FyunsqBx24A4qC2Y3gDwwMnx6kymhXxgi8l%2B%2BUKGh6P04c0ez9zO9r1%2BHBwDvOvL7reFvuTTA6G96cH7TaWZL16sd7aPoXal1%2BW5AOAAA%3D)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
