### PR TITLE
Add inbox-works.com mail template

### DIFF
--- a/inbox-works.com.mail.json
+++ b/inbox-works.com.mail.json
@@ -7,7 +7,7 @@
 	"syncPubKeyDomain": "inbox-works.com",
 	"syncRedirectDomain": "app.inbox-works.com",
 	"description": "Enable email signing and specify authorized senders for Inbox Works.",
-	"logoUrl": "https://app.inbox-works.com/brand/inbox-works-logotype.svg",
+	"logoUrl": "https://app.inbox-works.com/brand/inbox-works-logo.svg",
 	"records": [
 		{
 			"groupId": "outbound",

--- a/inbox-works.com.mail.json
+++ b/inbox-works.com.mail.json
@@ -12,7 +12,7 @@
 		{
 			"groupId": "outbound",
 			"type": "MX",
-			"host": "%spfDomain%",
+			"host": "send",
 			"pointsTo": "feedback-smtp.%region%.amazonses.com",
 			"ttl": 3600,
 			"priority": 10
@@ -20,7 +20,7 @@
 		{
 			"groupId": "outbound",
 			"type": "SPFM",
-			"host": "%spfDomain%",
+			"host": "send",
 			"ttl": 3600,
 			"spfRules": "include:amazonses.com"
 		},

--- a/inbox-works.com.mail.json
+++ b/inbox-works.com.mail.json
@@ -1,0 +1,35 @@
+{
+	"providerId": "inbox-works.com",
+	"providerName": "Inbox Works",
+	"serviceId": "mail",
+	"serviceName": "Mail",
+	"version": 1,
+	"syncPubKeyDomain": "inbox-works.com",
+	"syncRedirectDomain": "app.inbox-works.com",
+	"description": "Enable email signing and specify authorized senders for Inbox Works.",
+	"logoUrl": "https://app.inbox-works.com/brand/inbox-works-logotype.svg",
+	"records": [
+		{
+			"groupId": "outbound",
+			"type": "MX",
+			"host": "%spfDomain%",
+			"pointsTo": "feedback-smtp.%region%.amazonses.com",
+			"ttl": 3600,
+			"priority": 10
+		},
+		{
+			"groupId": "outbound",
+			"type": "SPFM",
+			"host": "%spfDomain%",
+			"ttl": 3600,
+			"spfRules": "include:amazonses.com"
+		},
+		{
+			"groupId": "dkim",
+			"type": "TXT",
+			"host": "resend._domainkey",
+			"ttl": 3600,
+			"data": "p=%domainKey%"
+		}
+	]
+}

--- a/inbox-works.com.mail.json
+++ b/inbox-works.com.mail.json
@@ -29,7 +29,8 @@
 			"type": "TXT",
 			"host": "resend._domainkey",
 			"ttl": 3600,
-			"data": "p=%domainKey%"
+			"data": "p=%domainKey%",
+			"txtConflictMatchingMode": "All"
 		}
 	]
 }


### PR DESCRIPTION
# Description

Adds the mail template for **Inbox Works** (https://inbox-works.com), a shared-inbox product for small teams in Japan.

- **providerId**: `inbox-works.com` / **serviceId**: `mail`
- **Purpose**: email sending authentication for our customers' own domains — SPF (via `SPFM` merge) + return-path MX + DKIM TXT. Records point to the sending infrastructure (Amazon SES / Resend) that delivers our customers' mail.
- **syncPubKeyDomain**: `inbox-works.com` (signing public key published at `_dcpubkeyv1.inbox-works.com`, RS256 — verified with `dc-debug-pubkey`)
- **syncRedirectDomain**: `app.inbox-works.com`
- DMARC is intentionally NOT included: an existing `_dmarc` policy must never be overwritten by a template apply.
- No click-tracking records: the product does not use link tracking.
- `dc-template-linter --merge-or-fail` passes (exit 0), logo reachability check included.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://app.inbox-works.com/brand/inbox-works-logo.svg` → HTTP 200, `image/svg+xml`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes:

- The MX + SPFM records use the **fixed** label `send` (the Amazon SES custom MAIL FROM / return-path subdomain of the sending domain), not a variable — rules 7 and 8 hold. Our service verifies that the live sending records really use that label before it offers the one-click apply at all; if they ever differ, we fall back to manual setup rather than write a record the template cannot express.
- Only two variables remain, both embedded in fixed text: `%region%` inside `feedback-smtp.%region%.amazonses.com`, and `%domainKey%` inside `p=%domainKey%` on the DKIM TXT.
- No record needs `essential: OnApply`: the template writes no policy record the end user is expected to edit (that is why DMARC is deliberately left out).

## Online Editor test results

**Editor test link(s):**

- apex, both groups (`example.com`, no host): [Test inbox-works.com/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALvfXWoC%2F%2B1WSW%2FqOhj9KyhSV0xJCKPURSClQEsaWqBAVSEndgYIcbCdkFD1%2Ffbn0AHQ5T69ZRfdWfbJ%2BQZ%2F58RvAkOb0AcMCa03ISQ49iAifSi0BC8wcVLcYbKmJQtvhML3sQ42HC70M0DuOQPwQ4pI7Fno8OkGeP5x6xM%2B%2FNiMEaEeDoSWxAFpYBmReYdSDfNvgotRM9Ajgh5BFvuGgTAs%2FQmFiFrEC9mBX7gJgOmjHMqyyVHPCbzAyYEA5miILM9OcyBiLibeHvEtFPDCaM7GJHdSV4mT%2BtjBE%2BJzQpexkLbK5QvByybhzOWT3WL2XYnGDqfgqWMCqdB6eRMcgqPw0CUcMRNHAeQAloaHFs342sWU8XWWUdZz7AWMjjHfsRGCJrDWRbphYemKIIfXeVUCG7DHAUVfTWCM51qpiWJ2YR6vj6W82eJ74b9jPxnd4R%2FRT7hoaD9GPqKHO7L8CKLWeeTzAHDtbY7k49n4yE1Qxl5awsNlrlF6HggCBjgqvL76APDpuMoQCevgwPY9iw0Bs1x%2BmUMMM3LV94X31%2FeCwJNBy2OvXznX17ygBPAxR58t%2BkyErw4JL70D%2FrQph%2FQ5QQgI2NBMG19UL2dcr19kL0K2PtD9herjvrJDEBYDTJiLAGVFSfjOk1eaHQ%2F7%2FXZ%2FpeptZ711195tcye21dFNV1UfOuqooWbnHeeOr2%2FU2EwwWE0HAyWkIyN2NFAVtQXqh659B%2B7tdoDr%2BX4C5m1JSwdGGimzaW0sjzdORzXGE7XfWc2A0stPB1K4jrtwwdLqXt8Nqo%2FIVcKxYtzuDNu%2BU5lk%2BouKdAvGPQh3I8epd%2BQZ9a1VvWuMAj0%2FcrS5W0WiLe8Typ4QrN8Y0jiVZEnvDbpyCLHzcGtgOZLXeJisza6mV3R6H953Eky3zU5DZ739QmFtbDX0%2FYAn8QCjcBrqq2gWmXJ8N%2B80F4utViWps1vNWYQqU%2BmZYPdxKiMN5w3vhg3vFbFiytpDkgBogCFQ9Gq1vNASJzbZYmP7Pc1fbPUumVtGPdlOd0%2B7Pn6eJLE1xe7t5LnOeo5CNNF0R31NHaltIZspbhuYoGVmH4BFhM8bIxEqCJvIZ94S7MBxC1pL7gx%2BykeQ8lN%2BlVzup8oOPozwU1ufc36u6vPR%2BL%2FaLghLaGVD6mXSs2ugWpUaVrEGTVRULLlabNRlqdi0JaVuNpGoQPvEzf9i9hf8%2FCgbRHkRzAP%2BQX47kFLhPdP%2FmdwvlhtfcyORchctJPcP8P3zKn9wXZds7Nu7fjX8QzT846bptcB%2FTL%2FG8GsMv8bwawxnxsDfgRTECC5BBpNFuVYU60VZHIuNllJpVZolsdasVBp5UWyJYlYAouxjsN74S%2BX0jSI0t2Z1G%2FSRiZ2k3R6wtV9TO2h%2B1xV3j9pkYufLXU2Zhe5ojq%2BF938BT%2Bzd8wYOAAA%3D)
- subdomain, both groups (`example.com`, `host=mail`): [Test inbox-works.com/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMrfXWoC%2F%2B1WW3OqOhj9Kw4zffIGCPUy0wcUrdpKsbXW2uk4gURAkKQkINjp%2Be0nqG31tD2zH%2FdD35hkZX2XrG%2BRV4GhNQkAQ0LrVSARTjyIogEUWoIXWjgtb3Dk04qN10LpY9sAaw4XBjmg8JAD%2BCZFUeLZaHd0Dbzgc%2BkAH%2B0XExRRD4dCS%2BKALLTN2LpCmY75mfDbqDnoFkEvQjb7gAFCKl%2BhEFE78gjb8QvdEFgBKqA8mwL1nNALnQIIYYESZHvLrABi5uLI2yK%2BhEJeGC0scVQ4qqvCSQPs4Pso4IQuY4S2qtVvgletiDNXj1bL%2BbkKTRxOwVPHEaRC6%2BlVcCIck12XcMwsHIeQA1hGdi2a8W8XU8a%2F84zynmMvZHSC%2BcoSIWgB2y%2FTNSOVswg5vM6zCliDLQ4pem8CYzzX2rko5hfm8fpYxpstvpX%2BP%2Fad2Rt9iX7ERcnyNg4Q3d2RHcQQtU4jnwaAvrf%2BJJ%2FMJp%2FcEcrZKwu4u0wfZaeBIGCAo8jF2R7A1XGWI1LWweEy8Gw2Asx2%2BWWOMMzJtSAQ3p7fSgJPBi0%2Be%2F3Mud71glLAZY4OLTokcpDpLumFtztz3JhdCZyEgAisaT4f73RPJ3zP74RPe8bnA%2BUPdPt7yzcBKYc4Yi4ClJUl4SNfXnG%2BPRoM2oOVZrQd%2F8X1vcvmRmxr425P02462rih5fsd54p%2Fd7XESjFYTYdDhdCxmTg6UEV9jgbEXV6B62U7xPXiIAWPbUnPhmYWK7Pp%2BUSerJ2OZk7utUFnNQNKvzgdSsRPenDOMnVrbIbqLXIVMlHMy425XF5pTLKCeU26BJM%2BhJux49Q78owG9qreM8ehURw7%2BqOrInEpb1PK7hCsd01pkkmyZPSHPZlA7NxcmliOZR%2BPUt%2Fq6UbNoNfkupNi%2BtLsNAzW384V1sZ2w9gOeRI3MCZTYqziWWzJydVjpzmfv%2BhqlDmb1SOLUW0qPUTYvZ3KSMdF0%2Buy0bUi1ixZv0lTAE0wAoqhqtW5njqJxebrZdDXg%2FmL0YsebbOevkw3d5sBfrhPE3uK3cv7hzrrO0qki5Y7HujaWGsLuba4feAILXIbASyOuO5YFKOSsI4D5i3ABnwuQXvBHSLIuBQp3%2BVXycf%2BeMLDvSHupuCgwYPoT0f8VB9%2FOuglYQHtXK1ePocKAGpdbsCyBBt2WQGNWtlSZFhWbUtsNhuqqiL5yNp%2FcP5vzP10hhDl1TAPBLt53ICMCm%2B5IZzM%2F891JxfcXqTCt8ZS%2BAcEwWm5f3mBXwzuP9WSi9%2FR%2FktG%2B6%2BU1XOJ%2F7t%2BPePXM34949cz%2FtQz%2BOuRggTBBcihsiifl8V6WRYnYqOl1FqqUmk2z2VZLYpiSxTzIhBle3G98vfN8ctG0KrIqRVDf9qYdsk5YeLNPCB6XB1N2ml4NXXi1PbFps9qdHMhvP0LZhNWwkQOAAA%3D)
