### PR TITLE
Add notdeploy studio Production and Sandbox customer hostname templates

### DIFF
--- a/notdeploy.studio.customer-hostname-sandbox.json
+++ b/notdeploy.studio.customer-hostname-sandbox.json
@@ -1,19 +1,19 @@
 {
   "providerId": "notdeploy.studio",
   "providerName": "notdeploy studio",
-  "serviceId": "customer-hostname",
-  "serviceName": "Custom Domain",
+  "serviceId": "customer-hostname-sandbox",
+  "serviceName": "Custom Domain Sandbox",
   "version": 1,
   "logoUrl": "https://studio.notdeploy.studio/assets/domain-connect-logo.svg",
-  "description": "Connects an exact customer-owned subdomain to a published notdeploy studio site.",
+  "description": "Connects an exact customer-owned test subdomain to a Sandbox-published notdeploy studio site.",
   "syncPubKeyDomain": "domainconnect.notdeploy.studio",
-  "syncRedirectDomain": "studio.notdeploy.studio",
+  "syncRedirectDomain": "sandbox-studio.notdeploy.studio",
   "hostRequired": true,
   "records": [
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "customers.notdeploy.studio",
+      "pointsTo": "sandbox-customers.notdeploy.studio",
       "ttl": 300
     }
   ]

--- a/notdeploy.studio.customer-hostname.json
+++ b/notdeploy.studio.customer-hostname.json
@@ -8,7 +8,7 @@
   "description": "Connects an exact customer-owned subdomain to a published notdeploy studio site.",
   "variableDescription": "%target%: the signed notdeploy studio CNAME destination for the selected environment.",
   "syncPubKeyDomain": "domainconnect.notdeploy.studio",
-  "syncRedirectDomain": "studio.notdeploy.studio, sandbox-studio.notdeploy.studio",
+  "syncRedirectDomain": "studio.notdeploy.studio,sandbox-studio.notdeploy.studio",
   "hostRequired": true,
   "records": [
     {

--- a/notdeploy.studio.customer-hostname.json
+++ b/notdeploy.studio.customer-hostname.json
@@ -4,7 +4,7 @@
   "serviceId": "customer-hostname",
   "serviceName": "Custom Domain",
   "version": 1,
-  "logoUrl": "https://sandbox-studio.notdeploy.studio/assets/domain-connect-logo.svg",
+  "logoUrl": "https://studio.notdeploy.studio/assets/domain-connect-logo.svg",
   "description": "Connects an exact customer-owned subdomain to a published notdeploy studio site.",
   "variableDescription": "%target%: the signed notdeploy studio CNAME destination for the selected environment.",
   "syncPubKeyDomain": "domainconnect.notdeploy.studio",

--- a/notdeploy.studio.customer-hostname.json
+++ b/notdeploy.studio.customer-hostname.json
@@ -8,6 +8,7 @@
   "description": "Connects an exact customer-owned subdomain to a published notdeploy studio site.",
   "variableDescription": "%target%: the signed notdeploy studio CNAME destination for the selected environment.",
   "syncPubKeyDomain": "domainconnect.notdeploy.studio",
+  "syncRedirectDomain": "studio.notdeploy.studio, sandbox-studio.notdeploy.studio",
   "records": [
     {
       "type": "CNAME",

--- a/notdeploy.studio.customer-hostname.json
+++ b/notdeploy.studio.customer-hostname.json
@@ -9,6 +9,7 @@
   "variableDescription": "%target%: the signed notdeploy studio CNAME destination for the selected environment.",
   "syncPubKeyDomain": "domainconnect.notdeploy.studio",
   "syncRedirectDomain": "studio.notdeploy.studio, sandbox-studio.notdeploy.studio",
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",

--- a/notdeploy.studio.customer-hostname.json
+++ b/notdeploy.studio.customer-hostname.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "notdeploy.studio",
+  "providerName": "notdeploy studio",
+  "serviceId": "customer-hostname",
+  "serviceName": "Custom Domain",
+  "version": 1,
+  "logoUrl": "https://sandbox-studio.notdeploy.studio/assets/domain-connect-logo.svg",
+  "description": "Connects an exact customer-owned subdomain to a published notdeploy studio site.",
+  "variableDescription": "%target%: the signed notdeploy studio CNAME destination for the selected environment.",
+  "syncPubKeyDomain": "domainconnect.notdeploy.studio",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds signed Production and Sandbox templates for connecting an exact customer-owned subdomain to the corresponding fixed notdeploy studio CNAME target.

The templates use separate service IDs and fixed destinations:
- `customer-hostname` → `customers.notdeploy.studio`
- `customer-hostname-sandbox` → `sandbox-customers.notdeploy.studio`

The application derives the environment-specific service ID server-side and signs the complete synchronous request. No browser-selected CNAME target is accepted or sent.

`hostRequired: true` matches the product contract: Domain Connect is offered for exact subdomains, not zone apexes. Therefore the repository's documented apex-test exception applies.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set for the synchronous `redirect_uri` flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is not applicable because the templates have no TXT records
- [x] no bare variable is used as a full record value; both CNAME destinations are fixed
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain; the standard `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] the connection CNAME is not independently editable, so `essential` is intentionally omitted

## Online Editor test results

[Test notdeploy.studio/customer-hostname example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL3UXWoC%2F%2BVT70%2FbMBD9VyJ%2FJUnd0h9ZpElDbEhoomMImBCqItc%2BWk%2BJHXyXhq7q%2Fz6naUthoO37PkXOvffu3vN5xQiKMhcELF2x0tmFVuDOFUuZsaSgzO0yRqqUtizc18eigENEsEcguIWWsBGQFZItwEVzi2Qayr6%2BFTjdIILPthDa%2BOoCHGprWNoNWW5n9sblHjUnKjHtdNom8eu5OgIRCDtqoxJJawxIihp%2BjIuZl1WA0umSNtLstAVgIEwAT0JSsB%2FU1gZUgNW01QrIBiIoq2muce4Lr%2F0GqAnixtXSyMtq%2BhWWWyspaxW2w8RvZNlwrkBp5%2Bt71jsWPbzJ8AoeK4%2F32ZKrIGSeap1Clt6vGC3LTaLjk4svW7g%2FfmouzWpDeG0PbgTf6kDkwz7mfD1Zh%2ByXNZA960%2FCrSEv4jPzGwOxtMVzo7qu%2FWHmbFVmekcphRMFNou1I9%2B%2FYE929PsNv%2BmrZ8Y6yNB%2FBVUOdlaLKiediVo8%2F1IyE2WZL%2F2Y6Kte5c8YTLtn7XRKkPjXEEKWKdlMrptN7gkuxcPDNJpKqaJ%2BV%2FYjMRjyKOkmPOknfNTr8YPn8d7z%2BdvjeJEl%2BK02pEXzAk7yWiyRrdeT0Of6H9j0m4FiASoTDbLHe8OIj6Iev%2BajdDBM%2B4N4cJz0u8kR5ylvZiJAao2v%2FBYd7g%2B7FfbxmI%2FKI3t2m%2BCPYf3t7vziJxzdXd58GOPt%2BZzOZmasYD74%2FpGtfwOo9EN9EQUAAA%3D%3D)

[Test notdeploy.studio/customer-hostname-sandbox example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOjUXWoC%2F%2BVTXU%2FbQBD8K9a91nYOkzTBUqUivoQqKKJQEUWRtfEtyan2nbk724Qo%2F73rOF9QkNrnPlnnm5ndmdtdMId5kYFDFi9YYXQlBZpLwWKmtBNYZHoeWlcKqZm%2Fvb%2BGHPcR3hZh0VQyxZVAWlqnczTBTFuniBJYUGKin3e4tdDJCumd6hyk8n5sURUaK7Vi8YHPMj3V9yYj9My5wsadTls0fNtnB6xFZztipRakWilMXdDwQ1tNSVagTY0s3EqanbQA64Hy8BlS520b17VC4Tm0zrPlpBX0nPZg02NQlJNM2hmh3obhWekwbKzOVXpTTr7hvPVHJVuldWfhO0E3nFsU0tD9lrVOL%2FjAN9GaoG%2FxqSQePYAzJfqMJLQRlsWjBXPzYhX39fHV2RpOx6%2FNy2qpnL3Te2U2Kdj3KjlHL3HI%2BXK89NmLVpjs6oz9tUESo0BpvDBMdb4rWNc1HaZGl0UiN5QCDOS2mcINefSKPd7QRyt%2BU1dOlTaYWPqCKw1uLOdl5mQCNex%2BiTSBosjm1KalW1L5Mw7VDmPbnQAH%2FxqGzxKRNg5kM%2F6H6SNA70gEANHnoPvIIYBuNw2wx%2FuTg8foYCIGezv10c797Ua9yhZpBZST0KzLcVbD3LLlcuxTzv%2BhbZocCxWKBBpkxKkt3g8ifsf7ca8fR4OQR%2F2jPv%2FEecx5Y4wWvg1iQVO2P1%2Fs5%2FD65eGijjrHp9%2Fvy5dBfnH2kA%2B7V5fdXvV09qvSYpbdn59DeTv8wpa%2FAQhgSMZeBQAA)

Both templates set `hostRequired: true`; the required subdomain tests are included and apex tests are not applicable.
