### PR TITLE
add Church Flow, Church Flow Portal

### DIFF
--- a/church-flow.com.portal.json
+++ b/church-flow.com.portal.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "church-flow.com",
+  "providerName": "Church Flow",
+  "serviceId": "portal",
+  "serviceName": "Church Flow Portal",
+  "version": 1,
+  "logoUrl": "https://church-flow.com/branding/monogram.svg",
+  "description": "Connects your own domain to your Church Flow portal.",
+  "variableDescription": "%target% is the tenant identifier of the Church Flow portal (the subdomain prefix of the tenant's <tenant>.church-flow.com address).",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "dc.church-flow.com",
+  "syncRedirectDomain": "church-flow.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%.church-flow.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Church Flow** (https://church-flow.com), a multi-tenant church management SaaS. The `portal` service connects a customer-owned domain to their Church Flow portal via a single CNAME to `%target%.church-flow.com` (the tenant's identifier). The template uses the synchronous flow with `redirect_uri` and signed apply URLs (`syncPubKeyDomain: dc.church-flow.com`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also linted with `dc-template-linter -loglevel error -tolerate info -logos church-flow.com.portal.json` — exit 0, no findings.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (n/a — the template contains no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) (n/a — no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (`pointsTo` is `%target%.church-flow.com` — variable is anchored to a fixed provider-owned suffix)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description (host is `@`)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead (the `host` parameter is used; `hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (n/a — the single CNAME is the entire service; removing it disconnects the domain by design)

## Online Editor test results

**Editor test link(s):**

[Test church-flow.com/portal example.org/members](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL2nW2oC%2F91Tf2%2FTMBD9KpGlCRBN6qRd1kWA2A%2BGGGxs06YiTVXk2NfULLGD7bTrqn537Ias3Tr4APzV9O753bu7dwtkoKwKYgAlC1QpOeUM1BeGEkQntaITf1zIWUBliTqP6XNSWjg6WgG8EwuwSQ1qyimsnlZSGVKsg9sPvIsWMgWluRQoCTuokLm8UYWFToypdNLtPhPRzRQRjIu8W0ohc0XKQE9zy8JAU8Urs2JCR1IIoEZ7c1krT86Ex2RJuPCMbEKbShqxgZNCFCdZAcdPyHYMUTmYHY9rz0zAMyCIMJ4dhDB8zMEWGK8S26TeaxfXdfanfKVgzO9bfEP0Snvvmq8PwbNuPcKYAq3fOHF6LuhhIekdSsak0NBBE6nNFfyquQI7dKNqaFAXdfYV5serklY%2Fo8H2Kh3uCph9Ss0jchtm01IxjZLbBTLzarXE84OzT6ipbv9%2BdL6QXBh9LTeG9UJJY%2BxiezHGy9Gygx6kgHRNP7IrbGXAPbGWhECqfF2nhDKzTrGBXMm6Snn7rCLWBdq5tyW4fcIwailuHzlsqJHpggxKiZwingupINX2l5haQTvSsi4MT8mMrEOMpqSqirltQNuspdmej2g8v9bNiCFuHbbev6bTQSmjrh3uLmlAMM4G%2BwOf9jLi90mc%2BftxuOdTOuhh3INd1u9tXOZfDvfF29warHWaszRx93dQzMhco%2BVy1LFD%2Fn%2B7s1bQZAosJQ4d4Sj28Z4fDq7DOIlwEvaCMBpE%2FfAtxgnGrhPQpul1YT2z6RbE989%2BXl6e3FXx56h4%2BB7fRMWE39HD4Y%2FhxXB3iKPZZDrm%2BNvpqX6Plr8BgQn7qXoFAAA%3D)

Result: `members.example.org. CNAME 3600 demo.church-flow.com` — as intended.

Apex test (domain only, no host): correctly rejected with "Template requires a host name" — expected, since the template declares `hostRequired: true` (per the exception noted in this PR template, an apex test link is not required for `hostRequired: true` templates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
