### PR TITLE
Add  Trust1 Product Review SES template

### DIFF
--- a/trust1.io.product-review-ses.json
+++ b/trust1.io.product-review-ses.json
@@ -1,0 +1,66 @@
+{
+  "providerId": "trust1.io",
+  "providerName": "trust1",
+  "serviceId": "product-review-ses",
+  "serviceName": "Product Review SES",
+  "version": 1,
+  "logoUrl": "https://trust1.io/wp-content/themes/trust1/assets/images/logo/trust1-logo-ts.png",
+  "description": "Enables a domain to work with Email Request Review",
+  "variableDescription": "%dkim1%, %dkim2%, %dkim3%: DKIM token CNAMEs issued for your domain; %region%: AWS SES region used for sending; %mailFromSubdomain%: subdomain used as the MAIL FROM address",
+  "syncPubKeyDomain": "trustshop.io",
+  "syncRedirectDomain": "app.trustshop.io",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": "3600"
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": "3600"
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": "3600"
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "MX",
+      "host": "%mailFromSubdomain%",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "ttl": "3600",
+      "priority": "10"
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "%mailFromSubdomain%",
+      "ttl": "3600",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "ttl": "3600",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "ttl": "3600",
+      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@%fqdn%; fo=1",
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template `trust1.io.product-review-ses.json` for trust1's **Product Review SES** service.

The service sends product-review request emails on behalf of the customer's domain via Amazon SES. The template provisions everything SES needs for a verified, authenticated sending domain:

- **DKIM** — three CNAMEs (`%dkimN%._domainkey`) pointing at the Easy DKIM tokens SES issues per domain.
- **Custom MAIL FROM** — an `MX` to `feedback-smtp.%region%.amazonses.com` plus an `SPFM` record on the MAIL FROM subdomain, so bounces/complaints are handled by SES and the envelope sender aligns.
- **SPF** — `include:amazonses.com` at the apex, expressed with the `SPFM` record type (merge semantics) rather than a raw TXT.
- **DMARC** — `_dmarc` TXT with `p=quarantine` and a `rua` address, marked `essential: OnApply` so the end user can tune or remove the policy later without breaking the template.

Records are split into the groups `dkim`, `mailfrom`, `spf` and `dmarc` so an operator can apply only the parts they need.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`trust1.io.product-review-ses.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `trustshop.io`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `app.trustshop.io`
- [x] no TXT record contains SPF content — both SPF records use the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — `_dmarc` uses `"All"`
- [x] no variable is used as a bare full record value — DKIM CNAMEs use the fixed `.dkim.amazonses.com` suffix, the MX uses `feedback-smtp.%region%.amazonses.com`
- [ ] no bare variable is used as the full `host` label — **see justification below**
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — set on the DMARC record

### Justification: bare `%mailFromSubdomain%` as `host`

The two `mailfrom` group records (`MX` and `SPFM`) use `%mailFromSubdomain%` as the full `host` label. Amazon SES lets the sender choose an arbitrary custom MAIL FROM subdomain, and the value is fixed per-domain at the time the identity is configured on our side — there is no fixed prefix or suffix we can pin without breaking existing SES identities. Misuse is bounded because both records only point back into `amazonses.com` (`feedback-smtp.%region%.amazonses.com` and `include:amazonses.com`), so no arbitrary destination can be introduced through the variable.

The DKIM records deliberately do *not* take this shortcut: they keep the fixed `._domainkey` suffix (`%dkim1%._domainkey`) as the guidelines require.

## Online Editor test results

**Editor test link(s):**
[Test trust1.io/product-review-ses herohostinger.email/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFxxaWoC%2F%2B1YW2%2FiOBT%2BK1YknoZwSSgtqZCKepkdzTBtgdXOblUhExvwJLGN7ZCyFfvb9zjcp8ygavehO8sTjs93rj7HX8KzY2giY2yoEzw7UokpI1R9IE7gGJVqUy0x4RTXgs84oWsR7GuqpiykOR4wJA2Nq%2BiU0czVVG8AS727BQR1cgjqXncBMqVKM8GdoFp0YjESv6oYoGNjpA7K5XUU5Uy6oeCGclM2Y5pQvZSVsdbU6DJL8Ag2rYmlxLVr1%2BiS5CNwRKgOFZMmd%2BZcczyIqUYYEZFgxpERKBMqQhkzY3QNWzHEOUmpXsVrY8WKWbWrHVMFErGkWiiifOGtFn4hQFcfP7TBckQ5uvzcal9rxLROKUFDodBMpGrp%2FRwVFB2BOdBp%2Fda1pUGLDZTqJVxTThgfAdQGd6NE0k0HC3XQ0qv1QgFrBFVC7daHT%2Bimc9tGmBBFdX4mMx7epYOPdHaVK6wOVI%2BFXBy3RXQoYYqGZo3BUpa%2BwYFcKKKd4OHZGSmRyrwRbO4gNDNpzzxPGx7HQptNrUr9RbARndn2Eowb3RNbcvtTwgn%2BU3DopFIocpPGtoZfr1ScefF1Lr0DLr1%2F36V%2FwKX%2FWpf22IdKbLltf9ny%2BbIrdp0OKSUDHEauTowsrfrtR%2B7t4DOhmJnBTvVwON27m%2FahgHbMaznspDCFsMN4GKeEBrvh7HoE%2BPecXfxD0yTBKtwY733pbWz318JtBwQbDE%2FT5lW71bmsniPZnKRYYW4Yp%2BdIpbhpC2BEkKtfFIYTwgvnMMpNe3WaJ3Mp%2BDBmoWljE45hstuCWN%2BtOAY5zCpcdQxbj7e8JWU8c%2BaP86IDKdD%2BZvIeIZLViI6pEjZmsEVViVr3myxglafbZys9CdEm2l78KwsPe008rmw8OHadT6h9mMms%2FvXrZFLP%2FPpARukwHIVmXItOB%2F5UZdRfgT0LpjVMVZTimopCmSnfG8unsRiO2LDOxmqUrcC%2BBWdpms5wHMY8q2ke6dink6EXyyjyCYsTYcEvussq2k1tpYvutlupdinWxvUcWz024kLRvoZfbFIF9YY7jYK1NDasjzO82SJhH9uyQ7E1SMEWXHPfzDtfENuhSuxeBMvOOaj0%2FdvBtmAR%2BjK0h8ds%2FzbqZw1v2Ki6Ph2Ebu20Qlx8NiBujdR8fHLaoF7Y2CLyFwx%2FkMk3XbTdma04wzPtzO0w7S%2FNoXPfW5qDSj9FaQ51%2Bd7SHFT6b5YmZ7JlXRZDvM54l7fW4%2FyjHDe0VX2zGS8oZn%2FK0ybQVxXtJS70F84J4s0f6U6CFz9zcusXhNe%2BE%2Bxh280LwpsqwfoVZP5YhHeHIxMemfDIhEcmPDLhkQn%2Fv0wI35kaTynpY4vzKl7drZy6XqNX8YNqIzipl%2Fy6Xzk7fVepBPl%2FBoZqs6jMM3yLbn%2BFOvXO%2FfvGWa87%2FaV7cn9Tz8zt7L73rntNazfR%2B6due8KjXvmPXiIbvzed%2Bd%2BVNiufuBUAAA%3D%3D)
