### PR TITLE
Add anvilmail.io templates (verify, dmarc, spf, dkim)

### DIFF
--- a/anvilmail.io.dkim.json
+++ b/anvilmail.io.dkim.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "dkim",
+  "serviceName": "Managed DKIM",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Delegates one DKIM selector to Anvil Mail with a single CNAME, so key rotation and record upkeep happen without further DNS edits. Mail signing itself is unchanged.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%selector%._domainkey",
+      "pointsTo": "%dkimTarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/anvilmail.io.dmarc.json
+++ b/anvilmail.io.dmarc.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "dmarc",
+  "serviceName": "Managed DMARC",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Delegates your DMARC record to Anvil Mail with one CNAME, so your provider can manage policy and reporting for you without further DNS edits. Your existing mail flow is not changed.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "_dmarc",
+      "pointsTo": "%dmarcTarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/anvilmail.io.spf.json
+++ b/anvilmail.io.spf.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "spf",
+  "serviceName": "Hosted SPF",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Adds Anvil Mail's hosted SPF include to your SPF record so your sender list stays under the 10-lookup limit automatically. Your existing senders keep working.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "%host%",
+      "spfRules": "include:%spfInclude%"
+    }
+  ]
+}

--- a/anvilmail.io.verify.json
+++ b/anvilmail.io.verify.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "verify",
+  "serviceName": "Domain Ownership Verification",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Proves you own this domain so Anvil Mail can monitor and protect its email. This adds one small TXT record; it does not change how your mail or website works.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_titan-verify.%host%",
+      "data": "%verifyToken%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Provider: Anvil Mail (anvilmail.io)

Anvil Mail is a DMARC operations platform for MSPs (monitoring, managed DNS hosting, AI-assisted remediation). These four templates provision the client-side delegations our managed features need:

| Template | Records |
|---|---|
| `anvilmail.io.verify.json` | TXT `_titan-verify.%host%` ownership token |
| `anvilmail.io.dmarc.json` | CNAME `_dmarc` → managed DMARC host in our zone |
| `anvilmail.io.spf.json` | SPFM swap to our hosted (flattened) SPF include |
| `anvilmail.io.dkim.json` | CNAME per DKIM selector → hosted key in our zone |

## Signing

- `syncBlock: false` (synchronous signed flow; works with Cloudflare's sync-only support)
- `syncPubKeyDomain: domainconnect.anvilmail.io`
- Public key published at `_dck1.domainconnect.anvilmail.io` (RS256, chunked `p=1..3` — resolvable now)

## Validation

- All four templates pass the community editor at https://domainconnect.paulonet.eu/ (structure, variables, SPFM usage)
- Apply-URL signing implemented and unit-tested against the spec's canonicalization (31 tests)
