### PR TITLE
Add Foundax storefront template

### DIFF
--- a/foundax.com.storefront.json
+++ b/foundax.com.storefront.json
@@ -3,6 +3,7 @@
   "providerName": "Foundax",
   "serviceId": "storefront",
   "serviceName": "Foundax Storefront",
+  "logoUrl": "https://foundax.com/images/logo-foundax.svg",
   "description": "Connect a domain to a Foundax storefront, verify ownership, and configure the www alias.",
   "version": 1,
   "hostRequired": false,

--- a/foundax.com.storefront.json
+++ b/foundax.com.storefront.json
@@ -1,0 +1,35 @@
+{
+  "providerId": "foundax.com",
+  "providerName": "Foundax",
+  "serviceId": "storefront",
+  "serviceName": "Foundax Storefront",
+  "description": "Connect a domain to a Foundax storefront, verify ownership, and configure the www alias.",
+  "version": 1,
+  "hostRequired": false,
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.foundax.com",
+  "syncRedirectDomain": "foundax.com",
+  "variableDescription": "IP is the Foundax shared ingress IPv4 address, TARGET is the site-specific Foundax ingress hostname, and VERIFY is the one-time ownership verification token.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%TARGET%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_foundax-verify",
+      "data": "foundax-verification=%VERIFY%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "foundax-verification=",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Foundax Storefront Domain Connect template. It configures the storefront apex A record, the `www` CNAME alias, and a scoped TXT ownership-verification record. Foundax uses the synchronous signed flow with public keys published under `domainconnect.foundax.com`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

The `logoUrl` returns HTTP 200 with `image/svg+xml` from Foundax's public website.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

None of this template's records are intended to be modified independently while the Foundax connection remains active, so `essential` is not required.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

- [Apex test: foundax.com/storefront on example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO8UXmoC%2F%2B1UTW%2FbOBD9KwKBnFZSaLtJbAMF6k3SrBskNRK3aDcIDJocyUQlUkvSXw3y33doSZZVJMDuLYeeRHH4hvMe38wTcZAXGXNAhk%2BkMHolBZixIEOS6KUSbBNznZNwH7plOR4lH8sgBiyYleSwg1inDSRGK9cE2oDg%2FvBIplP9xWQYXjhX2OHx8cGlxzJnKdhjfyiq9%2B0qRZwAy40snNQKsedaKeAuYIHQOZMqcBrX9YVNTWGwAiOTbaDXCoxdyCIMmBIB1yqR6dJA4BYQrNfrgGWS2RgvQoDdXdIJyUJbdwf%2FLKUB5JqwzAKS3Cr%2BZ6b5j9bOZDm%2Fhu3FrhossCyLl2XGbV398TsQmJS7PaB9ZMWMZPMMLlqsx5NA2l3Fe6YLhqUFUqUGrA3Gk9W7gAnhf8JgOrq7upzWECsdRLYALhPJ9wlqpGeq8NlKeb5e3o0%2Ffq%2BRWkHkZA6NiKWqkjNfGGr%2FA5SXDglpIywZPjwRty28B0akVBGXH7yltFTOTjX%2BHo0nR7jjHHqhd0rpc7gHnd%2BObi4bID7PL9CS2Wvw6bdpA55VwkalEbyTmGON4NEhlfdHJfNd5o1DlyWZ5O6GOb5ApW608PknaC65eflIFXslfavgx%2BeQ%2FERtZ41sj2FlHEwAG4ZdCpUhKja4So1eFjNZny%2BYYbn1nVwjH1rQxxr7QPx6PPGrLu3FNO50enGH%2Bt1STx%2Bp%2FBB1ur24WsdKeztaQP2zOmepk0c4sC7aWSBiBWyIpyVThR04s%2FhlDruMDJ1ZYqPky8zJGVuzZkvwGSuKbIsqWIxixrZ5VDlLPjQP1yr%2BQNCQzAT3Qkg%2Fl056c8pYIqIO7fejd2e0G%2FVPB2fRYH7CeRfEIBEnBzPuhfH36pRr3gLVAeUk8%2BNslK3Z1pLnF3xccSh9XLH4T0K%2FaXZlm1Xc%2Fl%2Bb%2FeqZN8jzMcTu%2Bm3F31Z8A1bEeWvZCsSMuZ3puqcRPYu6dNrpDnt02BvE9OSsT%2BkflA7pzohIqiT9hNP4cA6TyXag7q%2FS5c%2FPBTf5uvdpfXvRvbr%2FS1xnn%2FoLUHPqVqPLc%2Ff3efqePP8LxxXP%2FywKAAA%3D)
- [Subdomain test: foundax.com/storefront on example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPcUXmoC%2F%2B1UUU%2FbMBD%2BK5ElnpakaVNoV2nSCgPUTaCu6zYYQpWxL61FYme221IQ%2F33nJmkbVKQ98sBTYp%2B%2F832fv7snYiHLU2qB9J5IrtVCcNADTnokUXPJ6UPIVEb8TeiSZniUnBVBDBjQC8FgDTFWaUi0knYbqAO8H7tHUjVVP3WK4Zm1uek1GjuXNkRGp2Aa7lBQ7ZvFFHEcDNMit0JJxJ4oKYFZj3pcZVRIzyr8ry7c1uR7C9AiWXlqKUGbmch9j0ruMSUTMZ1r8OwMvOVy6dFUUBPiRQgw60uaPpkpY0fwdy40INeEpgaQ5Eqy41Sx%2B9rOcH73DVZf1tVggUVZrCgzrOvqjo%2BAY1JmN4D6kQXVgt6l8KXGejD0hFlXvGE6o1iaJ%2BRUgzHeYLhoe5Rzt%2FC9cX90fjquIEZYCEwOTCSCbRJUSMdU4rMV8vw6HQ3OriukkhBYkcFWxEJVwagrDLW%2FB%2BmkQ0JKc0N6N0%2FErnLngT4pVMTfz85SSkhrxgqXB4PhAe5Yi16Ij6Lo2d%2BATi77F6dbID7PC2jB7DX4%2BGq8BU9KYYPCCM5J1NKt4MEulU8HBfN15geLLktSwewFtWyGSl0o7vIP0VziYf%2BRMvZK%2BlrBt88%2BeURtJ1vZbv3SOJgAHih2KZSGKNmYmcpxNdVqnk9Ehcmppplx3Vyhb2rw2wp%2FUyTA9WDoVq0oDqOw2YzDZuR2C11dpPRF0GzFYfkfSuVsaQDfIa3yFno5hAVjg7UVAjO%2FKwtxHMVUYjtODH6pxZYjPavn2DXZPLViQpd0u8XZhOZ5ukJJDEYxbd1JshgspQrlQ9ZI7AjskwlnThTh5lSXtaJum%2FIg6QAP2vHHTkBZ3A14h9Mm73Y7h0lrZ%2BbtGYevTr3626BSIK2gbsT10yVdGfK8x9slFfR2WKfzX8q%2FeZpFD5YkX%2FTgC8J7O2Wvm94o61sfm%2FDdqO9GffNGxYFt6AL4hNq1H1tHQdQJWtG42erFUa%2FdCY9ah%2B346EMU9aK1R5Fdwf4JJ%2FnuDCejk7hxPV4d96%2FSr8uz9vn14fmfuHnP26eP8jfYX%2B3vgylE2RX%2Fyj6R53%2BuiN2VdQoAAA%3D%3D)

<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
