### PR TITLE
Wiply Studio, 2 templates

### DIFF
--- a/wiply.us.custom-domain-a.json
+++ b/wiply.us.custom-domain-a.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "wiply.us",
+  "providerName": "Wiply Studio",
+  "serviceId": "custom-domain-a",
+  "serviceName": "Connect an apex game domain",
+  "version": 1,
+  "description": "Verifies a custom apex game domain and routes it to Wiply's managed game edge.",
+  "variableDescription": "ownershipTarget is the Google Certificate Manager authorization target; routingTarget is Wiply's environment-specific game edge IPv4 address.",
+  "syncPubKeyDomain": "domainconnect.wiply.us",
+  "syncRedirectDomain": "platform-studio.wiply.us,platform-studio-staging.wiply.us",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%ownershipTarget%",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%routingTarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/wiply.us.custom-domain-cname.json
+++ b/wiply.us.custom-domain-cname.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "wiply.us",
+  "providerName": "Wiply Studio",
+  "serviceId": "custom-domain-cname",
+  "serviceName": "Connect a game subdomain",
+  "version": 1,
+  "description": "Verifies a custom game subdomain and routes it to Wiply's managed game edge.",
+  "variableDescription": "ownershipTarget is the Google Certificate Manager authorization target; routingTarget is Wiply's environment-specific game edge hostname.",
+  "syncPubKeyDomain": "domainconnect.wiply.us",
+  "syncRedirectDomain": "platform-studio.wiply.us,platform-studio-staging.wiply.us",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%ownershipTarget%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%routingTarget%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds signed Wiply Studio templates for connecting customer game domains through an ownership CNAME plus either subdomain CNAME routing or apex A routing. The bare targets are required because Google Certificate Manager generates the ownership target per hostname and Wiply's edge target differs by environment; every request is signed by Wiply.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (no `logoUrl` is included)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value unless necessary — both targets must be bare because they are exact provider-generated values; signed requests constrain them
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (neither managed record should be independently modified)

## Online Editor test results

**Editor test link(s):**

- [Test wiply.us/custom-domain-cname nocs-online.com/game](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHKAcWoC%2F%2B1U72%2FTMBD9VyxLiA8kWRpKugUh8RshGEJbBRLTVF3sS2pI7GA7rbpp%2FzvnZl3XDsQXPiDBpyi%2Bu%2Bd3753vkntsuwY88uKSd9YslET7VvKCL1XXrJLe8ejm%2FAO0lMc%2Fhwg79b1UhqIO7UIJXBeJ3nnTxtK0oHQsdCi4ybguf2G0RuEZsJoOmOvLIZ0SF2idMpoXo4hLdMKqzq%2F%2F%2BSe0qlLoqGq4Y6%2BYgZbMmt5TivLMG7Zmed%2BxFjTUKId8lDUm4SKwCsoGX%2B5cYpaaCMxVNwVbo2fKMT9H9saYukH2Aq0nDoLEYsdrUMug93Nj1QUEBObXZY%2FXPJSutygbLqgXyhrdovax61AEuC0xNjfOB8kCQ7fS4mNfvsPVy0Gdgg%2BdikG%2B5JY%2FIfcEpbJ0fpMdXK2MbWO3NuomP9oL0AdqYrsP%2BLwx4hsvKmgcRjxQO8HvPd1BPnvb0xldZ6x0vDi75H7Vrb398Oz4FR%2FS6XcGosVYzKFpUNdhFDqjtHdTQ8F7e3Lfo7D3DS8e5ml6Ff0K8%2Bkeyo7YuxjnVxG%2FMBpnW6bn0bWMVKqNcLHRjdKYCNNur6iHsa0JupupTV0HFloX3skG4ewOxPkG42wAof%2B9LkOoyseYT%2FAwnsDROB7nMovLKh3FmUzzyVFVHklZJaNJspkuwt7O3jDPNqlpKgP%2BTv8BfWDn7voa5FC1NhZnjr7ge4sbL9u%2B8WoGS9geSTGDjkpJPUdRgr7rsx6e9J7PybWAEjxQ9M%2B1e8vciM%2BkCGaosHdkLkaizDDODidlPJYgYkD5KIZqlGNVVogjeWuR7S%2B436%2Bw3clA5%2BgJKyAu%2FFmzhJXjVz%2BZ2Gt1dtX4pT1%2FdXPnET2B%2F%2F7%2Fu%2F7TpnGwQDmDkJqlWR6nh3E6nqZ5kWZFlidH%2BXicjx%2BkaZGmoRl0fmj5kvbO7Y3D1aOP9cFzaZcHuOq%2FILxJp4sv5afsdDr%2FutIPzFejLl53i%2FcnVf2EX%2F0Apk%2Fhl6QIAAA%3D)
- [Test wiply.us/custom-domain-a example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIiAcWoC%2F%2B1U30%2FbMBD%2BVyxL0x6WZGna0ZJpEr%2F2g00wGAgeEKoO%2B5p6JHZkO4WC%2BN93biihRdrDnjZpT3Huvvt8d9%2Bd77nHqi7BI8%2FveW3NTEm0%2B5Ln%2FEbV5TxpHI%2Be7IdQEY6fBw878Y1UhrwO7UwJXASJxnlTxdJUoHQMnfcxdNdojcIz0AxqvGUFmVmLJuwMrVNG87wXcYlOWFX7xT8%2FQ6smCh0D1l7xIpwoJbOm8QRSnnnDFmm%2BdqwCDQXKFoyywCRcBVbBVYl7K9eYG00pTFV9CrZAz5RjforsszFFiWwXracsBHWLHSxILYPGT41VdxAYmF%2BEvV%2FkoXTRsSxzQT1T1ugKtY9djSLQdYmx%2FaPZgIGUFp0LWbq5FkfN1Tec77U9ynlbrWj7mDwTKWB%2FoFSW7E%2FoIO3E2Cp2C7We8NGagz5QUMbrhDulEdc8n0DpMOJEbax0PL%2B4535eLwQ93D74SOCpcZ5%2BxyAqjMUUyhJ1gWF2jNLenRpyvlpr7ytye1%2FyvL%2BRpg%2FRE%2Bd2x7e1xrDS2NX4y4eI3xmN4y7Ly%2BixXRSKt0CDjokwVUdPp4Io67Fa4muwULmwDMvIi5XQy2XsBQ%2FntYqCeWUikt4wWRqIoBugdihtUtBoBaKVwgLNKMn6WZJRfNbr81CcKrSxOHb0Bd9Y6pS3DalSNaVXY7iBziTFGGoSknrhyEt8LxXT7Ua%2BVEyCB3L8QR3P5Ij4WIrQRhWeBTmBiRwORDyUVzIe9EUv3hzCKJYi6w%2By0bvNIQ6evTPr78%2FvX5hOS9oaWiwFZRii8gbmjj%2BszdVj1VtdnauN%2FitLuIxoNP8r%2BC8rSCvuYIZyDAGWpdlGnI7idHCabuRplg9GyWav19vsvUnTPE1DEeh8W9897f7zredfj8%2Bl3D2%2BrnH2%2FctbrefnzdHP2l9PRjuf5ODobH%2F7Ttnq7GD7xHzgD78AG50w5%2BMHAAA%3D)