### PR TITLE
Add xposureapp portfolio

### DIFF
--- a/xposureapp.net.portfolio-apex.json
+++ b/xposureapp.net.portfolio-apex.json
@@ -1,18 +1,17 @@
 {
   "providerId": "xposureapp.net",
   "providerName": "Xposure",
-  "serviceId": "portfolio",
-  "serviceName": "Xposure portfolio (subdomain)",
+  "serviceId": "portfolio-apex",
+  "serviceName": "Xposure portfolio (root domain)",
   "version": 1,
   "syncBlock": false,
   "syncPubKeyDomain": "_dcsync.xposureapp.net",
-  "hostRequired": true,
   "logoUrl": "https://xposureapp.net/logo-wordmark.png",
-  "description": "Connect a subdomain such as www to your Xposure portfolio.",
-  "variableDescription": "Points your subdomain at your Xposure portfolio and adds the record that proves you own it.",
+  "description": "Connect your root domain to your Xposure portfolio. Requires a DNS host that supports apex CNAME flattening (ALIAS/ANAME), such as Cloudflare.",
+  "variableDescription": "Points your root domain at your Xposure portfolio and adds the record that proves you own it.",
   "records": [
     {
-      "type": "CNAME",
+      "type": "APEXCNAME",
       "host": "@",
       "pointsTo": "proxy.xposureapp.net",
       "ttl": 3600

--- a/xposureapp.net.portfolio.json
+++ b/xposureapp.net.portfolio.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "xposureapp.net",
+  "providerName": "Xposure",
+  "serviceId": "portfolio",
+  "serviceName": "Xposure",
+  "syncBlock": false,
+  "logoUrl": "https://xposureapp.net/logo-wordmark.png",
+  "description": "Connect your custom domain to your Xposure portfolio.",
+  "variableDescription": "Points your domain at your Xposure portfolio and adds the record that proves you own it.",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%cnamehost%",
+      "pointsTo": "proxy.xposureapp.net",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_xposure-verify",
+      "data": "%verifytoken%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two templates for Xposure (xposureapp.net), a portfolio host for photographers:

| File | Service id | For |
| --- | --- | --- |
| `xposureapp.net.portfolio.json` | `portfolio` | subdomains (`www.example.com`), `hostRequired: true` |
| `xposureapp.net.portfolio-apex.json` | `portfolio-apex` | root domains, via `APEXCNAME` |

Both point the domain at our edge and add an ownership-verification TXT record. They are split because a template containing a `CNAME` at `host: "@"` must set `hostRequired: true`, which makes it subdomain-only; the root-domain case therefore uses `APEXCNAME` in its own service.


## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test xposureapp.net/portfolio example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC7IaGoC%2F%2B1U72%2FaMBD9VyxLlTaNQICSlkiV1h%2FTNK1F3US1ShWKTHyA28RObQcIiP99ZwKklFb7ukn7lMS%2B93jv3h1LaiHNEmaBhkuaaTUVHPQ3TkM6z5TJNbAsq0uwtLa77bEUq%2Bl9eY8XBvRUxLBGZUrbkUqEqs7368mugnww%2BZCrlAn5EaunoI1QkoZNRBYyvkhU%2FETDEUsMlCe3%2BfA7FFdrxFsCJ8rYn%2FCcCw0oxeoccYkaqzudYPnE2syEjcY%2BrOEKvJnSPGX6qZ7JMRJxMLEWmV3LoZdKSogtYWSnF9%2FiCWGGzGYzYhUpVK7JgcG6c8W0YMMErvYob5WQ1pSwipTZd4gIk5wwzg2xEyAaYpSLr1jvMoE1EVEzSYR1v1kWGBo%2BLKktMtf8y975zZdNi%2FDzs4tzraGvXGhazYv6QT%2Btxb61A99f1XZE%2Fft%2BRRNtIB5mJ0aF6xyzrIpmc352VD6tegJ55IjnFps6SkRsb5iNJ0KObxR39LcaRmL%2Bdsnm7oB9T%2BlgVaMLJSGqmjBAWduZgTnDcYd6rNLKBoaIH2Ot8iwSW0jGNEuN24ot%2BGEPPdjCH9b4wXqAtybdKRvGzVZ7Xiyo0yTGUmmIDD6ZdWuzmc80T6yI2IxVRzyOMIOkQAsGb5HrMEdZ7lSpfNP0P6VYoxGPnSHhFrXLoRkEfuCNhp2Wd3zKj73hSSfwTtpxmx9zH8XzF0v%2F9l%2FCe5u%2F11gwBqQVzC3heTJjhaGrg4naGHo1UfU9g69yrxr8t5oc1HCS%2Fof3j4aHK23YFHjEXGXLbwWef%2BK1TvvNTtg8Df2g3vW7rW7wyfdD33c%2BwNjS7RI3%2FuWu068Xx2lmenedsXns8cWvYJg0TD9JRuNeQz23n6fXd48Lvrhm9scZXf0GBfnqbpYHAAA%3D)
[Test xposureapp.net/portfolio-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGPIaGoC%2F%2B1U227aQBD9ldVKkRIFg4FwsxQpJCRSm5LShLZUEUJrew1b7F1ndw12EP%2FeWS4xCHp5bKU%2B2Zo5Mz5nzowXWNMoDomm2FngWIoZ86l852MHp7FQiaQkjoucalx4yz6QCNB4sM5DQlE5Yx5dVcVC6kCETFgkpmme3C9CbzB0KoXQyBcRYfwM8DMqFRMcO2Wozbh3HQpvip2AhIquI73EvadZZ1VxjGcoxuKzDCE10TpWTqm0DykZgDUX0o%2BInBZjPoYinypPslivPo1vBOfU0ygTiUQ7BJEW69iBjiJ6pC8Jk1QhgjoPT2gilEZ6QjRSSWxgkICJoJuHdvcWBTByTTnjY3Ta%2FvCu%2FVRqm%2FhZAdDeBBGFbkKR%2BACTtGimQiQjbkg7ezR7gnHoe8CS6J%2BwRIT7iPi%2BAmYUSerBENYkjbl01QqJOUdMm6%2BuAQo7zwuss9gY2O7dDlYSIG0kQujK7MaKSV%2BYDZAizYoHrmgNjlTrtr0svDXrD%2Fp5m9GmxIINYEFmPCGa5AZv4pcn66cWU8pPTONUg11ByDzdJdqbwEy7wjfte5IGLD0O2eQOuu8xHS4L%2BFVwOsoHMQRa282jKYHboUVPRLkMeBtLkcQjtsXHRJJImfvaVj7vlQ63tc%2FYvO%2FIMyHieuVKNc1esWHDxlxIOlLwJNpcn6NlAncRJaFmIzInecj3RjD9MAPyCrLQ67iLfH2ZV%2FnAf%2BdgAY98z%2Bhh5uID4hK7Wq9ZbqtRty5ajabVLNcuLNcOLty669s119v5exz%2Ft%2FzyF5JPlipFuWbEHHc7nJNM4eXBPm0E%2Fek%2B5QP%2BeyUOC7BI%2F%2B37Z%2B2Ds1ZkRv0RMbCKXalbdsOqNPvlmlNuOrVWsVVtNeu1c9t2bNsooUqv9S7g6nfvHQf9SH8StfO09%2F7%2B63knuyvV08b1l%2B%2F97rfHQdoYvOiLysdJ9S7qTC%2Fx8gfM63iB4QcAAA%3D%3D)
