### PR TITLE
add LeadApe, Email authentication (SPF + DMARC)

### DIFF
--- a/leadape.io.outreach.json
+++ b/leadape.io.outreach.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "leadape.io",
+  "providerName": "LeadApe",
+  "serviceId": "outreach",
+  "serviceName": "Email authentication (SPF + DMARC)",
+  "version": 1,
+  "logoUrl": "https://leadape.io/images/app-icon.svg",
+  "description": "Authorizes the domain owner’s mail provider (Google Workspace or Microsoft 365) to send email for the domain via SPF, and publishes a monitor-only DMARC policy that reports authentication results without affecting delivery. Only the records the domain is currently missing are applied.",
+  "variableDescription": "%rua%: Email address that DMARC aggregate (rua) reports are sent to. Only used by the dmarc_rua group.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "leadape.io",
+  "syncRedirectDomain": "app.leadape.io",
+  "records": [
+    {
+      "groupId": "spf_google",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.google.com"
+    },
+    {
+      "groupId": "spf_microsoft",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:spf.protection.outlook.com"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    },
+    {
+      "groupId": "dmarc_rua",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:%rua%; fo=1;",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for LeadApe's outreach email authentication service.

The template authorizes the domain owner's mail provider (Google Workspace or Microsoft 365) to send email for the domain via SPF, and publishes a monitor-only DMARC policy so authentication results are reported without affecting delivery.

Record groups are mutually exclusive by intent, so the applying service selects only what the domain is currently missing:

| groupId | record | value |
| --- | --- | --- |
| `spf_google` | SPFM at apex | `include:_spf.google.com` |
| `spf_microsoft` | SPFM at apex | `include:spf.protection.outlook.com` |
| `dmarc` | `_dmarc` TXT | `v=DMARC1; p=none;` |
| `dmarc_rua` | `_dmarc` TXT | `v=DMARC1; p=none; rua=mailto:%rua%; fo=1;` |

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checklist items:

- `syncPubKeyDomain` is `leadape.io`; `syncRedirectDomain` is `app.leadape.io`. `warnPhishing` is not set.
- SPF is published through the `SPFM` record type on the apex, never as a raw `v=spf1` TXT record, so Domain Connect merges it with any SPF already present.
- The only variable, `%rua%`, is scoped inside a fixed DMARC value (`v=DMARC1; p=none; rua=mailto:%rua%; fo=1;`). It is not used bare, and it does not appear in any `host` field.
- Both `_dmarc` records set `essential: OnApply` so the domain owner can tighten `p=none` to `quarantine` or `reject`, or adjust the reporting address, without the DNS provider treating the manual edit as a template conflict.
- Both `_dmarc` records set `txtConflictMatchingMode: Prefix` with prefix `v=DMARC1`, so applying the template replaces an existing DMARC record rather than creating a duplicate.

## Online Editor test results

**Editor test link(s):**

Run 1 — apex (`host` empty), groups `spf_google` + `dmarc_rua`, `rua=reports@example.com`:

[Test leadape.io/outreach example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE0sZ2oC%2F%2B1VYW%2FbNhD9KwSBAgliO7Id240CA%2FGSthk2L0GatAOyQKDJk0yEElWSsuME7m%2FvUbIjO3MHdB82YNgnSeTdu3t3707P1EGaK%2BaAhs80N3omBZifBQ2pAiZYDi2paePl5jeWoiX9Fe9GOeCFBTOTHEoPXTgDjE%2Fr45X5u5RJRVjhppA5yZmTOiN7H6%2FekwNyPh5dn%2B2jywyMxXMathtU6UTfGoWuU%2BdyGx4e1tkcypQlYA9Znjcl11nLzhJ0F2C5kbkrIegIY2kjn8ASDEqExgwyoucZmD%2BKTtA%2BtqTMac2L7H3QOlFAPmvzYHPGgWhDxpIbbXXsSLff2ydOEwuZIFC6xmiwgT2TjCCjBmFokRcTJe0UozOS6kw6bZo6U4uKLcm1knyB3swRA7k2zr6ujgFbKDyeSyRSOMLiGLiTWUIEKIm1WrTIpUf0KRjg2ogtqtISXhiDiGiTSmu9KzNAsGxKgmj5ijMj2UTB%2BVbp3piCvQnJqmdCYCa2SrVKniWJgQQVQ%2FbQcr8mgOBYHodlWqVWWBBkUqUoUmZ4hA4kMbrIfXi7yPhPSvMHGsZMWahOrorJL7A4L1m8VqG%2FvwYhka97sUBCrS2rVTVoePdMy2ClOG0eR0nZYzRxi9zrEvs1xq%2Bptg6%2FTn2EPL4uFKAzlRlXhYAwwrNW5dniOqXLxmvYdC2TH0T2wChA5xuLOsY2K60fdgQpi1eD3%2Fx%2BU2NH60vBHMPv2bBsU%2FuE5MNMZ3Di%2FRyOUrcfBA2KzfQqY362LrMRimHhDR7dmc5iVKUbM8enKJaxFj7WlYFYPu42Wd3VMXel7Xv%2Bd1Mn6Dv0OnQ6LGV5glM3bP%2BzlO6XDfqE2US1ru4x5bX84JHhAq2k8cIM38oyRLK03xZfXRbEyZlhqfXLd414twV5v8a8o%2F69RP1rRP9Ag9VYnm6BIRWZZNpAZPHJXGGwIM4UOHsprhsZsTmrjwSP%2FLZYRNUyQlScqK1GZtV%2BP93sIWbWJt8ZHvKVKbXuHjYPuxcJ7tnLUjBBDyYDOGr2oDtoHnVFv8m6x7zZiY%2F6g8FkEvSOuxs%2Foz%2F%2Fpr7zN6q7sqmVkZqzhaVLL9pdrH5InjvKvVOs%2Fx7d9Wgsl%2FcNVPD%2FrfxPtBIH3rIZiIh5u07Q6TeDQbMzuGkHYRCER73WIHjb6bw9CPy3JwDWVVV4xm2wuQfo6PLgy21xLebvvzydZRfxZ%2BgffYpjefFhOvh0oz9yNju%2BgvPuxe27IV1%2BA6WSW9U7CgAA)

Run 2 — subdomain (`host=mail`), groups `spf_microsoft` + `dmarc`:

[Test leadape.io/outreach example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKQrZ2oC%2F%2B1VbW%2FbNhD%2BK4SAAgnqF9nxS6LAQN1m3YrFq5FlWIPMEM7kSeZCiQJJ2XED77fvKNlxnGYdtg8bBuyTIfLuuXvueY5%2BCBxmhQKHQfQQFEYvpUDzQQRRoBAEFNiSOmg83vwAGUUGl3Q3LpAuLJql5Fhl6NIZBL7YH2%2FDv8lAKgalW2DuJAcndc6Ofpy%2BZ6%2FZxWR89e6YUpZoLJ0HUacRKJ3qn4yi1IVzhY3a7X03bZlBirYNRdGUXOctu0wpXaDlRhauggjGVEsb%2BRkto6JMaOogZ3qVo%2Fml7IadM8uqnna82NG3WqcK2c%2Fa3NkCODJt2ERyo61OHDsZ9I%2BZ08xiLhhWqQkFPMFeSmDEqMGAIopyrqRdUHVgmc6l06apc7Wu2bJCK8nXlA2OGSy0cfb5dAzaUtHxShKR0jFIEuRO5ikTqCTNat1iHz2ib8Eg10YcUJWW8dIYQqSYTFrrU8Ego7EpiaLlJw5GwlzhxcHoXpkSXkVsq5kQ1ImtW62bhzQ1mJJj2BFFHu8JEDiNx9GYtq2VFgWb1y2KDAyPKYGlRpeFL2%2FXOX%2BrNL8LogSUxfpkWs6%2Fx%2FVFxeK5C%2F39FQpJfN1jBBFqHURtpxFEtw9BVawypy2SOK00phC3LrwvSa8JfS20dfT1xlcokqtSISUHMueqFBjFdNaqM1tcZ8Gm8Rw229nkLyJ7YDKg88KSj0lmpfXdC0Wq4e3Brz9d77Hj3aUAB%2FS9HFUydc5ZMcp1juc%2Bz9EqnQzCsBGQmN5l4HfrYz4mM6x9wL17p%2FOEXOkm4PiCzDLRwteaGkzk%2Fcsh27t9zZfa9pr%2F3dYZ5Y68D52OKlue09aNOv8spdmmEXymbuK9r2bU8s5%2BeA%2F0gNbWeGTme6avahSxrHK%2BcEpNnqAKMJBZ%2F%2F7uQG8PUGc72Nsad7YF%2Fiqonzrdb5fzzQEeEZJprg3Gln7BlYbG4kxJG5jRoyNjWMH%2BSPDYvxnruH6SCJX26kDOvH7lt6QfxaTeOuzPvc5%2BA6V2ipKgpGgsuB%2BH9CbqdHunHURsDpI%2BNHsCw%2Ba83xk2Q3Ha6Z3wXn8IZ0%2F%2BoL786%2FqDf6hDpZ56aKxWsLbBxpv5JZ61bVvP6X517f5dRrut2GxmDTLv%2F%2Fr9d%2FWj1bawRBGDj%2B2G3UEzHDa7w%2BvwLOoPo%2F6g1e31TsPe6zCMwtCTQOtqjg%2B09083PhgvbP%2BiPcRfr%2Fnybfdm%2Bn7wYbCYl7bdvlEXlz1XTk8%2Brb5Td%2BXlzSjY%2FA4xUwE3KwoAAA%3D%3D)

Both runs produce exactly two records with no duplicates:

| Run | Records applied |
| --- | --- |
| 1 (apex) | `@ TXT "v=spf1 include:_spf.google.com ~all"`<br>`_dmarc TXT "v=DMARC1; p=none; rua=mailto:reports@example.com; fo=1;"` |
| 2 (`host=mail`) | `mail TXT "v=spf1 include:spf.protection.outlook.com ~all"`<br>`_dmarc.mail TXT "v=DMARC1; p=none;"` |
