### PR TITLE
Add digitaltec-solutions.de newsletter-domain-auth template

### DIFF
--- a/digitaltec-solutions.de.newsletter-domain-auth.json
+++ b/digitaltec-solutions.de.newsletter-domain-auth.json
@@ -1,0 +1,39 @@
+{
+  "providerId": "digitaltec-solutions.de",
+  "providerName": "Sahin IT Solutions",
+  "serviceId": "newsletter-domain-auth",
+  "serviceName": "Newsletter-Absenderdomain-Verifizierung (Ownership + SPF + DKIM)",
+  "version": 1,
+  "logoUrl": "https://sit-crm.digitaltec-solutions.de/assets/logo-C-2IVJXi.png",
+  "description": "Verifiziert eine Absenderdomain fuer den Newsletter-Versand ueber Mailjet: Domain-Ownership-Nachweis, SPF- und DKIM-TXT-Record in einem Schritt.",
+  "variableDescription": "%verifyHost%: Hostname/Subdomain-Label fuer den Domain-Ownership-Nachweis (Mailjet OwnerShipTokenRecordName); %verifyValue%: zugehoeriger TXT-Wert (Mailjet OwnerShipToken); %spfValue%: kompletter SPF-TXT-Wert (Mailjet SPFRecordValue); %dkimValue%: DKIM-TXT-Wert (Mailjet DKIMRecordValue, Host ist immer fest \"mailjet._domainkey\")",
+  "syncBlock": false,
+  "syncRedirectDomain": "api-sit-crm.digitaltec-solutions.de",
+  "syncPubKeyDomain": "connect.digitaltec-solutions.de",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "%verifyHost%",
+      "data": "%verifyValue%",
+      "ttl": 3600,
+      "groupId": "verify",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "%spfValue%",
+      "ttl": 3600,
+      "groupId": "spf",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "mailjet._domainkey",
+      "data": "%dkimValue%",
+      "ttl": 3600,
+      "groupId": "dkim",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/digitaltec-solutions.de.newsletter-domain-auth.json
+++ b/digitaltec-solutions.de.newsletter-domain-auth.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://sit-crm.digitaltec-solutions.de/assets/logo-C-2IVJXi.png",
   "description": "Verifiziert eine Absenderdomain fuer den Newsletter-Versand ueber Mailjet: Domain-Ownership-Nachweis, SPF- und DKIM-TXT-Record in einem Schritt.",
-  "variableDescription": "%verifyHost%: Hostname/Subdomain-Label fuer den Domain-Ownership-Nachweis (Mailjet OwnerShipTokenRecordName); %verifyValue%: zugehoeriger TXT-Wert (Mailjet OwnerShipToken); %spfValue%: kompletter SPF-TXT-Wert (Mailjet SPFRecordValue); %dkimValue%: DKIM-TXT-Wert (Mailjet DKIMRecordValue, Host ist immer fest \"mailjet._domainkey\")",
+  "variableDescription": "%verifyHost%: Hostname/Label fuer den Domain-Ownership-Nachweis (Mailjet OwnerShipTokenRecordName - ein zufaelliger, pro Domain von Mailjet vergebener Token, keine vom Nutzer gewaehlte Subdomain); %verifyValue%: zugehoeriger TXT-Wert (Mailjet OwnerShipToken); %dkimValue%: DKIM-TXT-Wert (Mailjet DKIMRecordValue, Host ist immer fest \"mailjet._domainkey\")",
   "syncBlock": false,
   "syncRedirectDomain": "api-sit-crm.digitaltec-solutions.de",
   "syncPubKeyDomain": "connect.digitaltec-solutions.de",
@@ -20,10 +20,9 @@
       "essential": "OnApply"
     },
     {
-      "type": "TXT",
+      "type": "SPFM",
       "host": "@",
-      "data": "%spfValue%",
-      "ttl": 3600,
+      "spfRules": "include:spf.mailjet.com",
       "groupId": "spf",
       "essential": "OnApply"
     },


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for Sahin IT Solutions (digitaltec-solutions.de) to authenticate a newsletter sender domain via Mailjet in one step: a domain-ownership TXT record, an SPF requirement (via `SPFM`), and a DKIM TXT record.

Uses the synchronous signed flow (`syncBlock: false`, `syncPubKeyDomain: connect.digitaltec-solutions.de`). The public key is already published at `_dcpubkeyv1.connect.digitaltec-solutions.de`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) - apex and subdomain/host tests done, see links below
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — mandatory
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — SPF is expressed via `SPFM` instead
- [ ] `txtConflictMatchingMode` — not set, see justification below
- [ ] no variable used as a bare full record value — bare on purpose, see justification below
- [ ] no bare variable used as the full `host` label — bare on purpose, see justification below
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify/remove without breaking the template

**Justifications for the unchecked items above:**

- *Bare `%verifyValue%` / `%dkimValue%` record values:* these must match exactly what Mailjet's own DNS-based verification checks for (the ownership token, and the DKIM public-key TXT content it issued). Prefixing them (e.g. `service-x=%value%`) would break Mailjet's own verification/parsing of the record - we don't control that format, Mailjet does.
- *Bare `%verifyHost%` as the `host`:* Mailjet assigns a random, opaque per-domain token as the ownership-record hostname - it is not a subdomain choice made by the end user, so there is no fixed literal prefix to anchor it to, and the `host` request parameter (intended for user-chosen subdomains) doesn't apply to this case.
- *`txtConflictMatchingMode`:* not set because both TXT records (`verify`, `dkim`) already use hosts that are unique/specific to this service (a Mailjet-issued random token, and the fixed `mailjet._domainkey` label) - no ambiguity with other templates' records that would need prefix-based disambiguation.

## Online Editor test results

**Editor test link(s):**
- Apex (`digitaltec-solutions.de/@`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJZlZmoC%2F%2B1WYW%2FaSBD9K6uVKrUqBuIQcriK1FwDdzmaNAokzSlBaG2PzRZ7be2uiUiU%2B%2B03awOGJIbcx576AWztzryZN%2FPGu49UQ5xGTAN1Hmkqkxn3QZ761KE%2BD7lmkQbPUkmUaZ4IVfeB1lZm5yxGNzpgEy7I6ZAMlmZoo0DOuAc5koB7FYHWIC0%2FiRkXFsv0pDRa4JyXZseuAoERFubXIHnAHzjITITk%2Fbd7AVJNeEo%2BksFFD%2F9P%2BqdnHxBwhuuYAHX2ajRKwuRKRgg80TpVTqOhuLY8GdcrmDWYUqBVwzhaXyz79PqvG15PRYjAPihP8lTn4LTMRxPgAshmviTIQBIfBFmjhD6KCZ9k4OLmGePRD9AOOSkYrihZ58yb3ANXNUPNIhm6GHbW8GZoXYKXSJ9gBBM1JgNvIrnWdcOcSc7cCE42En03M5nO%2F0yUfucQ8xBY68ZX5kJUZlmZA3m%2FyJPkewPcGyZTEEUepm3EMqmQhyxgEEU8BFkjKI8FJJklYkmVYCohckcckoPUyDSv3SyJyXmmH3A9hHsGE2wMGWRuUcsPn8iCxDWLMkAWD1kIkwSXQoOEVflu2lCRqXH3pzxeOq9KuelklgtSuWEtLxXh5hfHGCYAfL2jcWFeHxe5TWF%2BR43s1Fx4v0eJN6VOwCIFxcol%2BFyCp4taYDdYyq0dGlyAXWRuH%2BYrRy8RAoG2OMk8eUWd20eq56kZJ2SJGxMk8kwIRs5Ms3K1KA4ua43jst9uNms0lEmW5tNb2OAu4HgIzZkZqW%2FiOE2jOX2qreKhXM%2FKgJ8NkzS4zCLArCgXXpT54OBSfVlFL4npeiDc2x1lg9XLfqxxK9texcxYVEUcPdXoQyJgXFZ2hNjLjlR3YpHaktmY575lFQuWeWgETJlksTLf3iX0bSX2aAl%2BS817Dr8Fuuy4MWKut2fv%2BxC0Dtrlbl4fs72opFUsWxr1bs3yzVGBuLKcHuF37BNJj3rH%2FW6%2F%2B3fvqnt50j0fdgdDDEBN3XgoEgljhU%2BmM4luWuJQ0TiLNB%2Bze1Yu%2Bd6YmYJjmRXuYoDnAhbF4bCR%2F6rJ1WlvtHzse6bE3DT9gPmBG%2FiH1n4H2lbrsG1bzN2zLdcP7CAI%2FI7d8dfOuB1H4ZuOuVISr0rthboXlD%2BXPGdH2Ns9UjFF5B8WRUvGSPinZbxtnnfo7mfq96iG35JfOv%2Bl8%2F%2B7zvHsUGwG%2FpgZO7tpt63moWW3h3sd58B2Dlr1jn3YarU%2BNptOs2m4obCLOjzm78XJ%2BHqWpEEqMkOf5XU4B1g%2FCZ8P2MY5uHXO1k7B3U16w0Vh%2B%2Fn9ZO505kh85U73yqei6mpY3xTMQmN31UTvKK1S7a4QxUSuQrxhlrcEezki%2F5Xi9h6Z0CMcUFR6hFdr1KipQTXLarUhxvpVh%2FrfG9HFUKreF9fttnv7%2FYsfnavej1azF4de%2BEfY73xVB%2B3optX87Yg%2B%2FQuRgLTfgQ8AAA%3D%3D
- Subdomain/host set (`digitaltec-solutions.de/test`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMhlZmoC%2F%2B1XbW%2FaSBD%2BK6uVKrUK5sWQpHEV6ZIm0VFK2guUSy5BaLHHZg977dprCES5336ztsGQYMhVdyf1rh8S0OzMM%2FPMy87yQCV4gcskUOOBBqE%2F4RaETYsa1OIOl8yVYGqR78aS%2ByIqW0BLS7VL5qEZ7bARF6TZJZ2FGupEEE64CQmSgGnkgpQQapbvMS40FstRrpThXOZqJ8MIBHrI1HsQcpvPOYSxcMjrT1MBYTTiAdkjnc8X%2BP%2Bs1Wy%2FQcAJyjEAatRK1PUd%2F0voIvBIyiAyKpWIS80MvXIBswqLIpBRRRlq7zW92ftwzcuBcBDYgsgMeSATcJrHIwlwAWQ9XmLHEBILBFmhhDYRExaJYYiHbcbd30Ea5CxluKSkXTJzNAUelRQ1jcRoothp3euudgWmH1oEPSivHumYo5BLWVbMWcjZ0IWztUBfTVSks5%2F9SL4yiPoQmOvKRzYEN4%2ByMAbyOouTJGcdPOv6YxBpHKpsRFOhkHlsM3Bd7kBYItgeGSSZ%2BGJBlWAoDnJHHJKAlMg4yd3E98hlLOcod2DKYISFIZ14mObyzTuSkegxNwZkMY8dGPkochQSZuVXVYaCSJW5NebewniZynUjJU5JJYqlJFWEqz%2FPQzc24Nc76qXq5UEa2xhmd1S1XTQT5qnrm2Nq2MyNIJVcgcVDMGWaC6wGC7i2owczsM%2FxsAWzpaHpC4FAW4zCJPiIGrcPVM4CNU7IEg9GSORJI6h2ZpLl0jQ5KJYSx6V%2BUK2WqBP6cZBMb6qDp4DjISRnaqQ%2BiZMgcGf0sbT0h%2B3azh3%2BpJgE9lXsAkZFuTDd2AIDReVFFk3fo6uO8Gy3lzVWz%2Buxwi0vexEzpVHksf9YonNfwCDPbB%2BxFxUprkQWmsSOWbAb8MQ%2Bz2TKNHGPoAELmRep%2B3cBf1uI3184uE099DMXW%2BDzyislNjRret0Cu7F%2FkJ8meVLHWUa1VKwpH9okOeyniEvN8THeZ%2B9IcHxx0jpvnd9cfDm%2FOju%2F7J53uuiAqvxxR%2FghDCL8ZDIO0UyGOFzUi13JB2zKcpFlDphKPKY7wlN08LSRRbokVuMvZ0nOKl4c%2B1r9B5apcs1VB9hva4d2g%2BnaW2bva41ata4xqOuaXa3vH1kN3Wbm4crC27EXX7Tz1vtjY%2B89a%2FeM%2BzrdyTHWuUYKJov8wVx3QRx5f9fEn8%2F5k9LvaMbvrf79El42PwbgxwD8bwcAt03EJmANmNLVq%2FqBVj3U9INu7cjYrxuNRlk%2FPNIb9b1q1ahWFT%2BES3PxkHxP9%2BnmSEmFFESHNouHdAKwujvXV%2BeTzbl19lb25u5CveCJsX3jP6rXoFqiG16Dm%2B6QAj%2Fl9abJ%2BuyumOgdpUXtu8tFOp5LFy8Y7C3ONszKX6S4vUbKtUqyTv6j7bXhBfu3NZsC%2FTc67kV%2B%2Fum2%2BxayL%2Bm9R3XTuviDEO%2FHpErGtzQjoqw%2BzenX61%2F2WK%2Feen86PrhvB%2Fz%2BqPeh59zc%2F9astM2zuXvj3bdbjcOP09PpMX38E1fn7WM5EgAA