### PR TITLE
add Rekomi, Custom tracking domain

### DIFF
--- a/rekomi.com.tracking.json
+++ b/rekomi.com.tracking.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "rekomi.com",
+  "providerName": "Rekomi",
+  "serviceId": "tracking",
+  "serviceName": "Custom tracking domain",
+  "version": 1,
+  "syncPubKeyDomain": "rekomi.com",
+  "logoUrl": "https://rekomi.com/logo.png",
+  "description": "Connects a custom tracking domain to Rekomi so affiliate click tracking loads first-party from your own domain.",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.rekomi.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Rekomi (rekomi.com), an affiliate marketing platform. The template connects a brand's custom tracking subdomain (e.g. affiliates.example.com) to Rekomi via a single CNAME, so affiliate click tracking loads first-party from the brand's own domain.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (template does not use `redirect_uri`)
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (template has no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) (template has no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (template uses no variables; the CNAME target is the fixed value cname.rekomi.com)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description (template uses no variables)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead (`hostRequired` is true; the subdomain comes from the standard `host` parameter)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (the single CNAME is the entire service; there is no independently modifiable record)

## Online Editor test results

**Editor test link(s):**
[Test rekomi.com/tracking example.com/affiliates](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFQQcWoC%2F91Sa4vbMBD8K0JfE8eK47wMhR7X0oa2x5FHKYRgFHmTE7ElV5KTc0P%2Be9dJfEl6V%2Fq9YDDa2R3tjGZPHWR5yh3QaE9zo7cyATNKaEQNbHQmW0JntPmCPPAMO%2Bn4iGHdgtlKAccBZ7jYSLW%2BlM%2Fd94V1OiM1ThKdcamwbQvGSq1o1MaRUonHYvkFyg8n%2BI8NUr3WM5Ni%2Bcm53Ea%2Bf4H9Cmzlx6sTsMLI3B156b1WCoSzhBPx5hbEaXJSQ6wmfLWSqUQ3iEil2FyaU80TS1bSWOfl3LiSrAySlbowRO%2FUmayF9z9p68bws5AG0BRnCmiiEKFNYmk031NX5kdPHu6%2BfTy34%2FF95bGWytmpxqNQ6FzrRr9zqL3TY%2BywODTpL60gvtAuUHftGjxzfFE4j535X4RZrK2NLvJY1pOoh2e2ev%2BaY35DsqhZ5tc01RZyrbSB2OKfu8JArTcrUidjvuOXUiJinudpiUtbRJHstRfqFJebXRPu%2BD8MadI4EdX6skohZ0HI%2Bv2lNwwT8MLhsOstw3bHWy67XdbvrQZB2LkK9Ouo%2FyXSbxkJ1oJyklepvEt3vLT0cFg00dT%2FVhyGwfItJDGvBgIW9Dw28FhnGgQRC%2FFrVTv0Bw3GIsYqJWDdSeceE3OdFeqPtuCXn2TwHbqMf3Wzz9PnoP1g%2BuNBI50MZsWPojExfldORu%2Fo4TfWYyV%2BqwQAAA%3D%3D)
