### PR TITLE
add LnkFlow, Branded link domain

### DIFF
--- a/lnkflow.io.custom-domain.json
+++ b/lnkflow.io.custom-domain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "lnkflow.io",
+  "providerName": "LnkFlow",
+  "serviceId": "custom-domain",
+  "serviceName": "Branded link domain",
+  "version": 1,
+  "logoUrl": "https://app.lnkflow.io/favicon.svg",
+  "description": "Connect a subdomain to LnkFlow for branded campaign links.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.lnkflow.io",
+  "syncRedirectDomain": "app.lnkflow.io",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.lnkflow.io",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds LnkFlow's signed synchronous Domain Connect template for connecting a customer-selected subdomain to the LnkFlow branded-link CNAME target. The template requires the standard `host` parameter and creates exactly one CNAME to `cname.lnkflow.io`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

The single CNAME is the service connection itself, so it is intentionally integrity-managed by the template and is not independently editable.

## Online Editor test results

**Editor test link(s):**

[Test lnkflow.io/custom-domain example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIDLXGoC%2F91SXW%2FaMBT9K5Ffm4Qk0AQiTVrpOqnrVm2lfRlCkbENtXDs1HYCFPHfd034VKXtfU%2BRfc85PvfkbJBlZSWwZSjfoEqrhlOm7ynKkZCLmVDLkCvkHyePuAQk%2Bi4XX2EGA8N0wwnbMUhtrCoDqkrM5Wm25ww1lpRRT3C58I6YhmnDlUR57COh5upFC8C%2BWluZvNPBVRWefHRmGPSUDE0zByplhmhe2R0d3SopGbEe9kw9beU9q7y9U2%2BmtDfdOyC4rDCfy50VEzqna0mGQpEFymdYGNbe%2FKynD2z9pbWao1aUtO%2BEF%2FE49BOjXMPkiL80D6hXZewTe6sBBnFZXcM7wFCaGpSPN8iuKxfU7ePNj7s9HI6fXfyKS2uelQtZQpyXutZCZt00iraTrY%2FelWTFSXbi740Dl61gc8FCosqT%2FtxJzLWqq4IfGBXWuDSuEgfu%2BII8ObDHju5ehTiVZoWBL7a1Zof9ylpYXuAlPl1RUkA0Yg0mDUxB5OPusu3MzhvFFv9jcR8VlDi73PVwwFKaDDANYjJLgl4W4aCfTEmQ0TSZ9bI0ztL%2BWac%2Ftv1vpT5PjRnDpOXYVfZGLPHaoO124kOC%2F9dG8LsNbhgtsAMmUZIGURbEg%2Be4m0fXedQLk%2Fi61%2B1eRVEeRW4NZmy75Aa6cd4KhOOrUbJ66Q%2B4YPfr6mGQDukq7ry%2FfssaPl9kv9%2B0Hf1a9O5G5BPa%2FgEWaPGxoAQAAA%3D%3D)

`hostRequired=true`, so the required apex test is not applicable. The linked editor result tests `domain=example.com` with `host=go` and applies `go CNAME cname.lnkflow.io`.
