### PR TITLE
add 10ashara, 10ashara LMS (lms-subdomain)

### DIFF
--- a/10ashara.com.lms-subdomain.json
+++ b/10ashara.com.lms-subdomain.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "10ashara.com",
+  "providerName": "10ashara",
+  "serviceId": "lms-subdomain",
+  "serviceName": "10ashara LMS",
+  "version": 1,
+  "logoUrl": "https://cdn.10ashara.com/home_logolight_filehome-logolight-fileashara-logosvgwebp.webp",
+  "description": "Connect a subdomain to 10ashara LMS. Configures routing and ownership verification.",
+  "variableDescription": "verification-token: Unique subscription verification token. edge-host: Edge hostname for your package tier.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.10ashara.com",
+  "syncRedirectDomain": "10ashara.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_asharamulti-verify",
+      "data": "%verification-token%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%edge-host%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `10ashara.com.lms-subdomain.json`, the subdomain counterpart of the already published `10ashara.com.lms` service.

10ashara LMS customers connect either an apex domain or a subdomain to their LMS instance, and the two shapes need different DNS:

* **apex** (`10ashara.com.lms`, already in the repo): `A @ -> %ip-address%` plus `CNAME www -> @`
* **subdomain** (this template): a single `CNAME @ -> %edge-host%`, where `%edge-host%` is the edge hostname of the customer's package tier

Both templates publish the ownership verification record `_asharamulti-verify TXT`, which the platform reads back to confirm the subscription owns the name before the LMS instance is bound to it.

`hostRequired` is `true` and every record stays at host `@`, so the Domain Connect `host` parameter places the records under the requested subdomain — no variable is used in a `host` field.

**Justification for the bare variable value (checklist item 6):** `_asharamulti-verify TXT` carries the raw subscription verification token with no fixed prefix. The label itself (`_asharamulti-verify`) is service specific and cannot collide with another provider, and the token is compared byte-for-byte by the platform verifier that is already live for the published `10ashara.com.lms` v2 template — adding a prefix here would break verification parity between the two templates. `txtConflictMatchingMode: "All"` is set so re-applying the template replaces a stale token instead of leaving a duplicate.

Signing key: `syncPubKeyDomain` is `domainconnect.10ashara.com`; the RSA-2048 / RS256 key is published at `_domainconnectkey.domainconnect.10ashara.com` (records `p=1` and `p=2`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checklist:

* item 6 — the verification TXT uses a bare `%verification-token%`; the justification is in the description above.
* item 10 — both records are fully service managed (routing CNAME and ownership token); there is no record the customer is expected to edit or delete on their own, so no `essential` flag is needed.

## Online Editor test results

**Editor test link(s):** <<< https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACDccGoC%2F%2B1Ua2%2FaMBT9K5alfhoJ4bHSRpq0vjS1G1XV0qlbhSLjXIjbYGe2AwXEf991wiNQtM%2FTNCGF5N5zH%2Beeay%2BohXGWMgs0XNBMq4mIQV%2FHNKSNgJmEaeZzNaa1je%2BWjaHiRY8BPREciqB0bDyTD2I1ZkJufXtB5Fv3AZ0T0EYoScNGjaZqpB51iqDE2syE9TqPpV%2FtoZ6oMUQOl4pRYqOhSMGZvI3Jc6YyoDCayWgKg8x3DywXg%2BFaZLYoSS%2BUlMAtYWTTL7GKVFv0CYKGYpRrMESr3Ao5IkzGRE0ltp6IjCAFMRScuaS%2Bo8S0YIMULndqVVGeVa8gQ%2FIoxa8cXPENcicbKXA%2BgXgEXqKMDckVvhL3KnGcZKg0malck4zxV4YeK0C7HsxM8vNU8VcaDllqoLTc5YOvMLsshQlpyZiXQ%2FD3tHb4e4iFRt8mYg%2Fj%2BriHXzmCUHirc6yDeKVjQ8PnBbWzzEnee%2BqtwPgRlRnGeWqFV5CdOV2YZeg8ej%2BlI%2FTaN%2BtUSAW3XWZ5ghp0VexSn6Wp81tcmlYQLGubmhe3Z92rbdXPbnuVkNb0lKuzmehRNby%2FrNG5khBtSfRrqzFhFLwxPCdQIe9Gctr0G%2B6HphEuSBaJdWDmeBp3qNYpnndy9NdJnitZ%2BrUDq%2BIgFowtPxCy6b%2FIiR%2B78jkiYiSVhsjgP7O4vmuBislHbMq2pphHLMvSGfI26MWc%2B%2BLJ8vAeEM%2BvDmAl47bV7XBrNIq5m4Vwd0SrE7SP2wPwoNXqeO0OB%2B8EWNtrNk6H7LjdaAUsqFw4hy6jP105B7QBY0BawdJia6ZsZujywL6siB4g9X7Kfzm5fg2X8L%2BQ%2F4CQeOANm0AcMYdvBs1jLzjxglavcRI2G2Ez8Funx0En%2BBAEYeA6crqVbBd4E1TvAPpjeDdX8%2FN5ffry8jC4uYnj4Zfv7Z%2Bsfn3DY87ZEz97yF%2FSj0ly%2FYkufwPSDn5CHAgAAA%3D%3D >>>

Tested with `domain=example.com`, `host=lms`, `verification-token=testtoken`, `edge-host=edge.10ashara.com`.
`hostRequired=true`, so an apex test is not applicable.
