### PR TITLE
Add jettapp.ca agent-website template

### DIFF
--- a/jettapp.ca.agent-website.json
+++ b/jettapp.ca.agent-website.json
@@ -5,12 +5,12 @@
   "serviceName": "Jett Agent Website",
   "version": 1,
   "logoUrl": "https://jettapp.ca/favicon.svg",
-  "description": "Connects a customer-owned domain or subdomain to their managed Jett realtor website and adds a scoped ownership-verification record.",
+  "description": "Connects a customer-owned domain to their managed Jett realtor website and adds a scoped ownership-verification record. One Jett website per domain.",
   "variableDescription": "%verification%: the 64-character hexadecimal ownership token issued for this exact Jett website domain.",
   "syncBlock": false,
   "syncPubKeyDomain": "jettapp.ca",
   "syncRedirectDomain": "app.jettapp.ca",
-  "multiInstance": true,
+  "multiInstance": false,
   "hostRequired": false,
   "records": [
     {

--- a/jettapp.ca.agent-website.json
+++ b/jettapp.ca.agent-website.json
@@ -1,0 +1,33 @@
+{
+  "providerId": "jettapp.ca",
+  "providerName": "Jett",
+  "serviceId": "agent-website",
+  "serviceName": "Jett Agent Website",
+  "version": 1,
+  "logoUrl": "https://jettapp.ca/favicon.svg",
+  "description": "Connects a customer-owned domain or subdomain to their managed Jett realtor website and adds a scoped ownership-verification record.",
+  "variableDescription": "%verification%: the 64-character hexadecimal ownership token issued for this exact Jett website domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "jettapp.ca",
+  "syncRedirectDomain": "app.jettapp.ca",
+  "multiInstance": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "routing",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "45.55.161.106",
+      "ttl": 600
+    },
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "_meta-agent-verify",
+      "data": "jett-domain-verify=%verification%",
+      "ttl": 600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "jett-domain-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Jett** (`providerId: jettapp.ca`), service `agent-website`.

Jett is a CRM and website product for Canadian real estate agents. This template connects a
customer-owned domain or subdomain to their managed Jett agent website: an `A` record pointing at
our audited edge address, plus a scoped ownership-verification `TXT` record.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

What *was* verified directly:

| Check | Result |
|---|---|
| `template.schema` validation | 0 errors |
| `logoUrl` (`https://jettapp.ca/favicon.svg`) | HTTP 200, `image/svg+xml` |
| `syncPubKeyDomain` public key published | `_dcpubkeyv1.jettapp.ca` resolves, verified byte-identical to the derived value (RS256, SPKI DER) |
| `syncRedirectDomain` (`app.jettapp.ca`) | resolves to `45.55.161.106` |
| `A` record target | `45.55.161.106`, matches our audited edge address |


# Online Editor test results

Both an apex and a child-host application were tested in the Online Editor for template
`jettapp.ca.agent-website`.

**Apex** — [Test jettapp.ca/agent-website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHQ1emoC%2F%2B1UbW%2FbRgz%2BK8IB%2FVRLkWRLcQQMaNYAQdulKbq0GxYEBn1H2bdId9od7cQN8t%2FH85vsrdsw7Msw7JPP5EPyIfmIT4Kw7RogFNWT6JxdaoXujRKV%2BBmJoOsSCWKw97yHlpHiLfvY6tEttcQ1HGZoKH7AqdecbO87CIjOAyT6YQ9ZovPaGlFlA9HYmf3kGobOiTpfnZz09U9q4FTWJH454zCFXjrd0TpUvLbGoCQfQSQXnmyLLrYPBlWkbAvaRGQjmqN2UQuGSapozcUhNGRdtCUcgVERKBXSeGk7hoUkzs91FzNPXWsJoSIHSutUEl0b3GTaZejQbUsmoTdwGqYNXhyRfXGY6kUViEXlKJZzcCCJE8zxERRK3ULTE%2BAW7tFE2vsF86qZNc21jxgq6ZhDX9%2BvjPy2sfJeVDU0HjeWD4vpO1xdrFG%2FXXHwf0SluUHaI4L3CNUuGtJvjCcwEve559bTR%2FxlwcFqb9xMyovq9knMnF10a53wg7QJe6RVF6RxLjbx%2FHwVlGa1IX9j%2Be%2BoSIoiycosydIyBBDro0zT58FhwsOR9llvfrzp805aJIg3Cl3DV0FGQLCdQbyZ29b3zfGWDgrz65FYcHWjJV0ByTl3cmVVKPjBYa0fxVchW99Xi4nnu%2BeB%2BGINTvqB3TG93Qp4zfyFYiJt23fEr%2FUEJnqH71hCrQ9f8S7y9ij0bhd7K8L7aGpsg2yay6EaYVGX6Wk2zs%2BGMJoWslSnOK7P0r%2Fyi9CFnhnrcOL5F2jheCzkFrgVzQQeoDcpOWFNNStu2rOXKbBKDhRhNnfjVb%2BoP1LDQEyUDH3roIYRMzxVKovzfDyORyWoGOoa4jOVTk%2BLYlyn08N79vtL92c3rR8%2Bes8uDeFgnTcPsPLiOcjySH3bHv6m%2Bv7xJv6No7kbsEb%2F3%2FB%2FecN8VDwsUU0gwPI0L%2BN0HGfpTZ5Ww7wq8mRUDofj7GWaVum6B%2FS0GdIT347DqyHeNtezk8vvry%2FLi2H9PrscFvfF5wbqyytz%2FtN303ev68%2BPHV3Q%2FdLyAf0VEcV3x8UIAAA%3D)

| Name | Type | TTL | Data |
| --- | --- | --- | --- |
| `example.com.` | A | 600 | `45.55.161.106` |
| `_meta-agent-verify.example.com.` | TXT | 600 | `"jett-domain-verify=a1b2c3d4...8f90"` |

**Child host** — [Test jettapp.ca/agent-website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIk1emoC%2F%2B1U227bOBD9FYFAn2IputmxBSzQbINduEXSNnCRtoFhUOTIZiqRKknbcYL8e4eSb9qm7UNfFth9EsU5Z66H80gsVHVJLZDskdRarQQHPeYkI3dgLa3rgFHS21uuaIVI8hpteGtArwSDBk7nIK2%2FhtwIdLa3HRG8cwfxbvaQFWgjlCRZ1COlmqsPukTowtraZKenh%2FinBUVXSgZmNUcaB8O0qG1DJa%2BUlMCs8ajHlsaqCrSv1hK4x1VFhfSs8uwChPYqKjFJ7jW5aKClVdrbJuxRyT3KuXNjmKoR5pxosxC1j3mKQjDqIiKRKc0D762E1tPOQw16GzJwtVEtaF7CRSfZF8euXmQuMW%2BQ%2BmxBNWUWHSzgnnJgoqLlIQEs4QtITxizxLwKzNouhPEQymw3h0N8s5Hsz1KxLyQraGmgvXm3zN%2FA5qJB%2FXPEzn4NXGCBdo9w1g6qWpZWjKWxVDLY%2B14oY6%2Fh6xLJfH%2FZdsqQ7PaRzLVa1o1O8GCFdHO0m9pJ45y0fDy%2BdEpTQlozUfib9oN%2BP4gGURCFA0ewqI9BGD71jh0et%2FTgdfJxcvA7q8BSv1VoA984GVFLtz3w275tbX90p3QUGE%2F3FgVXlILZS2rZAiu5VNwFfKehEPfkWcjW9mww8jR96pEHJWF2aNgU09uNAMeMLxQCpqpDRev1Gn%2BaJszEjlKjiirjHvKOfNthT3f024Y%2F7XV7h9c0ymOW8BT6xSA8i4bxKKFp3mcDfgbDYhT%2Byk5cLWIulYaZwS%2B1S43NsXoJW%2BnM6JoerjibobLKDZZu0IopoFaOdCHb7dFWux3Yj1TRIzPOXPHCqeIsjaPhWZr7w5yBn%2BYR%2BKN4EPtJFKdFkSchZ8nRXvt%2B4%2F1st3WGAMagVVC3u87LNd0Y8uQU2hHitpDvhRh0antGH789kn9ph6Y9lOz%2F0%2F6vTBuXjaEr4DPqkHEYD%2Fxw6EfhJA6zJMmiJBglUToanoRhFjZlgLFtnx5xpxxvEyLnk%2BKvz39fXMPDzaur85N8fNK%2F%2FPpeXbHoTo35ezO%2BebhLeP9q9QnX6zdkNmo24wgAAA%3D%3D)

| Name | Type | TTL | Data |
| --- | --- | --- | --- |
| `www.example.com.` | A | 600 | `45.55.161.106` |
| `_meta-agent-verify.www.example.com.` | TXT | 600 | `"jett-domain-verify=a1b2c3d4...8f90"` |

`example.com` was used as the test domain deliberately, so no real zone could be touched. The
`%verification%` variable was filled with a representative 64-character hex token.

**Re-tested after review.** `multiInstance` is now `false` (b8d102d) — the reviewer correctly identified that this template self-conflicts as multi-instance: the `A` record is fixed at `@` and the TXT uses a shared prefix, so a second instance would overwrite the first instance's ownership token. The links above are regenerated against the corrected template.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `jettapp.ca`; the RS256 key is published at `_dcpubkeyv1.jettapp.ca` and DNS-verified
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — `warnPhishing` is absent
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `app.jettapp.ca`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the only TXT is the ownership token
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — set to `Prefix` with `txtConflictMatchingPrefix: "jett-domain-verify="`, so re-applying replaces our own record and never disturbs unrelated TXT records at that label

