### PR TITLE
Add Lettermint DNS configuration v2 template for email with managed D…

### DIFF
--- a/lettermint.co.mail-v2.json
+++ b/lettermint.co.mail-v2.json
@@ -1,0 +1,46 @@
+{
+  "providerId": "lettermint.co",
+  "providerName": "Lettermint",
+  "serviceId": "mail-v2",
+  "serviceName": "Lettermint Email DNS",
+  "version": 1,
+  "logoUrl": "https://lettermint.co/logo.svg",
+  "description": "Configure Return-Path, DKIM, and DMARC records for sending emails with Lettermint using rotating CNAME-based DKIM.",
+  "variableDescription": "dkimSelector1: Primary DKIM selector; dkimTarget1: Lettermint-hosted CNAME target for the primary DKIM selector; dkimSelector2: Secondary DKIM selector; dkimTarget2: Lettermint-hosted CNAME target for the secondary DKIM selector",
+  "syncPubKeyDomain": "lettermint.co",
+  "syncRedirectDomain": "app.lettermint.co",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "return-path",
+      "type": "CNAME",
+      "host": "lm-bounces",
+      "pointsTo": "bounces.lmta.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkimSelector1%._domainkey",
+      "pointsTo": "%dkimTarget1%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkimSelector2%._domainkey",
+      "pointsTo": "%dkimTarget2%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1;p=reject",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
…KIM CNAME records
# Description

Adds `lettermint.co.mail-v2.json` for configuring Lettermint sending domains with managed DKIM.

The template configures:

- A Return-Path CNAME
- Two CNAME-based DKIM records for managed key rotation
- A DMARC record

The existing `mail` template remains unchanged so integrations using TXT-based DKIM continue to work. The new `mail-v2` service ID allows Lettermint to adopt managed DKIM without introducing a breaking change.

Lettermint supplies both DKIM selector names and their hosted targets when applying the template. This avoids hardcoding selectors in the Domain Connect template and keeps their lifecycle under our control.

The DKIM CNAME targets use bare variables because each value is a complete, dynamically generated DNS target hosted by Lettermint.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality in the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done.

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set because the synchronous flow uses `redirect_uri`
- [x] No TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [x] No variable is used as a bare full TXT record value
- [x] No bare variable is used as the full `host` label
- [x] No variable is used in the `host` field to create a general-purpose subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` for the DMARC record

The DKIM CNAME targets are complete DNS names supplied by Lettermint and therefore necessarily use bare variables in `pointsTo`. The DKIM selector variables are constrained by the fixed `._domainkey` suffix.

## Online Editor test results

**Editor test link(s):**

[Test lettermint.co/mail-v2 lettermint.dev/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEoXamoC%2F%2B1VYW%2FaPBD%2BK5GlflqShhQozdQPqGxSt9FVQKV1VYVMfIDbJM5sJzSr%2BO87h9AAL%2B27Sq80vVO%2FgHN3fp4733P2I9EQpxHVQIJHkkqRcwbynJGARKA1yJgn2g0FsZ%2BcFzTGYPLlyY0%2BBTLnIZT7YsojJ%2Fdr6z82WB9MjNW7GGJQDlJxkZCgYZNIzMSVjDB4rnWqgsPDrSQOjd9V%2BQy3MVCh5Kkut5IzkUz5LJNgDUBnMnEuqZ7bVu%2Fzed%2B2aMKsXr87OLMkhEIyZU2FtBQkjCczC0wuylpwPbc2UsyUcUqhqTaLs4tu%2F4MzoQpYieqazKnkdBJBbysVds%2FjIUQQaiEbgXUpeUxlUW5CzpX9vWWiRlTOQGNMTevMhdJIUdJZugwos9VzsNLnodaEfmANscaEvUjp%2Fzal2g9melsk4WU2%2BQxFT%2BAJJnsEY0IGwDieun4Komnq7gaaDAbwI8NIFNCURgpsUvWKBDePZCZFlpbikqv2pthe3KiL1CirTL3CMXnEzkRkSQjKqFYgjRoJtFdGN4o1dRMwutUaxXbU9rylvclijupZ%2BIOtDh%2B4Y1bWdg%2FFNt3BRo8P%2Fgsu%2F7e4%2FJe4UD9hTTb6Nqqpxmsno5rid35azkzjfXoq4Q4T2ITF5YM2QxfxUPepDuc4JH3BDOqlhCl%2FIHtDKl%2BNjmGgcBQ1p2bsvybdNI0Ksrxd2uSnSGBcy%2BAWU9sjNQZ5XQSuymrHvNyyI5fqqFeFIlxKJY2VufjWwDe7yLdr6Bti1iX4vwNvKaREjRtre6WIyurSSchgOpvzu%2FsoTkT6Qyqd5YuH4qdromux7sD6KwB%2FG3ZtfQUsHjSfJULCWOE%2FxbKwiVpmOIJxFmk%2Bpgtam1g4pqZD2BeFXqTD8dzRbrK677fGsBLVSyNoowRD0wxupNqa%2BtRn7YbTCk9Cp9lm1OkctfGn0wynx7TjtfzWxqO098Xa%2FyrVUtlUXjda0EKRpRmY5%2BppbM9fVdOruvi%2Fqtd%2Fpl7%2F76h3df1V1b7y%2BvuTpTxdkstbG2%2FFtwF8G8C3AfxDA4ivr6I5sDE1cb7ntx3v2PFPRo1W4B0HrabrH58cnRy987zA80wJoPSqwkd8eTffXNK86hTfBucfu%2F3h3dehJ3r9ZidvZve81b7%2BJL%2FHrasFTK%2B%2FfLr%2BLk7J8hdbLrDdug0AAA%3D%3D)

[Test lettermint.co/mail-v2 lettermint.dev/dc](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFAXamoC%2F%2B1WXW%2FiOBT9K5GlPk2ShvQDyKgPbOlK3Vk6qGWllSqEnPgS3CZxxnZCMxX%2Ffa4DNIGlnRlppf1Qn4Dr63Pu8T3X5ploSPOEaiDBM8mlKDkDec1IQBLQGmTKM%2B1Ggtgvizc0xWTy%2B8syrimQJY%2Bg3pdSnjil30T%2FssG6MjnW8OYOk0qQiouMBB2bJCIWf8gEkxda5yo4Pt4p4tisu6qMcRsDFUme63oruRTZnMeFBOsWdCEzZ0z1wraGn65HtkUzZg1Hg9tLS0IkJFPWXEhLQcZ4FltgalHWkuuF1SqxUGZRCk21%2BXJ5MxhdOSFVwGpU11ROJadhAsOdUtgjT%2B8ggUgL2QmsseQplVW9CTnX8Y%2BWyZpQGYPGnIbWWQilkaKms3SdUFerF2Dlr0NtCf3AukONGXuT0v9hSnUYzPS2yqJxEX6CaijwBLMDhjEpt8A4nrp%2BSaJ57u4nmgpu4UuBmWigOU0U2GTTKxLcP5NYiiKvzSXX7c2xvbhRV7lxVl36BsfUkTqhKLIIlHGtQBo1ERjfBN0k1dTNwPhWazTbybnnrew2izmqV%2BGPdjp85M5Yre0Rql26o1aPj%2F4OLv%2BHuPy3uNA%2FUUM2%2BXPSUM22i4xqir%2FLi3pmOh%2FzCwkPWEAbFr8%2BaTN0CY%2F0iOpogUMyEsygjiXM%2BRM5mLJZa9AxDRSOoubUjP3nbJDnSUVW05VNvooMZo0NpljaAasxKBsRzAio9c54vWnPMJvDXktFwJxKmipz9W2h7%2Fexp1vwe4M%2B3cB%2FH3rHJTVu2tnGN67YRF0aRgzm8YI%2FPCZpJvIvUumiXD5VX12T3Rh2D9ZfA%2Fi7sNvoT8DiYfM4ExJmCj8pysJGalngGKZFovmMLmkTYtGMmi5hbxSuIh2O6J5%2Fs%2FWd34yiy1reemsSbXRiZDrCjWM9CE%2F7J9R35t0wdE7Pz6hDvc6pwyLm9UJ6Bt1u2HqbDj5chx%2BntmPaFhwkS1opsjKT85qoTmsQd4T9VDf%2FY6L910X7%2FxfR6xtxI3l9I%2B5I%2Fc6l%2BM%2Fqebk8V1Mbb8v3oXwfyveh%2FBcNJb7SipbAZtRk%2Bp5%2F7nhdx%2B9POmeB1ws8zz056fVPvQ%2Behz%2BMCFB6rfEZX%2Bj220wejxPeK5NFF%2F92LWm%2F%2BK3%2Fay%2F%2Bpaz83FdX3uDDuOxfn3UePkt9dUFW3wDgcAfJ5g0AAA%3D%3D)