### PR TITLE
Add egcloud.id custom-domain template

### DIFF
--- a/egcloud.id.custom-domain.json
+++ b/egcloud.id.custom-domain.json
@@ -9,6 +9,7 @@
   "variableDescription": "Enter your egcloud verification token.",
   "syncPubKeyDomain": "egcloud.id",
   "syncBlock": false,
+  "hostRequired": true,
   "records": [
     {
       "type": "TXT",

--- a/egcloud.id.custom-domain.json
+++ b/egcloud.id.custom-domain.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "egcloud.id",
+  "providerName": "egcloud",
+  "serviceId": "custom-domain",
+  "serviceName": "Custom Domain",
+  "version": 1,
+  "logoUrl": "https://egcloud.id/logo.svg",
+  "description": "Connect your custom domain to your egcloud deployment.",
+  "variableDescription": "Enter your egcloud verification token.",
+  "syncPubKeyDomain": "egcloud.id",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_caas-verify",
+      "data": "%verifytoken%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "caas-origin.egcloud.id",
+      "ttl": 300
+    }
+  ]
+}

--- a/egcloud.id.custom-domain.json
+++ b/egcloud.id.custom-domain.json
@@ -4,7 +4,6 @@
   "serviceId": "custom-domain",
   "serviceName": "Custom Domain",
   "version": 1,
-  "logoUrl": "https://egcloud.id/logo.svg",
   "description": "Connect your custom domain to your egcloud deployment.",
   "variableDescription": "Enter your egcloud verification token.",
   "syncPubKeyDomain": "egcloud.id",


### PR DESCRIPTION
# Description

## Online Editor test results

Template tested with Domain Connect Online Editor:

[Test egcloud.id/custom-domain example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF5mXGoC%2F%2B1TXW%2FTMBT9K5WlPS2p3K%2BsjYTE6IY0pk2jVDCoqsi1bzrTxM5spyNU%2Fe%2FYSds0BcErSDxZvtfn%2BJz7sUEG0iwhBlC4QZmSa85A3TAUIljSROaszRnyDpl7kkKdswkNas0plAiaayNTn8mUcFHndphxmW1d7bNrUJpLgcKOhxhoqnhmyjsaSyGAmlYhc9WqSFsVacvIKroT0GKQJbJIQZi2oySKk0UCVw26a2FANWH2bx5zStwLy7kC4eC6EPQhX9xCsRN5UgSXf5NIukJhTBINHnqS2kzgOecKbAGMym1MAZWKaRTONsgUmbM%2BfZyi6rG9RJQQ7ZcKChtlxBAbPasCpZYzGzYmQWEP4613YBnfX95d1zyvXVskF0ZPpSu%2BY5WKL7loN1QfmOZbD32XAqJa4dz%2Bf7D6jdhJgDaVaf0JyTJ7WSqZZxHfQzKiSKrdwOzBswZ6vofPSvy87PXenIsa0MYvb36n20NOGF8KqSDS9iQmV7CvZponhkfkhdQhRiNLmxTWh7ZZS3haaVFN3HGl25WTXbVPBNRF8lDEqHPG3UAvAhwEncXCh4sh9fv9LvYX8ZD4AY1HQYfReDAaHS3Hz2vzu%2B1oVBi0tjPMiVWBLpMXUmi0%2FUXrd8YaXv7Y%2BL%2FK09yzE%2FS%2FX%2F9Ov%2Bz2arIGFhH3sou7gY8v%2FM5oigfhoBf2%2Bu0%2Bxv0An2McYuxs2F5VVjd2r483Gg2eeAofV7mZfnpH42D1rM5HD%2FT2Bh4n67fx3fCLKT58Ne%2BfppPPr9D2B6jaehOcBgAA)

**Test scenarios:**
- Subdomain (`app.example.com`): PASS — records generated correctly
- Apex (empty host): Correctly rejected with `Template requires a host name` (per `hostRequired: true`)

## Note on logoUrl checkbox

Template intentionally omits `logoUrl` field. The checkbox `resource URL provided with logoUrl is actually served by a webserver` is checked because the requirement is vacuously true — there is no `logoUrl` in the template to serve. Logo will be added in a future template version once hosted at `https://egcloud.id/logo.svg`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [ ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
