### PR TITLE
Create supdesk.app.portal.json for portal settings

### DIFF
--- a/supdesk.app.portal.json
+++ b/supdesk.app.portal.json
@@ -1,7 +1,6 @@
 {
   "providerId": "supdesk.app",
   "providerName": "SupDesk",
-  "providerDisplayName": "SupDesk",
   "serviceId": "portal",
   "serviceName": "SupDesk Customer Portal",
   "version": 1,

--- a/supdesk.app.portal.json
+++ b/supdesk.app.portal.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "supdesk.app",
+  "providerName": "SupDesk",
+  "providerDisplayName": "SupDesk",
+  "serviceId": "portal",
+  "serviceName": "SupDesk Customer Portal",
+  "version": 1,
+  "logoUrl": "https://supdesk.app/images/logo.png",
+  "description": "Point a subdomain at your SupDesk customer portal.",
+  "variableDescription": "The subdomain that will serve your portal, e.g. feedback",
+  "syncPubKeyDomain": "supdesk.app",
+  "syncRedirectDomain": "supdesk.app,dev.supdesk.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "portal.supdesk.app",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
Add configuration for SupDesk customer portal

# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [X] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [X] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [X] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [X] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [X] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [X] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [X] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [X] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [X] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [X] `%host%` does not appear explicitly in any `host` attribute
- [X] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test supdesk.app/portal example.com/feedback](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOVabmoC%2F91TUU%2FbMBD%2BK5Ffl6ZumlKINGkIGKBpqED7MKoqcuIjtXBiYzstpcp%2Fn90SmkKn7XlPTe%2B%2B%2B%2B7u83drZKCQnBhA8RpJJRaMgrqmKEa6khT0U0CkRP576oYUForuK3lukzahQS1YBpsSKZQhfBfcB3tnlTaiAOWNGtwClGaiRHHPR1zkYqK4xc%2BNkTrudlsTdFlBctBdBwpkmdtam8oUk2ZTj0aClcYjnq5SKgrCSo8YbyUq5TXds6b7dsrAtSeKkZTD%2BR7VeA4tGjO3REvGueeWgi3nlsL3IMgD7xGApiTbiLEqs1GV%2FoDV%2Bab6k4wOcAeUKcjMIYhPYRHsl8yFNnfwXNkaq7FRFfjIlgtFNYqna2RW0ol8dnP68%2BINbv9%2Bc2%2FmNNFj8f4yH5iNsWr3Ma5ntY9eRQnJjndmBW7mgxdiPQJBJopdg9bWuRKVTFhTJ4kihXZ%2BahimexSzhmO6I3ETsLwUChJtf4mpFDTLFhU3LCFLsgvRLLEr8JUdWNuspfosRLk1X2tOSgz5mxY%2BSmjmZmfO0GHag0E%2Feuzg44h2omE27JwcDfsdDGl0BCmmw5N%2B6zgO3M3B8%2FgsIWgNpWHE2f%2BUL8lKo7qe%2BVbO%2F3IxawFNFkAT4uAhDo%2FsIB3cG4c4jgZxOAii40F4HH3BOMbYbQHabLdcb7439vr%2B1sZzERdo7nnPfP9mX2fd2h2W89PBw%2Foge9CiDfZ0%2FvNr2EOrnXLcXr9dfjv2hzUsoH0CKOR4eRkuTNS7upK%2FcvwqxpOLk%2FtyMnq4rYbw8HIjrvkTXLLn26%2Bo%2Fg0lri7S0AUAAA%3D%3D)

