### PR TITLE
add otterdeploy, Connect a custom domain

### DIFF
--- a/otterdeploy.com.connect.json
+++ b/otterdeploy.com.connect.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "otterdeploy.com",
+  "providerName": "otterdeploy",
+  "serviceId": "connect",
+  "serviceName": "Connect a custom domain",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.otterdeploy.com",
+  "syncRedirectDomain": "get.otterdeploy.com",
+  "logoUrl": "https://otterdeploy.com/favicon.svg",
+  "description": "Connect a custom domain to an otterdeploy server.",
+  "variableDescription": "IP is the public IPv4 address of the user's otterdeploy server.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a template for **otterdeploy**, a self-hostable deployment platform. The service connects a user's domain apex to the public IPv4 address of their own otterdeploy server — a single `A` record, `%IP%` supplied by the user's server.

Template file: `otterdeploy.com.connect.json`

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Linter passes with exit code 0:

```
$ dc-template-linter -loglevel error -tolerate info -logos otterdeploy.com.connect.json
$ echo $?
0
```

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Comments on unticked items

**Bare variable as full record value.** The template's single record is `A @ → %IP%`. An `A` record's value *is* an address, so there is no fixed prefix to scope it with — the guideline's `service-foo=%foo%` pattern has no analogue for address records. The variable is documented in `variableDescription` ("IP is the public IPv4 address of the user's otterdeploy server") and is constrained by the record type. Happy to change this if maintainers prefer a different shape.

**`essential`.** Not set. This template installs exactly one record, which *is* the service — if it is removed the domain no longer resolves to the user's server, so there is no "user may modify this without breaking the template" case that `essential: OnApply` is meant to cover. Please tell me if you would rather see it set explicitly.

**Note on `syncRedirectDomain` for Cloudflare.** Running the linter with `-cloudflare` reports an informational `DCTL5003: syncRedirectDomain is not supported`. Retained because the checklist above requires it for the synchronous flow; noting it here for transparency since Cloudflare is an intended DNS provider for this template.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

> ⚠️ **Not yet supplied — this PR is a draft for exactly this reason.**
>
> Per `AGENTS.md`, these links must be produced by a human actually using the Online Editor and must never be fabricated. Two runs are still required before this PR is marked ready for review:
>
> - [ ] one test against a domain apex
> - [ ] one test against a nested subdomain using the `host` parameter
>
> The `Copy Markdown` output from each will be pasted here, and the "Template functionality checked using Online Editor" box above ticked, before this leaves draft.

