### PR TITLE
Add ListingCopilot.io Website

### DIFF
--- a/listingcopilot.io.website.json
+++ b/listingcopilot.io.website.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "listingcopilot.io",
+  "providerName": "Listing Co-Pilot",
+  "serviceId": "website",
+  "serviceName": "Listing Co-Pilot Website",
+  "version": 1,
+  "description": "Connects a customer-owned domain to a website hosted by Listing Co-Pilot.",
+  "variableDescription": "apexIp is the Vercel IPv4 routing address, wwwTarget is the Vercel CNAME routing target, and verificationValue is an optional Vercel domain ownership challenge.",
+  "syncPubKeyDomain": "listingcopilot.io",
+  "syncRedirectDomain": "listingcopilot.io, www.listingcopilot.io",
+  "records": [
+    {
+      "groupId": "routing",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%apexIp%",
+      "ttl": 600
+    },
+    {
+      "groupId": "routing",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%wwwTarget%",
+      "ttl": 600
+    },
+    {
+      "groupId": "ownership",
+      "type": "TXT",
+      "host": "_vercel",
+      "data": "%verificationValue%",
+      "ttl": 600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "vc-domain-verify="
+    }
+  ]
+}

--- a/listingcopilot.io.website.json
+++ b/listingcopilot.io.website.json
@@ -1,10 +1,10 @@
 {
   "providerId": "listingcopilot.io",
-  "providerName": "Listing Co-Pilot",
+  "providerName": "ListingCopilot",
   "serviceId": "website",
-  "serviceName": "Listing Co-Pilot Website",
+  "serviceName": "ListingCopilot Website",
   "version": 1,
-  "description": "Connects a customer-owned domain to a website hosted by Listing Co-Pilot.",
+  "description": "Connects a customer-owned domain to a website hosted by ListingCopilot.",
   "variableDescription": "apexIp is the Vercel IPv4 routing address, wwwTarget is the Vercel CNAME routing target, and verificationValue is an optional Vercel domain ownership challenge.",
   "syncPubKeyDomain": "listingcopilot.io",
   "syncRedirectDomain": "listingcopilot.io,www.listingcopilot.io",

--- a/listingcopilot.io.website.json
+++ b/listingcopilot.io.website.json
@@ -7,7 +7,7 @@
   "description": "Connects a customer-owned domain to a website hosted by Listing Co-Pilot.",
   "variableDescription": "apexIp is the Vercel IPv4 routing address, wwwTarget is the Vercel CNAME routing target, and verificationValue is an optional Vercel domain ownership challenge.",
   "syncPubKeyDomain": "listingcopilot.io",
-  "syncRedirectDomain": "listingcopilot.io, www.listingcopilot.io",
+  "syncRedirectDomain": "listingcopilot.io,www.listingcopilot.io",
   "records": [
     {
       "groupId": "routing",


### PR DESCRIPTION
# Description

Adds a signed synchronous Domain Connect template that connects a customer-owned domain to a ListingCopilot website hosted on Vercel. The routing group configures the apex and `www` records. The optional ownership group adds Vercel's domain verification TXT value when Vercel requires it.

The `verificationValue` variable must remain the complete TXT value because Vercel prescribes the full `vc-domain-verify=<domain>,<token>` string. The template constrains conflict matching to the `vc-domain-verify=` prefix.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

The template does not set `logoUrl`, so the resource URL check is not applicable.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

None of these routing or ownership records should be changed independently while the connected ListingCopilot website is active, so `essential` is not set.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

- [Apex domain, routing group](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ0pbGoC%2F%2B1UbUsjMRD%2BKyHgp9stu33TLhwo6omoR5Gid0hZ0mTahtsma5K%2BWfrfb7Lbbqu299kPB4VmM888M%2FPMTFbUwSTPmAOarGhu9EwKMLeCJjST1kk14jqXmXY1qWlQAX6yCTrQ%2BxJyWULQbsHMJIfCfw4DK5G3uj3oRJ4r2AyMlVrRJA6oAMuNzF3xTS%2B1UsCdJYzwqXV6AibUcwWCCD1hUhGn0bQJSMbaOjQNluR9qJqPwYxkgwyu3vGzHBa3OZGWuDGQJzAcMnLbnTWJ0VPPQJgQBqwNyHw%2B7zEzAvcBffnz4uG6grsCEhCmBMGy5FBy5mM9sWwK3pMpoovoLNsybErxdRk7ljnhY5ZloEbgE7dLxbvTwR0srwrckQZ52CMIaVCu48AAq6gdckc3bYSlycuKjrCYvOjkpiq0u2XuW3iBR68yHs%2F9VGipnO1p%2FDwppTzxWJfRpB1F6%2BCfXIVwOz7M7ANjpfhx0kqzHW3vV29Hms4KifFCMMc86aem7JPjaeFw5oaZ5O6BOT7GjB%2B08LxdA0O5oAchG1tCZzwsuxkWcZbf6bq%2FDuibVpDuJO5jOtsWwYLhGkKN68kubTwVNaaywFfaoWPODJtYv7Nbipd3HP0tyQv154LmA0XZKX952q7hrx7jzxsqwb2NK9zaWqlfKJTdsn8SsAyFVcqR0gZSi%2F%2FMTQ0anJlCQCfTzMmUzdnuSvCU5Xm2RFEsWpEC525vxlT5YpzvGref6n7DUsG9GNJPQyM%2BY8047oTDZnsYNqO4EXYGg2bI6lGzU49bgwEM996yo4%2Fd4cds1xt8D0A5yTKfbTZnS0vXfi4%2FDPamiHKwN2UcVPVL1tMPcE7%2Fd%2BWrdQU30LIZiJR5WD2qt8PoNGzEvaiZtKKkcVqrt85ajehbFCVR5IsA68oyV7ij%2B9tJdedHrE1%2B86iMiev89bXX%2B21t4%2F757ELczd%2FulrPJ%2BLp70x2%2F%2FsGH7C9G3rL2MggAAA%3D%3D)
- [Subdomain, routing and ownership groups](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKwpbGoC%2F%2B1VbWvbMBD%2BK0KwT7WDE6dJahhs68botpbShb1QQrhI10SbIxlJiZuV%2FvedbOelaVr2cYOBIbLv9Nw9z73kjnucFzl45NkdL6xZKon2TPKM58p5pafCFCo3vqUMjzYOFzCnC%2FxT7XJau5DdoV0qgdX9EidOEe7m68FL7OvGbYnWKaN51o64RCesKnz1zk%2BN1ii8Y8DEwnkzRxubUqNk0sxBaeYNmZqAbGacJ9NkxR6GaoUYYBVMcnz7AB8KvD0rmHLMz5B9QSswZ2eXyy6zZhEQGEhp0bmIlWU5BDtFv%2Bd9evH6%2FN3G3VcuEQMtGdFSN0pAiPUF8gWGm6CZqaJDvkZoqARe1s1UwcQM8hz1FEPibqXF5WLyEVdvK78nChTcrlAqS3I97RgRi9ah63TNWOl4dn3Hp0SmqCrZsCK7XxWhhK%2FpGFSm46vQFUZp74aGXl%2FUUr4Ivj7nWS9J7qNnsSrhtniU2R7iRvGnQTeabWGH34Zb0PGykpg%2BSPAQQB8VZRecTreeeu4mV8KfgxczyvjcyIB7afFG3fKDLo0t40sR19WMqzirl%2Fx%2BdB%2FxX0bjeCvxiNJZlwhvgcYQW8LMt2nDFHWYqoroWFWXdgTcsiakAizMXRjiNeb1A9DRGvW6gR01uM9g1rUMDv1ei55Om55g2JQk2ISmuW7VCsdSu3W4RxIH50fKVMm0djKNYCLanZQHwdRUG4tjR7%2FgF5YQvF1gxOeL3KsxlLD9JMUYiiJfkb6OrBSLWninXXW9fNaSNn2wy2u3%2FmMpgpQqNFenP%2BikcCzjpDeZxF3sn8QDTE5iAUm%2FnZ70Bmlb7KzGJ3fn4d24V2raMXRQkIe08xJWjt%2BHXt8bloZNGOM9Rger8S9Qqwe2IdYM7D65P%2B%2Bev5fxKKLB%2F9%2Bb%2F3vzb%2BxNWtsOlijHEHw7SacXJ%2F04bQ%2BTbnacZMedVvs4baeDoyTJkiQwQedrAe5oX%2B9uat5F4b7Nbt69ef%2F5Z%2Fr%2BY1907eC7SFfTzofyx9XRZX%2F2Bs6NuppOSvp%2F%2FA2XwICAiQoAAA%3D%3D)

<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
