### PR TITLE
Add puestin storefront templates

### DIFF
--- a/puestin.com.connect-apex.json
+++ b/puestin.com.connect-apex.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "puestin.com",
+  "providerName": "Puestin",
+  "serviceId": "connect-apex",
+  "serviceName": "Connect your domain to your Puestin shop",
+  "version": 1,
+  "logoUrl": "https://puestin.com/logo.svg",
+  "description": "Point your bare domain (e.g. example.com) plus www at your Puestin storefront and prove ownership so Puestin can issue an HTTPS certificate for it.",
+  "variableDescription": "Adds an A record that routes your domain to your Puestin shop, a www CNAME (www redirects to the bare domain), plus a TXT record that verifies you control it.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "puestin.com",
+  "syncRedirectDomain": "app.puestin.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%cname%",
+      "essential": "OnApply",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_puestin-verify",
+      "data": "puestin-verify=%token%",
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply",
+      "ttl": 300
+    }
+  ]
+}

--- a/puestin.com.connect-subdomain.json
+++ b/puestin.com.connect-subdomain.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "puestin.com",
+  "providerName": "Puestin",
+  "serviceId": "connect-subdomain",
+  "serviceName": "Connect your subdomain to your Puestin shop",
+  "version": 1,
+  "logoUrl": "https://puestin.com/logo.svg",
+  "description": "Point a subdomain (e.g. shop.example.com) at your Puestin storefront and prove ownership so Puestin can issue an HTTPS certificate for it.",
+  "variableDescription": "Adds a CNAME that routes your subdomain to your Puestin shop plus a TXT record that verifies you control it.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "puestin.com",
+  "hostRequired": true,
+  "syncRedirectDomain": "app.puestin.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_puestin-verify",
+      "data": "puestin-verify=%token%",
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds Domain Connect templates for Puestin storefront custom domains:

- `puestin.com.connect-apex.json`: connects an apex domain with A, www CNAME, and TXT ownership verification records.
- `puestin.com.connect-subdomain.json`: connects a merchant-selected subdomain with CNAME and TXT ownership verification records.


**Bare variable justification (guidelines 6 & 7)**: `%ip%` and `%cname%` are bare because an A value has to be a raw IPv4
  and a CNAME value a raw hostname, so a prefix would just make the record invalid. The one free-form value, the
  ownership TXT, is prefixed (puestin-verify=%token%), and Puestin verifies that per-shop token at
  _puestin-verify.<domain>. No host field uses a variable. The labels are all fixed (@, www, _puestin-verify), so
  nothing gets relocated through record-host variables, and the template applies at the apex or through the standard
  host parameter.
  
  
## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test puestin.com/connect-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOvoaWoC%2F%2B1UXW%2FTMBT9K5alSUO0WZLSbq2ERNkmGPugsIIQ01S5zk1rSG3LdtqVqf%2Bd6yRd2m18PCEe9hTnXp%2Frc66P7y11MNMZc0B7t1QbNRcJmJOE9qjOwTohA65mtHGXumAz3EoHZRITFsxccCggXEkJ3DWZhps6VUEOyyRZqtyQRM2YkMSp8rcqR%2BxUaQTOwVihJO1FDZqpifpkMiwwdU7b3t7eBrE9nw3sfIKgBCw3QrsCSAdKyOqsMTOwPnAXgklA4IahaPAVnhGd5ZYsFgvC3D0yThlIjcI6TCbEdwCIWkgkNxWaWHW3kzNJhLU54EbydjgcXBIOxolUcOwsSZUhwgVeGDOCjTM42uLaTxLrkX1igCuTEDdFLkblDuwf29UgrGB%2FeNE%2FPya7fmkgEVjJWQ9wU9jswLNGKZiR4Zfh1nnYdCRcnkjwJp1RWUXbLiV%2FnSn%2BnfZSllkoI4N8fArLo6LsA7%2F4DR8rHndbmNbB9raSgKW9q1vqltr7pI%2FhqbIOl6%2B88fxF2qHC3x2hdzDiHLqh1QnDVeMOVKivgdiFe1Au0YUeDdaCdIJ5R72Xfa2z5S9qYoPqiqOKd7Nok4ckzLFadhV%2FuePUd5AFzRuHlk8zwd05c3wq5ORcJYXCLPsDEeRxvWrQH0rCqG7RNR66buWGhWuSuJqgbfRIrPdrZtjM%2Bre9Rl5tQa%2FX2Cvq10L7VRy2gjCIolbQ9sGidT7O%2BAy27g%2BThVyfRK%2B64ieKW9STFxOJ72dk8ctcbrCCMzlaZ5ZnTozYgtWhhI%2BY149aLWax3LYdSgKFHaqub1LcuL0GHSXcqxV%2BHCXRuNuOY9ZsdTvt5os0SptjgKSZxry9nx4ctNthvDHaHpl6vxludcs3L7KfLdjS0tUj1qxElNasZDzo6P%2BkZW3K1YM3UUn52zexZY3a4v%2BRwOsGPpYnzz157l96DqenZXNIRswV7oo7zXC%2FGXeHUdRrhz10WxwdxJ3O8xB%2FQi8CTy7V3uJ83Zys9PDFt3eTaaROPnTbb07OzNHgK7v5IidfT8af%2BTI9u4DL42%2Fd08P4zL6kq5%2BkQ6qT9gkAAA%3D%3D)
[Test puestin.com/connect-apex example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAErsaWoC%2F%2B1U227bOBD9FYJAgBS1FUlOfBFQoO69aJNNW3ebIAgMmhrbhGWSICk7auB%2F36Ekx5bTbV%2Fz0CeJMzzDc4aHc08dLHXGHNDknmqjViIF8zGlCdU5WCdkwNWSth5SF2yJW%2BlllcSEBbMSHEoIV1ICd22m4W6XqiGvqyQpVG5IqpZMSOJUtazLETtXGoErMFYoSZOoRTM1U99NhgXmzmmbnJzsETvx2cCuZghKwXIjtCuB9FIJWZ81YQa2Bx5DMAsI3DEUDb7CM6Kz3JL1ek2YOyDjlIGpUViHyZT4DgBRa4nk5kITqx52ciaJsDYH3Eg%2BjEaX3wgH48RUcOwsmSpDhAu8MGYEm2TwpsF1mKbWI4fEAFcmJW6OXIzKHdg%2FtqtFWMn%2B9cXw%2FC059r8GUoGVnPUAN4f9DjxrVYIZGV2NGudh05FwdSLBm3RGZTVtW0j%2BKlN8QZMpyyxUkct88gmKN2XZR37xG77WPB62MK2D5raKgKXJzT11hfY%2BGWJ4rqzD35feeP4i7Ujh8kjoI4w4h27odMNw03oAlep3QOzCAZRLdKFHg7UgnWDeUf%2FIodZZ8T81sUG7iuOad7tsk4ekzLGd7Dr%2B4sipBciS5p1Dy08zwd05c3wu5OxcpaXCLPsDEeRxu2nRn0rCeNeiWzx028o9C%2B9I1s9nhtbRY7HFaGbY0vr3vUXfNOC3W%2FxNVQDXQvtVHHaCMIiiTnDmg2ULfZzxJTTuEZOlbJ9Ez7pyEcUd6kWImcR3NLb4ZS43WMGZHC20zDMnxmzNdqGUj5nvA2q2mMVyTVtUBLYy6wvYZ7l3kS06TrkXLfxk6vfj7hlEg3bYYZ326YCdttlgGrUH%2FajXj%2Fv9sw6ke1PuFwPwN3Ou2f39ex1ma1ZYuvmFU2st6NSgqedRd5%2BaqK1ZN4%2FeSq3p4K0c6Dt4MA2%2F7Pz%2FxJTetvAl%2FTXjXzM%2BCTPivLVsBemYudJzcbcd9trxYBTFSXiaxN3gLO4N4u7zMEzC0AvB0yvF9ziR92cxtWs57%2Fwr869wdb0I8%2B%2BfZz8mkbwqiol413vbvehdLxa94v2XiF2%2FoJv%2FAM%2FJsDIwCgAA)
[Test puestin.com/connect-subdomain example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADHpaWoC%2F%2B1Va2vbMBT9K0JQ2Fjiyun6MhSWtmPdSruQZg8oJSjSjSPqSJ4k59GQ%2F74r23m1g%2B3jGPsUpKtzdc49x8qCehjnGfdAkwXNrZkoCfajpAnNC3Be6UiYMW2sS7d8jEdppypiwYGdKAElRBitQfimKwbSjPl2vcZdVCfI3BSWrI8Rb6qdui1xI5MjdgLWKaNpEjdoZlLzxWbYY%2BR97pL9%2FS2C%2B6EauUmKIAlOWJX7Ekg7RmlP%2BNZdryBKo%2FKGCGYcxUPo8Jpw%2F4yDNxaG1gS4liQMAIiZauQ0UjlxZn1ScE2UcwXgQXLV63XuiADr1VAJHCwZGkuUj4IebhUfZHC5Q7EtpUOGF7ftm%2FfEj5CHNYUH9ydDInlWBHDve49YEMbKqgNODq%2BvehC0xVuT1STcXIvzzIhHmgx55qDa6RSDa5hfVq49N39knO%2FCj0JZQJu9LWpQFyRuCb%2BG8TyPdqEVKUeT%2BwX187zMQBBad8Xlu5Cu4JLrGVzuCY1R2cNN79HtgyPGlo01FnVukP36qmapdh68555v2Nf7Z3vePIIuW848JnCYKeFvuBcjpdMbI0PjdpZhHZwD7RUPMfus23mezddEkMfDskGfjIb%2BRtUDXrpSvxWnDck6yil6mvfVCpNzy8cufHMr9P0O%2FGGFv68a4LqcS9jgYgw7U8ZiqTAUMTe%2BXMStAxr4qlRjjvsOf7kvLKz8GxeZV30%2B5ZstKfo8SEZ5DqvY7qVpFYmVqnreLxhtmdegfSmCUBVeCAZDySSXzRPGjppvIWbNwfCYN4U4YfIwPj1lLbH12vziIfrde7M79m1D29mUzx1dvohTrelZnKJdjc8ytTPnTUT%2BHrWr%2BC6XDw1M3H8n%2FwUn8Ut3fAKyz8PZFmsdNdlxs3Xai%2BPkME7ig%2Bi0FbOT%2BA1jCWNBDVKoZC%2FwLdh%2BBWg8%2Btb5xIb4hyTvHr9ezzKdTgdt8yE91%2FH08GrWlQNxkj51TfF4Rpc%2FAQGpJIwpCAAA)
