### PR TITLE
Add homshi.com website template (signed sync flow)

### DIFF
--- a/homshi.com.website.json
+++ b/homshi.com.website.json
@@ -1,0 +1,33 @@
+{
+  "providerId": "homshi.com",
+  "providerName": "Homshi",
+  "serviceId": "website",
+  "serviceName": "Homshi Website",
+  "version": 2,
+  "logoUrl": "https://homshi.com/icons/icon-512.png",
+  "description": "Connects your domain to your Homshi-hosted contractor website: www points at Homshi, an ownership TXT proves control, and the bare domain 301-redirects to www.",
+  "variableDescription": "verifyToken is a per-site ownership token issued by Homshi.",
+  "syncPubKeyDomain": "homshi.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "homshi.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_homshi-verify.www",
+      "data": "homshi-verify-%verifyToken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "homshi-verify-"
+    },
+    {
+      "type": "REDIR301",
+      "host": "@",
+      "target": "https://www.%domain%/"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template `homshi.com.website.json` for **Homshi**, a SaaS platform for home-improvement contractors. The service connects a contractor's own domain to their Homshi-hosted website: `www` → `homshi.com` (CNAME), an ownership `TXT` to prove control, and a `REDIR301` so the bare apex forwards to `www`. Uses the **signed synchronous flow** (`syncPubKeyDomain`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://homshi.com/icons/icon-512.png — `image/png`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `homshi.com`; the RS256 public key is published at `_dck1.homshi.com` (two `p=`/`a=`/`d=` TXT records) and signatures on the sync-flow apply URL verify against it.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — `warnPhishing` is absent.
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — **N/A**: the template does not use `redirect_uri`.
- [x] no TXT record contains SPF content — the only TXT is an ownership token (`homshi-verify-…`), no SPF.
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — set to `Prefix` with `txtConflictMatchingPrefix: "homshi-verify-"` so re-applying a new per-site token replaces the stale one instead of duplicating.
- [x] no bare variable as a full record value — the TXT value is `homshi-verify-%verifyToken%` (fixed service prefix + variable).
- [x] no bare variable as a full `host` label — all `host` values are literals (`www`, `_homshi-verify.www`, `@`).
- [x] no variable in `host` to create a subdomain — none; the standard `host` parameter is used (see subdomain test link below).
- [x] `%host%` does not appear in any `host` attribute.
- [x] `essential` (`OnApply`) on records the user may edit — **N/A**: all three records are provider-managed and required for the service to function; the user is not expected to edit them independently.

Note: the [`dc-template-linter`](https://github.com/Domain-Connect/dc-template-linter) reports two `info`-level notes only — `DCTL1021` (the `_homshi-verify` label isn't in the IANA underscore-name registry; this is a service-specific ownership label, which is standard for domain-verification records) and `DCTL1038` (`REDIR301` not widely supported; it is used only for the apex→www convenience redirect and degrades gracefully — the `www` CNAME is the functional record). No warnings or errors.

## Online Editor test results

**Editor test link(s):**
- Apex (host empty): [Test homshi.com/website example-contractor.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH5vWmoC%2F%2B1WYW%2FaMBD9K5ElPi2BJBSSRprUqq3UaitDFR2TKhQ5sQFvIU5tQxoQ%2F31nAiQFpu0j0goSJL7zu%2FfufCevkKKzLMGKomCFMsEXjFDxQFCApnwmp6wZ8xky95YenoEnut%2FYYF1SsWAx3WzIaSQZAO1X3zkbw715QYVkPEWBa6KET%2FizSHQ8pTIZtFpV3BaLeSo3v1bHcZtZOoHdhMpYsExtENANT1MaK2kUfC4MwmeYpYbi5WsZ2ZpyqSgxAEYJHCsujC3VwMjz3Mg4SwEAq62%2FaeDU4HkKLKcsMwY%2FBoaWT2WJwBPtQAw1pUaEBd0FbduOJShhYkMHKAB2U6vFguEoobfveEMO2LgY8F80NRgENzIqLM2pFlltrXIO7KNiS09jyiKN%2B%2FPoCy1uN8EPy6UVP9HXOZCByoxxIqmJgBgXRKLgZYVUkenS3PSuH%2B%2B2%2FrqCea5rvcnHgB%2BCKgVlandte23uASA51fawdLdKbc0SjWCF90hbk9WoyW%2FUoeHxTUFNxwmL1SNW8ZSlk0dOdKy%2BoGP2hk66bG2HcVCN6tPd7cMTFKnie6WxsJhQVTt%2BumqNsqSNFlqP1iZa8pSGVfZGIGqXdfqGoX2oVZ2tWgXADk8TwedZyHZbMyzwTOpu24G8%2FAlltIN5Qfq5ljO9ZDtu%2B6LT9fxLHMWEjg%2FfkabOJikXNJTwj9VcQB6UmMNZmM0TxUKc42qJxCHOsqQApRKsEOL4nKRlR5%2Bo7OEZMVFIYq2S6dEQtT2X%2BNiz4o7fti66xLPwheNYeEzG3XanE0VuVJsyx%2FPn9JypkkylpKliWA%2BS6yTHhUTro2O6Zf%2Fvx%2FSvKT5bwdeV3KtKneN6TRu%2Bzo74%2BfGGz0nqQXC%2BpGuT5Zh4fa6c7vMWOgc5IxOm00fHf3T8R8f%2FLx0PdwqJF5SEWLu5ttu1bM9yvIHjB7YXdPymc%2Bk5Xf%2BTbQe2rYtBpSpFruBuUb9VIOL3%2BsX9cuAR%2Fy5%2BvPxJvi9fv3aE1%2F7We8Z4mA%2F7%2BaTnLV%2FJkH9G69%2FZVfwRdwwAAA%3D%3D)
- Subdomain (host `shop`): [Test homshi.com/website example-contractor.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOtvWmoC%2F%2B1W70%2FiQBD9V5pN%2FGQLS%2Flpk0vOQ70zRs8YLneJIWRpB7qx7PZ2t9Rq%2BN9vlhYoiLmvfhATsJ3ZN%2B%2FNTF%2F6Sgws0oQZIMErSZVc8gjUdUQCEsuFjnkjlAvibiN3bIGZ5Mc6hvc1qCUPYX0gh6nmCLS9u5fs%2FN6Gl6A0l4IEvksSOZe%2FVGLrGZPqoNnc1W3yUAq9%2Fva6Lb%2BRijmejkCHiqdmjUCGUggIjXYKmSknkgvGhWNkeVlW9mKpDUQOwhjFQiOVU1ENnDzPnVRygQDMVPmuw4Qjc4EsY546oz8jx8oHXSLIxCZEjonBmTIFm6Jt2vIURFyt6SAFxG5YtUxxNk3gYo839oDPipF8AuFwLO6koDzLqVbZVFGdIftpUdGzmLoQ4X02vYHiYl38cFxW8QP8zZAMTmbGEg0uQWJSRZoEj6%2FEFKkdzfDu%2FPayyrcTzHM763U%2FRvIQ1BgcU7tH6crdAmBzdscnZbpXamuUaBEzbItUhbyTmvyTOjT%2B%2B2xwprOEh%2BaWmTDmYn4rI1vrXsGMP5OjKVXssA6pUX24vLh%2BwCHt%2BH61WEzNwdTWz07tpBzpSZOsxiuXvEgBk133xihq03V4Zvj4gLfbrdoEMK5jmeLVXMksnfDN8ZQpttD2idsAPb6HNN5APZZYY7e%2BOvY2bfntTrfXH5yxaRjB7PCaWAl8LqSCicZfZjKF%2FTAqw51YZInhE5az3a0onLA0TQpUrDGKJd7uiyifbNurSuHemA8XxiWTKLRyufWJfrtDe34bvGnYaXudKaPeAHzm0W5vFnb6vZYPg5rlvDWj46az33HQGoThzDrLeZKzQpPVm72tZLzd26OqNkv134Z%2FaOXnO937Ilt%2Bv0Hxr7Xh%2FzHp4%2Bc9BUHwsbnXHOgo%2F7oFHbeDJvkoqsYuGtmnMXwaw6cxfBrDnjHgG4pmS4gmzKb61O95tO%2B1%2BqPWIKBnQaff6La7A%2BqfUhpQaucC2pRCX%2FFNpf6OQp6%2BP1B9mZ1fcTEM49PijH4b5k%2BzZa99M%2BsMzSD6qdKXq%2FDsKaZfyOofnag%2Fyc0MAAA%3D)
