### PR TITLE
Add configuration for Grundy dominio-unificado service

### DIFF
--- a/grundy.app.dominio-unificado.json
+++ b/grundy.app.dominio-unificado.json
@@ -3,6 +3,7 @@
   "providerName": "Grundy",
   "serviceId": "dominio-unificado",
   "serviceName": "Grundy — Tu dominio (página + correo)",
+  "version": 1,
   "description": "Conecta tu página y tus correos de Grundy a tu propio dominio en una sola operación.",
   "variableDescription": "hostPrefix = 'mail' fijo. dkim1/2/3 = tokens DKIM generados por SES al momento de conectar. sesRegion = región activa de AWS SES (ej. us-east-2).",
   "logoUrl": "https://www.grundy.app/grundy-logo-negro.svg",

--- a/grundy.app.dominio-unificado.json
+++ b/grundy.app.dominio-unificado.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "grundy.app",
+  "providerName": "Grundy",
+  "serviceId": "dominio-unificado",
+  "serviceName": "Grundy — Tu dominio (página + correo)",
+  "description": "Conecta tu página y tus correos de Grundy a tu propio dominio en una sola operación.",
+  "variableDescription": "hostPrefix = 'mail' fijo. dkim1/2/3 = tokens DKIM generados por SES al momento de conectar. sesRegion = región activa de AWS SES (ej. us-east-2).",
+  "logoUrl": "https://www.grundy.app/grundy-logo-negro.svg",
+  "syncPubKeyDomain": "grundy.app",
+  "syncRedirectDomain": "grundy.app",
+  "groupNote": "El grupo 'dmarc' se pide aparte (groupIds=core,dmarc en la URL de apply) SOLO cuando checkDmarcAlignment(host) confirma que no hay DMARC previo — nunca se pide si ya existe uno (relajado o estricto), para no arriesgarnos a que el proveedor lo sobreescriba. Ver brief 'Corrección · Carril 2 y árbol de decisión' sección 5.",
+  "records": [
+    { "type": "A", "host": "@", "pointsTo": "76.76.21.21", "ttl": 3600, "groupId": "core" },
+    { "type": "CNAME", "host": "www", "pointsTo": "cname.vercel-dns.com", "ttl": 3600, "groupId": "core" },
+    { "type": "CNAME", "host": "%dkim1%._domainkey.mail", "pointsTo": "%dkim1%.dkim.amazonses.com", "ttl": 1800, "groupId": "core" },
+    { "type": "CNAME", "host": "%dkim2%._domainkey.mail", "pointsTo": "%dkim2%.dkim.amazonses.com", "ttl": 1800, "groupId": "core" },
+    { "type": "CNAME", "host": "%dkim3%._domainkey.mail", "pointsTo": "%dkim3%.dkim.amazonses.com", "ttl": 1800, "groupId": "core" },
+    { "type": "MX", "host": "bounce.mail", "pointsTo": "feedback-smtp.%sesRegion%.amazonses.com", "priority": 10, "ttl": 1800, "groupId": "core" },
+    { "type": "SPFM", "host": "bounce.mail", "spfRules": "include:amazonses.com", "ttl": 1800, "groupId": "core" },
+    { "type": "TXT", "host": "@", "data": "v=DMARC1; p=none;", "ttl": 1800, "groupId": "dmarc", "essential": "OnApply", "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "v=DMARC1" }
+  ]
+}

--- a/grundy.app.dominio-unificado.json
+++ b/grundy.app.dominio-unificado.json
@@ -8,7 +8,6 @@
   "logoUrl": "https://www.grundy.app/grundy-logo-negro.svg",
   "syncPubKeyDomain": "grundy.app",
   "syncRedirectDomain": "grundy.app",
-  "groupNote": "El grupo 'dmarc' se pide aparte (groupIds=core,dmarc en la URL de apply) SOLO cuando checkDmarcAlignment(host) confirma que no hay DMARC previo — nunca se pide si ya existe uno (relajado o estricto), para no arriesgarnos a que el proveedor lo sobreescriba. Ver brief 'Corrección · Carril 2 y árbol de decisión' sección 5.",
   "records": [
     { "type": "A", "host": "@", "pointsTo": "76.76.21.21", "ttl": 3600, "groupId": "core" },
     { "type": "CNAME", "host": "www", "pointsTo": "cname.vercel-dns.com", "ttl": 3600, "groupId": "core" },
@@ -16,7 +15,7 @@
     { "type": "CNAME", "host": "%dkim2%._domainkey.mail", "pointsTo": "%dkim2%.dkim.amazonses.com", "ttl": 1800, "groupId": "core" },
     { "type": "CNAME", "host": "%dkim3%._domainkey.mail", "pointsTo": "%dkim3%.dkim.amazonses.com", "ttl": 1800, "groupId": "core" },
     { "type": "MX", "host": "bounce.mail", "pointsTo": "feedback-smtp.%sesRegion%.amazonses.com", "priority": 10, "ttl": 1800, "groupId": "core" },
-    { "type": "SPFM", "host": "bounce.mail", "spfRules": "include:amazonses.com", "ttl": 1800, "groupId": "core" },
+    { "type": "SPFM", "host": "bounce.mail", "spfRules": "include:amazonses.com", "groupId": "core" },
     { "type": "TXT", "host": "@", "data": "v=DMARC1; p=none;", "ttl": 1800, "groupId": "dmarc", "essential": "OnApply", "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "v=DMARC1" }
   ]
 }


### PR DESCRIPTION
# Description

New Domain Connect template for Grundy's "Tu dominio" feature — connects a customer's own domain to their Grundy website (hosted on Vercel) and their branded email sending (AWS SES) in a single operation: A/CNAME records for the site, DKIM CNAMEs + SPFM + MX for email sending on a `mail.` subdomain, and an optional DMARC record only when the domain doesn't already have one.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`grundy.app.dominio-unificado.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — mandatory
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (template uses `redirect_uri` in the sync flow)
- [x] no TXT record contains SPF content — uses `SPFM` on `bounce.mail` instead
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`Prefix` / `v=DMARC1`)
- [x] no variable is used as a bare full record value — all variables are embedded with fixed prefixes/suffixes (e.g. `%dkim1%.dkim.amazonses.com`)
- [x] no bare variable is used as the full `host` label — DKIM hosts use `%dkimN%._domainkey.mail`, fixed suffix
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` request parameter is used instead (tested with apex and with `host=oficina` below)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record (user may need to remove/edit it independently)

## Online Editor test results

**Editor test link(s):**
- Apex: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHOhg2oC%2F%2B1X%2B2%2FbNhD%2BVwgBQVvUkvVw%2FCoCzEjSrcvcBk6GFUgDgyZphYlECiRlxwm8v31HS36otZvs8UMzGBAgine87z4deZ%2F06BiWZgk2zOk%2BOpmSE06Z%2BkCdrhOrXNCZh7PMqa0sH3EKns7PCxvMa6YmnLDFAipTLrh0c8HHnGAq1%2FbKMvQlD%2F2ggS5zVC5Br7Mvue%2BzIOYCo7eISKWYfAPrJ0xpLoXTDWoOZZoonpnFs3MsBSMGI5OjzcUzmNBlAI0oQyVm4ahkBmhLVCZQDku0TDCSGVOYcBtpHAnPQmPF8ShhJxXYG6nNuWJjfo%2BO0KsU8%2BQVGvNb6SF6x9OgHtYjMBh5x4RGJ2cf%2BihmAkJTyCaTCl2cXiCcoFSmTBhpEyQFEeUhzfSAxYADERQMymQQJoZPsPXt%2FXGxiPCa3Xoo1y7D2rjhG5tuImP5u0psisZkuluvT6dTb13EejF0rZ8rWKykpyexLdFMkPN8dMZmJxL4iK9Lb%2B0DRrmCLLd7gEUqqp3u1aNjZpmtdA%2Bm7auC4U92%2B0gujL6U8NhqenCFAVxgMAYyjpq%2BX4OQMs8WGwmiMWdeWwU7%2Ftjrn64DAq9qSCJge3mwVQhLXCq0R2T6D2MfLKp44A3pgukdm3m2xlW8pZO9eTjFD1JA6TZRg%2FbfRw2fgxr%2B16jRc1Cjf4Pa%2F7yGHMlcELYFZswYHWFy5%2BrUZN7B6iQcfIOZKS4VNzMA9p%2BZwcX5%2B%2F6uHHQ2HuQJg83rcEGSnLLu14i7A19%2Bvqzuc4oNhuHk6KTfGxwH71B2JOB4v9v1rmiKFQEj0xraAcf2%2BH4SvSxLbHM19wa63DjhxPSxITdcxH1JLXDRgba7lLZ1Fs78el5zgBIbrk%2Fqdc2hy8PM7jFoACvplnSWxId84V9wr5UZw%2BoMK5xqqxrLOFeVQNfLSFeOHS9ibYuzOEvWgEckCCPKxo3D5tIQWkMxFd%2FwVruzNETWUEzd3iV%2BEFrDatdY46o7OpY9jwXgDjXcsckhg65ROas5aZ4YPsRTvJ6iZIhtAeBlabBCrGpbE4WWbZR7Z0sbUmJfELelbkRsPMaEuc0ODdxGp0Nc3G613WYLd6JD34%2FCDt0Q2m8l%2BCmpXddtczf1kimeaWe%2BpQ2URIp2WlJ5upW%2BCE6be2lLfyvJVryeanAvgvfmUdnNu%2BL1v%2BC92Ql28654vUzeCzEtSVeFrORYFdJVE%2Fwe06qi%2Fpi8C6X9HvHJEUh5gLaKOPoTJ8mSNHSxl0Hz%2BR8UPwCZ5VfLfH5dg4%2BLvWTuJXMvmXvJ3EvmXjL3kvmkZNqfVzxhdIitX%2BiHTddvu0H70ve7fqPrR177sNPx%2Fbf22bdMmDYF0Uf4u938r3V%2Bm%2FSxDFvnjfa0%2F3AaN3st8fBrHOuowUaDQVu2g%2Fovn94%2BnL0f6SNn%2FhfslBzxARYAAA%3D%3D
- Subdomain (`host=oficina`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANiig2oC%2F%2B1XbU%2FbOhT%2BK5YltE1r0iSFUjoh3V7gsmkqQ5RpTAxVru0GQ2JHttPSod7ffo%2Fb9CW0DO7LB7iqVKmJz%2FFzXn0e5x5bnmYJsRw373Gm1UAwrj8x3MSxziUb%2BSTLcGUuOSEpaOLjiQzWDdcDQflkA1OpkEJ5uRR9QQlTC3lpG%2FqRR0G4jc5zVGxBb7MfeRDwMBaSoPeIKq25egf7B1wboSRuhhXMuKFaZHbyjg%2BU5NQSZHO0vHkEC6YAMIhxVNicKmqVgbWZVS5RDluMSghSGdeECofUr0nfmSZakF7CD0tmr5Wxp5r3xR3aR29SIpI3qC9ulI%2FYrUjDalStgcCqWy4NOvz8qY1iLgGagTeZ0qhz1EEkQalKubTKOUingWgfGW7OeAx2AEHDQ%2BEMItSKAXG6rW%2BdCcJbfuOj3HicGOtF75y7iYrVV504F63NTLNaHQ6H%2FqKI1emj5%2FQ8yWOtfDOIXYlGkp7mvc98dKggHvmw9E5%2BxpnQ4OV6DZAozQxuXt5jO8pcpVuw7FIFj7%2B59lFCWnOu4HW37sMvCuEHAmvB41o9CCoAqfJs0kiAxvG4Mgc7OGm1jxaAEFcZkkpoLx9ahfLEY9L4VKX%2FEHtrUsUtv8smkd7yke9qXLY3U3J%2FPknJTyWhdMtWw8bftxo9x2r0X1utPcdq7d9YbV8sTPZULilfY6bPOesReuuZ1Gb%2B1vwkbK3YzLRQWtgRGA6e6UHn9I%2F2Yz6YrH%2BWJxyaFwtJk5zx5kOLjwOfX5yX%2B5wRS%2BBxsH%2FYbp0dhB9Qti%2FheH94LFcsJZqCkBsD40AQd3y%2FyFaWJW642jsLU66fCGrbxNJrIeO2Ys7wdAKtVylkCy%2Fw%2BGpcwRAS7y5O6lUFs9lh5ncEOIAX4RbhKJjhMFBn8XfFZNs0BZXCcQDJiCapceQxg7ss4V3NAC%2FniFcF5Dq4yclyAtKjYVRjvL%2B9U58JIieYLsXXYrexNxPUnGC6dHObBGHkBPMecsL5rMQuFyKWYLdr4J%2FYHDxoWp3zCk7zxIouGZLFEqNd4soBqTMgBazykJNTZltkq2iBR8dcl1GXLeHK3wh62zRgDW97d3fH2%2B6FzGvs9va8HbZTI7RfC8K9xhL5rtLyU%2FS7UsvlRmslQzIyeLxmQhRROQZZiezpafuaQlzus4eTcDX2kvZTI%2FE1pWH5VD2dhpL2%2FykNyzPk6TSUtF91GiYcXeRgiR9XQy7z9Hyq%2FirwMmG%2F6DRM%2Bfw5eRjsw8UhRGuvDOhPkiSzHMBAfFVRr4n0l3eZlxPZ7N40Hl9V4HqzoekNTW9oekPTG5re0PSGpl8kTbuPdDLgrEucehREdS9oeGHjPAigCZtB4IODQT16H7gXFxA3dhrvPXzFL3%2B%2F484xHUa1jNQufqpR5%2Fe67V8cH31tf9%2BzH0%2Bia5ZXB3dqeP0licnRPh7%2FBRLKzy33FgAA

