### PR TITLE
add Edka, 2 templates

### DIFF
--- a/edka.io.cluster-cname.json
+++ b/edka.io.cluster-cname.json
@@ -1,0 +1,37 @@
+{
+    "providerId": "edka.io",
+    "providerName": "Edka",
+    "serviceId": "cluster-cname",
+    "serviceName": "Cluster domain (CNAME)",
+    "version": 1,
+    "logoUrl": "https://assets.edka.io/logo.svg",
+    "syncBlock": false,
+    "hostRequired": true,
+    "syncPubKeyDomain": "domainconnect.edka.io",
+    "syncRedirectDomain": "console.edka.io",
+    "description": "Point a subdomain or wildcard subdomain to an Edka cluster hostname and delegate DNS-01 certificate validation.",
+    "variableDescription": "%tlsTarget%: Edka ACME delegation target; %cnameTarget%: cluster hostname target.",
+    "records": [
+        {
+            "groupId": "tls",
+            "type": "CNAME",
+            "host": "_acme-challenge",
+            "pointsTo": "%tlsTarget%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-cname",
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%cnameTarget%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-cname",
+            "type": "CNAME",
+            "host": "*",
+            "pointsTo": "%cnameTarget%",
+            "ttl": 300
+        }
+    ]
+}

--- a/edka.io.cluster.json
+++ b/edka.io.cluster.json
@@ -1,0 +1,141 @@
+{
+    "providerId": "edka.io",
+    "providerName": "Edka",
+    "serviceId": "cluster",
+    "serviceName": "Cluster domain",
+    "version": 1,
+    "logoUrl": "https://assets.edka.io/logo.svg",
+    "syncBlock": false,
+    "syncPubKeyDomain": "domainconnect.edka.io",
+    "syncRedirectDomain": "console.edka.io",
+    "description": "Point a hostname or wildcard domain to an Edka cluster and delegate DNS-01 certificate validation.",
+    "variableDescription": "%tlsTarget%: Edka ACME delegation target; %ip4_1% to %ip4_4%: cluster IPv4 addresses; %ip6_1% to %ip6_4%: cluster IPv6 addresses; %cnameTarget%: cluster hostname target for wildcard records.",
+    "records": [
+        {
+            "groupId": "tls",
+            "type": "CNAME",
+            "host": "_acme-challenge",
+            "pointsTo": "%tlsTarget%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-a-1",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip4_1%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-a-2",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip4_2%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-a-3",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip4_3%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-a-4",
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip4_4%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-aaaa-1",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "%ip6_1%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-aaaa-2",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "%ip6_2%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-aaaa-3",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "%ip6_3%",
+            "ttl": 300
+        },
+        {
+            "groupId": "apex-aaaa-4",
+            "type": "AAAA",
+            "host": "@",
+            "pointsTo": "%ip6_4%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-a-1",
+            "type": "A",
+            "host": "*",
+            "pointsTo": "%ip4_1%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-a-2",
+            "type": "A",
+            "host": "*",
+            "pointsTo": "%ip4_2%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-a-3",
+            "type": "A",
+            "host": "*",
+            "pointsTo": "%ip4_3%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-a-4",
+            "type": "A",
+            "host": "*",
+            "pointsTo": "%ip4_4%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-aaaa-1",
+            "type": "AAAA",
+            "host": "*",
+            "pointsTo": "%ip6_1%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-aaaa-2",
+            "type": "AAAA",
+            "host": "*",
+            "pointsTo": "%ip6_2%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-aaaa-3",
+            "type": "AAAA",
+            "host": "*",
+            "pointsTo": "%ip6_3%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-aaaa-4",
+            "type": "AAAA",
+            "host": "*",
+            "pointsTo": "%ip6_4%",
+            "ttl": 300
+        },
+        {
+            "groupId": "wildcard-cname",
+            "type": "CNAME",
+            "host": "*",
+            "pointsTo": "%cnameTarget%",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Two new templates for Edka (edka.io), a Kubernetes cluster management platform. Users add a domain (exact host or wildcard) to their cluster and the templates create the routing records plus an ACME DNS-01 delegation CNAME used for certificate issuance:

- `edka.io.cluster.json`: apex/exact-host and wildcard A + AAAA routing, wildcard CNAME routing, and the `_acme-challenge` delegation CNAME.
- `edka.io.cluster-cname.json` (`hostRequired: true`): exact-host CNAME routing variant. Split into its own template so the CNAME on host `@` complies with the schema's hostRequired rule; our backend refuses to use it at the bare zone apex.

Only the synchronous flow is used. Every apply URL is signed (`syncPubKeyDomain=domainconnect.edka.io`, key already published at `_dck1.domainconnect.edka.io`), and the variable values are derived server-side from the authenticated, account-scoped cluster state (load balancer IPs, cluster hostname, delegation target). They are never taken from the browser.

Both templates pass `dc-template-linter -loglevel error -tolerate info -logos` (also clean in `-cloudflare` mode).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in these templates)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (n/a, no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — **justification:** the record values are cluster load balancer IPv4/IPv6 addresses (`%ip4_n%`/`%ip6_n%`), a per-customer cluster hostname (`%cnameTarget%`), and a per-domain ACME delegation target (`%tlsTarget%`). None of these admit a fixed prefix or suffix: IPs cannot be prefixed, the CNAME target can be a customer-owned hostname (e.g. a Tailscale tailnet host), and the delegation zone must remain rotatable without a template version bump. As mitigation, all apply URLs are signed and the values are computed by our backend from authenticated cluster state, never accepted from the client.
- [x] no bare variable is used as the full `host` label — hosts are fixed (`@`, `*`, `_acme-challenge`)
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not set: every record in the selected groups is required for the service to function, and the TLS delegation record is already independently selectable via its own `tls` group.

## Online Editor test results

**Editor test link(s):**
[Test edka.io/cluster example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHVdb2oC%2F%2B2W32%2FaOhTH%2F5XIUl82kuYXATJdaWxl2jS1arfuSlVVRYfEpdZMHNkGyqr%2B7%2Fc4ISSwrQTpPuxhvJAcf%2F3x8fHJ8Xkims4LDpqS%2BIkUUixZRuWnjMSEZt%2FBYYL0tuYLmKOMTHAArYrKJUtpqU35QmkqG%2BtG%2Br6yW5mYA8txeEmlYiInsdcjXMzEN8lR9qB1oeLTU1CKauVsVj41AkctZwa7ztN3XKTfSXwPXNHKcrmYfqbrswoek2qVVOQ5TbXT%2BG%2BkX2jGJJq3YpQpwWlLllGVSlbo0j9yKViuLbAehNI57sYS0loxnqUgs81%2BLC0syC0TD2sTAXzHUcrpDENqnV18tV3PSqnU7J6lxrQEzjIwazgmHCAZTDk921n6RHN1DXJG9Ulc0cfvzyc1FjWWLkffWCesCBPvxDhSPoY4ofbk0%2BUytCDLJMWoqlIbNdpoXxvtaFOz5a0PtWwbi2p9674dE4yukJky29o8kvj2icykWBRlkuCucEyvizIzLsbnE3w1SHxNIJ1TO30Azmk%2BoybpTPzVtdiNhwFoTJnAdZ97bTgU9NEG22tWGDf0t3u8KmqHWH5nln%2BQFXRmBQdZYWdWeIiFv52Q4e8lYnQ4aoboH0P0uxCDY4hBF2J4DPGFONbp%2F9vce3Vc7rV4fmee34kXdOYFnXhhZ16n%2BL2Yi6%2BOy8Vdqn8M1e9KDY6hBl2p4THULnEtK%2Flv6%2B4%2BtV332%2By75x75IXKaNKX9rre5cE2v8AjYRVAnFfOGjU%2BlPwkr9Zv63yrU7RqEtAIkzJXpQ2ru7Q74ribfEvNcsrtwt7eHETeXqO2BPw1Sx9w8VReQowT15RdqtN7Id1zHdzy3Nvv14uVX0n4Jm5eomu27rhdn02Ec1%2FOj9vyoPT9q5rdOoDJh5NksF5ImCv9BLySeo5YL7IHmC65ZAitoTFmaQFHwNR6UwlFE4B28d%2FZ51Zz9fOdiYwKmjzoQoyYveiTJUnNizORcFg5hNKJgp2FI7XDQB3s4cD373hu5rjvyBlF%2F2mon97rMX%2FeTTS6Z1iTXDEzDOOYrWCvybHK%2BVYI2G3vbbKV1hH%2Bm19U3%2FrPjO9nzB7l%2B18MP%2F29K%2FU2p%2FzGlsOopWNIsAV266Ue2O7Rd%2F9rrx%2B4wDgZOMBx4YfDadWO3dJ0qXW3qCatjuy6SySNcf7i5YV84%2FVisfPjWz68uz%2FsfRgO%2BvhnC1%2F7438kDvHOvVlf%2FkOf%2FAAmonU%2F%2FDgAA)
[Test edka.io/cluster example.com/apps](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALRdb2oC%2F%2B2WbW%2FbNhCA%2F4pAIF8yS5FIRbE1DJjTpGvQNcu6DCgWGAYtMTIRWdRI2qkX5L%2FvqBfrBW0sA%2FvQYtEXm8fjc8fj8XhPSLNVnlLNUPiEcik2PGbyKkYhYvEDdbhAo534mq5ADV3CBEgVkxsesUI3StdKM9lIK9U3pdyKxYryDKY3TCouMhR6I5SKRPwpU1Bbap2r8OSEKsW0cirLJ0bBUZvEYLdZdJ6K6AGF9zRVrJTcrBfv2faihIeotBKJLGORdhr%2FjepHFnMJ4p0yqCmRspZazFQkea4L%2F9CN4Jm2qLUUSmewG0tI65GncURlXO3H0sKimWXiYVURgDHMspQlEFLr4voP2%2FWsiEnN73lkRBua8pgaG44JB5WcLlJ20TF9pFN1S2XC9FFY0qdvPlzWWNCxdDH7o3XEc3%2FuHRlHir8%2BLKg9ubrZ%2BBaNY8kgqqrQDRrdoK8bdHQjs%2BWdD7XaLhalfeu%2BHROIrpCxMtuq%2FqLw7gklUqzzIklgVzCnt3mRGdfTD5cwNEgYzmm0Yna0pGnKsoSZpDPxV7eiGw8D0JAyxHWfR204zdlnm9peY2Ha0H%2Fu8cqo7WPhwSy8l0UGs8helj%2BY5e9jwdcJGXwvEYP9UTNEfAgRDyGSQ4hkCNE%2FhPhCHOv0%2F2ruHR%2BWey0eHszDg3hkMI8M4vmDeYPi92IuHh%2BWi10qPoSKh1LJIVQylOofQh0S16KSf7Xu9qntut9mz55H6B%2BRsXlT2mej6sE1vcJnCl0EcyKxatg0z03BL3ya82JN9Qa0inW3DvVuUz85wGROJV0p06zUxu861me1%2BbvS%2Fqxy4D8xvnuHDK15jm2P4gWJHPOGlf1EBiqgX9x1o%2BtNsOM62PHcWoyNuB6Q9sBvBkG5GruuF8aLcRjW64P2%2BqC9PmjWt86yFMEZ8iQTks0V%2FFK9lpARWq6hm1qtU83n9JE2ojiaQwTTLRy5gllAwGvey6KsbPN6r7dTnTz0OdS0ZXsC1aTZCM3jyJwtNyk8JqeMjH1sj8l4bPs4PrMn%2FoTZ95NTQk7pmU8nUas77TWtX25Pu6lpup1Mc2p60Gn6SLcKPZtr1Kpq1Q67O2od57frfFk9vuh%2FJ6G%2Bh%2FAfO9%2F7AfR38C0fwWwExf31sr9e9tfL%2Fj%2B47NApKLph8ZzqwlUc2O7YdvGtdxq6k9B3Hf%2BMEB%2F%2F4LqhW7jPlC439gQdRbuXQO8Wi5u%2F3yb0119%2Bvzr%2F6Ga%2F%2FXWirx%2BnyZKkD%2B%2BWwftPuX57u8Tn2aern9Dzv9FCTX99EgAA)
[Test edka.io/cluster-cname example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACleb2oC%2F%2B1UaW%2FbMAz9K4aAAjti13bSIx4GrNdOrAu6tMBWBAEjsalQxfIkOW1W5L%2BPsnOv3fZxA%2FbJsPT0SD4%2B8p45HBUKHLLsnhVGj6VA806wjKG4gUhq1lgcn8KIYOyELujUohlLjhWWq9I6NCHPPWRxN3twVN8GQo9A5sGTo9ODjydPCTZGY6XOWZY0mNJDfW4Uwa%2BdK2y2vQ3WorPRLI9tD4jseOjpJzk%2FVJrfsOwKlMUGu9bWneG3UhqkfJwpsUZ1ysEHnBxXgYm6zoDrPEfuomWFHnqGgl5ztwATzGqFKzCBlhtZuCpn1tEydwEEthzMKtMmuJVKcDBi5dTpAPLAqxbMdAp8ul4quhCBQIVD6kBwfPo5jJOAo3HySnJ%2FNAYlBfiAkdcLjISBwuO1PLacsl0wQ3RbWR3m4OjjyZyWMIGrbl8EW1V%2FFtifsqlxPhIJoY2wLLu8Z0Ojy6JqMwWiOzcpqq76LrJaevrtAx9hyK9BKcyH3gSF18d29XqKnsBRm5txPG2skkOBdwsDPRzj1QbrajmP8s478hvuZ3%2FI3Zs22HedY38pUa8xM5afmjugecKI69GSG4qCfqqU%2BrJ6MpNyreaNRIm1AAMj6ydzzn%2B5FqA3j3BZhejNYvwx%2F6Ir%2FsXSL2EC6aDJI9%2FR2v05QQi%2Fool%2FMfOPjRxIlaTNVkTjWkFJIznMtcG%2BpS%2B40uB8KkelcrIPt7A8ErxP6asJSWrplqjJdRtdyutVsuGyqFaWJgT8dP%2BmgmUXG6wvuNdVeoe00maM%2FArC9qDVClvtvXY4aLfSsLXXboo0GQhIxMoa3NiOv9qDa%2F1H2me5k%2BB33IG6hYllU2%2FVhytdq%2BxRpf%2Bpkp5F%2F25RvQaN%2BX9b%2FrflX2ZL2soWxij64JFpnO6G8X4Yp91kJ0uSrLkXteJ22kyfx3EWx74GtK6u9J629Op%2BZrl%2B%2B67TPRBn4%2BNk5%2F357fn4zdHFzWin%2FFrefbn4tL%2Fb4Yfw%2BnC3g19esukPRBc6izsKAAA%3D)
