### PR TITLE
Add HollaEx custom domain template

### DIFF
--- a/hollaex.com.custom-domain.json
+++ b/hollaex.com.custom-domain.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "hollaex.com",
+  "providerName": "HollaEx",
+  "serviceId": "custom-domain",
+  "serviceName": "Custom domain",
+  "version": 1,
+  "description": "Connects and verifies a custom domain for a HollaEx exchange or frontend.",
+  "variableDescription": "%cnameTarget%: the HollaEx Cloudflare for SaaS CNAME target selected for the exchange region or frontend. %ownershipVerification%: the fresh per-hostname ownership token returned by Cloudflare.",
+  "syncPubKeyDomain": "hollaex.com",
+  "syncRedirectDomain": "dash.hollaex.com,dash.testnet.hollaex.com,dashboard.testnet.hollaex.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cnameTarget%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownershipVerification%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new HollaEx Domain Connect template for customer-owned root domains and subdomains used by HollaEx exchange backends or custom frontend projects through Cloudflare for SaaS.

The template installs two required records:

- A routing `CNAME` to the HollaEx Cloudflare for SaaS target.
- A per-hostname ownership `TXT` record at `_cf-custom-hostname`.

The ownership value comes from Cloudflare's `ownership_verification` response for the newly created custom hostname. HollaEx signs it as `ownershipVerification` and requires the exact TXT record during server-side verification. This prevents a stale CNAME left behind after an earlier customer removes or unpublishes a site from authorizing a later tenant's claim: the later claim receives a fresh TXT token.

The bare `%cnameTarget%` value is necessary because HollaEx exchange backends use region-specific Cloudflare for SaaS targets while frontend projects use a separate target. HollaEx selects this value from server-side configuration and includes it in the signed synchronous request, so it cannot be replaced by an unsigned customer value.

The template uses `CNAME` at `@` with `hostRequired: true`. Subdomains use the standard Domain Connect `host` parameter. The provider-neutral Online Editor therefore requires a host, while Cloudflare applies the same record at the zone apex using CNAME flattening. Cloudflare-specific linting passes and reports the expected informational apex-flattening notice.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using the Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is served by a webserver — N/A because this template does not include `logoUrl`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set to `hollaex.com`
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set for all synchronous-flow Dashboard redirect hosts
- [x] No TXT record contains SPF content
- [x] `txtConflictMatchingMode: All` is set on the unique ownership TXT record
- [x] The bare `%cnameTarget%` record value is necessary and justified above; it is server-selected and signed
- [x] The bare `%ownershipVerification%` TXT value is necessary because Cloudflare supplies the complete per-hostname ownership token; it is server-fetched and signed
- [x] No bare variable is used as the full `host` label
- [x] No variable is used in the `host` field to create a subdomain; the standard `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not used because both the routing CNAME and ownership TXT are required for the custom domain to remain verifiable

## Online Editor test results

**Editor test link(s):**

[Test hollaex.com/custom-domain example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKRuamoC%2F%2B1UW2%2FaMBT%2BK5GlPpWgkEKhkSatotUuVateaFWtQpGxT4jXYKe2Q6GI%2F77jECC0aNrjJs0vic93Lt%2B5%2BCyIhUmeUQskWpBcq6ngoL9xEpFUZRmFWZOpCWlsoCs6QVXy1YHnMwQM6KlgUJqwwlg18bmaUCG3WGXTL1Fvg05BG6EkiVoNwsEwLXJb3klfSQnMGo9K7qGaSATgxWN1D16iNMoqJh7MWErlGDyUJlpJC5I3XRSqBR1lcLYT4YBJJDWgegz2IPJsChtH%2FUwVPMmohjLCHaV3Xv%2Fq9PLcs6W6ZyBDcsBL2FluQmsYo%2FsdBt6BepWYaCryhzIRRh2FKmaiwaReDtpPlbGOkrdR96x6Bok%2BbaElRhvNa9RcZmYu2XUxuoD52aqk73vmFG6BC410NyqcmrRZ02uUAgsYHuwHYKSo5vtQdO8o38JLgf6x%2BVYX0CAYSmluSPS0IHael213tavU8frZDZMS0pqBet8IhKzNSHR0HATLxsbD4HGwtY9Z4ldztq4Zgpxa6rztL3bdL%2F7OLA5YkglmL6llqZDjS8VdoNMsI8vhskHelIR4m8sQA6zrBzOKDwZqNUAhzXO8jLUq8lisTXKq6cS4d7U2ftqxHq7Nn0p7vNZq4aTrchuBzxPhvck5xVZ1%2FBCPf4THb%2BPxO7VDXF5iLJWG2OCX4ljBum2TIrMipq90K%2BIsRlbZHMtgEMUwH1sqVw97lX3Vgh3SO3WPOXPFEG5TtI6SAHoQ%2BsEJ5X67w0K%2FR497frfbCcJuN2E8aNW2zp6F9Lu9s9MVMAakFTQrG%2FxK54YsPwxXlcme4WruZPdHlf5rsx42cC7%2Ft%2FGfbyPuAkOnwGPqNMMgPPaDrh%2BeDMJWFAbIuNlq9zrd8DAIoiBwieACX6W%2BwC1Qf%2F%2Fk8S75%2BSCu3zppOn2U1%2BdiJn%2Fcf89ezg7nF6f9m5fBTedL%2F6Q9E8%2F3n8jyFwjmTLIwCAAA)

The subdomain test produces:

- `app.example.com CNAME hollaex.site`
- `_cf-custom-hostname.app.example.com TXT 11111111-2222-3333-4444-555555555555`

Because `hostRequired` is true, repository coverage requires the non-empty host test above. An explicit Online Editor apex test was also run and returned the expected `Template requires a host name` result. Apex application is supported specifically by Cloudflare's CNAME flattening behavior.

## Additional validation

- Repository JSON Schema: passed
- Official Domain Connect linter at the repository warning threshold: passed
- Cloudflare-specific linter (`-cloudflare`): passed
- HollaEx server test suite: 28 passed
- HollaEx client ESLint: 0 errors
- HollaEx client production build and TypeScript: passed
- Published public key TXT record: `_dcpubkeyv1.hollaex.com`

`--merge-or-fail` reports DCTL1040 for the intentionally bare `%cnameTarget%` value. This PR therefore needs manual review; the signed, server-selected regional target requirement is documented above.
