### PR TITLE
added new domain connect template

### DIFF
--- a/bharatgo.com.storefront.json
+++ b/bharatgo.com.storefront.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "bharatgo.com",
+  "providerName": "BharatGo",
+  "serviceId": "storefront",
+  "serviceName": "BharatGo Storefront",
+  "version": 1,
+  "logoUrl": "https://bharatgo-website.s3.ap-south-1.amazonaws.com/static/newLogoMobile.png",
+  "description": "Connect a custom domain to a BharatGo storefront.",
+  "variableDescription": "",
+  "syncBlock": false,
+  "syncPubKeyDomain": "bharatgo.com",
+  "syncRedirectDomain": "seller.bharatgo.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "3.7.220.6",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "3.7.220.6",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `bharatgo.com.storefront.json` — connect a custom domain to a BharatGo storefront (https://bharatgo.com). Applying it points apex and `www` A records to `3.7.220.6`.

Signed template — `syncPubKeyDomain` is `bharatgo.com` (public key published at `_dck1.bharatgo.com` as `p=1,a=RS256,d=...` / `p=2,a=RS256,d=...`).
`syncRedirectDomain` is `seller.bharatgo.com` for the synchronous flow with `redirect_uri`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes: Template is fully static (no variables). Apex and `www` A records are required for the storefront, so there are no `essential: OnApply` records. No TXT/DMARC/SPF records are touched. `logoUrl` is served from S3 (`newLogoMobile.png`).

## Online Editor test results

**Editor test link(s):**
- [Test bharatgo.com/storefront example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALCcaGoC%2F%2B1TbWvbQAz%2BK%2BG%2BNnZsJ01aw2DJunVj7RhtB11LMPJZTq6179y7c7ws5L9PlzQv7VrYtzEYGGxLj6RHj6QFs1hWBVhk8YJVWs1EhvpTxmKWTkGDnSifq5K1t74vUBKWjVbeU0Ueg3omOK6CjFUac62k3TmeRbQu9zEz1EYoyeKwzQo1Ud90QdiptZWJO50NB6%2FB1AiLvun6UHlG1XbqhT6U8FNJaIzj2DEWrOAdic0ZJTpXqSjQr%2BSEqmRouBaVXVVi75SUyG0LWrwmwmUrUyUI2bKKTFuau1Z8xxO0gLTAkyeZXJNzyUeF4vcszqEwuLZ8rdPPOD9Z5f1dS4e4wExoYrHFGCwK1P4z6FQZe4EPNWGzbQWKUzozLL5dMDuvnLrDRyx9vnXTUkJac6Xot%2BsP%2FCgK%2FD6ZrSV1u0GwbL8U2DTNH4SOl21GqmOyYzEmhTdt4A%2BghcI9%2BmudJlrVVSI2%2BIq6LI1buk3k7ZPQ8Sb2ljFXUUwkjSMx9AZba2JudU1SlHVhRQIN7EwZT6CqijkRNOSlFE9lkut9dDJlYOGVPtssybjjJ9xe9yFPBzwPvTw%2FDLzeYdb10t4x99KjtBfmeYjHfLB3JC8d0KtnstMIjUFpBbgTGBYNzA1bPhvVI%2Fn1qP4F%2BuM2jfv%2FAP7iAOiUDMwwS8DBoiDqe8HAi46uwiimpxv5UdDrHh4dBEEcBK4FNHbd2YIub%2F%2Fm2HT2cH43vG9GN%2Fd3D1n%2F4OaaTu6UD5vRx%2FAMLycn7z%2FA%2BXU%2B%2FW74G7b8BYdrfXdeBgAA)
- [Test bharatgo.com/storefront example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANGgaGoC%2F%2B1T227bMAz9lUCvjR3HTnMxMGC9YEXRdS3arhhQBAZt0YlQW%2FIkOW4W5N9HJcuta4E9bsCebInnkOeQ4oJZLKsCLLJ4wSqtZoKjvuQsZukUNNiJ8jNVsvY29gVKwrLTVfRCUcSgnokMVyRjlcZcK2l3gVeM1v0%2BZobaCCVZ3G2zQk3UV10QdmptZeJOZ6PBazA1wqJvIh8qz6jaTr2uDyX8UBIa4zR2jAUrso7E5jMlulapKNCv5ISqcDSZFpVdVWJnSkrMbAtaWU2CyxZXJQjZsoqutjJ3VnynE7SAtMDzg0zO5Fxmp4XKnlmcQ2FwfXNbp1c4P1%2Fl%2Fb2XDnGHXGhSscUYLArU%2FivoVBl7h99rwvJtBeIpzQ2LnxbMzivX3ZNfWPr96KalhLTmQdEx8gd%2BGAZ%2Bn66tpe5GQbBsv0VsmuYPqONlm1HXMdmpGFOHNzbwBehB4Z78beaJVnWViA2lIqOlce9uQ346YI839KcV39UVE0lDSQx9wdaa9FtdU0PKurAigQZ2VzxLoKqKOck0FKUsh82S61e5VsbBwjt%2B2yzhmRMp3PvuZwGkg17uRfko9HqQ9rwUEb08iqIejIb9Hud7y%2FLWIr27Lge9QmNQWgFuG06KBuaGLV9NbefA%2F6dcjNs0%2Ff%2FD%2BEuGQVtmYIY8AYcMg7DvBQMvHD50Q9IaByO%2F2xsGQXQU0CFwLtDYtbkFbeT%2BLrJjc9x%2Fvji7%2BHb5KZ3mJ%2BXtNYxuro5yezl8eZyePdwfzTuTwfPN4931B7b8Ca5%2BMAh8BgAA)