### PR TITLE
add Sending, 3 templates

### DIFF
--- a/sending.dev.dmarc.json
+++ b/sending.dev.dmarc.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "sending.dev",
+  "providerName": "Sending",
+  "serviceId": "dmarc",
+  "serviceName": "Sending DMARC Policy",
+  "version": 1,
+  "logoUrl": "https://sending.dev/logos/sending-mark.svg",
+  "description": "Publishes a monitoring-only DMARC policy (p=none), required by Gmail and Yahoo for bulk senders.",
+  "variableDescription": "No variables: the policy is built from the domain itself.",
+  "syncPubKeyDomain": "sending.dev",
+  "syncRedirectDomain": "sending.dev,sending-umber.vercel.app",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:postmaster@%domain%",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}

--- a/sending.dev.email.json
+++ b/sending.dev.email.json
@@ -1,0 +1,50 @@
+{
+  "providerId": "sending.dev",
+  "providerName": "Sending",
+  "serviceId": "email",
+  "serviceName": "Sending Email Authentication",
+  "version": 1,
+  "logoUrl": "https://sending.dev/logos/sending-mark.svg",
+  "description": "Publishes the DKIM, custom MAIL FROM and SPF records required to send authenticated email with Sending.",
+  "variableDescription": "dkim1, dkim2, dkim3: Amazon SES DKIM tokens for the domain; region: SES region of the sending identity",
+  "syncPubKeyDomain": "sending.dev",
+  "syncRedirectDomain": "sending.dev,sending-umber.vercel.app",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "MX",
+      "host": "mail",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "mail",
+      "spfRules": "include:amazonses.com"
+    }
+  ]
+}

--- a/sending.dev.inbound.json
+++ b/sending.dev.inbound.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "sending.dev",
+  "providerName": "Sending",
+  "serviceId": "inbound",
+  "serviceName": "Sending Inbound Email",
+  "version": 1,
+  "logoUrl": "https://sending.dev/logos/sending-mark.svg",
+  "description": "Points the domain MX to Sending so incoming email is delivered to your agent inboxes. Apply only on a domain dedicated to Sending: it redirects all inbound mail for that domain.",
+  "variableDescription": "region: AWS region that receives the mail",
+  "syncPubKeyDomain": "sending.dev",
+  "syncRedirectDomain": "sending.dev,sending-umber.vercel.app",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound-smtp.%region%.amazonaws.com",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Three new templates for [Sending](https://sending.dev), an email sending platform built on Amazon SES. They let a user publish the DNS records for their sending domain from the Sending dashboard instead of copying them by hand.

They are separate templates on purpose, not groups of a single one:

- `email` is the always-needed part: DKIM, custom MAIL FROM and SPF.
- `dmarc` replaces an existing DMARC record, so Sending only offers it after checking that the zone has no DMARC published. Keeping it apart means a user who already runs a `p=reject` policy is never shown an apply flow that would overwrite it.
- `inbound` points the apex MX at SES, which redirects **all** incoming mail for that domain. Were it a group of the email template, a DNS Provider that ignores the `groupId` parameter could apply it by accident and take over the user's mail flow. As its own template that cannot happen.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`dc-template-linter -loglevel error -tolerate info -logos *.json` exits 0 on all three.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) - the `email` template uses `SPFM`
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique - the DMARC record uses `Prefix` with `v=DMARC1`
- [x] no variable is used as a bare full record value - every variable has a fixed prefix or suffix (`%dkim1%.dkim.amazonses.com`, `feedback-smtp.%region%.amazonses.com`, `inbound-smtp.%region%.amazonaws.com`)
- [x] no bare variable is used as the full `host` label - the DKIM hosts are `%dkimN%._domainkey`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

## Online Editor test results

**Editor test link(s):**

- [Test sending.dev/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALRhb2oC%2F%2B1W227bOBD9FYJAnio5sizftOiDu0mxQddpEKdAiyAwaJK2FF0ok5RsOfB%2B%2Bw5lObY3br0B9qHF5okU53LmzAyHesKaJ1lMNMf%2BE86kKELG5RXDPlY8ZWE6azBeYOtZdE0SUMWjjRAEissipLwy4QkJ493ZoS66NFI0yHXAUx1SokORgnLBpTI7v2nhWMzEFxmDUaB1pvzz870ozo1UbU%2FshMiooQoTA%2BOKyjCrHPr4Jp%2FEoQq4QoCELj5dDS1Ec6VFgoaDqz%2FRx9vPQ0RShkY3H5HkVEimYJ3noeQMaYEMAiK7OOG0YoYWoQ5QTadhQicyJJOYXxzgsyhMmhYyi7tZWj4aJGQlUjS6HFURAUzEU4WmQlZRMgEA6W8Qxgyc%2BJXeZo%2FEtNKoaSMoAkSlS5PmMqVA9hMvLyrzF0UzCrecAS%2Bqj6lY21zmyYTLBlSC8rhBsgxsA6H0bZ0U7E9JrLiF62xh%2F%2F4Jz6TIs6rshiJY6DIz5f79ejC8rB3A51mVjrPGeEMx4ibyTISpVndiT26WBqmypLhqUFG51NALrY7jrK3XAbonAN3%2FGrB1ArD1OkDTblMp9kCHX3eI9TXbw5hyziaERrZKdNY427TO2Qu0TIZCmubxm84rsOGiDF%2Bgq2x6m8ccmgGHKY1zxv1DuPXD2sLwzce7tnmAy7ptRL4kMHp4HVrtHHZVJOOw0t9m%2FjkmcJARSRJl5tXW1f2Br4ets3ts9pW777iqes%2FIiBe0YyZpsYxpTt3lfFXM5jLIZq72Vp3V41bZNcqTbuJGei4Xy5RM8nYpp0UwV48samX9ZZMutsoto0z78066ylRRJoznPR3MJpGMF9NHr3DL9pIY5U25Kh65veBK201skhfOUiH5WMFKdC6hFFrmcA2TPNbhmCzI7ojRMdzbuIRcK5CCL7ii%2F%2BjXdDOPT3E9bGRGNPk3Rj%2FubguPGTUlC02Htbotj3jTru20e47t9d22PXE6XbtLu6TnTajbd5p7b86R5%2BjYq7PrIK6UGZLEPCSDeEFKhdemx4%2Fn41Q5j%2BbjpNGvm49THXs0HyeNfqF8VKO2TkZtW7M8HLPPl%2FVHvA5H7k%2FE8u7r3fdoFu9huDfR0bGO%2FiJxvKUIDH8GUg8WPCxv8%2B5t3r3Nu7d593%2BYd%2FDPqEjB2ZgYNddxO7bTsx33rtn23Y7veY1ev9PuuO8cx3ccEz3UbUP2Cf4r9%2F8o8beMzloJF97jkP3h9ng0u4qS8ubzKkjCEbluucPHDyyhH8S3wXu8%2Fht1QB2%2FMRAAAA%3D%3D)
- [Test sending.dev/email example.com/send](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI9ib2oC%2F%2B1WbW%2FiOBD%2BK5alftokJIEAzWk%2FoGt7V%2B2y1227d72rEDKJCS7OC7YTXirut%2B84hAItLVfpPuxKfHISz8wzz8zjcR6xonHGiaLYf8SZSAsWUnEZYh9LmoQsiayQFth42vpCYjDFN6tN2JBUFCygpQuNCeObb7u26Fzvok6uRjRRLCCKpQkYF1RI%2FeQ7BuZplH4THJxGSmXSr9W2sqjpXbn%2BYsZEjC1Z6BxCKgPBsjKgj6%2FyAWdyRCUCJHT26bJroCCXKo1Rt3P5GV1c%2F9FFJAnRzdUFEjRIRShhneRM0BCpFGkERDZ5wteSGZoyNUIVHUunTgQjA07PdvDDMYsdA%2BnFXS11H3ViskgTdHN%2BU2YEMGOaSDRMRZllmAJA8gukEUEQv7RbPaN0WFpUtBE0AbJSc13meRIA2U90fla6v2iaNrimIfAK1D4TY13LPB5QYUEnAsotkmXgO0qluq6Kgv0h4ZIauKoW9u8fcSTSPCvbrimCh5pnut2%2Fful0z6sA8HpSluPE6q8ojqnOPEtZouRturWvF4uUVZJUWkFahlSghXrTtpfG%2BwDdA4Du%2Fw1YPwBYfx%2BglttQpFug3bsNYnXMtjCGlIYDEoxNGavMOllJ5%2BQFWiZYKrR4fMd%2BBzYclO4LdJkNr3NOQQyYJQHPQ%2Brvwi17SwPDO%2B1vZNODw7oWIp0RGD20Sq0KrhUJb2U2fVb6rKv%2FlBcEyYggsdQzax3ufidebx3wfhWxV4V8JVypQb1HGiOPhyIoZjzIA3c2WRTRRIyyyFWNRXPxsDZ2tfGgFbtjNRHTWUIGuTcXw2I0kQ%2FhuJ6dzpxgujaua%2BPgdNJMFpks5nFI87YaRYOx4NPhQ6Nw596MaONV20ouuTmlUpkO1kVkUZIK2pewEpULaIkSORzHOOeK9cmUbD6FQR%2FOL59DzSXsQiw4qs90m6zm8iGuW4K2qraERJH%2F4vm21A3cDwPdO6bl1mgE7abt1U3PHjTNhtMcmIQ4jhm0HK%2FttWyvRb2tC2jP3bTvCtqVE5VST02ib5YOn5K5xEst%2Bv2FOdTX1wtz0PPnLswhDb9emIOeP1lhymlcVUX7P6O7O46fDvNbBHdH8w9G9%2Fbu9k2%2BxUe4DRy09x5A%2FxLO11yB6o%2FCrmfAbXQcjsfheByOx%2BF4HI7PhiP8jUpS0LBPtKlru03Tbpu2e%2Bt4ft323bp16rrtlv3Btn3b1gygiSvCj%2FDHuv2vivOrbjT%2B68Nnd5ZF%2F3jJ2cXpefNr7c%2B89bez%2BL05rV3ZvPv1N87uHqKPePkdGHyQ1JMQAAA%3D)
- [Test sending.dev/dmarc example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOtib2oC%2F%2BVU72%2FbNhD9VwgCBTbUciTZkh0VAdYlwH4UaY0sbRMEgUGLZ4sxRcokJVsO%2FL%2FvaEd1svnTvu6TSN473rt3T3ymDspKMgc0e6aV0Y3gYP7gNKMWFBdq0efQ0N6P0GdWIpT%2BdQhiwIJpRA77FF4ykx%2FP3mLJ1fXHm0sy0VLkLYIaMFZoRbOoR6Ve6K9GIrhwrrLZ2dmr6mc%2BaruTAGss%2B7bxtTnY3IjK7a%2Bhk3omhS3AEkZKrYTTxuO1ku1L7Wpfm%2FxUXSit4OceMbCqhQFOZi35rWRCEqY4uWeF1mSuDZnVckl8YeTa95yZEWwm4epN4c%2BadAGbEVdAV0hYvEFIR%2BZGl%2FsA11hFEeEsyLm%2F0bYqR%2BKfoL3ah%2F4lvAfcAEeWuTsF6XW61OUMTB9VzUH2WVVhbqGtu3lpkWZzJi30KF6kDbc0e3imrq38hG7vbl%2FQuJl2U%2BTMMdw3F3vxog%2FkINsHYmp24cVyOqswp2TWgfnl3aG3d5jpHI5ykIZhj4JFfk4wP9sv6mNVST97t3GXWs1RJHfNXF4g%2F2vNPZWJgbnYnIa8xI6U6O5x16NbJDU9dvWIzDudYMPQ3dDPdXlsEFcLo%2BtqKjp8xQwrrf8DusyHN6mPXe4D9Wu%2BFGXkN2xYJJKbvNnIvM7jzWrbLFamqBaxG27T7VMHjj14NirjpVuZ9UaxWZ20Zt4UK%2FvEl4PqfBPl6w488OD8fJWqbWWbtuRQj12xmC2NXM%2Bfhk3cJhvmwQYWe%2F8h1zpYg3VBRL0eYqG0ganFL3O1QVWdqXHwZS2dmLI1Ox7xfMr8SFA%2Bi1G865%2BmUId%2F%2BL%2Ba4u0AXvliynOvt%2FDPBrBkkEI6DkYQJcFwmITBeRQPg3TEBgBxmg5G8OoJOvE6nXqEjtM%2B5cHd7rGHo%2F8ftYuOsawBPmUeF4dxGoTjIIxvoyQbRFmS9MdRFEfD92GYhaGnj5Y69P%2BMrnrtJzq6u7%2BcFMWXybiw6v7bfft7%2Bmf0rbmE78v1p%2FWvKnTl3bnQ72%2B%2F5xd09zcbk%2BhUZQYAAA%3D%3D)
- [Test sending.dev/dmarc example.com/send](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEVjb2oC%2F%2BVUYW%2FaMBD9K5alSpsKISS0alMhDbXTOk1ljDFtbYUiJ76AVSdObSctQ%2Fz3nYEM2Piyz%2FsU2ffu3rt3viyphbyUzAKNlrTUqhYc9EdOI2qg4KKYeRxq2vodGrIcofTrJogBA7oWKaxTeM50urs7xJKbu8H4moyUFOkCQTVoI1RBo26LSjVT37RE8Nza0kSdzh57x0VNc9NGjifP1I6bg0m1KO26DB1ViRRmDoYwkqtCWKUdXhVyseUu19zkTdkvVAFvW0TDcyU0cJIsyIecCUlYwck9mytFMqVJUskn4ohRq%2Bc0My1YIuHmgHioSBMwEbFzaIiEwQpCWpJpla8DXCFLQYQ1IDNX0SyKFIV%2FgsXNOvSX8Q4wBo4qU3sM0mp8qfIEtIeupiA9VpaYO1fGjrct0ihj0kCLYiGluaHR45LaRekmNPkx2aLxEDdT5MwyPNf9tXndK7Kx7YroivWdWVZFJebkzFjQ7042vZ1gprU4yvDc91sUDOqzgrnZfi4GZSnd7O2rvVZFhibZO2bTOeq%2FU9xJGWnIxOtxyDa2k0RX01WL%2FkRR8a6rKSpvfIJXhq8bvFTluwadYXiaaVWVsWhySqZZbtwWNNmPB%2BnTJv9xU8Axi1mhNMQGv8xWGvVbXaHFeSWtiNkL213xNGaueRRqMIpl%2FrS%2F2GzLxn5vK%2FIfZ3DY794YYp661oTb0ixMwwu4zNoBpFm7l12etVkASbubhN0wSXpBAMHexh%2F5GRzb%2BUNzj419tZq20On%2FsW98PIbVwGPmsIEfnLf9i7YfTLpnURhGwZkX9np%2BcHnq%2B5HvuxbA2I0HS3xn%2By%2BMnt8PDYyk7Lw834r3pQkf%2BGRUfw8ubovBQzJ4%2FjIcn46s%2FAjXT326%2BgX1hQ8y4QUAAA%3D%3D)
- [Test sending.dev/inbound example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI5jb2oC%2F%2BVT227bMAz9FUFAnxY7zrWJgQEr1hUrdusl3boWQcBYTCLMtlxJduoF%2BfdRdtyklz%2FYi02Ih%2BThIbnhFpMsBos83PBMq0IK1OeCh9xgKmS69AUWvPXk%2Bg4JQfl17SSHQV3ICKsQmc5Vnor963M0O6%2F97FMCMiZUgdpIlfKw0%2BKxWqobHRN6ZW1mwnb7gEDbeU3z4iWg%2F%2FimcOUFmkjLzFZp%2BIWSqTXMrpAJRUVS9u2WWcUaAkYxmUYqcTY6EkwaJjCWxASFQ5Yq1wyWmFrmunlE47OTLItLptLqw6BJLVDIiJQTBxVCJi2jVFJjREQgjtlOFFaVWyhN7MDucvhOBNAS5jGePutE45KMkJ38uma1XcdRXiS2dY87GU2ZRhf5%2FAuWp1XWV8NzgKsdqbcgrUbYPJmj9kmMCGMfsoxiV8rYK3zIKZhGvIDYYIvYRUoLw8P7Dbdl5mb87XYHJvuDW5hqFBO1XwvPJDbzj%2BpujnxI4K9KYW18Gki1YVJpaUvahqDFraVV6A2DYDvdtjgBcbYvOqW5N23gI9AC4y7JjgBZS63ybCYbfAYaEuOWvIm8fxY6bWLvubNrkhUo99ZorNfhjohcpkrjzNAfbK6pcatzEiTJYytnsIb9k4hm4BaHeBvyUq4XYqX1cTixBFh4KdRT4VdKPWnzUrSZiFyH0t1iZxx0x4PxwFuMIfD6Q%2Bx74%2BGw4w3wGEdR1O0N%2BtHBXb9x8m9f9l5hNIS3EtzNnsRrKA3fbqctUvu%2FaJS2xECBYgYO1g26Qy8YeUF30hmEvX7YG%2Fmj8XF3PHoXBGEQuG6oybr%2FDW3S4Q7xpVkXP9rZ3U3wORvcfS3P%2B6eT5AE%2F%2FuwtLi8m12erh9WqLC7Pisnv93z7DwHNDIq1BQAA)
- [Test sending.dev/inbound example.com/agents](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK1jb2oC%2F%2BVUf0%2FbMBD9Kpal%2FbUkpJRCG2nS2NgmNEAM2NYNVdUlPlqLJM5spyWr%2Bt13zo%2B2FL7B%2Fmld37t3796du%2BIWsyIFizxa8UKrhRSozwWPuMFcyHwWCFxwbxO6goyg%2FLYJUsCgXsgE6xSZx6rMxfb2OZqdN3H2KQOZEmqB2kiV86jn8VTN1HedEnpubWGig4MdAQcuarobPwP9GJiFKy%2FQJFoWtqbh10rm1jA7RyYUFcnZ5ZhZxToBRjGZJypzZ3QimDRMYCpJCQqHrFSpGcwwt8x184QmYKdFkVZM5fUHg45aoJAJOSd2KkRMWkZUUmNCQiBNWWsKq8s9KE3qwLYcgTMBtIQ4xbNnnWic0SFipz9vWXNu8ogXSW3TY2ujqfLkuoy%2FYnVWs74YngPctKJeg3idsWUWow7IjATTAIqCcufK2Bv8U1IyjfgBUoMeqUuUFoZH9ytuq8LN%2BHLcgun83i1MPYo7tV0L32S2CN403bwJIIO%2FKoelCWgg9YZJpaWtaBtCj1tLq9A%2FDsP1ZO1xAuJ0W3RCc%2B%2FawCegBcaWpBVQD9DQ75lWZTGVXVYBGjLjVr3Lv39GMOkY7juKideOooaW%2FhKN9XvciZKzXGmcGvoGW2oyweqSzMnK1MopLGF7JZIpuCWiHgxFiWvPuLx5KBvdAizsO7ep%2FsK6jVn7Lk5F4pqV7nEeQT%2BGgYj9Ub8H%2FtFg%2BOAPe8O%2Bj8NRD0ehCKEX7zz0V%2F4DXn%2Fq%2B5ajoSwrwT3l03QJleHr9cQj%2B%2F%2B3nml3DCxQTMGBD8PDYz8c%2BuHhXW8Q9QdROAp6J%2F3h8OhtGEZh6HqiVhsXVrRfu5vFbf8C7Lfit80%2BP1aD0i6ujj7Eg2KM9sSeXH28GM%2B%2FjOKL22L549c7vv4H%2B6NHytcFAAA%3D)
