### PR TITLE
Add Knockwire sender authentication template

### DIFF
--- a/knockwire.com.sender-auth.json
+++ b/knockwire.com.sender-auth.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "knockwire.com",
+  "providerName": "Knockwire",
+  "serviceId": "sender-auth",
+  "serviceName": "Knockwire Sender Authentication",
+  "version": 1,
+  "logoUrl": "https://knockwire.com/logo.svg",
+  "description": "Authorises Knockwire to send on this domain's behalf by adding three CNAME records: a return path so SPF aligns, and two DKIM signing keys so DKIM aligns. Outreach then passes DMARC as the domain itself rather than arriving via a third party.",
+  "syncPubKeyDomain": "dcsig.knockwire.com",
+  "syncRedirectDomain": "knockwire.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "kw",
+      "pointsTo": "relay.knockwire.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "kw._domainkey",
+      "pointsTo": "dkim1.knockwire.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "kw2._domainkey",
+      "pointsTo": "dkim2.knockwire.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `knockwire.com.sender-auth.json`, a template that authorises Knockwire to send outreach on a customer's own domain.

It installs three CNAME records: a return path so SPF aligns, and two DKIM signing keys so DKIM aligns. Mail then passes DMARC as the customer's domain rather than arriving through a third party.

The template has no variables. All three records point at fixed hostnames under `knockwire.com`, which in turn point at the mail infrastructure. That indirection keeps the provider hostname out of the customer's zone, so changing provider later does not require every customer to edit their DNS.

| Host | Points to |
| --- | --- |
| `kw` | `relay.knockwire.com` |
| `kw._domainkey` | `dkim1.knockwire.com` |
| `kw2._domainkey` | `dkim2.knockwire.com` |

The DKIM selector is `kw` rather than a provider default, so it will not collide with records a customer may already have for their own use of the same provider.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Linter and schema results:

```
dc-template-linter -loglevel info -tolerate info    exit 0
dc-template-linter -tolerate warn                   exit 0
dc-template-linter -logos                           exit 0
dc-template-linter --merge-or-fail                  exit 0
check-jsonschema --schemafile template.schema       ok -- validation done
```

Under `-cloudflare` the linter emits one info-level `DCTL5003` for `syncRedirectDomain is not supported`, which is expected for that provider and not an error.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template

Two notes on the above. The template contains no TXT records, so the `txtConflictMatchingMode` rule has nothing to apply to. And `essential` is not set on any record because all three are required for the service to function: removing any one of them breaks either SPF alignment or DKIM signing, so none of them is safe for the end user to modify independently.

## Online Editor test results

**Editor test link(s):**

[Test knockwire.com/sender-auth example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMphcGoC%2F%2B1US2%2FbMAz%2BK4IuO8xJHLtNUwM7ZE3XpUW7po8dVgQGI6mxEMcyJNmpG%2BS%2Fj8qjafoEdhkK9GaTHz%2BR%2FEjOqBWTPAUraDSjuVal5EL3OI3oOFNsPJVa1JmaUO%2FBeQYTBNOTtRtdRuhSMrEIMyJDUA0Km2w8T2PI5QJFOogSmZUMrFQZ4kuhjfuKmh5N1Uhd6xTjEmtzEzUaWyk1nL9uyhGGcWGYlvmCJKKOVWlphCGbF60iLjWiMmITaQhXE5DZF0OGIoH0lgwrApzLbIRuLQQ5OOucHhItmNLcRATw0xY6IznYhBhFLs9%2FEEjlKDMeAeS1U0W6J71TYtDmaMaiMg64MC6RdfKrsFoAS4irG7mMS7J72rk4IGCccZUXkdYIzErja9gnm0BGQGtZOuZSAuaDVWiOFNpWddfpKmPnxfBEVN0FA%2FaBM8yl%2FlRHB7wQHA3MPkBfAn1P0UajW0iN8OiqEzS6mVFb5U7ORYsQnChjHcfUTYmSmTVXCv%2B1SKF69ry1qGjY8v259zpRPV62AXu4zcnHctL8N87gTdLgDdLB3KP3KhPxpgcDnLl178Qd4Aqtw1bv4ddIqyKP5RqPSsHEuDVbR95shQ7WsTeUuhdxYJQWsRsnwMnDmqwuUIhJkVoZwxQ2Js5iyPO0wgQNepHiuUjZcgUXInGw8L5AHo05c%2FlKt9ditxn6fhjW9loh1HYYb9eGjIc1fz%2BA9l57Z4%2B324%2BuxIsn5PU7semawJXAiwBu7zvpFCpD5y%2FI%2BlDOtqqryt4Zk49RWfBqacGHKG3g4dh%2FDuLnIP73QcTTaqAUPAYHC%2FygVfPbNT%2B88vejcD8KgnoraIXN4KvvR77vqhDGLsuc4SV%2BfINp4%2Bdu%2F%2Fiom6iwcXxv%2BkfD3%2Bq8savuhJ%2F%2BCfqX19V9r3fYvOsXrP2Nzv8CE8SbbmAJAAA%3D)

[Test knockwire.com/sender-auth example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEJicGoC%2F%2B1U227aQBD9ldW%2B9KGGGOMAsdQHEnpFpFEulaoIWYN3glcYr7u7hrqIf%2B8slxBylfrUSHmzZ86cnTlzWXCL0yIDizxa8EKrmRSovwoe8Umukslcaqwnasq9W%2BcpTAnM%2B1s3uQzqmUxwFWYwJ1ANSpvuPPdj2MUKxbqEwtzKBKxUOeFnqI37ihoez9RYXemM4lJrCxMdHOyldOD8dTMbU5hAk2hZrEgi7liVlgYN271oFXOpMZUzm0rDhJqCzN8ZNsIUshs2qhgIIfMxuTUiOzntDj4yjYnSwkQM6NOWOmcF2JQZxS7OPjHI5Dg3HgPitXPFev2vA2bI5mgmWBkHXBnXyDr7XlqNkKTM1U1cxiXZG3TPTxgYZ9zkxaQ1SFlpeo10sinkDLSWM8c8k0D5UBVaEIW2Vd0pXeXJWTnqY9VbMZAOIqFc6vf76IDnKMiQ2FvoY6DjjGw8uoHMoMc3SvDoesFtVbh2riQicKqMdRxzNyVK5tZcKvrXmEH14HlrqaPNlu8vvaeJ6vFaBtJwn1NM5LTxb5zBs6TBM6TDpcf%2FqBzjnQZDmrmtdvgbaIW2YZv3yJfR31irsojlNoa6BVPjVm0bfb0XPtzGX68J3Ms0OEpj7MYKaAKpNqtLasi0zKyMYQ47k0hiKIqsokQNeYnmYbPy9SqSxpsUBVh4uVsej0XiEpduyaGFzc7oEGttbLdqYdA6rMFNo10LWyGEDQF%2Bow13Tsaj9%2BTpo7EvIdKO0IkAdwi62Rwqw5eP9HlX167N90p8YXheT4nB8zUGr6bGoUdb8TajbzP6P88oHWUDMxQxOGjgB62a36n5zUv%2FKAobURDUW4EfhkfvfT%2FyfVcJGrsudUH3%2B%2B7l5k1RhFeByb614Tgbd8pT87lo%2Ffoyb3YHnfaPnz1hr%2FqlP8Ncqw98%2BRcpLN2rngkAAA%3D%3D)

Apex test produced:

```
kw.example.com.             CNAME  3600  relay.knockwire.com
kw._domainkey.example.com.  CNAME  3600  dkim1.knockwire.com
kw2._domainkey.example.com. CNAME  3600  dkim2.knockwire.com
```

Subdomain test with `host=mail` produced:

```
kw.mail.example.com.             CNAME  3600  relay.knockwire.com
kw._domainkey.mail.example.com.  CNAME  3600  dkim1.knockwire.com
kw2._domainkey.mail.example.com. CNAME  3600  dkim2.knockwire.com
```
