### PR TITLE
Add Fingerprint custom domain template

### DIFF
--- a/fingerprint.com.custom-subdomain.json
+++ b/fingerprint.com.custom-subdomain.json
@@ -35,7 +35,7 @@
       "type": "CAA",
       "groupId": "caa",
       "host": "@",
-      "data": "0 issue \"pki.goog\"",
+      "data": "0 issue \"%caa_issuer%\"",
       "ttl": 300
     }
   ]

--- a/fingerprint.com.custom-subdomain.json
+++ b/fingerprint.com.custom-subdomain.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://fingerprint.com/img/email-assets/fingerprint_logo_with_name.png",
   "description": "Connects a custom subdomain to Fingerprint, verifies ownership, and provisions the SSL certificate",
-  "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required. %ip1% and %ip2% are the two current ingress Fingerprint IPs. %dcv% is the dcv token+domain needed for each customer",
+  "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required. %ip1% and %ip2% are two ingress for the customer. %dcv% is the dcv address needed for each customer",
   "syncRedirectDomain": "fingerprint.com,dashboard.fingerprint.com",
   "syncPubKeyDomain": "domain-connect.fingerprint.com",
   "records": [
@@ -28,7 +28,7 @@
       "type": "CNAME",
       "groupId": "base",
       "host": "_acme-challenge.%fqdn%.",
-      "pointsTo": "%fqdn%.%dcv%.",
+      "pointsTo": "%dcv%",
       "ttl": 300
     },
     {

--- a/fingerprint.com.custom-subdomain.json
+++ b/fingerprint.com.custom-subdomain.json
@@ -4,8 +4,9 @@
   "serviceId": "custom-subdomain",
   "serviceName": "Custom Subdomain",
   "version": 1,
+  "logoUrl": "https://fingerprint.com/img/email-assets/fingerprint_logo_with_name.png",
   "description": "Connects a custom subdomain to Fingerprint, verifies ownership, and provisions the SSL certificate",
-  "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required.",
+  "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required. %ip1% and %ip2% are the two current ingress Fingerprint IPs. %dcv% is the dcv token+domain needed for each customer",
   "syncRedirectDomain": "fingerprint.com,dashboard.fingerprint.com",
   "syncPubKeyDomain": "domain-connect.fingerprint.com",
   "records": [

--- a/fingerprint.com.custom-subdomain.json
+++ b/fingerprint.com.custom-subdomain.json
@@ -1,0 +1,41 @@
+{
+  "providerId": "fingerprint.com",
+  "providerName": "Fingerprint",
+  "serviceId": "custom-subdomain",
+  "serviceName": "Custom Subdomain",
+  "version": 1,
+  "description": "Connects a custom subdomain to Fingerprint, verifies ownership, and provisions the SSL certificate",
+  "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required.",
+  "syncRedirectDomain": "fingerprint.com,dashboard.fingerprint.com",
+  "syncPubKeyDomain": "domain-connect.fingerprint.com",
+  "records": [
+    {
+      "type": "A",
+      "groupId": "base",
+      "host": "@",
+      "pointsTo": "%ip1%",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "groupId": "base",
+      "host": "@",
+      "pointsTo": "%ip2%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "groupId": "base",
+      "host": "_acme-challenge.%fqdn%.",
+      "pointsTo": "%fqdn%.%dcv%.",
+      "ttl": 300
+    },
+    {
+      "type": "CAA",
+      "groupId": "caa",
+      "host": "@",
+      "data": "0 issue \"pki.goog\"",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This pull request adds a new service definition for Fingerprint's custom subdomain integration. The main purpose is to enable connecting a custom subdomain to Fingerprint, verifying domain ownership, and provisioning an SSL certificate.

The record values intentionally use bare variables:
- **ip1** and **ip2** are the ingress IP addresses for each customer
- **dcv** is the DCV target as returned by Cloudflare
- **caa_issuer** is the CAA issuer for each customer

All apply URLs are signed (syncPubKeyDomain is set), so the value is attested by the key.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test fingerprint.com/custom-subdomain a-cool-saas.com/metrics](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACZPa2oC%2F%2B1XbY%2FaOBD%2BK5YlPjXJBih7AalSOfbutOq1una76octihx7AKuJndoOHF3x328cwjvsqf3USiukxS8zj2fmmRlmH6mDosyZAzp4pKXRcynA3Ao6oBOppmBKI5WLuC5osL1%2BxwoUp3%2FuBPDSgplLDrUqr6zTRWirTOiCSbW7blRHtQC52xOYg7FSKzpoBzTXU31vchScOVfawdXVkTFXspheAWrmIbMWnN0XSL16upBulip8LirVFPEFWG5k6eo36EgrBdxZwsjaWLI1ljhN9lwLCFomJxIs0QuFRs5kGRCmBKnD4W22xM2A3N39TTgYh7LcxxNdYkayLIebg6fvLZCp0VV5K15lDDdKm4Ll%2BTIg2hzcBJwxspiBIqPhkEhLDHytpAERkZYs263aClx1cGWAuIUmaLcBa8kEobxRa%2BfAoIbg85YH8ce4JkyIWlQBCBC1BjA%2B26p40paKfwCBT3J3sybqJC8Cwews08yI6DRjPMA%2FVfYGllv1dZBDvibgjA4%2Bpo2wdPDwSN2y9OkyxOMmMLjzocGDmbYOd699YmpUtx81buvA4JFzmD7dOF4FP4jSuYAyejd8%2B8cTSCnjBYR8howCuha1Jl%2BFakVH%2BJ6MC%2FjDQzsxBw7NFMwxXMbIpa2AfKYtFEnrjWl9pvuo41VAv2kF6S6m46BhACEYsqDz0DJmm9g3zxTgjOR2Y0cqa9WNo94ihCmZYYX1bWMD%2BHCCON5APmwxxw3oKSAy5w%2Fb%2FU7U9p%2F1Wac%2BS%2FbOMHZ7gNHRm1HST%2FoRykQ815WY5FgaG1t2gfIA5RcZTbWeUh8mOcUyhNTiN3OVQSacqSCgRZU7mbIF2x0JnrKyzJcYVYu3CHWYqWrd43ZBbBjbObajKKCp4D6G0nN93WeQ9HrXIeskWfgy68Qhm3R6Ybcv2IRlk4zHsNeHL7Tp%2F%2BnEJxxjEwDlJPP9dpgv2NLS1VHZXHQp%2BSVd2tRw49ZxyZ64%2Bb2p9msFY%2FgUw7s2symXgxbz0%2Fo3DrDVPdflc10%2B1%2BXPVZf4M2zZHETKvHQn7lyH8W9hN%2F7Y7g7aCdoevbzuJd3%2BizgexLF3CaxbO%2F1Yr%2BuRY96u%2FzYDdn1Ujw8HxVwPDwe1UI8OP5A2T4xMZ4eZlR9j%2FXBwMsY2fL4%2B4OqkEZ0v8%2FNKyRmlpwvpHMx3xiSilzL1rJFnsxXH05XPqhz%2FD8B88Nyi6Nw7QvcHMarU%2B8z8xRR%2FWyXJpLy9YaP33%2FBS9Ja%2FF18qO%2F2U%2FPvmRVnM7%2B0ruvoPBDxgdtMOAAA%3D)

[Test fingerprint.com/custom-subdomain a-cool-saas.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIlPa2oC%2F%2B1Xe2%2FbNhD%2FKgQB%2FxVJkZSscQwUmOesQ7G16BZ3rzQQaPJsE5FIhaRseIG%2F%2B460HfmVFC0wYAUCAzZ5vPvx3jw%2FUAdVXTIHtPdAa6NnUoB5K2iPjqWagKmNVC7huqLR4%2FF7ViE7fdMy4KEFM5McgihvrNNVbJuR0BWTqj1eiw4CA7neYpiBsVIr2ssiWuqJ%2FmhKZJw6V9ve6emeMqeympwCSpYxsxac3WYovHgxl25aKLwuqdUE8QVYbmTtwh10oJUC7ixhZKUseVSWOE22TIsIaibHEizRc4VKTmUdEaYECe7wOlvipkCur38hHIxDXu79iSYxI9mohKudqz9aIBOjm%2FqteD1iuFHaVKwsFxHRZuck4oyR%2BRQUGfT7RFpi4L6RBkRCOrLOOkELXOW4MkDcXBPU24C1ZIxQXqmVcWBQQvBZx4N4Mq4JEyKwKgABIkgA49NHER%2B0heK%2FgcArubtaBeogLyLB7HSkmRHJYcZ4gA%2FN6GdYPIqvnBzzVQCOyOBl2ghLezcP1C1qny59JK8dgzvvGiRMtXW4%2B94npkZxO9S4DY5BknOYPmdpuoy%2BEiV%2FAmXwvv%2Fux2eQCsYriPkUIwpoWtIZ3wvVSfbwfTCewO%2Fv6ok5sKumYI7hMsVY2gbIJ9pBliJsTOcT3Ua9XUb0H62gaH16G60jgBAMo6DL2DJm175fX7NRoJBBZmOhVwXla2ZYZX2%2F2CDdHEDdbrBuqF8HtEMkjJUnZpd5kvnPipYHWneLht7ytAqckdwme5cl3cvuZYI8CS91I8YlFsNGidY1HqC%2Bk8lE6wn1jpETLDwoLP4y1xj0vTMNRLRqSicLNmctSfCC1XW5QD9aPEWo3dxUq662FZ3WpDYcES0E926TPq45S7vjc57FjIssPk8Fi1n3YhTn32X5aHSevhL5xVbPfaIlf6brtvHESgflJPNNtV%2FO2cLS5V5tHLGi%2B21ZsanNtSV7pdja9aWJ9I1Y3z8exbZTbPJ%2Fp0v8%2F0y6jbBNvVTYS4W9VNh%2FVWH4NFo2A1Ewz5an%2Bas4vYjP0mF21svTXnqZZPlFlndPUtyk3hawbmXtQ1iH93%2BWhe%2F1mBtI4UnfKc7woO8kenjOvyJFnhlcjg4YSz9M%2Bgf7YJjcCmEbpIPG8nT1Hgp1jwh9tlgOYL7QJwl9LjkP0I%2BmKQ6JS59OJU7jmA8%2Btsg684bQ7eGI%2Fn1nf1fno%2BG4GZzgX4YfJuLkjf1wP%2FxTXA2G0P2pf%2FdrMyirP%2Bryr9d0%2BS9r%2BFjvWQ4AAA%3D%3D) (Apex)
