### PR TITLE
add Saiton, Saiton website

### DIFF
--- a/getsaiton.com.saiton.json
+++ b/getsaiton.com.saiton.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "getsaiton.com",
+    "providerName": "Saiton",
+    "serviceId": "saiton",
+    "serviceName": "Saiton website",
+    "version": 1,
+    "logoUrl": "https://getsaiton.com/logo.png",
+    "description": "Connects your domain to your Saiton website.",
+    "variableDescription": "target is the name (subdomain) of the Saiton site, forming target.getsaiton.com.",
+    "syncPubKeyDomain": "getsaiton.com",
+    "syncRedirectDomain": "getsaiton.com,saiton.bg",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%target%.getsaiton.com",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for Saiton (getsaiton.com), a website builder for small businesses in Bulgaria. The template writes a single CNAME pointing the customer's subdomain at their site's platform host. `%target%` carries only the site name — the `.getsaiton.com` suffix is fixed in the template so the record can never point outside our platform.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated with `dc-template-linter -loglevel error -tolerate info -logos` (exit 0, no findings).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in this template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) (no TXT records in this template)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (`pointsTo` is `%target%.getsaiton.com` — suffix fixed)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description (host is literal `@`)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (single CNAME that IS the service — removing it disconnects the site, so `essential` is left at its default)

## Online Editor test results

**Editor test link(s):**

[Test getsaiton.com/saiton example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABF7W2oC%2F91Tf2vbMBD9KkZQ2JiT%2BkdIGsNgpQljbA1bl9I%2FSjAX%2B%2BIKbMmRZGduyHffyU7Wusu%2BwP6y7%2FTe3bun054ZLMocDLJoz0ola56i%2BpKyiGVoNHAjxTCRBXP%2FHC6gIDD72Z5RXqOqeYItR79J9rDODteaUyeX1ag0J2DkuyyXmbxXOcGejCl1dHnZ63xpz4elyIiWok4UL01LZTdSCEyMdhpZKSeVBXDhGNmF%2FZZD2xMUh3WOs14RA4raOVw75gkdQXqdd7pad9XeO3LT5o%2FVbCnX2UhVcJE5HXXYU2sb6UYk36v1V2xmbZUzXlrIHaZckf7zIPf4u7ZzP0lt7nBbEZ5cNqpClxFVqlSz6HHPTFNam28W17fzI5zCT%2FbSJBdGLyWFF53ei%2BFbMcaQ%2BeHY8w6rg8uepcD4pfiKXD8JxF9Au4JH2rHLbrejIFOyKmN%2BopSgoNB2pU7kxx57daI%2FtnwKO3E2UTTtklgtPBNSYazpC6ZSeJq9qHLDY9jBSypNYijLvCHpmk6p0N%2B%2BiG4bO8UpGKCg6%2FZvT1wWp4kdhNv9noTpxA8CHEzDBAajxLsawGgzGkxG41Ho4yYMAF49lbPv6Ox76ZmJWqMwHOybuM530Gh2OKxcMvZ%2Fm4kuXkONaQwWGXjBeOBNBv7V0g8jbxqFk%2BHUD7yx98HzIs%2BzM6A23ZR72o%2FXm8GgEjC%2FeV5u6628x3lTLir%2FYbnLdP2wnc1nwfRWjL599u9r%2FuMjO%2FwGwEEaKvkEAAA%3D)

Note on apex: `hostRequired` is `true` (a CNAME template may not write the zone apex), so per the PR template instructions an apex test is not required — the subdomain test above covers the template's only shape.