### PR TITLE
Add RedAgents templates (blog, website)

### DIFF
--- a/redagents.io.blog.json
+++ b/redagents.io.blog.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "redagents.io",
+  "providerName": "RedAgents",
+  "serviceId": "blog",
+  "serviceName": "RedAgents Blog Autopilot",
+  "version": 1,
+  "logoUrl": "https://www.redagents.io/icon.png",
+  "description": "Point a subdomain at your RedAgents blog",
+  "variableDescription": "No variables. Static template.",
+  "syncPubKeyDomain": "redagents.io",
+  "syncRedirectDomain": "redagents.io",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/redagents.io.website.json
+++ b/redagents.io.website.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "redagents.io",
+  "providerName": "RedAgents",
+  "serviceId": "website",
+  "serviceName": "RedAgents Website",
+  "version": 1,
+  "logoUrl": "https://www.redagents.io/icon.png",
+  "description": "Point your domain at your RedAgents website",
+  "variableDescription": "No variables. Static template.",
+  "syncPubKeyDomain": "redagents.io",
+  "syncRedirectDomain": "redagents.io",
+  "syncBlock": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "216.150.1.1",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for RedAgents (https://www.redagents.io), a UK SaaS trading under Bitvero Limited that hosts websites and automated blogs for small businesses. Customer sites are served from Vercel, so each template points a name at Vercel.

- `redagents.io.blog.json` — one CNAME on a customer-chosen subdomain (`hostRequired: true`)
- `redagents.io.website.json` — an A record at the apex plus a www CNAME

Both are static: no variables, no TXT records, no SPF or DKIM.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [ ] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Opening as a draft: the Online Editor's "Check template" needs an account, which we've requested. I'll add the test links and mark this ready for review as soon as we have access. In the meantime the discovery and settings steps have been verified end to end against a live Cloudflare-hosted zone, and the apply URL reaches the Cloudflare sign-in with the template path intact.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `redagents.io` on both templates
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — not used
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `redagents.io`
- [x] no TXT record contains SPF content — no TXT records at all
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — no TXT records
- [x] no variable is used as a bare full record value — no variables
- [x] no bare variable is used as the full `host` label — no variables
- [x] no variable is used in the `host` field to create a subdomain — the blog template uses the `host` parameter with `hostRequired: true`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` where the end user may need to modify or remove a record — not applicable; both templates are the service's own routing records, which the user would remove only by disconnecting the service

## Online Editor test results

**Editor test link(s):** to follow — see note above.
