### PR TITLE
Add yousend.app.email template

### DIFF
--- a/yousend.app.email.json
+++ b/yousend.app.email.json
@@ -6,15 +6,14 @@
   "version": 1,
   "logoUrl": "https://app.yousend.app/logo-light.svg",
   "description": "Authorize YouSend to send email from this domain: SPF, DKIM signing, a DMARC policy, and the return-path and click/open tracking hosts.",
+  "syncPubKeyDomain": "yousend.app",
   "syncRedirectDomain": "app.yousend.app",
   "records": [
     {
       "groupId": "sending",
-      "type": "TXT",
+      "type": "SPFM",
       "host": "@",
-      "data": "v=spf1 include:spf.yousend.app ~all",
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=spf1",
+      "spfRules": "include:spf.yousend.app",
       "ttl": 3600
     },
     {
@@ -31,7 +30,8 @@
       "data": "v=DMARC1; p=none; rua=mailto:dmarc@yousend.app",
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "v=DMARC1",
-      "ttl": 3600
+      "ttl": 3600,
+      "essential": "OnApply"
     },
     {
       "groupId": "sending",

--- a/yousend.app.email.json
+++ b/yousend.app.email.json
@@ -1,0 +1,51 @@
+{
+  "providerId": "yousend.app",
+  "providerName": "YouSend",
+  "serviceId": "email",
+  "serviceName": "YouSend Email Sending",
+  "version": 1,
+  "logoUrl": "https://app.yousend.app/logo-light.svg",
+  "description": "Authorize YouSend to send email from this domain: SPF, DKIM signing, a DMARC policy, and the return-path and click/open tracking hosts.",
+  "syncRedirectDomain": "app.yousend.app",
+  "records": [
+    {
+      "groupId": "sending",
+      "type": "TXT",
+      "host": "@",
+      "data": "v=spf1 include:spf.yousend.app ~all",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=spf1",
+      "ttl": 3600
+    },
+    {
+      "groupId": "sending",
+      "type": "CNAME",
+      "host": "ys._domainkey",
+      "pointsTo": "ys._domainkey.%fqdn%.dkim.yousend.app",
+      "ttl": 3600
+    },
+    {
+      "groupId": "sending",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:dmarc@yousend.app",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "ttl": 3600
+    },
+    {
+      "groupId": "sending",
+      "type": "CNAME",
+      "host": "bounce",
+      "pointsTo": "mta1.yousend.app",
+      "ttl": 3600
+    },
+    {
+      "groupId": "tracking",
+      "type": "CNAME",
+      "host": "track",
+      "pointsTo": "mta1.yousend.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a template for **YouSend** (https://yousend.app), a transactional and marketing email platform, so a customer can authorize sending from their domain in one click instead of copying five records by hand.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — key published at `_dck1.yousend.app` (`p=1`/`p=2`, `a=RS256`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (DMARC)
- [x] no variable is used as a bare full record value — this template has **no** service-supplied variables at all
- [x] no bare variable is used as the full `host` label — all hosts are fixed strings
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on DMARC, which customers commonly tighten from `p=none` later

### Design notes
- **Fully static.** The only substitution anywhere is the `%fqdn%` built-in, in the DKIM CNAME target. No service-supplied variables reach DNS.
- **SPF via include**, so our sending addresses can change without any customer editing their DNS.
- **DKIM is a CNAME delegated into our zone**, not an inline public key — that is what keeps the template static, and lets us rotate keys without customer action.

## Online Editor test results

**Editor test link(s):**

[Test yousend.app/email watnext.app/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANfcbGoC%2F%2B1WW0%2FbMBT%2BK5alPS0tSXobQUhUXCTEClXptAFCkZu4rdXENrZTCFX323cceh8g2B7GpL7ZPvfvnPPJE2xoKhNiKA4mWCoxZjFVpzEOcC4yTXlcJlJiZyE6Jymo4iuRXYIQBJqqMYtoYUJTwpLl27ouOrZSZI%2BMD0BrTJVmguPAc3AiBuKbSkB7aIzUwc4OhC2vpLBjNUoJGwxNWY%2BteUx1pJg0hQvczMxQKPZI0TycEcgaoyIp1FciRWbINIoFPPAAXbZPHHR0dtpCmg04pOQggo5azc4hkiJhUQ5362ZIkaImU7wkiRkWbxGIRztCUo6MItEIjNFQaKPLtvicR%2B2sd0bzoyLSb1BahQ6NmaKRWahslAtqIBYq1ji4meCBEpksINYL%2BEwuLbpQRgtuNjzcDqx%2F2e9kCQVLzHiUZDEN4GnDuzEAdqXuulPnVfeH583W8dJ%2FrsvhE4AjmtuxEIwb3RWbovKn%2Fl3MP5XjEUv%2FMHL3R3cZN4xToiLbdWII3Mf7Rae8PST3ueB0D6mM7NtOGxEUugcbUR%2FMoeB9aJxpERMNIVRLxDZOW9E%2Be3heZSZbxlvN38FUQwTDiJ3bC96UMsnx%2B%2FDsiYxHdB3I1BDvbZjNh%2B9F94XCO7zfTh38CHCGy%2BG7BcznQ3pPDKcPZmY2iwGnIqOQzfUlUSTVllDmljdrprdz2xuMbURYP6FoaNeQwKJBHUZl1MFplhgWknuyfIqjkFiYIUENUnAB27E2MPyJdA5WZwXG30Mv7AL6SZJkva1hHNnkmYX4S8OrxJWaX3K9Sr9U9XteqefXolJUo1Gt3vOqLu2v0OMzzPkcQS6hWx2hZnJPco2ntskb%2FZxVtbl%2BswrXV28F6lf370MVuta8v9%2F2f1%2Fjgg9e7uZi%2BWdlvraaH3kq5yzzf5Rx6wBHbVljyxpb1tiyxttZAz4tmoxpHBKr5rt%2BveQ2ShWv6zWCSi3wdsu7bsWv1T%2B7buC6NnuqzVNtE%2FjjrP5u4KfZ985bsurL6t2l51%2BfNDw5%2Bi5P272Tr4N6s%2FN4fUF3x4%2Ft9tVoH09%2FAfF2nRWkDQAA)

[Test yousend.app/email check.watnext.app/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFTdbGoC%2F%2B1WbW%2FTMBD%2BK5YlPpGmSbu1W9Akqm1IAzrKVmAwTZFru41pYgfb6Ram8ds5p%2B%2FdixgS0pD2Lfad7%2B557u5RrrHlWZ4Sy3F0jXOtJoJxfcRwhEtVGC6ZT%2FIcewvTMcnAFX9VxSkYwWC4ngjKqyc8IyJd3q37okNnRe5TyBF4Tbg2QkkchR5O1Uh90il4J9bmJqrXIa2%2FUkLdedRSMUqsbybuOeOGapHbKgTuFDZRWvzkaJ7OKuQeo6ooNNQqQzYRBjEFFzJCp703Hjp4d9RFRowklOQhgg66nZN9lKtU0BLOLkzCkea20LKWE5tUdxTM47rKuURWEzqGxyhRxhrfgS8l7RWDd7w8qDLdotI5nHAmNKd24bIBF9zArDQzODq%2FxiOtiryi2Czos2Xu2AUYXTi59HB67eLnw5Mi5fASC0nTgvEIrjaiWwtkN1tBcOM9GH7%2FuNM9XMYvjR9PCRzz0o2FEtKavto0%2BS%2BGP5h84bOxyP4yc%2F%2Bsv8wbs4xo6rpOLIHzZK%2FqVPgK5XtSSf4K6YLsuU5bFVW%2BrzeyXtl9JYfQONslliaQqquYy9PTfCiu7naZ2Zb5Vuv3MDeQwQri5vaD7OR5WuLH8TlQhaR8ncjMkvDPOJsP373hK4dHRL%2B48fBPoDNeDt8FcD4fUppwOvYviZX8ys4ezzLNNr%2BqLRbzlznRJDNOWuYxzu8IcjGPcj4N46qAlVSax241CSwfYLO64B7OitSKmFyS5RWjMXHUQ9EGrBAGNmZtiORUiGY1LkYItiJE96wI%2BkXSdL3bMaMOiXDMh%2B3txnZ7t1HbCQastrUTBLVBa7dVY5RSQgaDdpNvr6jmHYJ6l26uc7k6XZ30kpQG37j%2Bb7R6Bm59%2Fdah3rb5t7rw4Ko%2BOfBrfZ2Kg7%2FZ3scqxNMAu9CR%2B1s9FY0NvA%2Ft9VOf3Uqm%2Fj88Fx5o3LPWPGvNs9Y8a82%2F1hr4STJkwllMnGsjaLRqQbvWDPthO2q2o8aWH7aCsN18GQRREDgE3Ngpvmv4n1r9k8JHyTf%2BpXH88mz09bR71dtO9%2FvB22JrdNw7C3e3Dj83PtZPWNIQ398f7eGb34sd6dAkDgAA)