### PR TITLE
Add Webloo custom-domain template

### DIFF
--- a/webloo.com.br.custom-domain.json
+++ b/webloo.com.br.custom-domain.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "webloo.com.br",
+  "providerName": "Webloo",
+  "serviceId": "custom-domain",
+  "serviceName": "Conectar domínio à Webloo",
+  "version": 1,
+  "logoUrl": "https://www.webloo.com.br/icon.svg",
+  "description": "Aponta o subdomínio para a Webloo e valida o certificado SSL.",
+  "syncRedirectDomain": "dash.webloo.com.br",
+  "warnPhishing": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.webloo.com.br",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_acme-challenge",
+      "data": "%txtvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "required-for-unique-records"
+    }
+  ]
+}

--- a/webloo.com.br.custom-domain.json
+++ b/webloo.com.br.custom-domain.json
@@ -8,6 +8,7 @@
   "description": "Aponta o subdomínio para a Webloo e valida o certificado SSL.",
   "syncRedirectDomain": "dash.webloo.com.br",
   "warnPhishing": true,
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",
@@ -20,7 +21,7 @@
       "host": "_acme-challenge",
       "data": "%txtvalue%",
       "ttl": 3600,
-      "txtConflictMatchingMode": "required-for-unique-records"
+      "txtConflictMatchingMode": "All"
     }
   ]
 }


### PR DESCRIPTION
# Description

Adds a template for **Webloo** (`webloo.com.br`, service `custom-domain`). Webloo
is a multi-tenant website platform; this template points a customer's subdomain
at Webloo and provisions the SSL-validation TXT record so the certificate can be
issued automatically. Same shape as the existing Cloudflare-for-SaaS custom-domain
templates in this repo.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [ ] `syncPubKeyDomain` is set — **not set**; see justification below (unsigned synchronous flow with `warnPhishing`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — only `warnPhishing` is set, never both
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [x] no variable is used as a bare full record value — the TXT value is SSL validation content, justified below
- [x] no bare variable is used as the full `host` label — hosts are fixed (`@`, `_acme-challenge`)
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` — n/a, both records are required for the service

**Justifications**
- `syncPubKeyDomain` omitted: this uses the **unsigned** synchronous flow with
  `warnPhishing: true` (the documented fallback). Request signing is planned as a
  follow-up; happy to add `syncPubKeyDomain` if required for acceptance.
- Bare `%txtvalue%` in the TXT: this is the ACME/SSL domain-control-validation
  value issued per hostname; it has no fixed content prefix to embed.

## Online Editor test results

**Editor test link(s):**
[Test webloo.com.br/custom-domain webloo.com.br/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALWLZ2oC%2F%2B1Ta2vbMBT9K0bQT7Vd5VEnMQwWuq4MlnVtM%2FpaMLIkJwJbciXZaRby33flPNqkY%2Fu6wT5Zvlf36J5z7l0iy4syJ5ajeIlKrWrBuP7EUIzmPM2VCqkqwlQjf5f8Qgq4jG6bNMQN17WgvKmhlbGqCJgqiJAvuU3JmZKcWqI9yH%2BvMOZMCuU1J%2Bzt8GqujVASxS0f5WqqvukcamfWliY%2BOZnP5%2BFeZyeCKhmaegqljBuqRWmbcjQslbTEU56p0r0XS6KJRzYvetyrSS6Yu0i5tiITlDDl3dx8Dh2DhaTXnAkNnX9Y04oRI2YWHuozJ1p%2BnQkzE3KKYqsr7qOZMvaaP1VQzrYxQFKaGRQ%2FLpFdlI0wX4ajc7S%2BDr%2FvndpKSGvGyokqQb43z1kLsnQijFf%2BDmd8N35BSQgteEBnJM%2B5nHInD7EEEkf22QLlih%2B9hoHjswWHslxQOyKWOh4jxRzuMM%2FRarLy0Q9wMHkhMAHMrSaH%2FW26AL%2FgZ6pVVSZiW%2BQMKIybuG3540H9ZAvw2CBMmu6apl3IcmN5q91BricxlUrzxMCX2Erzrc5FlVuRELBlF2I0IWWZL4CCgSxAvfVArmd13fdGsT844KOEUcdGuB3IuulpvxPRoJUN%2BkH3FLMg7WbtIOqnOGWn7azTp6%2FW6Ze79rud2hOWG8OlFSRvXJqThUGrNwOxoXQwEOEexZ2kfzGviQ%2FD89%2Bxf8kxWFxDas4S4m62cTsKcC9o98atKO724u4gHES9Qat3jHGMsaMCrNYEl7Dbr7caPZxfXbduzz5WF8e4d1dc1ro4f7ioh1eW3T%2FdjC4u73kneziOoJN3aPUT2IAw0toGAAA%3D)
