### PR TITLE
Add eldhorn.com.website.json (Eldhorn custom domain, single CNAME)

### DIFF
--- a/eldhorn.com.website.json
+++ b/eldhorn.com.website.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "eldhorn.com",
+  "providerName": "Eldhorn",
+  "serviceId": "website",
+  "serviceName": "Eldhorn Website",
+  "version": 1,
+  "logoUrl": "https://eldhorn.com/assets/eldhorn-mark-128.png",
+  "description": "Verbindet Ihre Domain mit Ihrer von Eldhorn erstellten Website (mit automatischer SSL-Verschlüsselung).",
+  "variableDescription": "",
+  "syncPubKeyDomain": "eldhorn.com",
+  "syncRedirectDomain": "eldhorn.com",
+  "hostRequired": true,
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "sites-fallback.eldhorn.com",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Eldhorn website template: one fixed CNAME to `sites-fallback.eldhorn.com` under the protocol `host` parameter (typically `www`). Used with Cloudflare for SaaS HTTP DCV so this single record enables routing and SSL.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (we use `redirect_uri` in the sync flow)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` N/A (no TXT records)
- [x] no bare variable as full record value
- [x] no bare variable as full host label
- [x] no variable used in host to create a subdomain
- [x] `%host%` does not appear in any host attribute
- [x] `essential` set to `OnApply` on the CNAME

## Online Editor test results

**Editor test link(s):**

[Test eldhorn.com/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK%2FHcGoC%2F91TW2%2FaMBT%2BK5GfNo2AQyFtI01a11ZT1bVbW3ZlKHKcA1h17GA7YRTx33dMCgW1e9jrnqxz%2BY6%2F71yWxEFRSuaAJEtSGl2LHMxFThICMp9qo9pcF6S1DV2zAlPJeRPEgAVTCw5ryBwyK7DU1rufHXzbxmswVmhFkqhFpJ7oL0Zi3tS50iadzs7XHWYtOLtxhQUz92HUPWqXaoJ1crDciNKta5GvYDKhcnDBxdRAcKYLJlRQiMY2Qa1VsOGCBBxI6WBLK3jlM1nlEOaE5VNE3N19DLEqGvJXRemYIxtZqcnrthfBjGCZhLM9El79QvHPVXYJi4bCs276hFvIhQHu%2FpIy1dbdwqzCHGytMxU0sPdS83uSjJm03jNl6%2FijifW0yS1JhkviFqXv%2Fen1ydX5Yz003%2FlZaqGcHWg0vW4bIlpmjN%2B39yk4h0M5iCltEUDdygnmp%2FRJnZSlXJDVaNUiD1pB%2BvTtCEey1fOb4WrBjh6%2FIvM5GhOjqzIVG0jJDCus38ANeLiHHm3gwzXe%2FysmShtILb7MVQY2LSoq6UTK5uzJlfOUecJI02IUqzzvjmoWtWGXM8f%2BoTdpzj114S%2BAcX7YP4774fE4i8Pe8REPM8ogBEp5nrMsinr9nWt64dBevqe97r04jNWoha38P5Xh%2FC2rIU%2BZT%2B3SbhzSo5AeDKI46fcSetiOe93%2BQe8NpQmlXgNY12hd4q7sbgnp1EgVbmZXEYrv3sBscFnPTos%2BO4zGHx5m36%2Fic0T%2B%2BDkf87dk9QfqoHILIAUAAA%3D%3D)

(`hostRequired: true`, so apex-only test is not required. Tested with domain `example.com` / host `www` → CNAME `www.example.com` → `sites-fallback.eldhorn.com`.)

## Provider / service

| Field | Value |
| --- | --- |
| providerId | eldhorn.com |
| serviceId | website |
| serviceName | Eldhorn Website |
| syncPubKeyDomain | eldhorn.com (public key TXT at _dck1.eldhorn.com) |
| syncRedirectDomain | eldhorn.com |

## Contact

Manuel Schneider · kontakt@eldhorn.com · Eldhorn
