### PR TITLE
Add Liha Sitebase custom domain template

### DIFF
--- a/liha.dev.sitebase.json
+++ b/liha.dev.sitebase.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "liha.dev",
+  "providerName": "Liha Sitebase",
+  "serviceId": "sitebase",
+  "serviceName": "Sitebase custom domain",
+  "version": 1,
+  "logoUrl": "https://liha.dev/favicon.svg",
+  "description": "Connect a custom domain to a Liha Sitebase website.",
+  "syncPubKeyDomain": "domainconnect.liha.dev",
+  "syncRedirectDomain": "sitebase-api.liha.dev",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "edge.liha.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a signed synchronous Domain Connect template for Liha Sitebase custom website domains. The template creates one CNAME pointing the selected host to edge.liha.app. Cloudflare will use DNS-only as the requested default proxy status during provider onboarding.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is served by a webserver
- [x] Official linter passes
- [x] Official linter with `-cloudflare` passes without errors

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set because the synchronous flow uses `redirect_uri`
- [x] No TXT record contains SPF content
- [x] No TXT records require `txtConflictMatchingMode`
- [x] No variables are used as bare full record values
- [x] No bare variable is used as the full `host` label
- [x] No variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in a `host` attribute
- [x] No record requires `essential: OnApply`; removing the only CNAME disconnects the website

## Online Editor test results

- [Test liha.dev/sitebase example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOjdamoC%2F91SXY%2FaMBD8K8ivzYdDIJBIlYquqGp7PaG74%2BmEIhMvYDWJU9tJShH%2FvWtCDuip%2FQF9inZ3ZjM7ngMxUFQ5M0CSA6mUbAQH9ZmThORixzwODXFe%2Bw%2BsQBy5x8ngSRhYMw041qAakcGJpd%2B0z6QeP8hqbWQx4LJgokRYA0oLWZIkcEgut3KpcoTvjKl04vu9Cn%2FDcJksPd1skcRBZ0pU5kQkd7IsITMDdrt8YCS2btQOWlhbiZ7Vty%2BzRb3%2BCvuPnZaEdLysW%2BddOWCxj8CFwv4rur%2FVZZW4Bu%2BkNo%2Fwo0Y0WmJUDQ5BolRck%2BTlQMy%2Bso7cPcy%2Bzc9wLD9Yo6UojX6WWALfQreUVRWOjEFbwojS4%2BrokF%2ByhPSyc%2BWcpVviT4YvCl4mi8vytm2x2CpZV6noKRVTrND24Xvyyw171dNfTnz7X7EtpYJU45eZWkF%2FXlHnRqSsZZcWz1JUnu9RpsYpbnl7etllo1PHmWH%2FOtwhKc%2BsWmGDxsOMjidh7IZxuHFH44C66xCoG42iiK0n8Sij7Cq6f0b6L5m9sQu0htIIZvM4y1u21%2BR4XDlo3f9xCb6vZg3wlFnkkA4jl07ckD7TcRKMkyH1JqMgmE7fUZpQag8AbbrbDpiF6xQQf%2Fl9sZhOg9F8KDfg82V8Hz2J%2BX6mxvPNbhr7sTJfJstPEOn35Pgbr0wQgXcEAAA%3D)

The template sets `hostRequired: true`, so the repository PR instructions do not require a separate apex editor test. Cloudflare documents that it ignores `hostRequired`; the signed production flow omits `host` for apex domains and sends the relative host for subdomains.