### PR TITLE
Add Custom Domain Kit custom domain template

### DIFF
--- a/customdomainkit.com.custom-domain.json
+++ b/customdomainkit.com.custom-domain.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "customdomainkit.com",
+  "providerName": "Custom Domain Kit",
+  "serviceId": "custom-domain",
+  "serviceName": "Custom domain",
+  "version": 1,
+  "logoUrl": "https://customdomainkit.com/custom-domain-kit-logo.png",
+  "description": "Connects a custom hostname to a SaaS application using Custom Domain Kit, verifies hostname ownership, and provisions its TLS certificate.",
+  "variableDescription": "CNAME_TARGET: the Custom Domain Kit routing target; HOSTNAME_OWNERSHIP: the Cloudflare for SaaS hostname ownership token; CERTIFICATE_VALIDATION: the Cloudflare for SaaS certificate validation token; REPLACEMENT_OWNERSHIP: the Custom Domain Kit replacement verification token",
+  "syncBlock": false,
+  "syncPubKeyDomain": "customdomainkit.com",
+  "syncRedirectDomain": "customdomainkit.com,www.customdomainkit.com,test.customdomainkit.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "service",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%CNAME_TARGET%",
+      "ttl": 300
+    },
+    {
+      "groupId": "hostname-ownership",
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%HOSTNAME_OWNERSHIP%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 300
+    },
+    {
+      "groupId": "certificate-validation",
+      "type": "TXT",
+      "host": "_acme-challenge",
+      "data": "%CERTIFICATE_VALIDATION%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 300
+    },
+    {
+      "groupId": "replacement",
+      "type": "TXT",
+      "host": "_customdomainkit",
+      "data": "%REPLACEMENT_OWNERSHIP%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the `customdomainkit.com.custom-domain` template for connecting a customer-owned hostname to a SaaS application through Custom Domain Kit. The synchronous flow applies the selected CNAME and Cloudflare for SaaS hostname-ownership/certificate-validation records after the customer reviews them in their DNS provider.

The record values intentionally use bare variables:

- `CNAME_TARGET` is the application-specific routing target selected for the custom hostname.
- `HOSTNAME_OWNERSHIP` and `CERTIFICATE_VALIDATION` are exact Cloudflare for SaaS verification tokens. Adding a prefix would make the records invalid.
- `REPLACEMENT_OWNERSHIP` is an exact replacement-verification token generated for the domain operation.

All record hosts are fixed. `essential` is not set because every record selected for an apply operation is a prerequisite for the active custom-domain binding; independently changing or deleting one would break that binding.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Initial hostname setup](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALqfamoC%2F%2B1WbW%2FbNhD%2BKwSBfqrkKC%2BaCxcF5jre6jV2AltpOwSGQFO0zZkWFZLyS4P89x4lOZJn2cPWL9tQ5ENA6u655%2B6e4%2FkJG7ZMBDEMt55wouSKR0z1ItzCNNVGLiO5JDxecNOgcomdF5MBWYIL7mRG6DqzQh%2B5ARPN1IpTVgFxc5Ty2773y9cVU5rLGLfOHSzkTN4rAVZzYxLdOjurIXS2h%2B%2FCrWv9Gkk8A7iIaap4YjJI3JFxzKjRiKDcC82lNjEwQUbC5YiQESJJIjgl1gWlmsczdJChg4Amn3KmSwC5joH6nCcOInGEsiLZTDTiEDC4GSHKlAEngGYNmylRnEwEu96nOGj3u2HQHv7aDVrIzNlhdKRkaiwvQ9SMmbfow%2B0oyNxuPw%2B6w9GH3l3hKWQaTQVRDE2lyrM75AupL1j8FnW6w6D3S6%2FTDrrhp%2FZN77od9G4Hx5Eq6aAVETzKS1agDbt3N%2B1Ot98dBAe0DhNioD%2FKliw2RWVpBcxqZhvT90LSBW5NidAsv7lLJx%2FZNsc5qlZrOGQRV9D4U6bOer1u1N0bpk2jHtsWc8geUwAHpRuVAjGII1WkcevhCc%2BgU0k2BIXowcdsE7brcwEBx5%2FtXEkeGx1IOL6qyuCV9TIwBpee9%2BxUUXfNdF%2BaWQYIvgQlfEinbjEnOx87HMQQG%2BxQP1nIjYF5mcIsmD4xdA6K68vIQreFOEqpogq3VMUxWoQCeTonQrB4VqVUL8Z%2FTquisKMl2m9xhUytlv8Wl%2FGzg7%2FKmIWlOsaAv5Mj2xB4gVlFVXAZSarhlOUQ8synIqPa1h8pPoRKiCJLbR%2F4XdCHvajjXdiHPO64CPxdQasitkB5hcGxdpzA4VCIFZ7uYXQ3fx9sqFq9VL3raZYItU22ANg2j89iqVio4T8xqWK7aV%2BmwvCQrEl5FdHQrpAt9FrDV4CAl%2BBPUx%2Fny69ocaGz0%2BUp1eTgMKK2ldwq%2B03zajr16ZXLPEbdq3Ofum%2F8c%2Bb6Hj2Hvwnxo2ZlaZ%2FY66eW9r4mmdYwSJyITOlrstX42c7b3lwVOdY8PY39vP%2Byv%2F%2FZ1PeftyNpnxTmvz71sQMv2Q%2BB%2FxD4%2F1bgsBs0WbEoJNb0wrv4yfWa7qUXeF7L91reRcNrNn3ffw1nz7MJwQ%2FGvARPsDmqOwPrzZfO9PNv96vJxlyYT4%2F3ZBM8nonXYvLH9Xq18C6vZHdiVP%2F34eIdfv4GH4wshpoNAAA%3D)
- [Replacement verification](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPyfamoC%2F%2B1WXY%2FaOBT9K5alPk3CBCgDm2qlpQxt2RmYEaQ7o45Q5DoGLEKctR0oO5r%2FvtdJmJjyod0%2BVdp9QnbuPT733nNsnrFmqzQmmmH%2FGadSrHnE5CDCPqaZ0mIViRXhyZLrGhUr7LyGjMgKUnAvD0LXeRS64RpCFJNrTpkF4hYo1bf97NevayYVFwn26w6OxVx8ljFELbROlX95eYTQ5R6%2BC7uuyaulyRzgIqao5KnOIXFPJAmjWiGCiiy0EEonwARpAZsTQiaIpGnMKTEpKFM8maODCh0ENPmMM1UBiE0C1Bc8dRBJIpQ3yVSiEIcDg9sJokxqSAJoVjOVEsnJ15hd71McdYf9MOiOP%2FYDH%2BkFOzwdSZFpw0sTOWf6Hfp0NwnytLuHUX88%2BTS4LzNjkUWzmEiGZkIW1R3yhdKXLHmHev1xMPgw6HWDfvhH93Zw3Q0Gd6PTSFY5aE1iHhUtK9HG%2Ffvbbq8%2F7I%2BCA1qHBTHQH2Urluiys9QCM5rZJvR9LOgS%2BzMSK1bs3Gdfb9i2wDmpVhM4ZhGXMPhzoc5ms6kd29dM6dpxbNPMMfszA3BQupYZEINzhIwU9p%2Be8RwmleYmKEUPOXqbst2cSwhY%2FmZ8JXiiVSBg%2BcaWwRuTpcEGTc97cWzU3TDd12FWBwSPQQUf0plb%2BmSXY8xBNDGHHeonP%2FKbBr%2FMwAt6SDRdgOKGIjLQ3Tg%2BSclShVup4hQtQoE8XZA4ZsncpnRcjD9Oy1LYyRbtj9gic1TL%2F4rL9MXBf4mEhZU6poC%2FkyP7RuAGZpaqYDMSVMEqryHkeY4lI7sggEqJJCtlLvAd6NMe6nQH%2B1TgTkvgs6C2CE1g0SEQ2lE7QMKhkCwe7qFa3cLf5qij87azjwurQjg6JBvAKs61L5kdBIyIzxMhWajgl%2BhMsp2nV1mseUg2pNqKaGgeii1MVMFXOAj8%2Fp23k%2BKJKwdZqul8EyvNODiMqBkoN%2Fr9pd1qtdrNpuu1KXXf0mbHJY23HZddRbTB2o2rq1ndeprPvN7nnuZ95TGloFecxLmeN2Sr8Itx1Z57yhq%2Fd09tv%2Bh%2FOIOfvvqpA779f9D%2FgUHDjaLImkUhMaENr3EFnNymF3ie36r7XqdWb3bqXusC1p5nCoK%2FCUUTnuEmse8QfDe6iQVZXnz%2B2PyihuMvM%2B%2F35eODfLjoXIyzxjYZtBvtrhptHzPxK375Gx%2FmjjqQCwAA)
