### PR TITLE
Kernstatt, 3 templates

### DIFF
--- a/kernstatt.de.custom-domain-apex.json
+++ b/kernstatt.de.custom-domain-apex.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "kernstatt.de",
+  "providerName": "Kernstatt",
+  "serviceId": "custom-domain-apex",
+  "serviceName": "Eigene Domain verbinden (ohne Subdomain)",
+  "version": 1,
+  "description": "Leitet Besucher Ihrer Domain ohne Subdomain auf Ihre Seite. Eine Domain ohne Subdomain kann keinen CNAME tragen, daher wird ein A-Eintrag gesetzt.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "kernstatt.de",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "159.195.76.181",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_fokara-verify",
+      "data": "fokara-verify-%verifytoken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ],
+  "variableDescription": "verifytoken: Eigentumsnachweis-Token, von der Plattform ausgestellt."
+}

--- a/kernstatt.de.custom-domain.json
+++ b/kernstatt.de.custom-domain.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "kernstatt.de",
+  "providerName": "Kernstatt",
+  "serviceId": "custom-domain",
+  "serviceName": "Eigene Domain verbinden",
+  "version": 1,
+  "hostRequired": true,
+  "description": "Leitet Besucher Ihrer Domain auf Ihre Seite und weist den Besitz der Domain nach.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "kernstatt.de",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "fokara.de",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_fokara-verify",
+      "data": "fokara-verify-%verifytoken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ],
+  "variableDescription": "verifytoken: Eigentumsnachweis-Token, von der Plattform ausgestellt."
+}

--- a/kernstatt.de.mail-sending.json
+++ b/kernstatt.de.mail-sending.json
@@ -1,0 +1,34 @@
+{
+  "providerId": "kernstatt.de",
+  "providerName": "Kernstatt",
+  "serviceId": "mail-sending",
+  "serviceName": "E-Mail-Versand freigeben",
+  "version": 1,
+  "description": "Erlaubt den Versand von E-Mails unter Ihrer eigenen Domain: signiert Ihre Nachrichten (DKIM), autorisiert unseren Versanddienst (SPF) und leitet Unzustellbarkeits-Meldungen zurueck.",
+  "variableDescription": "dkimselector: DKIM-Selector, vom Versanddienst pro Domain vergeben. dkimkey: oeffentlicher DKIM-Schluessel (base64). spfinclude: SPF-Include des Versanddienstes. bouncetarget: CNAME-Ziel fuer die Bounce-Subdomain.",
+  "syncPubKeyDomain": "kernstatt.de",
+  "syncBlock": false,
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "k=rsa; p=%dkimkey%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:%spfinclude%"
+    },
+    {
+      "groupId": "return-path",
+      "type": "CNAME",
+      "host": "bounce-zem",
+      "pointsTo": "%bouncetarget%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Three templates for a multi-tenant workshop/commerce platform. Tenants connect their own domain for their public site and, optionally, for sending mail through our provider.

| File | Applies to | Records |
|---|---|---|
| `kernstatt.de.custom-domain.json` | subdomains (`shop.example.de`) | `CNAME` + ownership `TXT` |
| `kernstatt.de.custom-domain-apex.json` | apex domains (`example.de`) | `A` + ownership `TXT` |
| `kernstatt.de.mail-sending.json` | mail, any domain | DKIM `TXT`, `SPFM`, return-path `CNAME` |

**Two routing templates rather than one.** A template lists fixed record *types*, and our routing record is a `CNAME` for a subdomain but an `A` record for an apex, since an apex cannot carry a CNAME. The service selects the template by whether the target is an apex. The subdomain template therefore sets `hostRequired: true`, which the schema independently requires for a `CNAME` on host `@`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver — **n/a, no `logoUrl` set**

All three validate against `template.schema` (draft-07) with ajv. The Online Editor
run is still outstanding — see the note at the bottom.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `kernstatt.de`; the public key is published at `_dcpubkeyv1.kernstatt.de` as two TXT parts (`p=1` / `p=2`), and apply URLs are signed RS256 over the query string excluding `sig` and `key`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — **n/a, we do not pass `redirect_uri`**
- [x] no TXT record contains SPF content — the mail template uses `SPFM`
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — set on the ownership TXT and on the DKIM TXT
- [x] no variable is used as a bare full record value — the ownership TXT is `fokara-verify-%verifytoken%` and the DKIM TXT is `k=rsa; p=%dkimkey%`, both with the fixed part in the template
- [x] no bare variable is used as the full `host` label — `%dkimselector%._domainkey` keeps the fixed suffix; the return-path host is the fixed label `bounce-zem`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — **n/a, none of the three carries a DMARC or similar user-tunable record**

## Online Editor test results

**Not yet run — this PR is a draft for that reason.** The repository's `AGENTS.md`
states that these results must come from actually using the Online Editor and must
never be fabricated, so the section is deliberately left empty rather than filled
in speculatively. It will be completed before the PR is marked ready for review.
