### PR TITLE
add XORAI, XORAI Website

### DIFF
--- a/xorai.com.domain-connect.json
+++ b/xorai.com.domain-connect.json
@@ -1,10 +1,10 @@
 {
   "providerId": "xorai.com",
   "providerName": "XORAI",
-  "serviceId": "website",
+  "serviceId": "domain-connect",
   "serviceName": "XORAI Website",
   "version": 1,
-  "logoUrl": "https://xorai.com/logo.png",
+  "logoUrl": "https://agentic.xorai.com/logo-light-bg.svg",
   "description": "Connects your domain to a website hosted on the XORAI platform and lets XORAI validate and issue a TLS certificate for it automatically.",
   "variableDescription": "RECORD_VALUE is the ACM certificate-validation value XORAI generates for your domain at connect time; it is prescribed by AWS Certificate Manager and cannot carry a fixed prefix.",
   "syncRedirectDomain": "api.xorai.com",

--- a/xorai.com.domain-connect.json
+++ b/xorai.com.domain-connect.json
@@ -1,22 +1,22 @@
-{
-  "providerId": "xorai.com",
-  "providerName": "XORAI",
-  "serviceId": "domain-connect",
-  "serviceName": "XORAI Website",
-  "version": 1,
-  "logoUrl": "https://agentic.xorai.com/logo-light-bg.svg",
-  "description": "Connects your domain to a website hosted on the XORAI platform and lets XORAI validate and issue a TLS certificate for it automatically.",
-  "variableDescription": "RECORD_VALUE is the ACM certificate-validation value XORAI generates for your domain at connect time; it is prescribed by AWS Certificate Manager and cannot carry a fixed prefix.",
-  "syncRedirectDomain": "api.xorai.com",
-  "syncPubKeyDomain": "xorai.com",
-  "hostRequired": true,
-  "records": [
-    {
-      "type": "CNAME",
-      "host": "@",
-      "pointsTo": "%RECORD_VALUE%",
-      "ttl": 3600,
-      "essential": "Always"
-    }
-  ]
-}
+  {                                                                                                                                                                                                                       
+    "providerId": "xorai.com",                                                                                                                                                                                            
+    "providerName": "XORAI",                                                                                                                                                                                              
+    "serviceId": "domain-connect",                                                                                                                                                                                        
+    "serviceName": "XORAI Website",                                                                                                                                                                                       
+    "version": 1,                                                                                                                                                                                                         
+    "logoUrl": "https://agentic.xorai.com/logo-light-bg.svg",                                                                                                                                                             
+    "description": "Points your domain at your website hosted on the XORAI platform.",                                                                                                                                    
+    "variableDescription": "RECORD_VALUE is the XORAI endpoint hostname your domain will point to, issued when you connect the domain.",                                                                                  
+    "syncRedirectDomain": "api.xorai.com",                                                                                                                                                                                
+    "syncPubKeyDomain": "xorai.com",                                                                                                                                                                                      
+    "hostRequired": true,                                                                                                                                                                                                 
+    "records": [                                                                                                                                                                                                          
+      {                                                                                                                                                                                                                   
+        "type": "CNAME",                                                                                                                                                                                                  
+        "host": "@",                                                                                                                                                                                                      
+        "pointsTo": "%RECORD_VALUE%",                                                                                                                                                                                     
+        "ttl": 3600,                                                                                                                                                                                                      
+        "essential": "Always"                                                                                                                                                                                             
+      }                                                                                                                                                                                                                   
+    ]                                                                                                                                                                                                                     
+  } 

--- a/xorai.com.website.json
+++ b/xorai.com.website.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "xorai.com",
+  "providerName": "XORAI",
+  "serviceId": "website",
+  "serviceName": "XORAI Website",
+  "version": 1,
+  "logoUrl": "https://xorai.com/logo.png",
+  "description": "Connects your domain to a website hosted on the XORAI platform and lets XORAI validate and issue a TLS certificate for it automatically.",
+  "variableDescription": "RECORD_VALUE is the ACM certificate-validation value XORAI generates for your domain at connect time; it is prescribed by AWS Certificate Manager and cannot carry a fixed prefix.",
+  "syncRedirectDomain": "api.xorai.com",
+  "syncPubKeyDomain": "xorai.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%RECORD_VALUE%",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for XORAI (`xorai.com` / `domain-connect`). Single CNAME record used to complete AWS ACM certificate DNS validation when a customer connects their domain to a website hosted on the XORAI platform.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://agentic.xorai.com/logo-light-bg.svg`, verified 200 image/svg+xml)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`xorai.com`) — public key published at `_dcpubkeyv1.xorai.com`
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`api.xorai.com`), matches the domain used in `redirect_uri`
- [x] no TXT record, no SPF content
- [x] N/A — no TXT record requiring `txtConflictMatchingMode`
- [x] no bare variable used as a full record value — `pointsTo` is `%RECORD_VALUE%`, a bare variable, but it's exempt per the rule's own exception: the value is prescribed entirely by AWS Certificate Manager (the ACM DNS-validation CNAME target) and cannot carry a fixed prefix
- [x] no bare variable used as the full `host` label — `host` is the fixed literal `@`, not a variable
- [x] no variable used in `host` to create a subdomain — `hostRequired: true` and the standard `host` parameter is used instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] N/A — no record the end user needs to modify independently; the single record is the ACM validation token itself, marked `essential: Always`

Linted clean with `dc-template-linter` (`-loglevel info -logos`, no findings).

## Online Editor test results

Tested with `domain=example.com`, `host=_25cf8e2c4605b44696233e55235bc80e` (representative ACM validation host), `RECORD_VALUE=_b2c294dd21e5a07c9a61dbded1322250.jkddzztszm.acm-validations.aws.` — resolved to the correct single CNAME record `_25cf8e2c4605b44696233e55235bc80e.example.com. -> _b2c294dd21e5a07c9a61dbded1322250.jkddzztszm.acm-validations.aws.` with no host-label doubling.

[Test xorai.com/domain-connect example.com/_25cf8e2c4605b44696233e55235bc80e](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAATgcWoC%2F91UbW%2FaMBD%2BK5GlfSIJhgZKI00aKp1abWsZ69tUochJTPAW7NR2SDPEf985KSUp3bTP%2BwS%2Be%2B7luecuG6TpKkuJpsjfoEyKNYupvIiRj56EJMyNxArZL45LsgIgur%2BajS%2FArKhcs4hW8FisCONOJDinkd47myHWHQ0Vg1o2WlOpmODI79koFYm4kSmgllpnyu92SUK5ZpH70kPXYJyUJUvthImr1gnkiKmKJMt0lQdNBeNaWaXIpVU3YxFdP4u6rLUUStPYEtzSS2rVLRnyCyFXrmmKSEbClE5aiWdnp1ezSXA7%2FnxzZjHViKU8zkzVKjEHoq3qBUtTq%2FZrYUOkyqF4saTcwKznSVXp6gjTgip5NKMxk%2BCaVFbogGTMbcphQNM8%2FETLF0jTbbqZ0ccckoAyWubURpBPyFgh%2F2GDdJkZSU4vx1%2FOnuHw%2FGB0rmZ4LeD5rkn7Hfi0BoWOhhjbiCpl9CFGsnFakFKh7Xxro1%2BC02BfaW4%2FbwXA6BOBPaONDsFYFAU8EinyLGC7kIxIslJmHXfBD63o%2BS78oYqHZ7NTYz7YHmSaYwkXkgYKfonOJd1NZpWnmgWkIHtTHAUky9ISuCjwQs7DqfF6r2sKMdHE6HRQuDW2II4MLWbOZbTAwyEZLJxw5GHH649CZxQeHzm4N4i9wcIbHFHSOLyDi%2Fzr6bXG%2B5ZY27kNo%2F7vSMEuKLKmcUAMso%2F7QwePHOxd9%2Fr%2BAPu9vntyjL0Tr4Oxj7HhQZWuaW6q%2F9XaVR05r%2BqDffd1qEDtnXtzSP%2B8%2B2bvt%2BZEzbK9eaJ7XdxGMretxB%2F1gtvcmuGmQASGY4juBv%2BaJuCaF4K6OLw9L2%2B%2Bff05na6%2FP04vriPS6fNL70fnfjkr4%2FvOJLv7eP44GRfv0fY3Nw2BfE4GAAA%3D)

hostRequired is true, so an apex-only test was not required per the PR template's own exception.

We'll follow up with a direct email/Slack contact for onboarding once this is reviewed.