### PR TITLE
faivelo.com email template v2: DMARC policy reject → quarantine

### DIFF
--- a/faivelo.com.email.json
+++ b/faivelo.com.email.json
@@ -3,7 +3,7 @@
   "providerName": "Faivelo",
   "serviceId": "email",
   "serviceName": "Faivelo Email",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://faivelo.com/logo.png",
   "description": "Point this domain's email at Faivelo — MX, SPF, DKIM, DMARC and autoconfig, all at once.",
   "variableDescription": "SES verification token and the three Easy-DKIM selectors, generated per-domain when the domain is added.",
@@ -26,7 +26,7 @@
     {
       "type": "TXT",
       "host": "_dmarc",
-      "data": "v=DMARC1; p=reject; sp=reject; adkim=r; aspf=r; pct=100; fo=1; rua=mailto:admin@faivelo.com",
+      "data": "v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r; pct=100; fo=1; rua=mailto:admin@faivelo.com",
       "ttl": 3600,
       "txtConflictMatchingMode": "All",
       "essential": "OnApply"


### PR DESCRIPTION
# Description

Version 2 of the **Faivelo Email** template (`faivelo.com.email.json`, merged in #1471). Single change: the `_dmarc` TXT policy is softened from `p=reject; sp=reject` to `p=quarantine; sp=quarantine` (alignment mode, `pct`, `fo` and `rua` unchanged). Customers commonly have third-party services (site contact forms, CRMs, payment receipts) sending as their domain that cannot DMARC-align; under `p=reject` that mail bounces outright the moment the template applies, while `p=quarantine` fails soft and still deters spoofing. No records added or removed; no variables changed; `version` bumped 1 → 2.

Signed template — `syncPubKeyDomain` is `domainconnect.faivelo.com`.

## Type of change

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `domainconnect.faivelo.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — apex and `bounce` SPF use the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (`_dmarc`, `_amazonses`)
- [x] no variable is used as a bare full record value, unless necessary — **exception, justified below** (`_amazonses` TXT)
- [x] no bare variable is used as the full `host` label — DKIM uses `%dkim1%._domainkey` etc.
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may modify (`_dmarc`)

**Justification for the bare variable at `_amazonses` (`data: "%sesverify%"`):** unchanged from v1 — this is the Amazon SES domain-verification token, an opaque base64 value that AWS issues with no fixed prefix or wrapping — there is no service-specific string to embed it in, so the value is necessarily the bare variable.

## Online Editor test results

**Editor test link(s):**
[Test faivelo.com/email — apex (host empty, @)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAgHb2oC%2F%2B1YW0%2FjOBT%2BK1YktA%2BkJUnvQZXocNEyTFkGWC2zLKpc22lNEzvYTktA7G9fO72mlC3sPgyV%2BtDGjs%2F9HJ%2FzKc%2BWIlEcQkUs%2F9mKBR9STMQptnwrgHRIQl5EPLLs2dE5jDSpdTI%2B1AeSiCFFJGMhEaTh%2FF2eFhxPTodESMqZ5Xu2FfIe%2F12EmqqvVCz9vb0FtXvmtBiznmbCRCJBY5UxWhecMgVUn0qAuRbLfpEgUw6gAlN9fyWe45ZB%2B8YGVxcnNjg6O23r%2F3br8hBAhgFMFEecBbRnAxhmrJwhUjQmQkFhNyRHOa1Xx1dAG08DiqB5BRQfEJbJUn2if4IQcAxlWjCqgCQhQYoLaYMeYUToIGMQE1EYmwxGfc1sGCd77QzEmGBjgEwZuki6ZyQ9yg619jGVNphpqcV8dgz5JcFU6KMZwxJJHwqikxTAUBLb0pRcYGn5t8%2BWSmOTp%2FaNJutzqfT6wKTcBFlec72NHovL5UC5oCq1fNexLaV0BktVx3mxZ9J0yNt5eTIOLpOQyEwegD5Pcm4A7VyYYOLDCD5xJonMdC2IvL65nkvs4AgKZCoDKqj3w2aWWXcfxM2HBArIFGVkH8j8FuIBjZpCL7Q55hkj1XQdZx8EvKmZRQKbppAU9yGOKDvI%2Bz3zVC8f1aGunpAi1YYK9SnrtTk2drZCU%2BZESqKVQlPcv7FWHIfpojOH56328dwdU4yYSsR1ga2J%2Fapor5A2Lu3%2FICsf5lk25qHe0bvsHqQ7HwnJ2%2BbumKS4O8XOuMYHJM2bPT03j2K%2BPN4VjozfWyPf%2B5%2FyS2vklz4gf%2FEqdnmiu1JeYEAI7kI0KMhIxUWSFJAuNQHDgvtK%2FEdv6kzdwnV942bevdiW3pPOvJnc2ZM%2B9ar%2FTMTrVU%2FwJO7QKX2sL2ckzfiZct7mWO%2BmvLeWWc9qz7yILyrsxnm6rA2%2Bd73oj4b6UU6%2B1YeHJfi1ik%2Fc3q%2BOvK6Qs8bjn9zwZmWUya89DkoPXvQUV0R95KpGWk6qQ4d1kYdJn95PiT1DDL3hqCHK6mFQi9zHylMdlbpV5sSYBP37sJdMiUuGOKp2H9xRnQxUKa0lHm3wclyROOj175kYoifLBI32GBekI%2FUTqkToJCiR6KYcJaGiHTiC81cYdaBpHTrGUp9qFUsNm42H7MH8er59yZeroYORiTs1s7uBEHTLVVLAFZcUysipF2DXRYXAdXDZ9QJSQ2gBB6yACKuQwDzri%2B2wFY5gKq2XV03ntTPDpq5DF7x%2FYIC%2FYdZ%2BM6e1z5%2FYzZ8%2Bwn5WYGbjcEVLncRmaR6%2Bo7Q%2FUZZX%2BDKbxpvlSb5eV2CBj3TgDUnXuuGQH%2FOTOKxl%2BvfZ%2F6nLd838WxmPtUybG491I35lPNYybVA8FnHHDC5O78H7kenGwZJlXyfYZGNgyJ2t8fYWPm7h4xY%2BbuHjFj5u4eMWPm7h4xY%2BbuHjO%2BGj%2BfoKhwR3oCHzHK9a0Iod79qp%2B5WGX%2FGKtWqlXPF2Hcd3HGM9kWrs7POLdmDhe6f15Tutt%2Bhu%2Fdt56TSty%2FRLuRKNnOPd8k01KOFzdrm39%2BNE1ONkt920Xv4BSmgoeKccAAA%3D)
[Test faivelo.com/email — subdomain (host = www)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACkHb2oC%2F%2B1YW0%2FjOBT%2BK1YktA%2BTliS9F1UalssMMGVZYLQwLKqc2GlNEjvYTkqK2N%2B%2BdnoNlC3sSrNU6gMkjs%2FF5zvH53zqoyFxFIdQYqP9aMScpQRhfoSMtuFDkuKQlT0WGeZs6xRGStQ4HG%2BqDYF5Sjycq%2BAIknD%2BrSgLDia7KeaCMGq0HdMIWZ9956GSGkgZi%2Fb29oLbbb1bjmlfKSEsPE5imSsaZ4xQCeSACICYMkt%2FESB3DqAEU39%2FJo5lV0H3ygQXZ4cm2D856qr%2F3d3zPQApAjCRzGPUJ30TwDBXZdTDZX1EyAl0Q7xf8HpxcAHU4YlPPKg%2FAckCTHNbcoDVH8cYHECRlbQrIHCIPcm4MEEfU8wVyAjEmJfGRwbDgVLWipO1CgYihJE%2BgMiod5a4JzjbzzeV97GUOjBVVsvF7Gjxc4wIV1szhWciA8ixSpIPQ4FNQ0kyjoTRvnk0ZBbrPHWvlNiACaneP%2BuUa5DFJVPL6KH8vBwI40RmRtu2TENKlcFK3bKezJk1BXm3aE%2FE%2FnkSYpHbA7DNkkIYQAUXJgi3YQRHjAoscl8LJi%2BvLucWeyiC3NOVASVU67STZ9beAXHnPoEcUkko3gGiuIQoIFGHqxd1HP2MPdmxLWsH%2BKyjlHkCO7qQJGtDFBH6uRj3LFL1%2BiD3VPWExJNdKL0Bof0uQ%2Fqcu6EucywEVk6hLu7f6G4ch9liMHunu92DeTi6GBERHlMFtgL7ZWgvsTYu7X9hqwjzLBtzqLfUKr8H2dZ7IHn9uFs6KfZWuTeu8QBnxWNP9%2FWjXCyPN8GR6zsr7Dv%2F0X5lhf3KO%2BwvXkWXJaorFQ36GCMXekFJRDIu46TkqVLjMCzZL8y%2F96bO3C1c11du5u2Taag17s2bya056VMv%2Bs%2FE%2FHA4VIs%2BZ0ncI1OVWN3PSOgJNFW%2BKWjfTtVvcv1bPWEmFai%2FxWc1emWNzhvB764T%2FdGS19XkWzPdq8DjOjq0%2B18tcVnDJ62HH0zr5sWUu2g8BJV7JxrFNd4c2rKVVZN6alHXcxAekLupsKOFoZMOW7wq74NGZD%2FURk2v4tapFSPsD%2B7CfjIVrmjhqO7e28MmDmQlayQOabFqXBPI7w%2FuKE%2B9kaGhI33KOO4J9YQy4SoVkieqNUdJKEkPDuH8E%2FJ6UDcQhbRQu8rFs7ZNx6N2jO7kmr5%2B2Z9XRQ95GnyiZ3jDgg7GDb9Us1qtUtXCfsltVP1S06ohG%2BEqbrr2Ah9YQhWWMYJC9hc74244hJkwnl70n2URpR1VlDZ4%2B%2FQAf8G8F%2BeRq8A%2FdqzjkVZ%2BFvJPHmv%2FIz6zKbmk004gWhyT5TdX%2B8fK%2BZKQxrN6XQMqFvH8AhbCeU%2BTXp%2FkrRohC5SgCMdKxX%2FmCh%2B9plcMy1dhWam41rCsogWvwrJScb1gWaQsY7757HK8nd6uI6dZFvKE2qwTi7k1FXff8NAND93w0A0P3fDQDQ%2Fd8NAND93w0A0P%2Fdk8VP8eDFOMelBLOpZTL1nNkuVcWq22ZbWdWrllO9WK9UktLEsHgIUcx%2Fv4pGJY%2BAXWOBXBkXt2%2FOk4DYLvB61rcfElyCrbR18GlWPqXv%2BoB99GQWNU%2Bfqr1TGe%2FgafA0QBPx0AAA%3D%3D)
