### PR TITLE
Add Render custom domain templates (render.com)

### DIFF
--- a/render.com.custom-domain-apex-a.json
+++ b/render.com.custom-domain-apex-a.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "render.com",
+  "providerName": "Render",
+  "serviceId": "custom-domain-apex-a",
+  "serviceName": "Render custom domain (root domain, A record)",
+  "version": 1,
+  "logoUrl": "https://assets.render.com/brands/logos/render-logo-black.svg",
+  "description": "Connect a custom domain to your Render application. For DNS providers that require an A record at the zone apex.",
+  "variableDescription": "%renderService%: the onrender.com hostname of the Render service the domain points at, for example my-app.onrender.com",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.render.com",
+  "syncRedirectDomain": "render.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "apex",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "216.24.57.1",
+      "ttl": 300,
+      "essential": "Always"
+    },
+    {
+      "groupId": "www",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%renderService%",
+      "ttl": 300,
+      "essential": "Always"
+    }
+  ]
+}

--- a/render.com.custom-domain-apex.json
+++ b/render.com.custom-domain-apex.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "render.com",
+  "providerName": "Render",
+  "serviceId": "custom-domain-apex",
+  "serviceName": "Render custom domain (root domain, CNAME)",
+  "version": 1,
+  "logoUrl": "https://assets.render.com/brands/logos/render-logo-black.svg",
+  "description": "Connect a custom domain to your Render application. For DNS providers that support CNAME records at the zone apex, via flattening or ALIAS.",
+  "variableDescription": "%renderService%: the onrender.com hostname of the Render service the domain points at, for example my-app.onrender.com",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.render.com",
+  "syncRedirectDomain": "render.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "apex",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%renderService%",
+      "ttl": 300,
+      "essential": "Always"
+    },
+    {
+      "groupId": "www",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%renderService%",
+      "ttl": 300,
+      "essential": "Always"
+    }
+  ]
+}

--- a/render.com.custom-domain-subdomain.json
+++ b/render.com.custom-domain-subdomain.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "render.com",
+  "providerName": "Render",
+  "serviceId": "custom-domain-subdomain",
+  "serviceName": "Render custom domain (subdomain)",
+  "version": 1,
+  "logoUrl": "https://assets.render.com/brands/logos/render-logo-black.svg",
+  "description": "Connect a custom domain to your Render application.",
+  "variableDescription": "%renderService%: the onrender.com hostname of the Render service the domain points at, for example my-app.onrender.com",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.render.com",
+  "syncRedirectDomain": "render.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%renderService%",
+      "ttl": 300,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Three new templates from [Render](https://render.com) (cloud application platform) for connecting a customer's custom domain to their Render service:

| file | purpose | records |
|---|---|---|
| `render.com.custom-domain-subdomain.json` | any subdomain | `CNAME @ → %renderService%` (applied under `host`) |
| `render.com.custom-domain-apex.json` | root domain, for providers that support a flattened/ALIAS CNAME at the zone apex | group `apex`: `CNAME @`; group `www`: `CNAME www` |
| `render.com.custom-domain-apex-a.json` | root domain, for providers that require an A record at the apex | group `apex`: `A @ → 216.24.57.1`; group `www`: `CNAME www` |

Design notes for reviewers:

- **Two apex variants exist deliberately.** Render's apex target is a CNAME wherever the provider can flatten it (better for anycast IP changes), and a literal A record everywhere else. Providers onboard whichever variant matches their capability; the variants are never both applied to one zone.
- **`hostRequired` differs between the apex variants and this is intentional.** The CNAME variant sets `hostRequired: true` because the linter (DCTL1012) requires it next to a `CNAME` on host `@` — a literal root CNAME is invalid DNS, so that variant is only onboarded by providers that flatten (e.g. Cloudflare), which per DCTL5006 ignore `hostRequired`. The A variant sets `hostRequired: false` and is the general-purpose apex template.
- **Record groups**: the apex templates carry the `www` record in a separate group so that configuring a root domain plus its `www` costs a single consent screen; the apply URL's `groupId` selects `apex` or `apex,www`.
- **`%renderService%` as a full `pointsTo` value** (checklist item below): the CNAME target is exactly the customer's `<service>.onrender.com` hostname, prescribed by Render's platform — there is no fixed prefix a CNAME target can carry. All apply URLs are signed (`syncPubKeyDomain` is set), so the value is attested by Render's key, and Render's server-side verification independently checks the resulting DNS before activating the domain.
- `syncRedirectDomain` is `render.com` (registrable domain), matching how the spec scopes redirect validation.
- Templates pass `dc-template-linter` clean (default, `-cloudflare`, and `-logos` modes) and validate against `template.schema`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead *(no TXT records in these templates)*
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) *(no TXT records in these templates)*
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description *(justified above: CNAME `pointsTo` is the service hostname itself; requests are signed)*
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`) *(hosts are fixed `@` and `www`)*
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) *(all records here are `essential: "Always"` deliberately: each one IS the service connection, and a manual edit to any of them breaks the domain — there is no record a user should change independently of the template)*

## Online Editor test results

**Editor test link(s):**

- [Test render.com/custom-domain-subdomain example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANBnZmoC%2F91T72%2BbMBD9VyxLlTYVCNA22ZAmLf2xqdrWrWn7qYqQY47EKtjMNulYlP99ZyBNsvTDPu8T%2BO6987135xW1UFYFs0CTFa20WooM9HVGE6pB4m%2FAVUm9l8wNKxFJJ20O4wb0UnBoCbw2VpV%2BpkompG%2FqWfe3Re2RSQcnHYi8ecG%2FRcIStBFK0iTyaKHm6kEXSFxYW5lkMGDGgDXBtsHBTDOZmYGDmkEX993BnxWMPwVmOceiGRiuRWXbwvRCSQncEvZXI1aRRtWa9F2yqioEZ44UuMaYFmxWwOVeraPuyrtO5lFC7AKIktsGyUIZK1E%2BUXmb7Kv3xrSh%2Fv5KCWkNYdYjudIEfjGcD5Cy8bGVYLeoM7aR%2FLxQ%2FIkmOSsMdJEf9ewLNJed%2BwntCvNOb3DAn0AmNGZe8HsI1%2FgEftYIwRlbXeMdiFY6MzR5XFHbVG6mFzfjb1c9HI8f3cq0Qu7VoT%2BYtBYHehKGHgUcprSCuQGPi2fWGLqerj36W0lItzdNvV4HwnpPdjrEILqDh7lWdZWKDaVimpXGrfaG%2FLjHnm7ojy1%2F6tG9Tl38NeNdf2IulYbU4JfZWsPGnLIurEjZM9uGMp66NWpQjsEsVj00TnZvo1ORMcvw8PrMt9alGXfShHt8wzxieQjgx2fvM%2F90FHKfjUaRH4c5n%2FGcDU%2Fe5Tvv%2BPCF%2F9tL3jP7tdGtpx4a%2Fz%2FrwyUxbAlZyhwyDuOhH478eHgfh0kYJ%2FFpEA%2Fjsyg6DvEcOkFgbKd4hXuzuzH0%2BO7k%2BVZHQv28Da%2Bvxqcgv5%2BPdfYpqiv9eVKNvw4e%2BPX51QKW5gNd%2FwG%2B6EXsrQUAAA%3D%3D)
- [Test render.com/custom-domain-apex example.com/site](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAdoZmoC%2F91UXW%2FaMBT9K5alSpuahPDRwiJNGv3Y1G6rNlqeKoSMcwG3wfZsB5pW%2FPddJ6FA22kPe9sT%2BH4c33PuiZ%2Bog4XOmAOaPFFt1FKkYC5SmlADEv9GXC1o8Jy5YguspIMyh3ELZik4lA08t04twlQtmJAh0%2FCwLdjrI1UlqSrJO6OUqw8BOb3qfz9%2Fj51LMFYoSZNmQDM1U0OTIcLcOW2TRoNZC85G2yEbE8Nkahu%2B1DaqeOgP4SRj%2FD6yyxmCpmC5EdqVwPRUSQncEfZiIqdIoXJD6nGZ1pngzDdF5LMy5OzqmmwUscTNmSM211oZV41PDHBlUksw4eZAHpUE4gUJyFIwMkW9HUghZwTB%2Bt8u%2BteRJ8yMYJMMzvZmPKioXFc6HiQloJJb4mSurJOoL1HTMllPXStfhmpeWgnp%2FFQBmeLN8MBw90AWBW5LR7ugfnOF5CeZ4vc0mbLMQhX5kU%2B%2BQnFW4uF0FTCvdIxe9Q8gFaiFe67fq%2FCDD%2BBXjiXoH2dyvKNWjia3T3RmVK5La9VmcoX2Lio1rvvx%2BMn7s2R2o14L5tscOqcdxwEFdI10gnkn9bMVKyxdB7sXrVarP95T5f7hptE6oN4K4y3JUVBLiGX1OnbEwaAV%2BGkG1YRjUfZUamCnZoYtrP9wNxi3eyCjDcptBTOqcXYx9ij4xFtm8IOLmVQGxhZ%2FmcsNbBa2yDMnxmzFtqGUj%2F0nUyBPi1lExWW%2B0FRWD0JNL2WO4eltI25FHafcsxV%2BU1POWKvdjUOYQhp2ukc8ZClMwl6vfXzUbfV60GnuPFyvn7S%2FPl37G3hroetRgBv8b8mhPSxbQjpmvrQVt47DuBu2jm9acRK3k%2BaHqNmLe53mYYzn2JMB6yq2T%2BiYXa%2FQAvT5nZlaqSerL6e80Tp8vMxn7q592EtPZNYZ8g4b8uH54PLnR7r%2BDX0ECPGXBgAA)
- [Test render.com/custom-domain-apex example.com/site](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABtoZmoC%2F%2B1UXW%2FaMBT9K5alSpuWhAAdLZEmjbXdSj9QRdu9VCgyjgMeiZ3aDjRF%2Fe%2B7TkKBwrSHPVXaU2Lfe4%2FvOffYS2xYmiXEMBwscabknEdM9SMcYMUE%2FHpUpth5jQxICpl4WMZgXzM155SVBTTXRqZuJFPChUsy9rRO2KpDVSaqMtEHJaWpFw46GfSuzz5C5ZwpzaXAQdPBiZzIe5UAwtSYTAeNBtGaGe2tm2yMFRGRbthU3aj2XbtwxwmhM0%2FPJwAaMU0Vz0wJjE%2BkEIwaRN50ZCQqZK5Q3S7JsoRTYos89F0qdDq4RStFNDJTYpDOs0wqU7WPFKNSRRpBwEwZepaCISuIg%2BacoBj0NkxwMUEA1rvq9249S5goTsYJO93q8aCiclvpeBCUgFKsiaOp1EaAvkjGZbDuula%2B3Kp5ZZILY7tyUAwnsycCs2coLWBambcJaidXCPotkXSGg5gkmlU7N%2Fn4khWnJR50VwHTSkdvp37IIg5amNf8rQzb%2BJA95pAC%2FjEqhzNq5XDwsMQTJfOstFZtJlNk1kWlxnU9LL9af5bM7uSuYLbMgHPavu9gBq4RhhPrpF6yIIXGL87mQYvF4o%2FnVLF%2FOGn04mBrhXBNcuTUEkJaPY4NcWBTc7iaTtVhyMualRq2H6jPiCKpttd3hfSwBTVaYT1UYKMabRdpi44N7zOGJcEnQioWavgSkyu2Gl6aJ4aHZEHWWxEN7fUpgLOGKKDCYN%2FoK6rHoaYaEUNgtd%2BUa4HDiFrO3E7tuN3utuLO2CXRke8eRoexS47HTfew2Y47x3HMuuPmxiO2%2B7z99Rnbnsa%2B4Vof7ecF6nrvnNvIAaf%2BH9w7HBxca03mLAqJTW35rY7rH7mtzl3LD%2Fx20O56n%2F3WUcf%2F5MPat2SYNhXbJdz0zTuOu7Pz1vP5TeeX6F6c3V0WT1fdi3b%2Fkd40%2FeGPn8%2F8enZ%2FPqAxvWaTL%2FjlNw1I6oxbCAAA)
- [Test render.com/custom-domain-apex-a example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANNpZmoC%2F91Ua0%2FbMBT9K5YlpE0kaZq%2BI01agVVsCLbRbhJCVeXEbuuR2sF2WkrV%2F77rJJAU0LbP%2BxTnPs8959o7bNgqTYhhONzhVMk1p0x9pjjEigk4erFcYefZc0VWEImvcx%2FYNVNrHrM8Ic60kSuXyhXhwiUpe3BJFXKQiYpYVMSid0pKU%2F44aIgUi6Wi7yF5zZTmUuCw6eBELuQPlUCRpTGpDhsNojUz2quQNiJFBNUNG6obhd21P26UkPjO0%2BsFFKVMx4qnJi%2BMT6UQLDaIvABlJNrKTKESMUnThMfEJnloJBU6uxqjJ1o0MktiAPd9xhVDRDwPgcBslgw9SgF24MSzUxHFSZSwswMgRwXeccHXUZjnSVFNh5ZSGwE8IjnPnSW0kuHcVIJPJRdGQ3MHzQEreyCgMkOrLeiSevWiVqGtiE8SGd%2FhcE4SzQrLtyy6YNuzvB6gKwrHBVneq%2FxrRmHy2DzHH0RY4NcFOfS5SUGQxuHtDi%2BUzNJ8iyxHkGG2qV2XYZkMx492DfOxJhJ%2Bg2bXC9pep%2Bc1bbiBvWj5voMZ7IQwnNg9GSYbstV479QbbDabqv7p1fDyU9Wj8NW6vNDkr52mewdbqWfVcFOn5A7CSh1qrIARTjm6Gc%2FjCwYgKyWKrLS9l0%2F5twcFpk8VbrE95zXq%2BQfQreMt9S1gvhBSsZmGLzGZglijMhBolSWGz8iGVCYaz%2BxF2MJ8GrxQFcSraSWKW261osSQP%2Bg0o7EdjVtJaLPdiga06%2FbmAXXb7Shy%2B71o4PYH87jfIox0O7T2CL1%2Bnv7hGarIfku3%2FdQBof6XWUB8TdaMzogNC%2Fyg6%2Fo9N%2BhOAj9s%2BmFn4LX7ge%2B3jn0%2F9H07CtOmmHEH%2B1DfBCxGp9F9RtfpaHL%2BaxR0zsdfOvzmcnJ8wmV08f3rONHm4VGf%2F%2BzdfMD739Z2KNVQBgAA)
- [Test render.com/custom-domain-apex-a example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOZpZmoC%2F%2B1UbWvbMBD%2BK0Iw2Kjt2ImXNIbBsqYdpWlXmhY6SghnS0m82pYnyXlZ6H%2FfyXbe2rLtYz%2Fsk%2BXTvTzPPXdaU83TPAHNabCmuRTzmHF5zmhAJc%2Fw6EQipdb25gpS9KQ35R3aFZfzOOJlQFQoLVKbiRTizIacL23YuRxEksqXVL7kvRRC1z8W6RHJIyHZBwyec6likdHAs2gipuJOJphkpnWugkYDlOJaOTukjVBCxlTDuKpGZbfNjx0mED06aj7FpIyrSMa5LhPTE5FlPNIEnoHSgqxEIUmNGPI8iSMwQQ45E5L0r4Zk0xZF9Aw04v5ZxJITyLYkCJr1jJNfIkM79sQxrEDGECa8fwDkXYV3WPXrXVDGiWzHjsyE0hn2kYhJeVlDqztcmmrwuYgzrbC4RSaIlS8BVeYkXaEuubOf1Ci0yqIviYgeaTCBRPHKcl2EF3zVL%2FMhuipxVDXLeRF%2Fwxkyj%2FTW%2F8DDAL%2BpmsO2RaoGKRo8rOlUiiIvp8j0CCP0Kjfj0quD8fjZjGFJ61bgb9NrO03f%2BdhxPOOucS5armtRjjOR6RjMnPSSBawUfbL2CywWi13%2Bk6ve5emuRnW3V%2BWZJn%2BtNHqyqJF6vCM3sureoVutw15X0IinEt04Lv03HTBYMDYHCaky27nJ8nCQZrTJ80DNucz0MssBDXP92iQY8PE0E5KPFX5BFxJ9tSxQrLRIdDyGBexMLBqbpVghV4W3mBWF3NMtqzbe6MZAwx80G7PIEIyNPB0W8q4LzG5HrGX7zY5nhxOvZUOzO%2Bm0u77P%2FHDvQXr5VP3Dk7Rr%2FGsamnF5Nh41lWo8ajKv79KbJTWycBL%2FC%2FSGBcI1VTDnbAzGrek227bbsZvt26YbeF7gHTtdv9v2jo9cN3BdQ4UrXXFd4%2Bbu7yw9e%2Bx%2F9Zb9ZCnPv4cMBv3h9bDVmEDrx9390cL%2FNoDL%2B8HF6eDI8z%2FRp9%2F5p08tBggAAA%3D%3D)
- [Test render.com/custom-domain-apex-a example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGxoZmoC%2F%2B1UXW%2FTMBT9K5alSSCS1E3TrY2ERPcBG4gC68YDU1W5ttuGJXZmO%2B1Ktf%2FOdZJ%2BbRPwCBJPra%2FvPb7nnHuzwlZkeUqtwPEK51rNEy70Bccx1kLC34CpDHubmz7NIBNflncQN0LPEybKAlYYqzKfq4wm0qe5uPfpNmWvElW5qMpFL7RStj54qIe0YErzl1A8F9okSuK46eFUTdW1TgFkZm1u4kaDGiOsCbadNsaaSm4aLtU0qrjvDv44pew2MPMpgHJhmE5yWwLjEyWlYBbRR01ZhZaq0KjumOZ5mjDqigL0Vml02h%2BgtSwG2Rm10PddkWiBqNyQQBC2M4F%2BKAlx0CRwrKhO6DgVp3uNHFT9Diq9DuKyTsktOzRTxkrQEalJeVm3Vitchurmc5VIa%2BBxD02gV3FPwWWBsiX4kge7oM6hpWTHqWK3OJ7Q1Igq8rkYfxDL0xIPuquAWSVW8KT%2BUnBgzuwmfy%2FDNX5ZicM3j1QCGRzfrPBUqyIvp8hpBBV2mbtx6dXF8PeNG8OS1pWCY9g8DMIoaB8FTZduYS5ahHhYwExIm1A3J710QZcGP3i7DywWiy3%2BSb%2F38Wz7RnW388ojT3770vDBw87q0Zbc0Ku1g7Tahx1VSsY5HMoGR0lZshbBtQPlOdU0M25B10A3e0jDNdRNiTWswZ4C7ZFx18%2FNg6OQTKXSYmTgl9pCQ67VBViWFalNRnRBtyHORm41lsDYwC2ggp077slq7yuSnFr6C%2B9GnDmWibNpcsSbHRaGfos0mR%2BRiPjjbof4rTDiUbfLBWu2dz5MTz9Zf%2FBp2jPgOTvd5DyalJoPKBrscXp%2Btf5mbkMPZvO%2FWf%2BIWbC%2Bhs4FH1GXGZLw0CdHfnh4FZKYtGNCgqjb6ZDOKwJn4tgIYyu6K9jo3V3Gg%2F65uR60W1mXT4uTtPh69uXdeP6etT4dDxpXi14UXZyrxrfv%2BXXvNX74CSEmtPUkCAAA)
