### PR TITLE
Add webuno.es and webuno.io site templates

### DIFF
--- a/webuno.es.site.json
+++ b/webuno.es.site.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "webuno.es",
+  "providerName": "Webuno",
+  "serviceId": "site",
+  "serviceName": "Webuno website",
+  "version": 1,
+  "logoUrl": "https://webuno.es/favicon.svg",
+  "description": "Connects a domain to its Webuno website (Cloudflare Pages). Adds two CNAME records only; never touches MX/TXT/NS.",
+  "variableDescription": "cname = the Cloudflare Pages hostname for the site's template family, e.g. webuno-sites-tapas.pages.dev",
+  "syncPubKeyDomain": "webuno.io",
+  "syncRedirectDomain": "webuno.es,webuno.io",
+  "shared": false,
+  "hostRequired": false,
+  "records": [
+    { "type": "APEXCNAME", "groupId": "1", "pointsTo": "%cname%", "ttl": 3600 },
+    { "type": "CNAME", "groupId": "1", "host": "www", "pointsTo": "%cname%", "ttl": 3600 }
+  ]
+}

--- a/webuno.io.site.json
+++ b/webuno.io.site.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "webuno.io",
+  "providerName": "Webuno",
+  "serviceId": "site",
+  "serviceName": "Webuno website",
+  "version": 1,
+  "logoUrl": "https://webuno.io/favicon.svg",
+  "description": "Connects a domain to its Webuno website (Cloudflare Pages). Adds two CNAME records only; never touches MX/TXT/NS.",
+  "variableDescription": "cname = the Cloudflare Pages hostname for the site's template family, e.g. webuno-sites-tapas.pages.dev",
+  "syncPubKeyDomain": "webuno.io",
+  "syncRedirectDomain": "webuno.es,webuno.io",
+  "shared": false,
+  "hostRequired": false,
+  "records": [
+    { "type": "APEXCNAME", "groupId": "1", "pointsTo": "%cname%", "ttl": 3600 },
+    { "type": "CNAME", "groupId": "1", "host": "www", "pointsTo": "%cname%", "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
# Description

New templates for **Webuno** (`webuno.es` for the Spanish market and `webuno.io` for the global market), a website platform for local businesses. Each template connects a customer's own domain to their Webuno website hosted on Cloudflare Pages: an `APEXCNAME` on the apex and a `CNAME` on `www`, both pointing at the site's Pages hostname (passed as the `%cname%` variable, e.g. `webuno-sites-tapas.pages.dev`). No MX/TXT/NS records are touched. The two templates are identical apart from `providerId`/`logoUrl`; both publish the same signing key and share `serviceId=site`.

The synchronous flow is signed: `syncPubKeyDomain=webuno.io` with the public key published at `_dck1.webuno.io` (TXT, `p=<i>,a=RS256,t=x509,d=<chunk>` format). Redirects are restricted via `syncRedirectDomain=webuno.es,webuno.io`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Both template file names follow the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key live at `_dck1.webuno.io` TXT
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the sync flow uses `redirect_uri`)
- [x] no TXT record contains SPF content — template has no TXT records
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [x] no variable is used as a bare full record value — `%cname%` is the record target (`pointsTo`), which is inherently the full value for a CNAME; the value is constrained to the service's own `*.pages.dev` hostname generated per customer site
- [x] no bare variable is used as the full `host` label — hosts are fixed (`www` / apex)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — n/a, both records are the service connection itself; manual changes should surface as a template conflict

## Online Editor test results

**Editor test link(s):**

`webuno.es.site.json`:

- Apex: [Test webuno.es/site example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJD4XGoC%2F%2B1Ua2%2FTMBT9K5alCRBJmnR9rEGTqLYBE9roRtGmTVXlOTeppdQOttOuq%2FrfuU5f6yjwFSQ%2Btb7Pc8%2B5N3NqYVzkzAKN57TQaiIS0OcJjekUHkqpAjDU2zgu2RgD6U3lQrsBPREcqngjsMjGtBNJsNbKPQFthJI0jjyaq0x90zmGjawtTFyrbXrWUoZVlAzMJMOsBAzXorBVJj1RUgK3hjCSqDETklhFBL53u5HXJ7kqkzRnGkiPZWDeBKSbJIbYqSInl92LM6KBK40WJfPZOyIB4WGxko%2FAkIvbWv%2B2X7v8GjjcTAv2kMPpDhIucUxyTOwIyMtmZKSMrfyp0lWEA%2FUKu68YJykbi3zmEQiygCxH912M8S0rmAkKVyZIYOJonUneKx8%2Bw%2By0GnkrkFAr9zUkAuexLwPAeDuhI4SIgqUsN%2BBRh%2FIavpfiuXFFC43v59TOCqdkt3d2W3GGJTKtyqISPXLLoYS0pq%2FweVARcoBGa1HXw1YYLrxNif3pDoADO53%2BudZg4dEnJWG4BTjA7VgPDI8MqYWAq%2FG28LrhUKzjC6bZ2LiFX2fe76QO1rn31P2vcLjHbyVy0EQmlYahwV9mS41JVpdI57jMrRiyKduaEj5kRZHPcBKDXiy%2Fn%2Bplb%2FreHQGzbKPqLxdlQ5ZHhwl3QwrHdNqJ6mGrwfx2J2n6jaje8Duccx%2BO0rDVTqJmvfHw7NB%2F%2BgLsufQtv2AMSCuYO%2BVuPmUzQxd7dF%2FNslT6H5tm4OHm%2FJfor5YIb9WwCSRD5sLqYb3lh20%2F6vSjVhy143oYNKLO0WHnbRjGYeigg7HLIed4vc%2FvlrLTK%2FXYfrLnsp3xu%2BaXab2R9rhs9q5u%2BLnV2ad696kT3Xz8cJcd08UPqdBwpUcHAAA%3D)
- Subdomain (host=shop): [Test webuno.es/site example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJP4XGoC%2F%2B1UbW%2FaMBD%2BK5alapuWhEApjEyVhmgnVS0ItXRrVSFk4gt4CnZmO7AM8d93Dm%2BlY9vnSvsU%2BV6ee%2B65uyyphVmWMgs0WtJMq7ngoK84jegCxrlUARjq7Rw9NsNA%2BrV0od2AnosYyngjEGRnOogkiLVxz0EboSSNqh5N1UTd6xTDptZmJqpUdjUrCUMUJQMzn2AWBxNrkdkyk3aUlBBbQxjhasaEJFYRge%2FDauRtJ1U5T1KmgfTZBMy7gLQ5N8QuFOn02t1LoiFWGi1KpsVHIgHpIVgeT8GQ7kNl8DCo9O4Cx5tpwcYpXBwwiSW2Sc6JnQJ5WYxMlbGlP1G6jHCk3mD1jeIkYTORFh6BYBKQdeu%2BizG%2BZRkzQeZgAg5zJ2sh434%2Bvobiomx5PyChNu5b4AL7sS8DwHgHoVOkiANLWGrAo47lLXzPxXPjRhYaPS2pLTI3yXb%2F8qHUDCEmWuVZOfSqWw4lpDUDhc%2BTUpATNFqLcz1thOHK20EcT3cEHNnF4t9Yw5VHfyoJoz3BIW7HtmH4wVBaCGI12wObqcq2RUdim5MxzWbGLf02%2B%2BkgfbjNf1oD4Lvk4wx%2FHZWjKCZSaRgZ%2FDKba0yyOkdZZ3lqxYgt2N7E4xHLsrTAjgx6Ef645Ova9JM7BmbZbrp%2FXJidaB4d8dg1KpziH4CxsMVD%2F2xc5X69cQY%2B4yzxx%2FU4adZOW3Vej58d%2FG9%2FgiMXf6gzGAPSCubOup0uWGHo6sgObPrBqQebxFfY1tDDVfo%2Fr9czL7xiw%2BbAR8yF1sJaww%2BbfrU1qDaiajOqnQaNWqvWqL8PwygMHX0wdt3oEu%2F6%2BUXT5s0dG5izx879Tf%2B6uO4OxOf73iAUUl3xb9XTx66ORZh8Ud26OaerXyPfv5dpBwAA)

`webuno.io.site.json`:

- Apex: [Test webuno.io/site example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAsDXWoC%2F%2B1U207bQBD9ldVKqK2wHSfkZldIDZdShECIpgIVRdFgT5IF22t210nTKP%2FeWedGaNq%2BtlKfkp3rmXNmPOMG0zwBgzyc8VzJsYhRncc85BN8KDLpCcmdteMKUgrkt6WL7BrVWERYxmtBRdamrUhGtZbuMSotZMbDqsMTOZRfVEJhI2NyHVYq656VAVAVmXl6PKSsGHWkRG7KTH4sswwjoxmwWKYgMmYkE%2FTe7sbeHieyiAcJKGTXMET9zmOdONbMTCQ7vupcnjKFkVRkkVkyfc8yJHhUrIhGqNnlXaV7161cffYsblACHhI82UISZTQmO2RmhOx1MzaS2pT%2BgVRlhAX1hrovGWcDSEUydRh6Q48tRndtjHYN5KC93JbxYhxbWqdZdF08XOD0pBz5lUDWfYOxoHnM6wDUzlboiCCSYANINDrcorzB50K8NC5p4eH9jJtpbpXsXJ%2FelZxRiaGSRV6KXrXLIUVmdFfSc68kZI%2BMxpCuB03fnzvrErvTLQALdjL5c63e3OHfZYb9DcAebcdqYPwGRC16kUw3hVcN%2B2IVn4OCVNuFX2Xeb6X2Vrn33P4vcdjHbyWy0MQwkwr7mn7BFIqSjCqIzrRIjOjDBDamOOpDnidTmkSTl8rvpnrRm3%2BwRwAG1qr%2BclHWZDm8H0d2SGGZbgatah1qNRdaUcOttwdtFwYQu36EWG8EtWY7aL849J%2B%2BADsufcMvao2ZEWBPuZNMYKr5fIfuy1kWSv9j0%2FQc2pz%2FEv3VEtGtahhj3AcbVvNrTddvudWgW22Ffi30Dzy%2FHTQbtX3fD33fQkdtFkPO6Hpf3i3%2FVBX1xplsHzw%2B%2Bs9pUNtvHBWnF8XoKLgNPj59rdfzNDo7vxhXRk%2BHfP4D9VACPEcHAAA%3D)
- Subdomain (host=shop): [Test webuno.io/site example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACgDXWoC%2F%2B1U22rbQBD9lWUhtKWSLNutLyqBOk5oQhoTUpcGgjFjaWRtkbXK7sqOYvzvnZUviVO3fQ70Sexczpw5M6MlNzjLUzDIgyXPlZyLCNVFxAO%2BwEmRSU9I7uwcA5hRIP9RuciuUc1FiFW8FgSyM%2B1FMsLauOeotJAZD%2BoOT%2BVUflcphSXG5Dqo1XY1azEQisw8PZ9SVoQ6VCI3VSbvyyzD0GgGLJIzEBkzkgl671djb%2FupLKI4BYXsGqao33msF0WamYVk%2FUHv6owpDKUii8zS8hPLkOgRWBEmqNnVbW14O6wNvnmWNygBkxRP95iEGbXJjplJkL0sxhKpTeWPpaoiLKk3VH2jOIthJtLSYehNPbZu3bUx2jWQg%2FZyC%2BNFOLeylll4XUwusTytWn4xIOu%2BwUhQP%2BZlAGpnLzQhijSwGFKNDrcsb%2FC%2BEM%2BNG1l4cLfkpsztJHvXZ7eVZgQxVbLIq6HX7XJIkRk9lPQ8qgQ5IqMxNNdmy%2FdXzg7icLolYMkuFv%2FGGq0c%2FigzHD8RHNF2bBvGByBp0Qvl7AlYJzLfFh2LbU4OCmbaLv02%2B24vfbTNv1sD0LviYw1%2FHZWlKKaZVDjW9AVTKEoyqiBZZ0VqxBgW8GSKwjHkeVpSR5q8BH9Y8nVt%2FtkeAxjYTfePC7MTzeHjKLSNCqt4u9tudluR70aTeuh%2BiJtdF7qdrovN9se4jtDxW%2BGzg%2F%2FtT3Dg4vd1Rq0xMwLsWffSBZSarw7swKYfmrq3SXyFbY0cWqX%2F83o986Ir1jDHaAw2tOE3Wq7fduvdYb0d%2BI2g2fDanXarUX%2Fv%2B4HvW%2FqozbrRJd3184vmtRMT175OuukgOY8vip%2Fn%2FuXJl1S%2Bv7iPoT%2BR0LmdPt48TJK89I%2F56hdWm6uZaQcAAA%3D%3D)
