### PR TITLE
add Wasied, Wasied website custom domain

### DIFF
--- a/wasied.com.site.json
+++ b/wasied.com.site.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "wasied.com",
+  "providerName": "Wasied",
+  "serviceId": "site",
+  "serviceName": "Wasied website custom domain",
+  "version": 1,
+  "logoUrl": "https://wasied.com/favicon.png",
+  "description": "Points a hostname at a website hosted on Wasied. The HTTPS certificate is issued and renewed automatically.",
+  "syncPubKeyDomain": "wasied.com",
+  "hostRequired": true,
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "ssl.wasied.net.",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Wasied, a French hosting platform. Customers host a website with us and want to serve it under their own hostname. Today they have to create the CNAME by hand, and the most common failure (leaving the record proxied at their DNS provider) gives them no feedback at all - this template turns that step into one click.

A single CNAME is all we need: TLS for the custom hostname is issued and renewed on our side (Cloudflare for SaaS custom hostnames), so there is nothing else for the end user to maintain.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Validated with the official linter, exit code 0, no output:

```
$ dc-template-linter -loglevel error -tolerate info -logos wasied.com.site.json
$ echo $?
0
```

`logoUrl` checked: `https://wasied.com/favicon.png` returns `200 image/png` (33 kB).

The public key is already published and recomposes correctly from DNS:

```
$ dig +short TXT _dck1.wasied.com
"p=1,a=RS256,d=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAteY+..."
"p=2,a=RS256,d=..."
"p=3,a=RS256,d=...QIDAQAB"
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set - published at `_dck1.wasied.com` (RS256, 3 parts)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow - not applicable, this template does not use `redirect_uri`
- [x] no TXT record contains SPF content - no TXT record at all
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique - not applicable, no TXT record
- [x] no variable is used as a bare full record value - no variable at all
- [x] no bare variable is used as the full `host` label - no variable at all
- [x] no variable is used in the `host` field to create a subdomain - uses `host` parameter with `hostRequired: true`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify - not applicable, the single record IS the service

## Online Editor test results

**Editor test link(s):**

- [Test wasied.com/site beggin.fr/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABJtaWoC%2F91Sf2vbMBD9Kkb%2FLnGVOr9qGKztBhujXdplFFaCkaWLq82WPOkc1w357jslTdOuYx9gYLB1unf33vNbM4SqLgUCS9esdnalFbhPiqWsFV6DiqWtWO%2Fp5lJU1MlutndU9%2BBWWsIW4DVNeSq96IxayMN1JBuPtoqUrYQ21LwC57U1LB30WGkL%2B82VBLpDrH16dHSgcLQUNNSauDYFwRR46XSNWyibWW3QRyK6sx4N7Y0E0mm%2FM1SJgjXRjkwcze8g%2Bjifz75GEhzqpZZkQKQ9Pb6hVmFU5MBAG74bIiyQWsqyi4O%2BzshZk3%2BG7v1OxR9WhXXX8KvRjhxK0TWww5yVVv5k6VKUnioOpHXKs%2FR2zbCrg1Xnl6cXHx4H0PFdsH2rbG6Du76MH%2FcYwEAEkbxKxpxvFpsee7AGssPUBZm0p5dDUWgTL91hOAK9eqxwtqkzvUfUwonKhyTssbfPwIs9%2BnYHD1t1YayDzNNbYONgL7hqStSZaMWhpGQm6rrsiKSnWxrzWrrZheaRnRIo%2Fq28xzIlA18dAjgensBomKi%2BUNO8P1TJoH%2ByzHl%2FNJFiOswnOeTjZ1l%2BnfK%2FpPmlX%2BA9GNQihPS0bEXn2Waz6JF3%2F4sW%2BslerEBlIrQe8%2BNxn0%2F6xydznqR8kCbTeMBHfJS84TzlPPCnaTtxa8rD8ySwh6vhtPp%2B0U1aPP9S35zdo3KQT26uLqenCbbTe%2FMDLcj8obh6yza%2FAWCBLAmLBAAA)

- [Test wasied.com/site example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABZtaWoC%2F91Sa2%2FaMBT9K5G%2FlocJjJJIk9aVPdoNRAcTqhCKjH0Bb4md2g40Q%2Fz3XfMosE77AZMiJb6%2B595zTs6GOMjylDkg8YbkRq%2BkAHMnSEzWzEoQNa4zUnm56bMMO8l4d4d1C2YlOewAVuKUl9JFZ7CGmb8OeGGdzgKhMyYVNq%2FAWKkViRsVkuqF%2Fm5SBC2dy21cr58o1OcMh2pVy9UCYQIsNzJ3OygZaKmcDViw1NYp3Bswh6fjTl9FCloFezK1YLSE4PNoNBgGHIyTc8nRgEBafGyBrUyJwICCtf8ukDBz2JKmZc3rKxUfFLMvUHb3Kv6wyq%2F7Bk%2BFNOhQ7EwBe8z7VPOfJJ6z1GLFANdGWBJPNsSVubfqtn%2FT%2B3AYgMd33vadspH27tq0dtijwHkizqFXzTal2%2Bm2Qn5pBclp6hRNOtKDZ4b%2FGM74%2BXlLneNpYXSRJ%2FKIyZlhmfVZOKInF%2FDpET%2FZD%2FCb5UJpA4nFN3OFgaPorEidTNianUqCJyzP0xKJWrzFMa%2Flq31wDvwEc%2Bzf6iskEdwzlj6E7WYjakZzWr2m86jaChtQ7cw7b6oQtWcQ8SaIBjvL8%2Buk%2FyXRl46BtaCcZD6oN%2BmalZZst9MKuve%2FaMGfbNkKRMJ8a0jDdpVeV8NoRJsxbcStsEbbrXarc0VpTKnnD9btxW0wD%2BdJIPX70SP%2F6u5mvbXs8r7gvR8zCLsP91eNh4%2Bd1fjZPH26fRyO0yF9S7a%2FAQxsIaSPBAAA)

Both runs are with a host set (`hostRequired: true`, so no apex run): a subdomain of a zone we own, and the generic `example.com/shop`. Both apply cleanly to the single CNAME.
