### PR TITLE
add CoDuck, 2 templates

### DIFF
--- a/coduck.ai.hosting-apex.json
+++ b/coduck.ai.hosting-apex.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "coduck.ai",
+  "providerName": "CoDuck",
+  "serviceId": "hosting-apex",
+  "serviceName": "Connect your domain to your CoDuck site (root domain)",
+  "version": 1,
+  "description": "Points your root domain (e.g. example.com) and its www variant at your CoDuck-hosted site, and adds a verification record so CoDuck can confirm the connection. No other DNS records are changed.",
+  "variableDescription": "%token%: per-domain ownership verification token issued by CoDuck when the domain is added to a project.",
+  "syncPubKeyDomain": "coduck.ai",
+  "syncRedirectDomain": "coduck.ai,app.coduck.ai",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_coduck-verify",
+      "data": "coduck-verify=%token%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "170.205.30.188",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    }
+  ]
+}

--- a/coduck.ai.hosting-subdomain.json
+++ b/coduck.ai.hosting-subdomain.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "coduck.ai",
+  "providerName": "CoDuck",
+  "serviceId": "hosting-subdomain",
+  "serviceName": "Connect your domain to your CoDuck site (subdomain)",
+  "version": 1,
+  "description": "Points a subdomain (e.g. app.example.com) at your CoDuck-hosted site, and adds a verification record so CoDuck can confirm the connection. No other DNS records are changed.",
+  "variableDescription": "%token%: per-domain ownership verification token issued by CoDuck when the domain is added to a project. %target%: the coduck.app subdomain label assigned to the CoDuck project this domain routes to.",
+  "syncPubKeyDomain": "coduck.ai",
+  "syncRedirectDomain": "coduck.ai,app.coduck.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_coduck-verify",
+      "data": "coduck-verify=%token%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%.coduck.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two templates for **CoDuck** (coduck.ai), an AI app-building and hosting platform, so users can connect custom domains to their CoDuck-hosted sites without manually editing DNS records:

- `coduck.ai.hosting-apex.json` — root domain: `A @` to CoDuck's hosting IP, `CNAME www → @` (we serve the www variant on one certificate), and a `_coduck-verify` TXT ownership-verification record.
- `coduck.ai.hosting-subdomain.json` — subdomain (`hostRequired`): `CNAME` to the project's `%target%.coduck.app` hostname plus the same `_coduck-verify` TXT record.

Both templates pass `dc-template-linter` with no errors or warnings (only info-level DCTL1021 for the `_coduck-verify` underscore label, which is our service-specific verification name).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — no `logoUrl` is set on either template (it is optional), so there is no unserved resource.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `coduck.ai` on both templates
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `coduck.ai,app.coduck.ai`; the synchronous flow uses `redirect_uri` back to our app
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the verification TXT records (`All` — the `_coduck-verify` label is exclusively ours, so any pre-existing TXT there is a stale token that should be replaced)
- [x] no variable is used as a bare full record value — the token is embedded in a fixed prefix (`coduck-verify=%token%`), and the subdomain CNAME target is constrained to our zone (`%target%.coduck.app`)
- [x] no bare variable is used as the full `host` label — all `host` fields are fixed (`@`, `www`, `_coduck-verify`)
- [x] no variable is used in the `host` field to create a subdomain — the subdomain template relies on the standard `host` parameter (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not needed — all records are required for the service to function and are re-verified by CoDuck's periodic health checks, so none are intended for independent end-user modification

## Online Editor test results

**Editor test link(s):**

- [Test coduck.ai/hosting-apex — apex (example.com, no host)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOeLXGoC%2F%2B1UW2%2FTMBT%2BK5YlpCGSkDS9Rpq0sY6LYIWNjts0Va7tNmaJHdlOuzDtv3Ocpmu7acAbPPAU2%2Bc7l%2B%2BcL%2BcGW54XGbEcJze40GohGNdvGE4wVaykVwER2LszjEgOQHykhmCCd8P1QlBe41NlrJBznxT8emO685CSU4sqVWrEVE6ERFatrqtoyAjL0Z5WyjaApxBlwbURSuIk8jDjhmpR2PqOPyghrVlF2HJCezyYB4hfE6DFA6ryp4hIhgRgl8slWhAtiLSI2O3kviues7oGr8YTxgwiCPKLmaDEJUWaU6UBpNYlUyIRVXImdI5syt3ZsQRsgEYKKXjTaDj62HhCQA2glMg5Z4Fj54qZZny4w%2ByJVVdcPklQwbXfsFJLCZ1IRbFbUY1EwpgSip9W67qWKby6ghpvYRwfgEDLCYJhfocqXQGmkvRDOX3Lq2GNvDd2Zz7jTED59iHAI0URbMMblji5uMG2Ktzcx1%2FGYHDdhctkBfZrChW8M2LJXcTmeb%2BhD2Z7bUE3s0xQe0IsTUFdJ4q5sIdZ5uw2w0ncDcNb7y7h4SbdgRNurZKxgmvUC4NW2AniMIj6%2FUfcj0aHJ8ebEKCY3SAHO36Xtx7%2BoSSfbJhfAqt1p7ZEuAkJp7lWZTERa3xBNMmN%2B%2F%2FWnhc7rpdr3wvsznV73GVwdRovvkxb%2BbhXvFu2z8g32n85i8rXpjuah18ZduWJuVSaTwx8iS01cLS65B7Oy8yKCVmSzROjE5hoVgEbA1ZIcX%2BOcvUz%2F9kcf1veVic9PGHUdUC4TdLhbNbpdTp%2B3Ov0%2FXbIZv6gRWd%2B1OrErEPJlNP%2B1lJ6sK1%2BsZU2Q%2BDGcGkFyWo5LUll8O09HTV0DzYMH9fQv8dgLeWGxUrKDY9dZf5zJC49%2BC%2F%2Bi%2B%2B%2F%2BP6K%2BGDHGrLgbEIcrBW2un7Y86PBOOwncZy046DXi9px9CwMkzB0FLixK243sHG3dy0eDuLzMH7x6TBKj0%2FTsUmZeXMq3%2BefR68Y73enL5%2BfD9rh9xNW9ffx7U9usyF3jgkAAA%3D%3D)
- [Test coduck.ai/hosting-apex — with host (example.com, host=www)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPOLXGoC%2F%2B1UbU%2FbMBD%2BK5YlpCGSLGnTFiIhwejG0NaOl26DIVS5ttuapnZkOy0Z4r%2FvnLa0gbF95QOfWt899%2FLcPbl7bPk0S4nlOLnHmVYzwbg%2BYTjBVLGcTgIisPfo6JIpAPGRaoML7IbrmaC8xI%2BVsUKOfJLxu7XrMUJKTi0qVK4RU1MiJLJq8VxkQ0ZYjt5ppewSsA1ZZlwboSROIg8zbqgWmS3f%2BFQJac0iw0YQeseDUYD4HQFaPKBquo2IZEgAdj6foxnRgkiLiN0s7rvmOSt78Eo8YcwggqC%2BGApKXFGkOVUaQGrVMiUSUSWHQk%2BRHXP337EEbIC6CimwadTuXiwjIaEG0JjIEWeBY%2BeaGaS8XWG2ZdWEy60EZVz7S1ZqLmESY5FVOyqRSBiTQ%2FODYtXXfAxW19AyWhjHByAwcoJgmbfQpWvAFJKe5oMvvGiXyCdrd%2B5zzgS0b58DPJJlwSZ8yRIn1%2FfYFpnbe%2B%2ByBw43XXj0F2C%2FpFCAnRFLHjMuzftL%2BuC2dxZ0M0wFtR1i6RjU1VHMpT1MU%2Be3KU7qzTB88B4LHq7LHTjhlirpKXhGrTCohY2gHgbR7u4L4Ufdw87HdQpQTDXJQSXu5sHDv5Xk%2FTXzG2C1mtSGCJ%2BmHGmVZ32xCsmIJlPjPsFV8HUl%2BmYVfl3Gw7McknvvTc7qs8tBbdprZV%2Fn8Tn5RXc%2FDaP8s2l2R%2BEVw65JMZJK876BX2JzDUytzrmHp3lqRZ%2FMydrEaB%2F2mhbAyYAXSjzdplx80tVtBgtef93of1vcmKmH%2B4y6QQh3U%2BJGM6oNY%2BLXWyH1YxJTfxA1mz5txq1wGLViFscb5%2BnZ3frHfaqsgxvDpRUkLbU1J4XBD09EtWRdofmypF4ljZW411SqW3OGqmZfI58bD76YN02%2BafI1aRIusiEzzvrEIWthremHLT%2Fa64W7Sb2eNBpBFNdacXMnDJMwdCy4sQuK93CfNy8zPn5%2F%2BG1MJ8cffl8dTc7avFGL24OT25MfIu6k0fHFqHNxVQxGrZ2f3%2Ffxwx%2F7Ku%2F2wgkAAA%3D%3D)
- [Test coduck.ai/hosting-subdomain — with host (example.com, host=blog)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP6LXGoC%2F%2B1U227bOBD9FYJAgBaVBFm%2BJQIKNKhbtGjjplkXm00QGGOSltlIpEpSdrRB%2Fn2HknzbtujrYtE3cebM5ZwZzSN1oihzcIKmj7Q0ei25MO85TSnTvGL3EUga7BxTKBBIX%2BsJutBuhVlLJhr8SlsnVRbaasF1AVLt%2FbswpQRzpNaVIS2GON0%2B25TESifIs12K55hjLYyVWtG0F1AuLDOydM2bXmqpnCVAdnjyTERZRKAsI%2FEASExETBfPCbjDKqFvVfCmWEBAcQKc%2BzxYSi4lA5%2BfGMG0QZDe9sZAEabVUpqCuJXw354OYiMy1USjzZDJ9I8uEhMaBK1AZYJHnggYCYtcTI5InDh9L9RJSkphwo6F3igkvZLlcUcNkkhrK2x%2BUW%2F72qzQ6hvqoqX1fBCC2gLB0X3FLiNy4sBkwmGltvl2umV5oF4OC5ETsFZmqo330K5MlwhNWKALMLpywiLQ87O1YpfV4oOoJ%2B38j3fIu68El6iO%2Bx4Q%2BJkdwv2MrsS3CvG4Xc5UIqCdsDS9faSuLv1Oza5nHRgf8zZB2KhWo52Dg12VzvyyUxzd7sHhTi5zydwFOLbC9b3Q3Kc9z3PvdzlN%2B6M4fgp2BV9Pzy%2Fe7Eu%2B8n9Hs4cz3UyzFTna63uU5%2B4poH9rJeZ7KnfY5laOg6Xdl1jkOsNXhmKXc7mNKcFAYf1fu42%2BPQq%2F28bftgnw3fD2hrP7z%2F319SIpZuPy42ZwBTfs9O2yV72zo2kW%2F8UbcEPEo5Vcujpc6odwkFBPALdDGzH3WwKuMmI7nqLKnZzDBvYmzuYoQV4jX4teTPfv0an2NhyPLuo4%2F3B%2Bv%2Bz%2BQPCAzjnzIkl%2FogZJzBfLISCR3lk4GDEeAvQHoThjrJf0h1wMBgfX7rsz%2BKtzdzwwYa1QTkLe7NMGakuffrBInQDHjA81%2F8ku%2Feeo3QW4l7%2FH%2B78dLx4FC2vB5%2BChSZyMwngc9s5m8WnaH6TxKEri4XAcv4jjNI49F2FdS%2FgRr8bhvaAfzvlsWK4%2Fx%2BfV9Zcv4z%2FVdJgkH8cw%2BXSjJ6dvmCxGN9fVTcl62Uv69A%2FBJpzxpggAAA%3D%3D)
