### PR TITLE
Add bytsend.com.mail.json template

### DIFF
--- a/bytsend.com.mail.json
+++ b/bytsend.com.mail.json
@@ -26,13 +26,17 @@
       "type": "TXT",
       "host": "dkim._domainkey",
       "ttl": 3600,
-      "data": "%dkimValue%"
+      "data": "v=DKIM1; k=rsa; p=%dkimValue%",
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
     },
     {
       "type": "TXT",
       "host": "_dmarc",
       "ttl": 3600,
-      "data": "v=DMARC1; p=quarantine;"
+      "data": "v=DMARC1; p=quarantine;",
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
     }
   ]
 }

--- a/bytsend.com.mail.json
+++ b/bytsend.com.mail.json
@@ -1,0 +1,38 @@
+{
+  "providerId": "bytsend.com",
+  "providerName": "BytSend",
+  "serviceId": "mail",
+  "serviceName": "Mail",
+  "version": 3,
+  "syncPubKeyDomain": "bytsend.com",
+  "syncRedirectDomain": "bytsend.com",
+  "description": "Configure DKIM, SPF and bounce handling for transactional email via BytSend.",
+  "logoUrl": "https://bytsend.com/logo.png",
+  "records": [
+    {
+      "type": "MX",
+      "host": "bounces",
+      "pointsTo": "mail.bytsend.com",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "ttl": 3600,
+      "spfRules": "include:_spf.bytsend.com"
+    },
+    {
+      "type": "TXT",
+      "host": "dkim._domainkey",
+      "ttl": 3600,
+      "data": "%dkimValue%"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "ttl": 3600,
+      "data": "v=DMARC1; p=quarantine;"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect sync-flow template for BytSend (https://bytsend.com), a transactional email API, so customers can authorize DNS changes directly through Cloudflare's own UI instead of a third-party OAuth app.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — see test link below
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — `bytsend.com.mail.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://bytsend.com/logo.png is live

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `bytsend.com`; the corresponding public key is live at `_dcpubkeyv1.bytsend.com` (TXT, `p=`/`a=RS256`/`d=` chunked format matching the live `resend.com` record)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`bytsend.com`) since the flow uses `redirect_uri`
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type instead
- [x] `txtConflictMatchingMode` set to `All` on both TXT records (DKIM and DMARC), since each should have at most one value at that host regardless of prior content
- [x] no variable is used as a bare full record value — the DKIM record fixes the `v=DKIM1; k=rsa; p=` prefix in the template itself; only the key material is `%dkimValue%`
- [x] no bare variable used as the full `host` label — all hosts are fixed (`bounces`, `@`, `dkim._domainkey`, `_dmarc`)
- [x] no variable used in `host` to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` set to `OnApply` on the DKIM and DMARC records (values a customer may reasonably want to change later, e.g. DMARC policy)

## Online Editor test results

Ran against `bytsend.com`, once at the apex and once with a host set, both with `dkimValue=teste123`; resulting records matched the template exactly in both cases (MX, merged SPF, DKIM with the fixed prefix, DMARC):

**Editor test link(s):**
[Test bytsend.com/mail bytsend.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN5Qb2oC%2F%2B1VXU%2FbMBT9K5Elnpa2ST9oF1SJAkIwVmBQNiRURa7tth6JndpOIKu6377rUpp0UG2a9sADUqVG1%2FfjnHvvsefIsDiJsGEomKNEyYxTpk4pCtAoN5oJWiUyRu766BzH4IoOcnMNh3Cgmco4YcuQGPOoMK1c%2B0%2FGjCnNpUBBAxxyQS7T0RnLjyTEiBfVrMMVo1wxYra4UKaJ4olZ5kSHUoz5JFXMOTo77bvO9eWxgwV1RjIVhDlT%2BI64mDhjqRyjsNCY2EgcOcyCdjKOnRWnKiSP5ETeqAgST41JdFCrlYrX7Gk1ERNwBIBSUY2CuzkyebLkewv2qdTGQl6W17Z%2FkgujB3LVpeomGWOgVmPX82yjuVTc5CjwvYW7zgqE%2BkXe%2Fc0YnYyv0gjqBIgLEqWUBSHYNoqUcg1uB0Uqes%2FjakiXTb5n%2BWZiig0Gn6xru%2BrvOfddpfGek3R3bNhXHKVsx0Y8GjuAiBPTx4ZModN9SW2pXmRnzzTAMBzbhl6IXpJE%2BVY8IY2xIttg9HtXh74FMEsxjNFwwfb%2BFcBw4aIfUrCwGOIQar2%2Bbit08DVRMk1C%2FuyfAI5YW%2FU8R95thA6fY%2B%2BQ%2FV73zRoM04b59QayUPhESMVCDf%2FYwCajwKiUuShOI8ND%2FIALEyUhthwAuYZTSPXb%2Bokn6RXrt%2Brg36%2BeC4MglhW3wm41aXvstduVdoO2Ks1GB1c6mPgV36eEjEmr4Y8%2Bli6JV%2B6PV66JoqXl8fSiB5xrtHixHytO%2B6i0D7DkvrNt5Z2feDn8EsM3yumlBrcKb70yb4HXWkrbiK3F%2FGcFvyEyQxeE%2Fa6od0W9K%2Bp%2FKQpePo0zRkNs%2FepefbfidSpefeA3A%2Fi1mlW%2FU2%2FX%2FQ%2BeF3ieRQ9TeaI4h7ex%2FCqiy4PvJz6Zfvp2MxnR492DL9cafz7PZvHswhtQrzX2RSzbj9OTGumixS9vPvig4goAAA%3D%3D)

[Test bytsend.com/mail bytsend.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABRSb2oC%2F%2B1VXW%2FaMBT9K5GlPg3SkFBoUyGNtqoKFWtHYatWocjYLnhN7NR2oBliv33XfEOLNE2a1Ic%2BQa7vxzn33mNPkGFJGmPDUDhBqZIjTplqUBSifm40E9QlMkGF1dEXnIArOsvNHRzCgWZqxAmbhSSYx2vTwrU1N46Y0lwKFAbgkAtym%2FWvWX4hIUa8qmYd2oxyxYjZ40KZJoqnZpYTnUvxyAeZYs7FdaNVcO5uLx0sqNOXmSDMGcL%2FmIuB8yiVYxQWGhMbiWOHWdDOiGNnwcmF5LEcyK6KIfHQmFSHh4cbxQ%2FtqZuKATgCQKmoRuHDBJk8nfG9B%2FtQamMhz8pr2z%2FJhdEdueiSu03GGKgVVDzPNppLxU2OwpI3LayyAqHWOu%2Fn7RidPrazGOqEiAsSZ5SFEdi2imzk6tx31qnoE0%2FciM6a%2FMTy7cQUGww%2Bo5rtaunUeaopjU%2BdtHZgw77hOGMHNuLF2AHEnJgWNmQInW5JakvVYzt7pgGG4dg29EbU0zTO9%2BKJaIIV2QejVW%2BflyyA5wzDGA0X7PRfAfSmBfRLChath9iDWm%2Bv2wLdeDyGj4GSWRrxZUgKUBJtBbQMftiK7i3DH2bxtsiye9ZmmDas5AfIAuIDIRWLNPxiA%2FuMQqMyVkBJFhse4TFemyiJsGUC%2BDWcQqqdJRRzAS6W0J1jX%2FTy75ewACMhlhy3Ej%2BqVhk%2BYaTo%2B7hcLFdPcLFfDsrFqkePMDv2SJV6G9fFGzfJGxfGVnM3Z1WPxzjXaPpqWRbUtiiNarDzJWefApzfeLYLGzTfL7EdVbo7RHfluFqhd0JvpbF9%2FOYqf0Vrn7zfF6deAVT%2FobUPrX1o7f9rDV5LjUeMRti6%2Bp5fKXrHRc%2FvlMqh74Ve2a1UjoMg%2BOTBh4Vg5zNnOYH3dPMlRd%2BbTX53VWGm2SaDm5dxULn6mXVSetIVzVa1e3vZaH9l12fdH36jhqZ%2FAFA8RPccCwAA)
