### PR TITLE
Add template: out.win / outwin-email (Outwin email sending setup)

### DIFF
--- a/out.win.outwin-email.json
+++ b/out.win.outwin-email.json
@@ -1,0 +1,65 @@
+{
+  "providerId": "out.win",
+  "providerName": "Outwin",
+  "serviceId": "outwin-email",
+  "serviceName": "Outwin Email Sending",
+  "version": 1,
+  "description": "Authorizes Outwin (DALMA LLC) to verify this domain and send email on its behalf: domain ownership proof, DKIM signing key, SPF authorization, bounce (return-path) alignment, open/click tracking host, and a baseline DMARC policy.",
+  "variableDescription": "ownershiphost/ownershipvalue: domain ownership TXT proof. dkimhost/dkimvalue: the domain's own DKIM public key (host gets '._domainkey' appended). spfhost/spfvalue: SPF record naming Outwin's mail platform. returnpathhost/returnpathtarget: bounce-alignment CNAME. trackhost/tracktarget: open/click tracking CNAME. dmarcvalue: baseline DMARC policy. All hosts are relative to the domain+host the template is applied at (the sending domain); '@' means the sending domain itself.",
+  "syncPubKeyDomain": "out.win",
+  "syncRedirectDomain": "app.out.win, out.win",
+  "records": [
+    {
+      "groupId": "ownership",
+      "type": "TXT",
+      "host": "%ownershiphost%",
+      "data": "%ownershipvalue%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "%dkimhost%._domainkey",
+      "data": "%dkimvalue%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "spf",
+      "type": "TXT",
+      "host": "%spfhost%",
+      "data": "%spfvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=spf1",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "return_path",
+      "type": "CNAME",
+      "host": "%returnpathhost%",
+      "pointsTo": "%returnpathtarget%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "track",
+      "type": "CNAME",
+      "host": "%trackhost%",
+      "pointsTo": "%tracktarget%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarcvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ],
+  "logoUrl": "https://out.win/img/outwin-mark-512.png"
+}


### PR DESCRIPTION
# Description

New template for **Outwin** (out.win, DALMA LLC) — a self-serve email platform for small campaigns and businesses. The template applies the DNS records our onboarding needs so a customer can authorize their sending domain in one click: domain-ownership TXT, DKIM public key TXT, SPF include TXT, return-path (bounce alignment) CNAME, open/click tracking CNAME, and a baseline `p=none` DMARC record. All values are per-customer via template variables; hosts derive from variable-driven prefixes.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template validated against `template.schema` (ajv, draft-07, `--strict=false` matching CI)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://out.win/img/outwin-mark-512.png → 200)
- [x] Record rendering reviewed against the Domain Connect spec (sync flow); `syncPubKeyDomain=out.win` with the signing key published at `_dcpubkeyv1.out.win`

Notes for reviewers on conflict modes (deliberate choices):
- SPF TXT uses `txtConflictMatchingMode: Prefix` (`v=spf1`) so an existing SPF record is replaced rather than duplicated (invalid double-SPF).
- DMARC uses `txtConflictMatchingMode: All` at `_dmarc` — we only set a baseline `p=none` when none exists.

Contact: dalmasmedia@gmail.com (also being sent to domainconnect@godaddy.com for provider onboarding).
