### PR TITLE
add FormsVS, Domínio próprio no FormsVS

### DIFF
--- a/formsvs.com.custom-domain.json
+++ b/formsvs.com.custom-domain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "formsvs.com",
+  "providerName": "FormsVS",
+  "serviceId": "custom-domain",
+  "serviceName": "Domínio próprio no FormsVS",
+  "version": 1,
+  "description": "Publica os formulários da sua empresa num endereço seu, como formularios.suaempresa.com.br",
+  "syncBlock": false,
+  "syncPubKeyDomain": "formsvs.com",
+  "syncRedirectDomain": "app.formsvs.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.formsvs.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a template for **FormsVS** (https://formsvs.com), a Brazilian form builder. Customers point a
subdomain of their own at us so their forms are served from their address
(`forms.theircompany.com/<form>`) instead of ours.

Single CNAME to our SaaS ingress (`cname.formsvs.com`, a Cloudflare for SaaS custom hostname).
No variables — the target is fixed, so an apply request cannot influence anything beyond `domain`
and `host`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — **n/a, `logoUrl` is not set**: we have no logo published yet, and pointing at a 404 would render broken on the authorization screen

Also clean under the official linter at every log level:

```
$ dc-template-linter -loglevel error -tolerate info -logos formsvs.com.custom-domain.json ; echo $?
0
$ dc-template-linter -loglevel info -logos formsvs.com.custom-domain.json ; echo $?
0
```
(dc-template-linter version 119 — no output at any level.)

The signing key is live and verified end to end: a representative query string was signed with the
private key via WebCrypto (`RSASSA-PKCS1-v1_5` / SHA-256, the same path our service uses), the
public key was reassembled by reading the TXT records from DNS the way a DNS Provider would, and
verification succeeds — while altering a single character of the query string makes it fail.

```
$ dig +short TXT _dcpubkeyv1.formsvs.com
"p=1,a=RS256,d=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmsKAci5I0j/Sv90NEtAxkpeUmeymFi2z..."
"p=2,a=RS256,d=GR9+DZB3lk8vDUi+zNanyfrcosvj4hoO7v6CsRFSlGnJ3WAyE23wd38/xltuOzoV+nFRKjNsTm7a..."
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead — *n/a, no TXT records*
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — *n/a, no TXT records*
- [x] no variable is used as a bare full record value — *n/a, the template has no variables*
- [x] no bare variable is used as the full `host` label — *n/a, no variables*
- [x] no variable is used in the `host` field to create a subdomain — uses the standard `host` parameter, with `hostRequired: true`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — *n/a, the single CNAME **is** the service; removing it removes the service*

## Online Editor test results

**Editor test link(s):**
[Test formsvs.com/custom-domain exemplo.com.br/formularios](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKQeamoC%2F91TXW%2FaMBT9K5FfIcwBEkqkSWPr0NppqOvQNImhyLEvndXETm2HNkX8913zUT5Wbe97Iva95%2BSck8OKOCirgjkg6YpURi%2BlAHMlSEoW2pR2aTtcl6T9MpqwElfJ2A%2B%2Ff8OBBbOUHDYQXluny1Dokkl1mO0wl7r8WVMKQkkdVMY%2FL3qVwYPSwYFwCcZKrUgatYkAy42s3OZMbuq8kJwF2gZeXF1s6CJksIFgga1ZgGYMWBaougxAoV7Y7Ax0YKFuB%2BhF77DMwzqI2UG8z05uvOpG8feF5vckXbDCwvYGX%2F4ZmsuttfN0%2FMItCGmAu5cVVlWd07Vf2rpbeKhxD%2BNypkZuhGgjLElnK%2BKaygf1YTL68nG3jsd3Pn4tlbNT7UNWGOcZsXMFSXsJpev5uk2etYLswDvHHPea4Ml%2Fbn0wu3vHUSZ4eWd0XWVyj66YYaX1BdnzzM6J5num2QmVVyPvlDaQWfxlrjawN45LTmbskR2uBM8wtKJB8RanyPZnKGpbplPBgjn2r2jaJBPcm5C%2BqrQr%2BgseR2E87MVhf8j64cVgSMNBn4kuzWneBziq%2FSv%2FiL8V%2F9VUwVpQTjLUQ0bFI2ssWa%2FnbUz4%2F3eJ%2FbBsCSJjHtGl3SSkg7A7nEZx2humUdJJkiSK4xalKaXeEFi39bvCDh23hzyNo2bSm06eyzH%2FNKKxHuRXebK8brWu83E9%2BvqG0hv7kNz%2F6PO3ZP0biJVPGOIEAAA%3D)

Result — exactly one record, as intended:

| Name | Type | TTL | Data |
|---|---|---|---|
| `formularios.exemplo.com.br.` | CNAME | 3600 | `cname.formsvs.com` |

No apex test: `hostRequired: true`, so per the instructions in this template it is not required —
and a CNAME at the apex would break MX and everything else on the customer's domain, which is
precisely why the flag is set.
