### PR TITLE
add Lockally, Lockally Email

### DIFF
--- a/lockally.com.email.json
+++ b/lockally.com.email.json
@@ -1,0 +1,58 @@
+{
+  "providerId": "lockally.com",
+  "providerName": "Lockally",
+  "serviceId": "email",
+  "serviceName": "Lockally Email",
+  "version": 1,
+  "logoUrl": "https://lockally.com/mark-navy.png",
+  "description": "Set up SPF, DKIM, DMARC and MX records to send and receive email with Lockally.",
+  "variableDescription": "The domain-verification token and DKIM public key are supplied by Lockally.",
+  "syncPubKeyDomain": "lockally.com",
+  "syncRedirectDomain": "app.lockally.com",
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_lockally-verify",
+      "data": "%verify%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.lockally.com",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "%dkimval%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.lockally.com",
+      "priority": 10,
+      "ttl": 300
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx2.lockally.com",
+      "priority": 20,
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:dmarc@%domain%; fo=1",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **Lockally** (`lockally.com` / `email`). It provisions the
records a domain needs to send and receive email with Lockally — a domain-ownership
verification TXT, SPF (via `SPFM`), DKIM, DMARC, and MX — using the synchronous flow with
RS256 request signing (`syncPubKeyDomain`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated with the official `dc-template-linter` — the error gate passes (exit 0). The
only remaining advisory is `DCTL1021` for our custom `_lockally-verify` TXT host (an
ownership-verification label that is intentionally not an IANA-registered underscore name).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `lockally.com`; the RS256 public key is published at `_dcpubkeyv1.lockally.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.lockally.com`) — the synchronous flow uses `redirect_uri`
- [x] no TXT record contains SPF content — SPF is applied via the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on the TXT records (DKIM & DMARC = `All`, verification = `None`)
- [ ] no variable used as a bare full record value — **exception, justified:** the
  `_lockally-verify` TXT uses `%verify%` as its full value. This is a domain-ownership
  verification record (same shape as many providers' `_<x>-verify` TXT records); the value is
  an opaque Lockally-issued token, not a structured record, so a `name=value` prefix would not
  be meaningful. The DKIM record's `%dkimval%` is likewise the full standard DKIM value.
- [x] no bare variable used as the full `host` label — DKIM uses `%dkimselector%._domainkey`
- [x] no variable used in `host` to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

## Online Editor test results

**Editor test link(s):**
- Apex (`lockally.com`, host `@`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADkbaGoC%2F%2B1XW2%2FiOBT%2BK1EknhZoCJQAFVLDpQyllIZLYaeqkEkcsAhxxnagacX%2B9j3mUkJLd2fnZWc0fWmT43P5zs0feVEFXgQeElgtvagBo0viYNZ01JLqUXuOPC9K23ShJl%2FPbtECdNWb3SmccMyWxMYbI7xAxDvI3igr9d3xEjNOqK%2BWMkmIM6UD5oHaTIiAl87O4pHPFojNUz5aRunAn4Kpg7nNSCA25moPCyUMlN7dVVKptZpt%2BNs2u1UF%2BY7SHikM25Q5XBFU4RhEUgwyTJZY2UBVVkTMlD2%2BtISGGEETD9eO4vRnWHEoWPgpwE5cYiN5Ao7n2N%2B4ldGVIJx4xFbmOFIQwwoPg8Aj2FEm0VEMHvn2XThp4ai28fm%2B2lKjix0CYMWrDgqC9Am9ipSpJRd5HINkBpGd19ddBdTSw4sqokB2oz%2Fqg%2BWMcgEv473DbV6ynw4SCE4SW0ECJEJAe7KaBk9Pokp9F5IUbSTsGfGnbepIr7fUx%2Bo6%2BRoFWtI%2BhLmUWAO3G3oYsKjEt73QwaUxyN6mtA8W83WEOOHMyYJjDypDWSI93rYFSh6DLlWWyPte7KbnxaG3R8fAA0p8wfsUXhdPmfS7xSCUERHBMGsn0f%2BjO%2F1jd7r278UYO7Af9iHzZXkz%2F5kLJSj70JELhYWoLCdd0NJG9zKxLVjiQnFpOfMfKpRUMYctEgTJZe34Jgx3pK4f10n1GUKND6P2CHg%2BGOwdbniaMhoGY7I3CBBDCy5vob3pw7Ht4974QZXPu3GNaR1tZrngZlHGLmJ9Yjg57TwPL4VJ1tFxxtWKyLClj%2FgkbTzNI13T85qhF%2FbHS5nsg6wr7DeUdV5mHMnqtpsNt21qjWrvW6PXnGRrVr1iWgPTzDVuzVq1QqxWZWrVGqx9k6fVav6aOUto6%2B2MDprDu%2B658PshjbRO9t5i5tKtGDeG%2FVx3hE5o9vqqEGULqy93572gVfO7onUzn3emfeySe82s5BkbakHtnI4Go8FqVX%2B23M6sa66a80Y0m57zgdcZXWHu8ee8M6m7X91nW%2Bt4Sz6cEhHSHrnOWVYuv8oNWl%2FqFfpnYId37NywmjXTMiuq7CeZ%2BpThMYf%2FSIQMJkCwEG6TRegJMkYrdBA59hjJQYD2cziFYr29afwtCXx80%2FxgA%2BOTO3ZsOTpEctDENnScz%2BoprVAspnI2KqaK%2BsRNoaKuF41ssaAbOEZop8juFKUdJje%2BBqa3QhFX1%2B8WdJf1ZXw34bbLKB%2FefcpfaLNlv0BWsUU5eQH%2FRuvys%2FZrwzrvh%2FAEgR3wH1PZL5GN%2Fj3Z6D%2FzLv0AhcexnKDx%2Fy3V198E68ckcPonEXwSwScRfBLBJxH8xkQA31EcLbEzRlJPXhYpzUjphb6WLWlaSSumtbxR1HN%2FyBdNwsdcbCvwAl8i8W8Qtd5oXVn68BvHs3lnYQ2Hhm%2FqflCdtJ6wxsj8a7vuWfe3q%2BFsWlbXfwP0dEJ%2F3BIAAA%3D%3D
- Subdomain (`lockally.com`, host `www`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH8baGoC%2F%2B1Xa0%2FiShj%2BK00TPi1gyx0MyZaLiIiIwIrHGDJ0pjChdLoz07LVuL%2F9vAMiRXF3z%2FlydnP4os57vz%2F2SZdk6btIEr3ypPuchRQT3sZ6RXeZvUCuG6VtttSTr7wrtARZ%2FfKFCxxBeEhtslYiS0TdHe2NsNZ8YYeEC8o8vWImwc%2BMjbgLYnMpfVE5OYl7Plkivkh5KIzSvjcDVUyEzakv1%2Br6gEgt8LXB9VlSa3TaXfjZtW7qGvKw1h1rnNiMY6FJpgkCJEUGGqEh0dahaisq59o2vrQKDXGKpi5p7PkZzomGGWh4KYidOtRGigOGF8Rbm1XeNT%2BYutTWFiTSECeaCHzfpQRr02jPh4g8%2BzqYdkjUWNt8X20lcUMwhWDlqwzy%2FfQBuZqi6RUHuYIAZQ6e8evzpQJ65f5Jl5GvujEcD0FzzoSEx2RrcJOX6idGEgEnsSEkgCIltCdrGPDXN1lnngNJyi6S9px6sy7DyuoV84j%2BnHz1Ai3p7tx8VrH6zk3gEohFp57tBphUJkB7m9LWWczWXsQJvKBLQVyoDOOJ9GTTFih5LHQlEiL3V2O3XDceene8H7jPqCfFkMFz%2Bc1Mv1sMyjiVEQyzcTD6H5rLfGwuY%2Fy8GBMM%2B2HvMg%2Br6%2Fk3TzW%2F6kFHTjUeoKqadMkqa9nPiU3BEqeaw6rmP6hQUicCtkhSpJa151kw3JH%2B%2FPCc1B%2FB1WQ3ag8QzweD%2FRL3arWCx4yzwJ%2FQrY6POFoKdYi22vf76g9b%2Ffu1gYf1IVFDGxPc289qycki0y6TzLSIc0a%2BAI%2FSNIszxHSMMiraykZ8ntaWFlHGyBSMYqa0ZYcq5XtVXdhyKO6iygVSNe62W07XMlr1wdfWoD3NNvrNmtUfWVaudWU16jXa79Rm%2FUaLdy8LrF4vXHAcQnOv5mzUvr2%2ByUtvGLDI6GW%2F9LkVOrXiZdF%2BbGKZoSx7cVaKsqXV%2BXV%2B4Hca3o3sXC4WvdmQOPSLYdUKnN8afiPPxqPxaLVqPvad3vzGWrUXrWg%2By4uR2xufEeGKxwKeNp2%2FnEfb6LmhuJ1RGbABvcj1%2B7nCKjfqnDdr7M63g2ueL%2FbbDatv1XTVVTrzGCcTAb%2BRDDjMgeQB3JRl4Eo6QSu0I2F7gtQ4wBAI4EKx3t4bbwMFb%2B9NejMJL%2BP7L5sYn%2BEJttUEUYVG5TzJF4q5acog2WkqN0UkVSrkyym7aOfMYgmMlMwYtB2CvUPgtjfD8Z2w3BWKhP78bltfkt%2FLNazC8TO1D0%2Bh9h2tl%2B7PSC22NLGTnH6T8f9mfX7jtq3h6NBAHsC2XRL7KPfnpJT5lZQyv%2FlybVD%2B3TL9DOnjIR1A%2B%2F8y49f%2FHp4fkgD9R7A4gsURLI5gcQSLI1j8ECzge0ygkOAJUqLqiKSMYipTGhrZimFWzHI6UyxnS%2FlPhlExDJUBEXJThCf4ool%2Fy%2Bi4v7xq4fNBePkJf3VLl006xOKu7s6Xd9kGuiLmLN86u6DLR3NV1Z%2F%2FBoz9OcMqEwAA