### PR TITLE
Add combined MailLogic email forwarding and sending template

### DIFF
--- a/maillogic.io.email.json
+++ b/maillogic.io.email.json
@@ -1,0 +1,57 @@
+{
+  "providerId": "maillogic.io",
+  "providerName": "MailLogic",
+  "serviceId": "email",
+  "serviceName": "Email Forwarding and Sending",
+  "version": 1,
+  "logoUrl": "https://maillogic.io/static/images/mail-orbit-logo.svg",
+  "description": "Configures inbound email forwarding and outbound email authentication through MailLogic.",
+  "syncPubKeyDomain": "keys.maillogic.io",
+  "syncRedirectDomain": "dc-lab.maillogic.io",
+  "records": [
+    {
+      "groupId": "mx",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.maillogic.io",
+      "ttl": 300,
+      "priority": 10
+    },
+    {
+      "groupId": "mx",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx2.maillogic.io",
+      "ttl": 300,
+      "priority": 10
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "smtp1._domainkey",
+      "pointsTo": "smtp1._domainkey.%fqdn%.maillogic.io",
+      "ttl": 300
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "smtp2._domainkey",
+      "pointsTo": "smtp2._domainkey.%fqdn%.maillogic.io",
+      "ttl": 300
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:smtp.maillogic.io"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

## Summary

Adds `maillogic.io.email.json`, a combined MailLogic Domain Connect template for configuring email receiving and sending in one authorization flow.

The template installs:

- two MailLogic MX records for inbound forwarding;
- two DKIM CNAME records;
- the MailLogic SPF include;
- a default DMARC monitoring policy.

The existing `email-forwarding` and `email-sending` templates remain available for users who want to configure the two functions separately.

## Validation

- `dc-template-linter -loglevel info -tolerate info -logos maillogic.io.email.json` — passed with exit code 0 and no notices.
- `dc-template-linter -cloudflare -loglevel info -tolerate info -logos maillogic.io.email.json` — passed with exit code 0; emitted only info-level `DCTL5003` (`syncRedirectDomain` is not supported) and `DCTL5008` (`txtConflictMatchingMode` is not supported).
- `dc-template-linter -merge-or-fail maillogic.io.email.json` — passed with exit code 0.
- `python -m check_jsonschema --schemafile template.schema maillogic.io.email.json` — passed (`ok -- validation done`).
- Filename/record-union invariant check — passed: filename matches `providerId.serviceId`, the exact 2+4 source-record union is present, there are six records, MX priorities are 10, DKIM/SPF/DMARC values are unchanged, group IDs are exactly `mx`, `dkim`, `spf`, and `dmarc`, and `%fqdn%` is the only substitution.
- Online Editor without a group selection — apex and `www` subdomain tests each produced all six expected records.
- Online Editor selective groups — `mx` produced two MX records, `dkim` produced two CNAME records, `spf` produced one merged SPF result, and `dmarc` produced one TXT record.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`
- [x] no TXT record contains SPF content; `SPFM` is used
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in `host` to create a subdomain
- [x] `%host%` does not appear explicitly in a `host` attribute
- [ ] `essential` is set to `OnApply` on records users may need to modify

`essential` is intentionally not added because this combined template is the exact record union of the two already-accepted MailLogic templates; adding it would change the DMARC record definition relative to `maillogic.io.email-sending.json`.

## Online Editor test results

[Test maillogic.io/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHT9XWoC%2F%2B1WXU%2FbMBT9K5ElnmiKGyBAEBKMD2naiqpSGBNCkRs7qUdiZ7ZTKFX323ed0qYtdBu8DKQ%2B1c39OPfc63vkITIsy1NiGAqGKFeyzylTnykKUEZ4msqER3UuUW1qOycZ%2BKImWL9aK5g0U30esTKK2bDq25P3qf3qnEl1TxTlInGIoM4FE%2FYMzn2mNJcCBY0aAkh5qVII6hmT62BjY7aQDW2I4dEGz0jCdGlypepy49q4uu7bdJTpSPHclCnRsRQxTwrFtMNFVxaAXBbpxPPlyMLMWklhekwAFrF5HNNTskh6zpR33ZIciKhVdL%2BwwYmEIIt2xwa6vtA669ZmlCsWmakjjdyUdBddwUUqqlFwM0QJIObjUTyAyQzysvHXcO5JbeB8aOciuTC6I0u3xmI%2BY6CTmxjb%2BXGpuBlAk%2FGo9qbs3luy0zueVfmPz4%2BapxWEzkzeqIe0bAq0bh5x0Vpfi39Ssbasilfien%2FE9d6Kq%2FO4gr1onTXnGwrmdpEymDDiIkoLygILN597gUlGVFTl7Fx3qpThxEiJIfC%2Ff3DSPGofN%2Fad%2FEBIwfbnpmQejN2GlEemSUzUg6vflNQmPUpTNLod1dAjBIXVLbyFzJMbyx4ISAWrRzKrCoBTWWnIJ%2F45USTTVk4mkTdzobeT2BuELCJPhFQs1PBLDKwpCowqWA1lRWp4SGBFp59oFJI8TwdQoAYrpIA1mb25Yiw3h1VD%2FnknatDLyFbNbc9xN%2Fb9iG25MfaJu%2BX72y7x97ZciulOI27sxjt0b0YUXxLMl1SxahrT2qoLScvm35OBRiM79r%2Bx8T4im8n2PRF6Yeuf%2BD3b%2BJmLs5z4O6fqLaXqfWiqYyF6fkn7ByByDWepvDm%2FSJpOWPn4XdN6nb7%2Bfxq3NZDglSiuRHEliitRXInikyjCk1OTPqMhsW4e9nwX77ge7jRwsI0Db7e%2B6e1tY38d4wBjWz3TZkxuCC%2FU2bcpaq%2BfFZtXySYmYrt3LFjxvXO6fjloJThvf%2Fv0kD%2Be7%2FJHefWjpZoHaPQbgNRq72APAAA%3D)

[Test maillogic.io/email example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIT9XWoC%2F%2B1WW0%2FbMBT%2BK5ElnmjSJIRbUKV1Bca0lVWlYyCEKtd2U0MSB9tp6VD323ec0ks6YBtPbOpTLufyne%2F4nE9%2BQJolWYw1Q%2BEDyqQYcsrkR4pClGAexyLixOECVea2U5yAL2qC9bOxgkkxOeSEFVHMhC3%2BPXofmb%2FWsZAjLClPIwun1DpjqXkH5yGTiosUhV4FAaT4KmMIGmidqbBaXS6kqjTWnFR5giOmCpMtZI9r28Q5amjSUaaI5JkuUqKGSPs8yiVTFk97IgfkokirXy5H5HrZinM9YClgYZPH0gMp8mhgzXk7huQ4Ja2894mNDwUEGbRbNlbOSuuMW5tRLhnRc0dK7Bj3Vl3BRUiqUHj1gCJAzKZHcQ8mPc6Kxl%2FA%2B0AoDe%2FvzLkInmrVEYWbt5pPa%2Bjkluua8%2BNCcj2GJruTyquy%2B6%2FJTm95ssjfOK03jxYQKtGZ53Rp0RRoXRlx1eps9O9ouvFcFX%2BJ67%2BI678WV2X9BexZ67hZbiiY23nM4IQRT0mcUxYauHLuFSYJlmSRs3PRWaTszowUawzfw9phs95ueAdWVktFyg5Kp6TvtdmGmBPdxJoMYPSbgpqk9ThGk%2BtJBX2HoO5iCq8h82xi2T0GqWAOEcmigNFoBB9FsV0%2BC8mwxIkyijILvipFX8%2FCr4p4g8ujVEjWVfDEGpYVhVrmrIKSPNa8i2FR578o6eIsi8dQpgIrZIFlWZ7fdCo609IeG%2FPHu1GBnhJTOje994Nt6vX2qI33%2B4EdBLueve%2BSPXuP9YNewHa9rf72kjg%2BJZxPqWOpeUwpIzQ4Ls5hhMcKTcwE%2FJ6S%2F49Smm3jI6tf9rxE8ymrszRNz%2Ffg7bP2X2Tt%2Fw%2Bsp3L11PwOayCGnvWsDFo%2FcBzPqO24b53bVIqdFYovyfGbYHNdAcVeC%2BhaQNcCuhbQtYC%2BQkDhNqvwkNEuNp6%2B6%2B%2FY7q7tux3PDbfdMAic3Z3A33I3XTd0XUOAKT3l9wA33%2BU7Lzq9vZHnZ7J1Ur%2FsZS1%2F59v7Br083LxsfPFOWqR9iS8%2B3JxXyXj%2FLqqhyU%2FL%2FoZzvg8AAA%3D%3D)
