### PR TITLE
Add Lucitech managed site template

### DIFF
--- a/lucitech.net.managed-site.json
+++ b/lucitech.net.managed-site.json
@@ -1,0 +1,38 @@
+{
+  "providerId": "lucitech.net",
+  "providerName": "Lucitech",
+  "serviceId": "managed-site",
+  "serviceName": "Lucitech Managed Website",
+  "version": 1,
+  "logoUrl": "https://lucitech.net/images/logo.png",
+  "description": "Points your domain at your Lucitech-managed website and adds a verification record.",
+  "variableDescription": "%checktoken%: Lucitech site verification token; %ip%: IP address of the Lucitech web server",
+  "syncPubKeyDomain": "keys.lucitech.net",
+  "syncRedirectDomain": "lucitech.net,www.lucitech.net",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600,
+      "groupId": "site",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600,
+      "groupId": "site"
+    },
+    {
+      "type": "TXT",
+      "host": "_ltcheck",
+      "data": "lucitech-verification=%checktoken%",
+      "ttl": 600,
+      "groupId": "verify",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "lucitech-verification="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template for Lucitech, a managed website service for small businesses.

`lucitech.net.managed-site.json` points a customer's domain at their Lucitech-hosted site
and adds a service verification record. Three records:

- `A` at the apex pointing to the assigned web server IP (`%ip%`)
- `CNAME` at `www` pointing to the apex
- `TXT` at `_ltcheck` carrying a prefixed verification token (`lucitech-verification=%checktoken%`)

Synchronous flow with signed requests. The RSA public key is published and resolving at
`dck1.keys.lucitech.net`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [[Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Additionally validated with `dc-template-linter` in default and `-cloudflare` modes. All
findings are informational; details below.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [[Template Quality Guidelines](https://claude.ai/README.md#template-quality-guidelines)](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Notes on the checklist

**Bare variable as full record value.** The `TXT` record uses a fixed prefix
(`lucitech-verification=%checktoken%`) per the guideline. The `A` record uses `%ip%` as a
bare `pointsTo` value, which is unavoidable: the value is a server IP address assigned per
customer, and there is no fixed prefix that a valid A record target could carry.

**`essential`.** Set to `OnApply` on the apex `A` record only. End users may legitimately
edit their own apex A record, and we would rather tolerate that than have the whole
template invalidated. Deliberately not set on the `CNAME` or `TXT`, which no end user has
reason to hand-edit.

**`txtConflictMatchingMode`.** Set to `Prefix` with an explicit
`txtConflictMatchingPrefix` of `lucitech-verification=`, so re-applying the template
replaces only our own verification record rather than any unrelated TXT at that label.

**Underscore label.** `_ltcheck` is not an IANA-registered underscore name (linter
DCTL1021, informational). It is service-specific and namespaced by the record's own value
prefix. Happy to rename if the maintainers prefer a different convention.

## Online Editor test results

**Editor test link(s):**

Test 1 — domain apex (`example.com`, host empty, both groups applied):

[[Test lucitech.net/managed-site example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGYgXGoC%2F%2B1VXW%2FaMBT9K5alPi0JIeGjZJpUBp3UtXSso12lCkXGMWCRxJFtoCnqf5%2BdBJIgVu1p6kOfAN97zz3nfrGDkkRJiCSB3g4mnG1oQPhVAD0YrjGVBC%2BtmEhoHGy3KFK%2B8KawKosgfEMxyYIiFKMFCUyhjKXpKAaMci%2Fwm8wKxw3hgrIYek0DhmzB7nmoApZSJsJrNKpUGjRSsaKhvawkXqjggAjMaSIzADhmNJYCpGzNQcAiRGOAZP5zT8AsaIJtTgCgOAAoCARAQDGhc4qRRgOcYMYDSxNEnKJZSIa1XGd4SfBKshWJz7wDPMgwa0CZy2dwRhPldzXWyTgRArA5kEtSRipCQBeNcF29NMbj9eyapMNMh0q4Iqmwjjqj3e5IQBVZeXCs%2Bhjb7fY4KFcmoPe0gzJNdHv66nnJhFRfL3TDszpOmJapaKsXKVVT3I5tG3DB2TrJOl40UIkhsaRIt%2B1H3E%2BSMIWvxgF7cNsfXZb4ilA9w8Wb8BWgyeOkhPFDmTVAzwCSqCLbrFb%2FS7VN%2B0RHeTL%2FVBuf5YDF85BiOUIKnsaLEQt06jEnc%2Fp82qWw%2FY0AfJ2%2BGvCFxcQvCz9VrPftIs9IrSGxMItKebAg6NPMH5a7oqmq8ARxFAm9uXugpxrSdA%2F1BPX3DOwkEM2eHdu1bKvZdK2Wo1%2FLqmkrmuGm40IthC5ixokv1CeSa66KI%2FmaGDBah5L6aIvKpwD7SA%2BD0i2UVQHVBy7OT8NF2cIai9pU%2BAHWWqnuF3Y6PbeDOyZq2k2z1eu5Jmpj1zyfn7fbLaftzrp25Wqdumhv3K2yASfn%2BsRgFzrywS6U1Jv6joT0wy1KRU1HvleFin%2Fdq2Ikqhv1bqRNDbVgH7P2MWv%2FY9bUsRRoQwIfyWyqnI5pd81mb2LbXrvt2Y5ld%2B12x%2F2kftuahyRC5nJ36p5WLylsOMPBaCvufs6%2Fdr9%2Fe5Et8Qs%2F3gyvyeIbvl49PCwHrDu%2BGrbml%2Ffqf%2BUPhzRyb8EJAAA%3D)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGYgXGoC%2F%2B1VXW%2FaMBT9K5alPi0JIeGjZJpUBp3UtXSso12lCkXGMWCRxJFtoCnqf5%2BdBJIgVu1p6kOfAN97zz3nfrGDkkRJiCSB3g4mnG1oQPhVAD0YrjGVBC%2BtmEhoHGy3KFK%2B8KawKosgfEMxyYIiFKMFCUyhjKXpKAaMci%2Fwm8wKxw3hgrIYek0DhmzB7nmoApZSJsJrNKpUGjRSsaKhvawkXqjggAjMaSIzADhmNJYCpGzNQcAiRGOAZP5zT8AsaIJtTgCgOAAoCARAQDGhc4qRRgOcYMYDSxNEnKJZSIa1XGd4SfBKshWJz7wDPMgwa0CZy2dwRhPldzXWyTgRArA5kEtSRipCQBeNcF29NMbj9eyapMNMh0q4Iqmwjjqj3e5IQBVZeXCs%2Bhjb7fY4KFcmoPe0gzJNdHv66nnJhFRfL3TDszpOmJapaKsXKVVT3I5tG3DB2TrJOl40UIkhsaRIt%2B1H3E%2BSMIWvxgF7cNsfXZb4ilA9w8Wb8BWgyeOkhPFDmTVAzwCSqCLbrFb%2FS7VN%2B0RHeTL%2FVBuf5YDF85BiOUIKnsaLEQt06jEnc%2Fp82qWw%2FY0AfJ2%2BGvCFxcQvCz9VrPftIs9IrSGxMItKebAg6NPMH5a7oqmq8ARxFAm9uXugpxrSdA%2F1BPX3DOwkEM2eHdu1bKvZdK2Wo1%2FLqmkrmuGm40IthC5ixokv1CeSa66KI%2FmaGDBah5L6aIvKpwD7SA%2BD0i2UVQHVBy7OT8NF2cIai9pU%2BAHWWqnuF3Y6PbeDOyZq2k2z1eu5Jmpj1zyfn7fbLaftzrp25Wqdumhv3K2yASfn%2BsRgFzrywS6U1Jv6joT0wy1KRU1HvleFin%2Fdq2Ikqhv1bqRNDbVgH7P2MWv%2FY9bUsRRoQwIfyWyqnI5pd81mb2LbXrvt2Y5ld%2B12x%2F2kftuahyRC5nJ36p5WLylsOMPBaCvufs6%2Fdr9%2Fe5Et8Qs%2F3gyvyeIbvl49PCwHrDu%2BGrbml%2Ffqf%2BUPhzRyb8EJAAA%3D)

Test 2 — subdomain (`example.com`, host `sub`, both groups applied):

[[Test lucitech.net/managed-site example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMkgXGoC%2F%2B1VTW%2FaQBD9K9ZKOQUbGwghrioFkRyShpS0RK0aIbSsB9jG9lq7a4iL8t87awy2Ec21OeSUeGfmzXvzxYZoiJKQaiD%2BhiRSrHgA8iYgPglTxjWwpRODJo297Z5G6EvuCitaFMgVZ5AHRTSmCwhshcbSdBBjDbde1g%2BYFY4rkIqLmPheg4RiIR5liAFLrRPlN5tVKk0eYaxqGi8niRcYHIBikic6ByAjwWOtrEyk0gpERHlsUb393BGwC5rWekvAonFg0SBQFrWQCZ9zRg2aJYEJGTiGIJWczkK4quU6YUtgz1o8Q3zi7%2BGtHLMGlLt8sk54gn43I5NMglKWmFt6CWUkErJM0UCa6mUxG6WzL5Bd5Tow4TNkyjnojHH7BgFHsnrvWPVprNfrw6CtMkX8pw3RWWLa08fnpVAa%2F700Dc%2FrOBZGJtLGF62xKe2u6zbIQoo0yTteNBDFQKw5NW37GveTJMzIa2OPPbjvD69LfCRUz3D5JnwFaPxzXMJMQ503wMwA1bQi265W%2F3O1TbtEB3ly%2F8wYX%2FRAxPOQMz2kCM%2FjxVAEJvVIwpy%2FHHcpbP8iQF4nrw3yR8QwLQs%2FQda7dsELxTUEh4molKfSGSk4TnkeQsp1MWwRIaGSRsos7w7rqQY22aE95XCTAu8oFs%2BfW27bcR3Pazudlnkta2esdMa8VpsYOXwRCwlThX%2BpTiWWSMsUGiRKQ82ndE3Lp4BNqRkJVK%2FQikD1sYu3B2IruGhljUdtOqYBM4K56ZsHXqflQttmXpfandlZx%2B71Oq59zhhzWbc3g8CtXK9jl%2B2N%2B1VrxNERPzLjhRizdDVB%2BOHU%2B%2Fy%2BNPXDNc1UTdJ22wpBu22rqzo%2B8MWYVHftPSmcNHD7PkbwYwT%2F4wjiaVV0BcGU6nzUWl3bPbe9i7Hr%2Bmddv%2BM5btfruO1T%2FHYNFQ1KbxVv8PpW7y4Jf%2FWuqXf7ePF4NRgPQQ70cyvSo4vk9uE7zE5%2F37GH9IF6kGYd%2FC36C5RFOm%2F1CQAA)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMkgXGoC%2F%2B1VTW%2FaQBD9K9ZKOQUbGwghrioFkRyShpS0RK0aIbSsB9jG9lq7a4iL8t87awy2Ec21OeSUeGfmzXvzxYZoiJKQaiD%2BhiRSrHgA8iYgPglTxjWwpRODJo297Z5G6EvuCitaFMgVZ5AHRTSmCwhshcbSdBBjDbde1g%2BYFY4rkIqLmPheg4RiIR5liAFLrRPlN5tVKk0eYaxqGi8niRcYHIBikic6ByAjwWOtrEyk0gpERHlsUb393BGwC5rWekvAonFg0SBQFrWQCZ9zRg2aJYEJGTiGIJWczkK4quU6YUtgz1o8Q3zi7%2BGtHLMGlLt8sk54gn43I5NMglKWmFt6CWUkErJM0UCa6mUxG6WzL5Bd5Tow4TNkyjnojHH7BgFHsnrvWPVprNfrw6CtMkX8pw3RWWLa08fnpVAa%2F700Dc%2FrOBZGJtLGF62xKe2u6zbIQoo0yTteNBDFQKw5NW37GveTJMzIa2OPPbjvD69LfCRUz3D5JnwFaPxzXMJMQ503wMwA1bQi265W%2F3O1TbtEB3ly%2F8wYX%2FRAxPOQMz2kCM%2FjxVAEJvVIwpy%2FHHcpbP8iQF4nrw3yR8QwLQs%2FQda7dsELxTUEh4molKfSGSk4TnkeQsp1MWwRIaGSRsos7w7rqQY22aE95XCTAu8oFs%2BfW27bcR3Pazudlnkta2esdMa8VpsYOXwRCwlThX%2BpTiWWSMsUGiRKQ82ndE3Lp4BNqRkJVK%2FQikD1sYu3B2IruGhljUdtOqYBM4K56ZsHXqflQttmXpfandlZx%2B71Oq59zhhzWbc3g8CtXK9jl%2B2N%2B1VrxNERPzLjhRizdDVB%2BOHU%2B%2Fy%2BNPXDNc1UTdJ22wpBu22rqzo%2B8MWYVHftPSmcNHD7PkbwYwT%2F4wjiaVV0BcGU6nzUWl3bPbe9i7Hr%2Bmddv%2BM5btfruO1T%2FHYNFQ1KbxVv8PpW7y4Jf%2FWuqXf7ePF4NRgPQQ70cyvSo4vk9uE7zE5%2F37GH9IF6kGYd%2FC36C5RFOm%2F1CQAA)

Both tests applied both groups (`site` and `verify`). Test 2 confirms all three records
shift correctly under the `host` parameter, including the `www` CNAME resolving to the
host apex rather than the domain apex.