### PR TITLE
Add BuckCRM email sending template (buckcrm.com.email)

### DIFF
--- a/buckcrm.com.email.json
+++ b/buckcrm.com.email.json
@@ -12,7 +12,7 @@
   "records": [
     {
       "type": "TXT",
-      "host": "_buckbeam",
+      "host": "buckbeam-verify",
       "data": "buckbeam-verify=%token%",
       "ttl": 600,
       "groupId": "core",

--- a/buckcrm.com.email.json
+++ b/buckcrm.com.email.json
@@ -1,0 +1,43 @@
+{
+  "providerId": "buckcrm.com",
+  "providerName": "BuckCRM",
+  "serviceId": "email",
+  "serviceName": "BuckCRM Email Sending",
+  "version": 1,
+  "logoUrl": "https://buckcrm.com/brand/buckcrm-logo.png",
+  "description": "Authorizes BuckCRM to send email as this domain (SPF + DKIM) and proves you own it.",
+  "variableDescription": "%token% is a single-use per-domain ownership proof that BuckCRM reads back over DNS before enabling sending. It is signed, as this template sets syncPubKeyDomain. All other values are literals: the SPF mechanism is merged via SPFM so an existing SPF record is never duplicated.",
+  "syncPubKeyDomain": "buckcrm.com",
+  "syncRedirectDomain": "buckcrm.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_buckbeam",
+      "data": "buckbeam-verify=%token%",
+      "ttl": 600,
+      "groupId": "core",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "buckbeam-verify="
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:buckbeam.app",
+      "groupId": "core"
+    },
+    {
+      "type": "CNAME",
+      "host": "bbeam._domainkey",
+      "pointsTo": "bbeam.dkim.buckbeam.app",
+      "ttl": 600,
+      "groupId": "core"
+    },
+    {
+      "type": "CNAME",
+      "host": "link",
+      "pointsTo": "track.buckbeam.app",
+      "ttl": 600,
+      "groupId": "tracking"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

> **Updated 2026-08-06.** The ownership TXT host was `_buckbeam`, an underscore label that is
> not in the RFC 8552 registry, so `dc-template-linter` emitted `DCTL1021` — informational on a
> default run, but fatal under `--merge-or-fail`. It is now `buckbeam-verify`, and both editor test
> links below were re-generated against the updated template. No other change.

New template authorizing BuckCRM to send email as a customer's domain (SPF via SPFM merge, DKIM CNAME, click-tracking CNAME) plus a signed ownership-proof TXT that BuckCRM reads back over DNS before enabling sending.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`  (`buckcrm.com.email.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver  (`https://buckcrm.com/brand/buckcrm-logo.png` → HTTP 200, `image/png`)

Additionally validated with `dc-template-linter` (version 119): exit 0, no warnings or errors, and **exit 0 under `--merge-or-fail`** as well. Also run with `-cloudflare`, which reports only informational notes that `syncRedirectDomain` and `txtConflictMatchingMode` are unsupported by that provider.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `buckcrm.com` (public key TXT at `_dcpubkeyv1.buckcrm.com` is published and resolves, returning `p=1,a=RS256,d=…` across two TXT strings)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — this template does not use `redirect_uri`; `syncRedirectDomain` is nonetheless set to `buckcrm.com`
- [x] no TXT record contains SPF content — SPF is applied via the `SPFM` record type (`include:buckbeam.app`)
- [x] `txtConflictMatchingMode` is set on the ownership TXT (`Prefix` on `buckbeam-verify=`)
- [x] no bare variable is used as a full record value — the token is embedded as `buckbeam-verify=%token%`
- [x] no bare variable is used as the full `host` label — all hosts are fixed (`buckbeam-verify`, `@`, `bbeam._domainkey`, `link`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — n/a; this template contains no DMARC or policy records the user would independently edit

## Online Editor test results

Tested with `token` = `test123abc` and both groups (`core`, `tracking`) selected.

**Apex** — [Test buckcrm.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADu0dGoC%2F%2B1W70%2FbSBD9V1YrVeqJJDiEpNRSpeaAClSFcpC7XoVQNPaO4yVrr7W7DgTE%2Fe2dNXF%2BkKDjw0nXD3wJyc74vXmzb8Y8cIdZocAhDx94YfRUCjSngoc8KuNJbLJWrDPeWITOIKNU%2FjsFDy8GFLBopjLG6hHMQKrl2XouO%2FZRdom5kPmYsqZorNQ5D9sNrvRY%2F2kUZafOFTbc3V2h340M5KI%2BafrcVlFBCLSxkYWrYHi%2FdKk28h4tqzmdZpYIWVUZA8tcKi0Tmn7m7P3l%2BRe2w46%2Bng5%2BY8TAvEh6eKZLpm9zJl3LlwlGQqTwaI3rndMTzN8xQgNmSZDCZmmRFWiac3iCIIWpLDyuToga3KIwgyAsiyCeMOI07OjskkWYaIMMc6IjxKpy%2Bttip87zWDnOUTQWKuqbozxH0Vken5fRV5wdVfQt1leKaZcS%2BBRUSbqAwJV0aEDZkDCQ%2BQZkGKeQS5t5jgzNGAWbSvCxAbOaGsPwTlrnK%2FL5BmNthE%2FO0VcuykLJmOoQvlvPy9gwkk%2B4QCEJxr2Q8sRgeXj1wN2s8B4a%2Fj2kQKqtm2dHCFmT6GUy8z4AB5uBT%2FNLogTnyFu9IGjwsdFlUbmVSNCH7tyhzhPS4Abg4pR0DrTwpOcGE3m3PWUe2%2BTkj41F1b6Fy7I%2Fe%2FVFclEqJG1c5rEqBYY1QAuKgm%2FUt4J2eNYfHK90oXpo9GS2Cfo2FFrmzg71IiomMms9I3ixFS9TkRsn6%2FDOkHNfg1wl%2Bnl%2FvH5s8Hud42h5vdd0c7UF8A7Izji3wJy47sdIVvmLK6tBCaAAA5n126uGulrDuq7Brrj%2FXjnC%2F3BoXXuvA1HsjyuWrQxUNc0dnY78%2FIErKR46U2KDZ6VycgS3sDwS8Yh6oWYk0lKUEJ97OH9aiq%2F28Eqdqx0eidhrlr7HbcQgiZJus4vdD839ADtNSDr0ESUHXdEJgu5HWFnhW7b7tiW%2BvAK0tImcBL%2Be%2B%2BoWZpY%2FrphlTdfnpZLpJ3J7m23zOfsHlFrR82sJqt1fX9XmoNV39Yoh%2B3V1zad6ruVfJvp%2Fl3HdoHXxNkxvw%2FQ2TP%2FBMNErz8IUxQh82l6w12sGB82gN2z3wr0gbLdb3aB30NvfCYIwCHzxNDlP4h7ojbj6LuQ3Dv74djIR4%2Bn3%2FQ%2FlD91Od60dfunciJvjk6yf3e%2F8OPj%2B8WTnL6Hpv6OfqSrehHIMAAA%3D)

| Name | Type | TTL | Data |
|---|---|---|---|
| `buckbeam-verify.example.com.` | TXT | 600 | `"buckbeam-verify=test123abc"` |
| `example.com.` | TXT | 6000 | `"v=spf1 include:buckbeam.app ~all"` |
| `bbeam._domainkey.example.com.` | CNAME | 600 | `bbeam.dkim.buckbeam.app` |
| `link.example.com.` | CNAME | 600 | `track.buckbeam.app` |

**Subdomain** (`host` = `mail`) — [Test buckcrm.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEu0dGoC%2F%2B1WYW%2FaSBD9K6uVKrUqJg5QQixVKpf07tIWGiW0ulMUobF3DCvWXmt3TUKj9Ld31mAChOj66ZQP%2BYS8M35v3uybMXfcYVYocMijO14YPZcCzZngEY%2FLZJaYrJnojDfWoSFklMr%2FoODJxYACFs1cJli9ghlI9XC2ncs%2B%2Bii7xFzIfEJZczRW6pxHhw2u9ER%2FM4qyp84VNjo42KA%2FiA3koj4JfG6zqCAE2sTIwlUwvF%2B6qTbyB1pWczrNLBGyqjIGlrmptExoeszZ68vzP9lbdvr5bPCGEQPzIunlhS6ZvsmZdE1fJhgJscLTLa5XTs8wf8UIDZglQQqD0iIr0AQreIIghVNZeFydEjW4dWEGQVgWQzJjxGnY6fCSxZhqgwxzoiPEqnL6bbIz53msnOQoGmsV9c1RnqPoIk%2FOy%2FgzLk4r%2BibrK8W0mxL4HFRJuoDAlXRoQNmIMJD5BmSYTCGXNvMcGZoJCjaX4GMDZjU1huGttM5X5PMNJtoIn5yjr1yUhZIJ1SF8t3bLeGQkn3CBQhKMeyJlyWB5dHXH3aLwHhr9M6LAVFu3yo4RsoDoZbrwPgAHjwPvV5dECc6Rt7ph2OATo8uiciuRoA%2FduhOdp6TBDcAlU9I50MKTnhtM5e3%2BlFXsMSe%2Fb6yr9i18KPuDV1%2BkF6VC0sZlnqhSYFQDNKEo%2BKP6NtBOhv3Bx40uVC%2BNl2aboW9DoWXu7Eivo2Ims%2BYOwZOteJqK3DjbhneGnPs7yFWin%2Ff76%2FsG%2F6FzHD9c7zXdXG0BvAWyM64ssCJe7ZMKbiyrd9bXVgMTSAEGMus3WA13tYV3XQNeLRHpuXKGP3Bo3WGrDXHijyumvSxUPc0fnY79HIIrKR45U2KDZ6Vycgw38HAkkjH1RC1IrKUoIe56OV8uxx37NFeKnzD0RrGb7R6LxIuXvuFp0kugfZwGvfSoE3RanTQgL%2FQCSKF13E5E%2FC5tb%2BzzPat%2B30bfvg%2B0tJqcBL%2Bv%2B%2BoGFpbfb7hnS%2BC2oPl7moBDts%2F77CcotSHr%2Bemqp6K%2Bup0B3L2735jA5y3Qj%2F2OqP%2BY%2B2eh57pBi%2BVl3F7G7WXc%2Fpdxo8%2BmhTmKMfjUVtjqBmEvCLujw27UCqPWUbPdCTvdd2%2FDMApDL4DGainwjr6qm99T%2FncMN9978tNx%2BU10v8YtHOWT7N9y9n14BB1szcu%2B%2FjL4Sw31pxn90%2FoFcuJxIL4MAAA%3D)

| Name | Type | TTL | Data |
|---|---|---|---|
| `buckbeam-verify.mail.example.com.` | TXT | 600 | `"buckbeam-verify=test123abc"` |
| `mail.example.com.` | TXT | 6000 | `"v=spf1 include:buckbeam.app ~all"` |
| `bbeam._domainkey.mail.example.com.` | CNAME | 600 | `bbeam.dkim.buckbeam.app` |
| `link.mail.example.com.` | CNAME | 600 | `track.buckbeam.app` |

