### PR TITLE
StorM, 2 templates

### DIFF
--- a/stormapplications.com.storefront-apex.json
+++ b/stormapplications.com.storefront-apex.json
@@ -4,7 +4,7 @@
   "serviceId": "storefront-apex",
   "serviceName": "Loja web (domínio raiz)",
   "version": 1,
-  "logoUrl": "https://stormapplications.com/brand/icon.svg"
+  "logoUrl": "https://stormapplications.com/brand/icon.svg",
   "description": "Conecta um domínio raiz à loja web da StorM hospedada na Vercel.",
   "variableDescription": "%ip% is the Vercel anycast IPv4 for the A record. %verifyHost% and %verification% are the Vercel domain ownership TXT name and full value returned by the Vercel Domains API (typically vc-domain-verify=...). Bare variables are required because Vercel dictates both the label and the complete TXT payload.",
   "syncBlock": false,

--- a/stormapplications.com.storefront-apex.json
+++ b/stormapplications.com.storefront-apex.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "stormapplications.com",
+  "providerName": "StorM",
+  "serviceId": "storefront-apex",
+  "serviceName": "Loja web (domínio raiz)",
+  "version": 1,
+  "logoUrl": "https://stormapplications.com/favicon.ico",
+  "description": "Conecta um domínio raiz à loja web da StorM hospedada na Vercel.",
+  "variableDescription": "%ip% is the Vercel anycast IPv4 for the A record. %verifyHost% and %verification% are the Vercel domain ownership TXT name and full value returned by the Vercel Domains API (typically vc-domain-verify=...). Bare variables are required because Vercel dictates both the label and the complete TXT payload.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.stormapplications.com",
+  "syncRedirectDomain": "stormapplications.com,www.stormapplications.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 600,
+      "groupId": "pointing"
+    },
+    {
+      "type": "TXT",
+      "host": "%verifyHost%",
+      "data": "%verification%",
+      "ttl": 600,
+      "groupId": "verification",
+      "txtConflictMatchingMode": "None"
+    }
+  ]
+}

--- a/stormapplications.com.storefront-apex.json
+++ b/stormapplications.com.storefront-apex.json
@@ -4,7 +4,7 @@
   "serviceId": "storefront-apex",
   "serviceName": "Loja web (domínio raiz)",
   "version": 1,
-  "logoUrl": "https://stormapplications.com/favicon.ico",
+  "logoUrl": "https://stormapplications.com/brand/icon.svg"
   "description": "Conecta um domínio raiz à loja web da StorM hospedada na Vercel.",
   "variableDescription": "%ip% is the Vercel anycast IPv4 for the A record. %verifyHost% and %verification% are the Vercel domain ownership TXT name and full value returned by the Vercel Domains API (typically vc-domain-verify=...). Bare variables are required because Vercel dictates both the label and the complete TXT payload.",
   "syncBlock": false,

--- a/stormapplications.com.storefront-subdomain.json
+++ b/stormapplications.com.storefront-subdomain.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "stormapplications.com",
+  "providerName": "StorM",
+  "serviceId": "storefront-subdomain",
+  "serviceName": "Loja web (subdomínio)",
+  "version": 1,
+  "logoUrl": "https://stormapplications.com/favicon.ico",
+  "description": "Conecta um subdomínio à loja web da StorM hospedada na Vercel. Use the Domain Connect host parameter for the shop subdomain (e.g. host=loja).",
+  "variableDescription": "%target% is the Vercel CNAME target (cname.vercel-dns.com). %verifyHost% and %verification% are the Vercel domain ownership TXT name and full value from the Vercel Domains API. Bare verifyHost/verification are required because Vercel dictates the label and complete TXT payload per domain.",
+  "hostRequired": true,
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.stormapplications.com",
+  "syncRedirectDomain": "stormapplications.com,www.stormapplications.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 600,
+      "groupId": "pointing"
+    },
+    {
+      "type": "TXT",
+      "host": "%verifyHost%",
+      "data": "%verification%",
+      "ttl": 600,
+      "groupId": "verification",
+      "txtConflictMatchingMode": "None"
+    }
+  ]
+}

--- a/stormapplications.com.storefront-subdomain.json
+++ b/stormapplications.com.storefront-subdomain.json
@@ -4,7 +4,7 @@
   "serviceId": "storefront-subdomain",
   "serviceName": "Loja web (subdomínio)",
   "version": 1,
-  "logoUrl": "https://stormapplications.com/brand/icon.svg"
+  "logoUrl": "https://stormapplications.com/brand/icon.svg",
   "description": "Conecta um subdomínio à loja web da StorM hospedada na Vercel. Use the Domain Connect host parameter for the shop subdomain (e.g. host=loja).",
   "variableDescription": "%target% is the Vercel CNAME target (cname.vercel-dns.com). %verifyHost% and %verification% are the Vercel domain ownership TXT name and full value from the Vercel Domains API. Bare verifyHost/verification are required because Vercel dictates the label and complete TXT payload per domain.",
   "hostRequired": true,

--- a/stormapplications.com.storefront-subdomain.json
+++ b/stormapplications.com.storefront-subdomain.json
@@ -4,7 +4,7 @@
   "serviceId": "storefront-subdomain",
   "serviceName": "Loja web (subdomínio)",
   "version": 1,
-  "logoUrl": "https://stormapplications.com/favicon.ico",
+  "logoUrl": "https://stormapplications.com/brand/icon.svg"
   "description": "Conecta um subdomínio à loja web da StorM hospedada na Vercel. Use the Domain Connect host parameter for the shop subdomain (e.g. host=loja).",
   "variableDescription": "%target% is the Vercel CNAME target (cname.vercel-dns.com). %verifyHost% and %verification% are the Vercel domain ownership TXT name and full value from the Vercel Domains API. Bare verifyHost/verification are required because Vercel dictates the label and complete TXT payload per domain.",
   "hostRequired": true,


### PR DESCRIPTION
# Description

Add two Domain Connect templates for StorM (`stormapplications.com`) so merchants can point a custom domain/subdomain to a StorM storefront hosted on Vercel (A/CNAME + Vercel ownership TXT).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set - **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` - the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) - use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary - prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label - the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain - use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Bare variable justification

`%verifyHost%` and `%verification%` are bare because the Vercel Domains API returns the exact TXT host label and the full TXT payload (typically `vc-domain-verify=...`) per domain. A fixed StorM prefix would break Vercel ownership verification.

`storefront-subdomain` uses Domain Connect `host` parameter (`hostRequired: true`, CNAME `host: "@"`), not a host variable for the shop subdomain.

`essential` is left unset: A/CNAME/TXT are required for the storefront to work; they are not independently user-tunable like DMARC.

`syncPubKeyDomain`: `domainconnect.stormapplications.com` (TXT at `_dck1.domainconnect.stormapplications.com` already published).

## Online Editor test results

**Editor test link(s):**

[Test stormapplications.com/storefront-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ4MfWoC%2F%2B1UYW%2FbNhD9KwSBAC0myZLsOomBAnXXAQu6BNmWtQOywDiRlM2VElWSkqIG%2Fu87yrKtIE23jxswwIDF4927d3eP90CdKCoFTtDFA62MbiQX5oLTBbVOmwKqSkkGTurSRkwXNDg4XUGBQfRXdLtEsxWmkUwcQkVudOlCqMT98XaI%2BUn%2FCaQVGXnBdfFHHceCl1ITA%2FLLS3RuhLGYkC6SgCq91r8ZhUEb5yq7mEy%2BymuSGSj5RDJdRrZZIwgXlhlZuR6Ifq9LwRyQuiBPUpL%2BGBO1Z8WB9FWRjbaV4IDnEsgHYZhQkecHRkKmxLtHKU5kdUKkJW4jBl8CZcfAOnJx3cxIrk1%2FtyRGMG14RE6wUJl3P2rrTtCXD4ahLjQZMUZD4iBLotsS%2B7ORFbn5%2FQaJFaKPzWulSAOqFojvalMKTrJuHP%2Buj7dkeX1BXriuwjxKdaRh4Q453NF5HUXRy4i89dn3ldqeixGfa2k8rmBQ2yMxia116JRpt%2BkzKsj68nl%2FwvlUSjjRE66gUxq476PtSvZWafaJLnJQVuws13X2XnQ7stjWHTecqx9g9JwofeAvgiM75g6hX3UO2rZ9FmY3GUsXtw8UO%2BS1ukQz6sDh5xuvfi1LZ2%2F0MHC0OIfqnMdxQNdG11X%2FAHovWa7pNjgAYfFHqPHovVjBwcG6n%2F8z2GMf73LvUNw5VuIuwbENZr3U3Ce8Qs3T7d02oF%2Fwa3Ws7S4YuopO4h78cIb6B3Z0yLeSvf%2BxnOBxdgSqwEBh%2FfLYQ94%2Bwrzbg95S%2F93D%2Fg2k7B1O5xH%2B0gR%2F3njsl79cNb3yDhf7aLx6IucRmwAylqRT6nsi1yUuqZXFf8Dngg1zpkYJFrVycgUtHE2crbxWOmyhxVvM8lge5W6rvTkOckx%2BPMUVZ75V0s8xjadZnp3Ownx6zsLZeQrh2fT8LEzzBOIsns%2FyMz5at9%2Fcyd9evsepCmsFth38Pl2qFjpLt08kOpSz7%2FGhqH%2FS2X99sXcByv%2F%2F8f1nx4cv3kIj%2BApczyudh%2FFZmExv4niRvFqkOLnTafIq%2Fg7PcewLEtbtOvCAr3783qku1bqazK%2BWyQ8fl7NJ%2Bt78LJdtAra9TjcCJtWmur%2F4PJ0V4tNruv0LrsCFISsJAAA%3D)

[Test stormapplications.com/storefront-apex example.com/loja](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK4NfWoC%2F%2B1UbW%2FbNhD%2BKwSBAC0qKfJLHMdAgTktsGVNiix1uw2ZYZzEk82FFlWSsiMH%2Fu87yvIb0nT7umGAAJvHu%2Bfuued4T9zhvFDgkA%2BeeGH0Qgo0V4IPuHXazKEolEzBSZ3bKNVzHuycPsKcgvgncrshs0WzkCnuQjEzOnchFPi4v21irvWfwJaYsFdCz%2F8o4xhFLjUzIFevyXmBxlJCPmgFXOmp%2FmwUBc2cK%2Bzg9PSbdZ0mBnJxKlOdR3YxJRCBNjWycDUQf6dzTB2wcs6epWT1MWZqW5UAVrNiM20LFEDnHNgXNCmqyNcHRkKi8P1RihNZnDBpmZth48sgr1Kwjl3dLros06a%2BGzKDqTYiYidEVGbVT9q6E%2FIVjaHhRSaDh2hUOMic6WVO%2FZnJgo1%2BG1Fhc6xjs1IptgBVIuG70uQoWFIdxr%2Bv4y0b3l6xV64qKI9SFVuk4QY53JTzNoqi1xG79Nm3TG1di8GvpTQeF1Mo7b4wSa115JRoN6szKkhq%2BqI%2BkT6FQod1wQVUSoPwfbRVnl4qnT7wQQbK4sZyWyYfsNoUS23d1Ea6egGjl4bSB96hoOpStwv9pnOwXC5fhNkoY%2Fng%2FolTh%2FysDslMc%2BDo7w9%2B%2BrXMnR3pRnCyOEfT2YvjgE%2BNLov6AdReMp%2FydbADIvJ7qEPp%2FbCCg511q%2F8L2Ic%2B3uXR0XBnxMTdgEtnlPVGC5%2FwI808X4%2FXAV%2FRv8me2zhoukpO%2BAhenIZ%2FU51%2FCbzJOZF1zJ5ScFwBgRVgYG79AtnC3h%2FhjrfA9xvkcQP9N7CydjjvRfS1W%2FR5475v%2FnKyqCdwd7GNpqtnY%2B1TRwdlBZCkrXaH%2BwbJaU4ba2LpF%2BjtUPecKWke56VycgJL2JtEOvGDU1E%2FLd1SquNZyTcrrmlhI%2BwhiUNVJyL1bZNe13PMRNLtX4RdPOuH3QTisN%2Ftd8J25wIu4gw7MfYO1u93d%2FT3l%2FGxymgtkgTgd%2BxQLaGyfP1sbBtWTb%2BjY3b%2FuNX%2FCurjgB7I%2F5r%2BtzSlBWFhgWIC3rUdt3th3A9bnVEcD1oXg7M%2Badnudntv6BzHnhRat2nFE%2B2Hw83As2z14dPDSN6drfqP6c%2B%2Ft1a%2FPFy%2BKcSPd8Prd7MR2Omv16JznnzF5Vu%2B%2FguPrOR%2FYgkAAA%3D%3D)

[Test stormapplications.com/storefront-subdomain example.com/loja](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOIMfWoC%2F%2B1VYW%2FbNhD9KwSBAAkmybKt2YmAAkuTFSu6ZG3qrg0yw6DIk81WEjWSsuMG%2Fu87SrItt0nbr8P2SdLx3bu7d8fTA7WQlxmzQOMHWmq1lAL0S0FjaqzSOSvLTHJmpSpMwFVOvR3omuXoRN8i7ArNBvRScti5QqpVYX1TJULlTBZ7SOv4u%2FrIyAoSctxg%2FqrCEEQh1QlCl6ANxqRx36OZmqt3OkOXhbWliXu9R1PrJZoVoie5KgKznCOJAMO1LG1NRC9UAdwyUuXki4CkfgtJts1IMFKXRRbKlCAYfheM%2FAmaQxaQdwaIXQC5rOsiyOuIHdaSkmmszoImqdI1yixUSXYqkGMI5kGNfebCnQSuWKYlSzK4PMj3yDI9B3tEpKmJmvDk4vr86lfSnJFjXmC4YFkf%2BaIR4iQgR2iR6fo3DHNEUJXW0MqFJg1dzjY3tSpQ9oUsyeTDhDjm2jetsowsWVYBwZ7mXcdGAkPOX78MyHPHug%2Fc64asI2r4u5IaBEmAs8rsw0vsi4WmzIwlaHJxsZQyQy3rbEq2zhQTpERpm3Sdck7Hm5aVxlZXgFO2LvjzTPFPNE5ZZlrL6yp5BesmXxS3oeBN64KnRt053oBAdm53ro%2BCvdVq9SQNuistDI3vHqhdl2746y62BeDnL%2B5eKVlYM1Gd1qPVWhz8URh6dK5VVdbXq0bKYk433o4QNdrTddvv7gGzbGfdzsAT3F2Mg9xbnO8UK7JXzPIFRr1SwgW8xutEN9ONRz%2Fj22xf49Rr1UUQ3DPXw1aHNjs397SNOZO1z74k7zADJKuvlHHraUt7d8A73RLfNczTlvo7tI3EDvTYHXKIvYgONWsAu4MtFR4tud%2Bk5jcu9c0OOjl6LOH9wZA6teS8wOU4M%2FhkttKwHdu8yqycsRXbmwSfuWlao7gGTzHU1wNUNMu01bTt9KMVdfs9E9wJKl3Hw%2BiMD4dn4AMbjf0oTEZ%2Bkv488MdJdDoYD9Io4tBZ%2B9%2F8N%2FzAT%2BBwCMAYwA4xt93PsxVbG7r5aqrbGtsOBIe1%2FrD4%2F576px5eov9b%2FZ9oNa4Tw5YgZsxBB%2BFg5Ienfn84CcO4P4qHURAOxlG%2F%2FxN%2Bh6GrDIxt9HjAbdLdI3Ty4vQ2Oh2O%2Fhhf3Jqz4tM8n3y4fPH%2BBniR55WIBiJN7qve24%2B3b57RzT9EBK2z%2BwkAAA%3D%3D)