### PR TITLE
add AskSoma, Website hosting

### DIFF
--- a/asksoma.ai.hosting.json
+++ b/asksoma.ai.hosting.json
@@ -1,0 +1,28 @@
+{
+    "providerId": "asksoma.ai",
+    "providerName": "AskSoma",
+    "serviceId": "hosting",
+    "serviceName": "Website hosting",
+    "version": 1,
+    "logoUrl": "https://asksoma.ai/AskSoma-ai_Logo.png",
+    "description": "Connects your domain to your AskSoma-powered site: an alias record pointing the domain at the AskSoma edge, plus a TXT record proving you control the domain. The TXT record can be removed after verification completes.",
+    "variableDescription": "%target%: the AskSoma edge hostname this domain aliases to (e.g. ssl.asksoma.xyz). %token%: the per-domain ownership-verification token issued when setup starts in the AskSoma dashboard.",
+    "syncPubKeyDomain": "asksoma.xyz",
+    "records": [
+        {
+            "type": "APEXCNAME",
+            "host": "@",
+            "pointsTo": "%target%",
+            "ttl": 600
+        },
+        {
+            "type": "TXT",
+            "host": "_asksoma-verify",
+            "ttl": 600,
+            "data": "asksoma-domain-verification=%token%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "asksoma-domain-verification=",
+            "essential": "OnApply"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **AskSoma** (`asksoma.ai`) — connects a customer's domain to their AskSoma-powered site. Two records: an alias at the apex pointing the domain at the AskSoma edge (Cloudflare for SaaS custom hostname target), and a prefix-scoped ownership-verification TXT record that the user may delete once verification completes.

Apply URLs are generated exclusively server-side by AskSoma and are digitally signed (RSA-SHA256 per the spec's "Digitally Sign Requests"); the public key is published at `_dck1.asksoma.xyz` in the spec's chunked TXT format (`p=N,a=RS256,d=…`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated locally with `dc-template-linter -loglevel error -tolerate info -logos` (exit 0) and against `template.schema`.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `asksoma.xyz`; the signing public key is live in DNS at `_dck1.asksoma.xyz` (chunked `p=N,a=RS256,d=…` TXT records), and our service signs every apply URL
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — not set at all
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A: the template does not use `redirect_uri`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the only TXT is a service-prefixed verification token
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — the verification TXT uses `Prefix` with `txtConflictMatchingPrefix: "asksoma-domain-verification="`
- [x] no variable is used as a bare full record value unless necessary — the verification TXT embeds `%token%` behind the fixed prefix `asksoma-domain-verification=`. The one bare variable is `pointsTo: "%target%"` on the APEXCNAME. Justification: the template is signature-gated (`syncPubKeyDomain`), and apply URLs are minted only by AskSoma's backend with the current edge hostname (e.g. `ssl.asksoma.xyz`), so the value cannot be attacker-chosen; keeping it a variable lets us migrate the edge hostname without a template version bump that would strand connected domains.
- [x] no bare variable is used as the full `host` label — no variables appear in any `host` field
- [x] no variable is used in the `host` field to create a subdomain — subdomain installs use the protocol's `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — set on the verification TXT, which users are told they can delete after verification completes

## Online Editor test results

**Editor test link(s):**

[Test asksoma.ai/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL4AcWoC%2F%2B1VXW%2FbOBD8KwSBAD2cJau24zgCClyQ9qHX5gOtiwYIAmEtrSXCEimQVGw58H%2FvUpYtpQnae7wD7skUd4e7Mzukn7jFoszBIg%2BfeKnVo0hQf0x4yMGsjCrAB8EHx8g1FJTJL8zqK8UoYFA%2FihgbRKaMFTLtdtvs77gwwiLr4o%2BojVCSh28HPFep%2BqZzh7e2NOFw2FUetoU8ENFnyvPLBp6gibUobXMEv1RSYmwNq1WlWULpQjKr9p%2BHA0q1Ro0Jc42EDCSDXIBhGmOlE1YqIV1rzGZ4OAFs89UewDBJccDKvDIM2PxufoQ6ZQhJ1VispNUq753iszmte%2BkxlV4gfRXqkdqBpUXNSA6xFDE4QnQIDQQtGt8JBVrAIsf3zxifWNAp2pPwRYeNxpJkp4gwRyqOKxonyhv0U58Zk%2FsHlTf19g%2BfnVi1QtmeWKL2WqhaS5pVJkrvWZNNNhPGVERindHaoK1KZqgzmoQbQK%2BzBEy2UKATR8nUMr6tFp%2Bwft%2BU6FmNWqGEvVKGh%2FdP3NZl47fbD3eX1xdXHyjsGNLWX86VbmxmrnqS0K61ZKZpEOwGRzwNoENGbbk9o7qHIGeBha6hVoRn1N%2B1SjnYxpL3lrmI7RXYOCMbXKnE1bvVuBSb11Pa2K%2BLEBSNQTIluJtxIy%2FKMq%2F57mE34FslMepEeqCuD0LiBpx5fPJQx5dWqVZVGYlDfgkaCuNu%2FAF5%2Fwz6cMDec7feS%2Bu%2BfvJNE3RquFiBm2q73ZQ4myRiUm1Op8tVXCV1oafZpl6tuOtdpFJpjAz9gq00aWV1hQNeVLkVEayh20riCBxpomooSiVe94PcPzLOD%2B30fu6yP%2BAoiR1v4d6r08Vsdj46X3qAydibxOOpB0kM3mR6fjaJFyNYwKT39r18FV9%2F%2FDrZ%2ByO8yNdQG7574cq2%2F5eu%2FAde%2FK3m%2FwrqR%2FfuHgZkv%2F%2FH%2BJ8fI917A%2FT%2FFYHLGwWjqRfMvGA8HwXh6Vk4nvij2dtgOvozCMIgcO2jsXshnugV6N9%2FbrbzBPOPRXZT%2F51%2FP1vLzJrh7WUhr%2BX4S3WeDicqvZvOTiGI3%2FHdD%2FxNiZuxCAAA)

[Test asksoma.ai/hosting example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMIAcWoC%2F%2B1VYW%2FTMBD9K5alSSCaLN3aLouExBgIENuYRAeIaYquybW1msbGdtqmU%2F875zRt020CPiLEp9Y%2Bv7t7716v99ziVGVgkUf3XGk5EynqDymPOJiJkVPwQfDWNnIFU3rJz8zkM8UoYFDPRIIVYiyNFflod1u%2F%2FooDIyyyXXyG2giZ86jd4pkcyRudOby1ykSHh7vKh3UhD0R8Qe98VcFTNIkWylYp%2BLnMc0ysYaUsNEvpuciZlevjJoGSc9SYMtdIxCBnkAkwTGMidcqUFLlrjdkxbjKArU51AobpCFtMZYVhwPrf%2BluoU4aQVI0lMrdaZo0sPuvT98bzhEoPkE5TOaN2YGhRM5JDDEUCjhAloYGgReM7oUALGGT4Zo%2FxgQU9QnsQPeqw0jgn2SkizJaK44rGifIM%2FZHPjMn8jcqLcvncZwdWTjCvMyrUXg2V85xmNRbK22uyes2EMQWRmI%2Fpu0FbKGaoM5qEG0CjsxTMeCBBp46SKfPkuhh8xPJNVaJhNWqFHqyVMjy6vee2VJXfrt9%2BO786u3xLYceQrl45V7qxmb5sSEK31pKZekGwam3xNIAdMq7LrRmVDQQ5CyzsGqpF2KP%2BslbKwRaWvDfMRGIvwSZjssGlTF29a41DsXj6SR37dRGCojFIpgT3y%2FiUnymVlXx1t2rxpcwx3ol0R11vhMQFOPP45KEd3%2Fl8ToeRloWKxQaiQMPUuB%2F9Bny7h77bwG8rPB3XAruLB%2B6pgk4TF5violguFwrDTio6xaLbG06SIi2nujdelJMJdwzEKJcaY0OfYAtNilldYItPi8yKGOawu0qTGBx1ImwoSiWedkW%2BXjXOFfUMH3bZHHOcJo66cFvrKEjCbhiCF8Ixep3uadsLEU%2B9Dg7DMDw9aXfgpLEBH%2B%2FGp1fgnvjNWZ5lcygNXz2yZ03hgT39dYY%2FMOZvpf9bFNi6eXXXIi%2F%2BH%2Bg%2FNFDaBQbony0GWzVy1POC0AuO%2B0dB1D2JjkO%2FF4ado%2BBFEERB4BigsWst7mkzNHcC7x7O2jdXyy%2BfbSZhNuq%2Bvnz3%2FsegOL9YZnIC8L7daSefvr9o3wySl3z1E%2Fe7jUDLCAAA)
