### PR TITLE
Add solstral.com.website template

### DIFF
--- a/solstral.com.website.json
+++ b/solstral.com.website.json
@@ -7,7 +7,7 @@
   "description": "Point a domain or subdomain at Solstral to serve a website or a white-labelled CRM address.",
   "version": 1,
   "syncBlock": false,
-  "syncPubKeyDomain": "_dcsig.solstral.com",
+  "syncPubKeyDomain": "dcsig.solstral.com",
   "syncRedirectDomain": "solstral.com,app.solstral.com",
   "hostRequired": true,
   "records": [

--- a/solstral.com.website.json
+++ b/solstral.com.website.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "solstral.com",
+  "providerName": "Solstral",
+  "serviceId": "website",
+  "serviceName": "Solstral custom domain",
+  "logoUrl": "https://solstral.com/api/brand/asset/logoLight",
+  "description": "Point a domain or subdomain at Solstral to serve a website or a white-labelled CRM address.",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "_dcsig.solstral.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "saas.solstral.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_acme-challenge",
+      "data": "%dcv1%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_acme-challenge",
+      "data": "%dcv2%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/solstral.com.website.json
+++ b/solstral.com.website.json
@@ -8,6 +8,8 @@
   "version": 1,
   "syncBlock": false,
   "syncPubKeyDomain": "_dcsig.solstral.com",
+  "syncRedirectDomain": "solstral.com,app.solstral.com",
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",


### PR DESCRIPTION
# Description

Adds a new template for **Solstral**, a CRM and website platform. Customers point their own domain or subdomain at Solstral to serve a website built in our page builder, or to reach a white-labelled instance of the CRM.

The template creates one CNAME to our Cloudflare-for-SaaS fallback origin, plus the ownership and certificate-validation TXT records that a custom hostname requires.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also checked locally with `dc-template-linter -cloudflare`, which reports no errors or warnings (four informational notices only: three are Cloudflare-specific "field ignored" notes, one is `_cf-custom-hostname` not being an IANA-registered underscore name).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Justification for the three unticked items:**

1. **`txtConflictMatchingMode` not set.** The two `_acme-challenge` records are deliberately a pair at the same label — ACME DCV issues two distinct tokens for a single hostname and both must resolve simultaneously for validation to succeed. Any conflict-matching mode that enforces uniqueness at that label would cause the second record to displace the first and break certificate issuance.

2. **Bare variables used as full record values.** The values of `%ownership%`, `%dcv1%` and `%dcv2%` are issued verbatim by the certificate provider and are compared byte-for-byte during validation. Prefixing them (`service-foo=%foo%`) would cause both ownership verification and DCV to fail, so the bare form is necessary rather than a convenience.

3. **`essential` not set.** All four records are required for the service to function: the CNAME routes traffic, and both TXT families gate certificate issuance and renewal. There is no record here the end user can safely modify or remove, so `OnApply` would misrepresent them.

Tested with `hostRequired: true`, so an apex test is not applicable per the note in the PR template.

## Online Editor test results

**Editor test link(s):**

[Test solstral.com/website ianbensley.com/lp](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD2IbGoC%2F%2B1VYW%2FaMBD9K5GlfSqBBCilkSata%2FuhK1RVR9VNFYoO24A1x85sBwaI%2F75zCTSlVTVp0qRJfLPP75793vnsFXE8yyU4TpIVyY2eCcbNFSMJsVpaZ0DWqc5Ibbd2AxliyddyFVcsNzNB%2BVPSnI%2BsQLJddA8e0MI6nQVMZyAUwqSe6HsjETJ1LrdJo1HdtwG5aIwMKNYAa7lreHhPTKYOUxm31IjcCa0w%2FVYL5QIomQNtAluMygm4YHcApwN%2FNI7Q8rAei5MpDkMJIy4lZ8H5XT8Axgy3to57zbixT%2FvEqGyh6Gep6Q%2BSjEFavoncFqNrvrjY6EoIo1ZM6nseetwdZ8Jw6nbIKqYGeb6fNNXW3fGfBWahw84UuCESaMMsSR5XxC1y7%2FD5zVn%2FsoTj9JMvmbfEDrTfBMDuEzuHtrc6UbSu7VgG3wbPHCkdh5t6hT6ifCnRdnCAix%2F0XKEpU5F%2F%2BCMuoBkP6RTQXTWp8jA6i%2F%2BeovmSYriukaVWPH12aoj4recC1IgrK%2FmiYjLGZY7jidFFnoptUg4GMuvbY5v%2BuJ8%2F3BI8egac7bzxIR%2FwIivj5maMhxQTpQ1P8bIocIXh2wpnhXQihTk8hxhN8XrIBWqyuIoUr6uvNu32pKN0593S10jKqNcmfPd2aad7fMqPwxEb87DdZn503A5bzTF0T2kcj7u08hS89Uy8%2FRhU7cWO4soJ8D1%2FJuewsGT9quSljjduYL2q7X%2BS8vL2HmT8GxnDGvbwoU8OF%2Bwg4%2F0%2BwY%2FJwoyzFDywGTU7YXQStuJBHCetdtKM61GrddqNjqIoiSIvgVu3EbTCf6z6g5Ej%2B2B7R8Vy8uuS8Wsdw6DzIGbFl1vTn%2FaW%2FeX9xdXJ5aLX%2Fz6%2F%2BkjWvwHGswDkhAoAAA%3D%3D)


