### PR TITLE
Add eusend.dev mail template

### DIFF
--- a/eusend.dev.mail.json
+++ b/eusend.dev.mail.json
@@ -1,0 +1,54 @@
+{
+  "providerId": "eusend.dev",
+  "providerName": "Eusend",
+  "serviceId": "mail",
+  "serviceName": "Eusend Email",
+  "version": 1,
+  "logoUrl": "https://eusend.dev/brand/eusend-logo-black.svg",
+  "description": "Authenticate and send email with Eusend: DKIM signing, SPF authorization, a DMARC policy, and an aligned Return-Path for bounce collection.",
+  "variableDescription": "%dkimselector%: DKIM selector Eusend generated for this domain (e.g. 'eusend'); %dkimpub%: base64-encoded RSA-2048 DKIM public key Eusend generated for this domain",
+  "syncPubKeyDomain": "eusend.dev",
+  "syncRedirectDomain": "eusend.dev",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimpub%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "Always"
+    },
+    {
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.eusend.dev"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:dmarc@%fqdn%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "returnpath",
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:_spf.eusend.dev"
+    },
+    {
+      "groupId": "returnpath",
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback.eusend.dev",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/eusend.dev.mail.json
+++ b/eusend.dev.mail.json
@@ -5,7 +5,7 @@
   "serviceName": "Eusend Email",
   "version": 1,
   "logoUrl": "https://eusend.dev/brand/eusend-logo-black.svg",
-  "description": "Authenticate and send email with Eusend: DKIM signing, SPF authorization, a DMARC policy, and an aligned Return-Path for bounce collection.",
+  "description": "Authenticate and send email with Eusend: DKIM signing, a DMARC policy, and an aligned Return-Path for SPF alignment and bounce collection.",
   "variableDescription": "%dkimselector%: DKIM selector Eusend generated for this domain (e.g. 'eusend'); %dkimpub%: base64-encoded RSA-2048 DKIM public key Eusend generated for this domain",
   "syncPubKeyDomain": "eusend.dev",
   "syncRedirectDomain": "eusend.dev",
@@ -18,12 +18,6 @@
       "ttl": 3600,
       "txtConflictMatchingMode": "All",
       "essential": "Always"
-    },
-    {
-      "groupId": "spf",
-      "type": "SPFM",
-      "host": "@",
-      "spfRules": "include:_spf.eusend.dev"
     },
     {
       "groupId": "dmarc",


### PR DESCRIPTION
# Description

Adds a new template for **Eusend** (`eusend.dev` / `mail`), a European transactional email
service. The template configures everything a customer needs to send authenticated mail:

- **DKIM** (`TXT`) — per-domain RSA-2048 public key, selector passed as a variable
- **SPF** (`SPFM`) — merges `include:_spf.eusend.dev` into the apex record
- **DMARC** (`TXT`) — `p=none` starter policy with a per-domain `rua`
- **Return-Path alignment** (`SPFM` + `MX` on `send`) — an aligned envelope MAIL FROM so DMARC
  passes on SPF as well as DKIM, and asynchronous bounces are routed back to us

The four groups are independent, so a customer can apply only the subset they want; the
`returnpath` group contains both of its records because our verification only enables alignment
when the SPF and MX are both present.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on specific rules:

- **`txtConflictMatchingMode`** — `All` on the DKIM record (`%dkimselector%._domainkey` is a label
  we own exclusively, so a re-apply during key rotation should replace the old key rather than
  add a second one). `Prefix` / `v=DMARC1` on the DMARC record, so applying the template can never
  leave a domain with two DMARC records, which RFC 7489 treats as no policy at all.
- **`essential`** — `OnApply` on DMARC and on the Return-Path `MX`, both of which a customer may
  legitimately tighten or remove later. The DKIM record is `Always`: its removal stops signing
  outright, so it should be reported as a conflict.
- **Variables** — `%dkimselector%` and `%dkimpub%` are both per-domain values generated by us.
  Neither is used bare: the selector is fixed to the `._domainkey` suffix, and the public key sits
  behind the fixed `v=DKIM1; k=rsa; p=` prefix.

## Online Editor test results

**Editor test link(s):**

<!-- REQUIRED. Paste the "Copy Markdown" links below, replacing each placeholder. -->

- **Apex** (`example.com`, no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKm6bWoC%2F%2B1YaW%2FiSBD9K5al0eyKyzjcUaQ1Z0iGcARyMBOhtrttN%2Fii3SaYKPvbt9tAgAwZMqtdTTTiE6arXFXP9fyq208iRbZnAYrE0pPoEXeGISJNKJZEFPjIgUmIZmL8xXIFbOYp1iIbW%2FcRmWENRTfYAFubpR1PobYyzhDxseuIpXRctFzDHRCLOZmUen4pldqkTKkEOHC1kOCeCdUC2iTpzwwWBiJfI9ijUShRCaiJHIo1BkNgtwlRSsRTCo%2BYmsKyiJJQvWy2BB8bDnaMuACEakvpVQTPtbAWxqM7gSMAizkgKPQQDYiT6AAWQHeJcN2pL202yxU5q27gaEjQXMtCGq8lyRECgoFqoepOiZ%2FgBNs%2B4n4u%2BbSuZPV%2FVZ9gIAcRhgFG%2BaiJfQG6DIUj%2FIGSRlL4vHwcn%2F88FaJ4XqCyUCrwUS6TQI7mQl72tZKQpUxhmYK5MHDCBIUHk%2FDWhY7WCdRLFFaXS69YwO09BDFhZe%2F3YBaXQF8sfX0SDeIGXsQMXiwz0tDjlOjf9dkf0%2FXpdw8mOVrWwurlXQYUMJfZGYeSPhUmZ8QHp4J39oKeB6WMQSc5SWKXc1pxHZ0Bpi1ANZN1ucWeCWeIxcmHfJ%2FTBFjRyiMIffE5vlOnDYj2RqGjtXFTFWdPmtfjuA46FUgAzjjnqFuKfP%2F6pE%2Bh8%2B4aOwTpeC7udVnZNllfoWk7iudZ4Ss4JGKwxwi8wcRY3NqAWr%2FFnt4LLMTaJmJHswKISiO2ltxq7eHIrbvv4noudqjfd9mKjhBU%2BQv8SlawSzANmR5IO49pL7iH57i4YI96tGHZA%2BvHCxHngEkZSmquvamEXUVlj3Dkv6biuplbQFgoDxBg%2B1wJ10G%2F7kR9WIf9KvLrKPDBoNsEjwIutXNlYSzmi61ms9wcK1dlYzI1J7hRfJTKSrdWV5R2RekWFG6vGJfsuqZQ68oypAWUcqrXLCxwhaCpPo5BXU31Xeq2x9XbsWUoheEclYtqI9VqpMre1RAuqkU%2FP%2Bxlq%2BedqSXnZ%2FJjWWrmW%2FZAzi%2BKTbN2PRhAGY%2FrytQZo2rlS9fHJ53Yhdm05JvpALhKN1ajt9nmZHZxM0R2A9T71UtSzbbqHZQpZNUJrJi21RlY5tVwIJ%2BfWFrH91rtoZFdjMcTJAfF%2B1iYq6nWbSt7r%2BdvM6GVVxyYaaW0rp2%2BNaoxOWjLs7rUuszDaVVXY%2B22ko3F5F47HHsZ2XN7oW%2F2ML0rLhqVYU%2F9cp8CXnHRu9BjJ3MSdhre4PzmbkKgkj5ZTGM9fdrXvXqjbdjzeQqaSKbS5UCjfRjO7PKjfYPnVzlzfHlyTbDZbVaVrlIWOceYxrsEjfigAKyTjNyUBCgu2oFF8Qg8gs0S1EaAk5NR0mdW1komfDvy4Szn4Ir279O3Ixs%2BCBt2NGkENS4NmAugCjOooGVAIgs0PZGRirlEEeZRoqDJmporaHmgg61t0%2Fcbqj0bp41i7RtUXID3EetfzKVdofzlCF%2F0%2FS2Iq2nyApCNprTwxqAS%2FgbRrI9QMVAfqW%2FRhNyLaf903OrM7qD81X16iLPBexS6o9Adhe4odL%2B10LFdug9mCI4A95MlOZeQCgkp3ZeKJTldymSTcjqdl%2FMxSSpJEoeCfLrE%2BhRdR6cJ4KE5%2F11%2FG1geMXbOBetjwdap4Hgo%2BDjq%2BMYh8z0nwGf%2Blx8Oll9F3jUzk1tpkrsvyOpF%2Bnacph%2BWL99E8cdD7J3t%2FYnx9oOUEbX2JVwOja2EB8fNbpbXKn8YVVoS9g2A6MOOH6jrl%2BwolL%2BdUK4G7Wrs%2Fm%2ByyeMftfP31s6f6PEhAX0d6pCKvpn6P5fS94F8W0%2B5oEaSybaufBvKnKNNKFvf%2Fq4p%2BtPJ3AT3RuF2YIf1mpNtZ%2FOVm2LlvGEEZZS%2FzUqV8lBHjHqDM%2FH5H1zPpTEuHAAA

- **Subdomain** (`example.com`, host `mail`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALy6bWoC%2F%2B1YaW%2FiSBD9K5al0eyKy5ibKNKaM4QhHIEkw0yE2u623eCLdpsAUfa3b7eBAAksGWlXikZ8AneVq%2Bq5nl91%2B1mkyPYsQJFYfBY94s4wRKQBxaKIAh85MA7RTIy%2BWm6AzTzFamhj6z4iM6yh8AYbYGu7tOcpVNfGGSI%2Bdh2xmIyKlmu4A2IxJ5NSzy8mEtuUCZUAB64XYtwzplpAm8T9mcHCQORrBHs0DCUqATWRQ7HGYAjsNiFMiXhK4QlTU1gVURQqzUZL8LHhYMeICkCotJReWfBcC2uLaHgncARgMQcEhR6iAXFiHcAC6C4Rbju1lc1muUJn1Q0cDQmaa1lI47XEOUJAMFAtVNkr8QucYNtH3M8lXzaVrK%2FX9QkGchBhGGCYj5rYF6DLUDjCHyhuxIWvq8fx9c8LIYznBSoLpQIfZdMx5Ggu5GXfKjFZSudXKZgLAydM0OJkEt66haN1ArWJFpXV0hsWcHsPQUxY2Yc9mMUl0BeLP55Fg7iBFzKDF8uMdOFxSvQf%2BuzCdH367sHER6taWL28y4AC5jK75FCSF8LkkvjgQvAuX9HzoJQxKJWVJPZ3TsuuozPAtAWoZrIut9gz4QyxOPmQ73OaACtceQILX3yJ7tVpA6IdKXS0MW6r4uxJ8noc10EXAgnAJeccdYuh719f9Cl0PlxjhyAdz8WDLmvbNusbNG1H8Txr8QYOCRnsMQJvMTEWt7agNm%2Bxp%2FcCC7G2idjRrACi4oitxXdaezpy6%2BFdXM%2FFDvX7LlvREYIqf4HfyAp2CaYLpgfS3mM6CO7xJSou2aMebVn2yPrxSsQ5YFKG4pprbytZ605Y%2BgiH92zouGnoDhgWzgME2D5Xw03gH3uRHzehf6xiP66Dnwy8S%2FQw6EpD1xbGZr7YajRKjbFyUzImU3OC64UnqaR0qzVFaZeVbl7h9rLRZP%2BrCrVuLENaQimreo38EpcJmurjCNTVRN%2BlbntcuR9bhpIfzlGpoNYTrXqi5N0M4bJS8HPDXqZy1Zlacm4mP5WkRq5lD%2BTcstAwq7eDAZTxuKZMnTGqlL91fZzqRK7NhiXfTQfAVbqRKr3PNCaz67shsuug1q80SSXTqnVQOp9RJ7Bs2lZnYJk3w4F8lbK0ju%2B12kMjsxyPJ0gOCt8ji2xVte5bme967j69sHKKA9OthNa1k%2FdGJSIHbXlWk1rNHJxWdDXSbiuZSETutRdjLy17bm%2Fhmz1MHwrLennYU799TwCvsOxd65HUnCw6dW9wdfcwIVBJppbTSE%2Bf9nWvVm8b9nyegCaSqdQcaLQPFzO79GTf4flN1hw3U7cEm91GRekqJZFzjWm9S9CIDwzAOslITkmAoqIdWBSPwBPYLkFtBDhJGTV9ZmWtZAK4JyPOah6u6b%2FVufiaoUfF7kyJT0KJPYEaQY1rBOZqqGXzOkiryZispVAsXUjpsTxMopiUz%2BupXB7mUDa3s4d6v7s6sIval69Dk4sr8iGGrQbVe1qdmlb8Ir6voZ8C76v8HwMcBn4Ll42vpHBkmAl%2Fg3A%2FEMJj6D5bO8NJehzc4VG606v9qfoZOvcYZZP6rIhnRTwr4lkRz4rIFZHt%2B30wQ3AEuK8syVmWMyYl%2B1KhKMtFKR2XklIyLUUkqShJHA7y6Qrvc%2Fg%2FPKMAD8357%2Barw%2BrgsnfS2Bw0ds4Z52PG51HQI8fXj5wpX%2FglP26svrd8bLjupInvvyTrl%2BnneeJ%2BWr78FMUTQ%2B5j7T01%2BXai%2FEvKkFqHEq4myE7Ck7NnP8s7uT%2BJKikJh4ZA%2BMnID9TNS3YWyt9OKA985%2Fs%2FZPPtXvCsnb%2Bfdv5Cj3%2F16HBKRY%2Bm%2Fs%2Bl9GMgj%2BspF9RQMtnWlW9DedxXgWXG3c%2BlYipndOeBOU2DCcpduXUr%2BS2g6eHVUk5MMk7Wq2XKbZjJpOrIvRRf%2FgFZDs13jRwAAA%3D%3D

