### PR TITLE
Add configuration for Crescendo Email Service

### DIFF
--- a/crescendo.run.email.json
+++ b/crescendo.run.email.json
@@ -4,7 +4,7 @@
     "serviceId": "email",
     "serviceName": "Crescendo Email Service",
     "version": 1,
-    "logoUrl": "https://crescendo.run/logo.svg",
+    "logoUrl": "https://app.crescendo.run/logo.svg",
     "description": "Configures domain ownership verification, SPF, DKIM, and DMARC for Crescendo email delivery.",
     "variableDescription": "%token%: verification token for domain ownership; %dkim_pub_key%: Public key for DKIM signature",
     "syncPubKeyDomain": "keys.crescendo.run",

--- a/crescendo.run.email.json
+++ b/crescendo.run.email.json
@@ -1,0 +1,45 @@
+{
+    "providerId": "crescendo.run",
+    "providerName": "Crescendo",
+    "serviceId": "email",
+    "serviceName": "Crescendo Email Service",
+    "version": 1,
+    "logoUrl": "https://crescendo.run/logo.svg",
+    "description": "Configures domain ownership verification, SPF, DKIM, and DMARC for Crescendo email delivery.",
+    "variableDescription": "%token%: verification token for domain ownership; %dkim_pub_key%: Public key for DKIM signature",
+    "syncPubKeyDomain": "keys.crescendo.run",
+    "syncRedirectDomain": "app.crescendo.run",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_crescendo-verify",
+            "ttl": 3600,
+            "data": "crescendo-verify=%token%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "crescendo-verify="
+        },
+        {
+            "type": "SPFM",
+            "host": "@",
+            "ttl": 3600,
+            "spfRules": "include:spf.crescendo.run"
+        },
+        {
+            "type": "TXT",
+            "host": "crescendo._domainkey",
+            "ttl": 3600,
+            "data": "v=DKIM1; k=rsa; p=%dkim_pub_key%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DKIM1"
+        },
+        {
+            "type": "TXT",
+            "host": "_dmarc",
+            "ttl": 3600,
+            "data": "v=DMARC1; p=none;",
+            "essential": "OnApply",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

This JSON file configures the Crescendo Email Service, including domain ownership verification and email delivery settings.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 

1. Apex Domain Test (Host is blank):
[Test crescendo.run/email crescendo.run/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACgSXmoC%2F%2B1WbW%2FaMBD%2BK5alfmqgCU1bCEIqa1e1q1hR6bpVFYpMbMAi2JntQDPEfvvO4Z3CvmyTVqlfUOJ7znfP3T0XJtiwYRITw3AwwYmSI06ZuqE4wJFiOmKCyqJKBXaWxs9kCGB8sTCDSTM14hHL3diQ8Hh1to1GH60dtWZWwI2Y0lwKHHgOjmVPflEx4PvGJDo4OiJJUtxI5MhiinrUA1cK54onJnfHF1J0eS8FMKISgggkxwIu7%2FMEQRDe5RGxUAe1mlcOury9aTiICIouG%2FX7C9SVCq2yzFkgymIOrlnR5kkUJ52YXW4EPTBywMRBsBEB5Yf5jduZVNEBHfBhmKSdcMAycGymnZhHCF5yB5sW0rwniAEqto6ZiABzy7LL%2FC4IClhd3G6Pxd0zyhWLzBL5qnwABIBUVOPgeYJNltjuPHx7AENfagMv4dKhkJPKwGQMNOX41HWh6MSQ9emYg2rzSljwi7G9AFamQUzU56LXkNTGaSrW5S%2B7IXPbjpvx1FlmCq1rrFI930xNJ937NGZADXMRxSllARxtFWDtsg3aK1Q4axpUeSfzUc32yKuiQU1pUkVJbbOlf16BeYS9qYZ0SFS0Lzk7zZ5NS0jBqoBiWjNhOLG6uhP1JImzv5JjHghP21MH%2F4BQ4Wqw2pDPYgS3x2%2FOAZ56SqZJyBceCVFkqO0aWvg%2Bbzm3F97P2D7nA2dfvNKxf2JP1vtgDYZpU7DPNkfQlFQsXGkrMCplDh6mseEhGZPVEY1CYssElDRY4aptrYjZWtullX0CmWW50bSQRpYvt3vTL%2FmdqHPCCmUCP%2F7pcVSo%2BH630C11%2FArt0ujM66xt4Z0retceXtV7fQ7q8ZhkGk9fjdic2DleGykQkYf2Kgr9JHH8VnjtUfleaS8n6I3wW66G3%2ByD%2F4LIYhFNp20H1P%2Bur3d9vevr3%2BgLPoyajBgNicWV3NJpwT0rlNwHrxR45cAvF72KXz6rHLpu4LqWADRlxm8C3831LyZ%2B%2FPTSGnvfvYFI6teHsnySfmh6w6vWNfzP95%2FuHkn%2FcfD965PwB3X43%2FYLTG5oO14MAAA%3D)

2. Subdomain Test (Host is "mail"):
[Test crescendo.run/email crescendo.run/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFUSXmoC%2F%2B1WW2%2FaMBT%2BK5alPi1AApSWVEirYOuqiRVBp7WqqsjEBiwSO7IdKEPst%2B84XBPo0yZtlfpGzvnO5Ts3s8SGxUlEDMP%2BEidKzjhl6pZiH4eK6ZAJKssqFdjZKb%2BRGMC4vVWDSjM14yHLzFhMeLSXFdHok9WjwVoLuBlTmkuBfc%2FBkRzL7yoC%2FMSYRPuVCkmSci6RisWU9WwMphTkiicmM8dtKUZ8nAIYUQlBBJJzAc4nPEEQhI94SCzUQYPeZwd1vt52HUQERZ3udb%2BNRlKhfZYZC0RZxMF0UbZ5EsXJMGKdXNAzI6dMnPm5CCgTZh6LmVyhMzrlcZCkw2DKFmDYS4cRDxF8ZAY2LaT5WBADVGwdFyIEzFe26GS%2BIChgdbnYHovrM8oVC80OeVQ%2BAAJAKqqx%2F7TEZpHY7tw%2F3INiIrWBj2BnUMpILUBlDDSl1nBdKDox5HA6NqDWphIW%2FGJsL4CV6RITTrgYdyW1cXqKjfjLachGd8IzXjm7TKF13X2qH%2FOp6WTUTyMG1DAXYZRS5oOoUIADZznae1SwbhpU%2BSTzWcv2yLtC05bS5AolrXxL%2F7wCmwivphrQmKjwteTsNHs2LSEFuwIU05oJw4ndqztxnSTR4q%2FkmAXCq%2BeVg39CqGA%2FWM%2BQz3YEi%2BO34bC5EmMl0yTgW6uEKBJre4q29k8FB89bD09rF%2FCdDZ4VeNVa%2FdxKDvthFYZpU7K%2Fba6wW1KxYL9jvlEpc3CcRoYHZE72IhoGxJYLqGnQgqvizoj1eTvamfKG32vbsk4118GAhpY4t0e0dkm8Jjn3SvVGfVSqu9Xz0hBkJUJHF%2FWGG46a5PLgJJ%2B816eOcr74h4NxHc3JQuPV0cxtGOb5zFqwWB56dcvQLxJFb4neqe0vFzkX9343Vm%2BI6Pp2HFM7uhr%2FDaPtyVqtnh24Ee8b%2BL6B7xv4rzYQHldNZowGxGKrbrVRci9KVffeq%2Fpe06%2FVym6z7l1WP7iu77qWBHRozXEJb%2B%2Fhq4sfG5Wb2HuIb6ssctt3j%2FN2%2BkM9zgb3N3dSDCZf%2Bg3dMZ3BpFefw3%2FA371qnSGqDAAA)