### PR TITLE
add OpenCartAudit, Free scan domain verification

### DIFF
--- a/opencartaudit.com.domain-verification.json
+++ b/opencartaudit.com.domain-verification.json
@@ -8,7 +8,7 @@
   "variableDescription": "verificationToken is the unique, time-limited token generated for an OpenCartAudit free scan request.",
   "syncBlock": false,
   "syncPubKeyDomain": "opencartaudit.com",
-  "syncRedirectDomain": "opencartaudit.com, dev.opencartaudit.com",
+  "syncRedirectDomain": "opencartaudit.com,dev.opencartaudit.com",
   "logoUrl": "https://opencartaudit.com/opencart-audit-og.svg",
   "records": [
     {

--- a/opencartaudit.com.domain-verification.json
+++ b/opencartaudit.com.domain-verification.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "opencartaudit.com",
+  "providerName": "OpenCartAudit",
+  "serviceId": "domain-verification",
+  "serviceName": "Free scan domain verification",
+  "version": 1,
+  "description": "Adds the temporary TXT record required to verify control of a store domain before an OpenCartAudit free security scan.",
+  "variableDescription": "verificationToken is the unique, time-limited token generated for an OpenCartAudit free scan request.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "opencartaudit.com",
+  "syncRedirectDomain": "opencartaudit.com, dev.opencartaudit.com",
+  "logoUrl": "https://opencartaudit.com/opencart-audit-og.svg",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_oca",
+      "ttl": 300,
+      "data": "opencartaudit-verification=%verificationToken%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "opencartaudit-verification=",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the OpenCartAudit template used to verify control of a store domain before a free security scan. The template creates one temporary, prefixed TXT record at `_oca` and does not request broader DNS access.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

The template passes the official `dc-template-linter` with the standard and Cloudflare-specific checks. The published signing-key TXT record passes `dc-debug-pubkey` validation.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Apex-domain test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ4LcWoC%2F%2BVUXU%2FbMBT9K5ElntaUtAn9iMQDg4HGYLDRSUioilz7prWa2MF2SkvV%2F77rtKUttOMH7Cm277m%2B59xz4zmxkBcZtUDiOSm0mggO%2BjsnMVEFSEa1pSUXts5UTmpvgJ80xwRyh5BzhJw5CIYN6IlgUKVzlVMh%2FQlokQpGrVByg1jlX2oAzzAqvSXae4fGrXGruFEjHAzToqgiMTnj3Hh2BJ6jrzTVM6%2F32PM0MKU5fp5LoYF7Vi2vnHlMSatV5qnUo56xSsO65gBSt0MSO3K8tCIHrNTCziqWdUeJakEHGVzs0Nnm3VNjkJ5Y0iuleC6h5lmRg5%2BJXNiKlUMMQYKmbo%2F1D5V3vXFqwFhX3cwk%2B5opNiZxSjMDy5P7cvADZheVnAPGOdhv4NgUZg8Daxwm9X3pmRqqPzrDnJG1hYmPjz%2Bg3k786shXw7qZDDF36Ykh8dOc2FnhfEerMDBSxuImUYzizlq8PgwCdJpa%2Bp7dzhydHn3o95G7YWrPlUwzwewttWwk5PBWcVfvXkMqpvshq9g%2F62EmGAPSCup6cCfPiiKbkUV%2FUSOvSkKy0divrSYfcTCl%2BG%2FBqocrubgaalUWiVjjC6ppbtz%2Ft8582kntr3OfiFt%2F0O4CFgfEr%2BbKDxrNMDpptTtd4viJocTxTgx%2BqS01tsNqnEiSl5kVCX2hmyPOEuqEoRyDUbz3vWVy%2Bd%2BuLPvcqP20ts1OOHPKhXsyuikE3QYP%2FGjAG37UTkN%2FEHTBb6etMOIBD1sNvvUIHXylPn%2BGNl7s9XXRr6Ex%2F614HDJDJ8AT6nDNoNnyg44fhL1mI47C%2BKRTb7bb7Vb4JQjiIHCKUOmyH3OcuO1ZI%2BLbw6%2FosbTnV53I3ly%2BPjw%2F3F%2B%2F3uTTcZSXk8uRCY5vrjtXRjfGp2TxF5szpU%2BPBgAA)
- [Subdomain test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL8McWoC%2F%2B1U207jMBD9lcgSTyQlvYdIPHDRrtBegKWsVouqyHUmqZfEDrZTGqr%2B%2B46TFlpolx%2FYp2Q8Z2bOzBl7QQzkRUYNkHBBCiVnPAZ1GZOQyAIEo8rQMuamxWRO3BfAd5pjALlCyDlCTi0E3RrUjDOow2OZUy68GSiecEYNl%2BIVsYr%2FpAAczahwGrTzBo2mtn9h2yUxaKZ4UXtCchrH2jFTcCx9qaiqnNGvkaOASRXj57HkCmLHyCZl5TApjJKZIxOHOtpIBeuaE0ishSS22nGSmhywUnFT1SxblhJVnE4yuNiis8l7JB9AOLyhVwr%2BWILrGJ6Dl%2FGcm5qVRaQgQFFrY%2F195e1sbDegja2uK8HOMskeSJjQTENzcl1OvkB1UbezRzgL%2BwExDoWZ%2FUA3hllrV3gmU3mnMoyZGlPo8OjoHerlxKuPPJm29CzF2EYTTcL7BTFVYXVHqdAxldqgEUlG0TIG03d9H5Wmhr5lt7VHJwfv5n1gM8zNuRRJxpn5Rg2bcpF%2Bk7Gtd60g4fPdkJXvn%2FUwErQGYTi1M7gSp0WRVWQ5XrrkWQqIXnscu6vNRxzMKd4tWM1w1a6eygKtVMmyiPg6pqCK5trewXX0%2FVb4eB1%2F3yQYu%2B93zjoNLopX75fntzvdXn8wDI6J5clTgWseafxSUyoci1G4mSQvM8Mj%2BkRfj2IWUdsgtqXRi3nfSiea%2B2ula60a%2Bli13dw2lY9iZkfA7fsBFHptv514g37Q9XowoF4wGSZe4geTQSdo92HY23iR9j5ZH79J28LsFHo5dlGl%2F1PAtdN0BnFELbbjdwaeH3h%2Bd9Rph70g7A1b3ePhoN059P3Q921X2G0zkwXu4Ob2keqsmqib%2Befju%2Bzx98%2FuWZkd3nbTyxu47essP%2Ff%2FVF%2Fnh8%2Fzp6eb9IQs%2FwJ0XFiZqQYAAA%3D%3D)
