### PR TITLE
Update Peleka domain auth JSON: increment version, replace SPF with mail_from CNAME, add essential flag to DMARC

### DIFF
--- a/peleka.io.domain-auth.json
+++ b/peleka.io.domain-auth.json
@@ -3,7 +3,7 @@
   "providerName": "Peleka",
   "serviceId": "domain-auth",
   "serviceName": "Peleka Domain Authentication",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://files.peleka.io/assets/images/text-logo.svg",
   "description": "Configure DNS records for email authentication and improved deliverability",
   "variableDescription": "dkim_selector: Unique DKIM selector for your domain (e.g., 's1', 'peleka')",
@@ -12,17 +12,17 @@
   "syncRedirectDomain": "app.peleka.io",
   "records": [
     {
-      "groupId": "spf",
-      "type": "SPFM",
-      "host": "@",
-      "spfRules": "include:spf.peleka.io",
-      "ttl": 3600
-    },
-    {
       "groupId": "dkim",
       "type": "CNAME",
       "host": "%dkim_selector%._domainkey",
       "pointsTo": "%dkim_selector%.dkim.peleka.io",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mail_from",
+      "type": "CNAME",
+      "host": "plesp",
+      "pointsTo": "mailfrom.peleka.io",
       "ttl": 3600
     },
     {
@@ -31,6 +31,7 @@
       "host": "_dmarc",
       "data": "v=DMARC1; p=none; rua=mailto:dmarc@peleka.io",
       "txtConflictMatchingMode": "All",
+      "essential": "OnApply",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
# Description

- Adds custom MAIL FROM (Return-Path) support to the Peleka domain authentication template so outgoing email shows the customer's own domain in mail clients ("mailed-by") instead of the default. Removes the old apex `SPFM` record, which is no longer needed — SPF is now satisfied through the new MAIL FROM CNAME's target instead. 
- Adds `essential: OnApply` to the DMARC record, which was missing even before this change, so customers can tighten
  their DMARC policy over time without it being flagged as breaking the template.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test peleka.io/domain-auth example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFmabmoC%2F%2B1WbU8jNxD%2BK5alE62abHZDCGRPSE2h1SEaiu5ArYrQauKdJBZee7G9OXIo%2F73j3YRk26Oq1C98uC%2BJ7Xl9Zp4Z7TP3WJQKPPL0mZfWLGWO9iLnKS9R4QNE0vDOi%2BAKClLk17WI3h3apRRY6%2BemAKm7UPnFTtIyYOe1ChuTCmovBXhpNCkv0bpwSvsdrszc3FpFRgvvS5f2ejOp0EUv6fTAOfSuJwuYo%2Bt5fPLdYBS55Zx85eiElWXtOeVnRs%2FkvLLIzq8%2BMYvC2NyxmbEMKRXFoJUKA50zWQS0mLMclaTMYCqV9KuQJlgJU4XnrRD5gywyR9kJb2zKbrV8rCjc5cWEbV%2FrgCtTWdYUiX2H0TzqsAOXHNBvA%2B3g%2B1C2lRY%2FKSMeeDoD5bB5ua6ml7hqqvdSaWG0Ju%2FRfp%2BC8kfMJQH1L%2BpQli2lTRV4evfM59ZUZdM%2BgkFCvypDw86uxpOf6bowztP1XQvkuyhrUnjAUJbSSO3djfmKXri2YntPnT0cxvG6sx889CKbWfN6BiVxoGwHC0bB5r8EyAuwYuf85o%2BbnetsK8zBA92Xp%2BeT8cez5D0rT7XR%2BJ7ZCk5DNG%2FSWvfHVsQnH1impPAT8GIh9Xxi8hBlrBTJkehKDINA6d%2F0uCzVqpXn%2FbrDv1CYbNeX%2B86mx2SCT0ADipGoi7NJmU41tkxu9UuwULgwxFvLu5bp%2Fdb2jodzq0%2Fh0SU8JCLn2ljMHP2Dp7HhqbcVsbColJcZfIbdUy4yCGAob0dSckJ8%2BlvzdDP%2BLmkzZlNoen6dIB3qiwh4ZN2%2F42k%2BOD4edUcnArqDfoJdGBzG3SOMp%2F3jJMGjGPb21D8W2OuLalfR%2FUaN1WdYOb4OLPo6pi0hN1j%2BnYxvDkwzABso%2F3cA3gbK7Wyt1%2FcdmohvZPxGxjdBRtq2Duh7IoOg14%2F7w2580o37N3GSJsM0HkWDk%2BFhf%2FRDHKdxHCCg8w34Z9rI%2B7uYT385Gj1%2BeTKfbvOjgV5camH%2FHFyPYr%2Fo984eP5xMf%2B%2FpCzH8daZvT%2Fn6LwzG1UzdCQAA)

[Test peleka.io/domain-auth example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPmZbmoC%2F%2B1W227bOBD9FYJAkV3ElmXZSb0qAqzX2QXawGnRjYECqSHQJCUTpkSWpJy4gfvtHUq%2BKZc2fctDX2xRM8OZM%2BcMqTvseK4lcRzHd1gbtRSMm7cMx1hzyRckEAq3doZLkoMj%2FlCZ4L3lZikor%2FyZyoko2qR0872lEYDOKxc0BBdeOEGJE6oA5yU31j%2FFUQtLlamJkRA0d07buNNJheQ22JXTIdZyZzsiJxm3HcdvXdsHBXaZwV6MW2qErnaO8UgVqchKw9H55f%2FIcKoMsyhVBnEoRSLSKAWRgiGRe7ScIcalgMrITEjhVr5MYgSZSX7eSMEWIk8sVEedMjGaFOJLCeku3o7R9m2VcKVKg%2BomoT94kAUtdGS7R%2FBbQzv607dtVdB%2FpKILHKdEWl6%2F%2BVDOLviq7t6u01QVBeweHPLknT9yJgCo27kTrRtOmy7g%2BPoOZ0aVuqYPYIDRrbQnbHQ5HP8Ly7myDpavGiBfBUldwoL7tmglCmev1CN%2BftnI7Rww2zsNw3XrMLnnIkmNeroCDRrQzWQ%2ByMc8JwHLiaH7za8%2BXe23TrZGRhyB9fLsfDz8OOq%2BQfqsUAV%2Fg0xJznw2p%2BLK9%2B9GxlvnVSYFdWPi6FwU2Vgxn2UoJdg5yBUURryk3xdDreWqUed03cJfIU2y52Xa2nAMIfyWwIDygFbN2ZTsi4FVhS8R2xhNDMmtH%2BRt9HUjfLqNv6438GkO%2BfIGG2FfkMgKZXhi4Z84GB8cO1OCGvNSOpGQG7J%2FxWhCPCio34IVNgFd3SOxqI8BGx0oJ9iA2HQdbE%2BrpQUkUQ9MeDIHESUsTWft0zSk7X7EBu1Zb9ZrpwManqQnvDf4ix0cWg9Os6dPrWZ7D5kbyhuysnjtZfU4uEqh90D9WKIvElU9GhtM9WjcA%2FWr8%2FFy4G7Hb72etmBgfuv0t05fuk7hjLYEvkYS4n2jMDpth4N2GF2F3bjbj3u94PR1vx9Fx2EYh6GHwa2rG3BXPVf3gY2Qf%2FaP24%2BY%2Bp5oHv%2F%2B9P%2BVq8dfO2v%2FQeEP%2FvqD4jF2fEhwsFnQ7PaGrs9AmNVpF8GnjSwZj2Gx1yP6RqT8jPHTun44tD%2FP%2BXCYn6Gw50F5vvY8qilIG9dEANc1VzvWwHR4E%2BMvx6Pu5N1kshjczs37vJuxdzef%2BpYUuneSDb%2F2RqPw8jj9L7tYhmd4%2FR1iiolb4wsAAA%3D%3D)
