### PR TITLE
Add tjservice.route template

### DIFF
--- a/tjservice.mcroute.json
+++ b/tjservice.mcroute.json
@@ -1,0 +1,26 @@
+{
+    "providerId": "tjservice",
+    "providerName": "TJService Hosting",
+    "serviceId": "mcroute",
+    "serviceName": "TJService Hosting Minecraft Route",
+    "version": 1,
+    "logoUrl": "https://client.tjservice.org/assets/img/logo.png",
+    "description": "Point a subdomain of your own domain at your TJService Hosting Minecraft server via an SRV record.",
+    "variableDescription": "host apply-parameter: the subdomain label to create (e.g. play, or leave empty for apex); %target%: the proxy hostname to point at (e.g. proxy.tjservice.org); %port%: the Minecraft server port to connect to",
+    "syncPubKeyDomain": "tjservice.org",
+    "records": [
+        {
+            "type": "SRV",
+            "service": "_minecraft",
+            "protocol": "_tcp",
+            "name": "@",
+            "target": "%target%",
+            "port": "%port%",
+            "priority": 0,
+            "weight": 5,
+            "ttl": 300,
+            "essential": "Always"
+        }
+    ],
+    "hostRequired": true
+}

--- a/tjservice.route.json
+++ b/tjservice.route.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "tjservice",
+    "providerName": "TJService Hosting",
+    "serviceId": "route",
+    "serviceName": "TJService Hosting Game Server Route",
+    "version": 1,
+    "logoUrl": "https://client.tjservice.org/assets/img/logo.png",
+    "description": "Point a subdomain of your own domain at your TJService Hosting game server proxy.",
+    "variableDescription": "host apply-parameter: the subdomain label to create (e.g. play, or leave empty for apex); %target%: the proxy hostname to point at (e.g. proxy.tjservice.org)",
+    "syncPubKeyDomain": "tjservice.org",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%target%",
+            "ttl": 300,
+            "essential": "Always"
+        }
+    ],
+    "hostRequired": true
+}

--- a/tjservice.taiwanroute.json
+++ b/tjservice.taiwanroute.json
@@ -6,7 +6,7 @@
     "version": 1,
     "logoUrl": "https://client.tjservice.org/assets/img/logo.png",
     "description": "Point a subdomain of your own domain at your TJService Hosting Minecraft server over the Taiwan route, using a CNAME plus an SRV record.",
-    "variableDescription": "host apply-parameter: the subdomain label to create (e.g. play, or leave empty for apex); %target%: the Taiwan proxy hostname to point at (e.g. taiwan-proxy.tjservice.org); %port%: the Minecraft server port to connect to",
+    "variableDescription": "host apply-parameter: the subdomain label to create (e.g. play, or leave empty for apex); %target%: the Taiwan proxy hostname to point at (e.g. taiwan-proxy.tjservice.org); %port%: the Minecraft server port to connect to; %proxytarget%: the fully-qualified name of the CNAME record created above (e.g. proxy.play.example.com), computed by the caller",
     "syncPubKeyDomain": "tjservice.org",
     "records": [
         {
@@ -21,7 +21,7 @@
             "service": "_minecraft",
             "protocol": "_tcp",
             "name": "@",
-            "target": "proxy.%host%.%domain%",
+            "target": "%proxytarget%",
             "port": "%port%",
             "priority": 0,
             "weight": 5,

--- a/tjservice.taiwanroute.json
+++ b/tjservice.taiwanroute.json
@@ -1,0 +1,33 @@
+{
+    "providerId": "tjservice",
+    "providerName": "TJService Hosting",
+    "serviceId": "taiwanroute",
+    "serviceName": "TJService Hosting Taiwan Minecraft Route",
+    "version": 1,
+    "logoUrl": "https://client.tjservice.org/assets/img/logo.png",
+    "description": "Point a subdomain of your own domain at your TJService Hosting Minecraft server over the Taiwan route, using a CNAME plus an SRV record.",
+    "variableDescription": "host apply-parameter: the subdomain label to create (e.g. play, or leave empty for apex); %target%: the Taiwan proxy hostname to point at (e.g. taiwan-proxy.tjservice.org); %port%: the Minecraft server port to connect to",
+    "syncPubKeyDomain": "tjservice.org",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "proxy",
+            "pointsTo": "%target%",
+            "ttl": 300,
+            "essential": "Always"
+        },
+        {
+            "type": "SRV",
+            "service": "_minecraft",
+            "protocol": "_tcp",
+            "name": "@",
+            "target": "proxy.%host%.%domain%",
+            "port": "%port%",
+            "priority": 0,
+            "weight": 5,
+            "ttl": 300,
+            "essential": "Always"
+        }
+    ],
+    "hostRequired": true
+}


### PR DESCRIPTION
# Description

Three templates letting TJService Hosting customers point a subdomain of their own domain at their game server, matching how our own Cloudflare-managed subdomains already work:

- `tjservice.route` — web route (single CNAME)
- `tjservice.mcroute` — Minecraft route (single SRV record)
- `tjservice.taiwanroute` — Minecraft route over our Taiwan proxy (CNAME + SRV, the SRV targets the CNAME we create in the same apply)

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `tjservice.org` on all three templates
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` not used — none of these templates use `redirect_uri`
- [x] no TXT record in any of the three templates
- [x] n/a — no TXT record
- [x] no variable used as a bare full record value — n/a, no TXT record
- [x] no bare variable used as the full `host` label — `route`/`mcroute` use fixed `@`, `taiwanroute` uses fixed `proxy`
- [x] no variable is used in the `host` field to create a subdomain — the subdomain always comes from the `host` apply parameter (`hostRequired: true` on all three)
- [x] `%host%` does not appear explicitly in any `host` attribute (it's used inside the SRV `target` field on `taiwanroute`, which is not a `host` attribute)
- [x] `essential` is set to `Always` on every record since removing/changing them would break the routing entirely

## Online Editor test results

**tjservice.route** — [Test tjservice/route example.com/play](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACuFcWoC%2F91T227bMAz9FUFAgRWLHSXOrR4GrFiHXoZ1va3YUBSGYjOuCsdyJTqpG%2FTfR9lJkyDdD%2BzJJsVDHvKQC44wLTKJwMMFL4yeqQTMacJDjo8WzEzFwFtvD%2BdySoH85uy6eWIn2qLKUwpZBtdQo0uEte9fKHZMD8w5wbCrJYb%2BrdI5DzstnulU%2FzIZYR8QCxu223GmIEf%2FjZuvTdqW1gLatpqmbYfwi5pQAjY2qsA6Gb%2FQKkcmmS3HiZ5KlTM9YZUuDdPznC1dEhvXLtPUMbUNUxrGc%2BU7qtIoOc7gaKvSA0GYLIqs8gppCIdgQoYPsFE7k2PIGGoWG6DZsw%2Fgpz4jHaoW04ZlIGfASBis2IRsWcDz%2Fie2h9KkgHtNtpoGc9VyR46SFU2PuEpX89wa1b4Tpcrji3L8Haqjmsym1C6GQgzE2iSWh3cLjlXhxPt6fvjjGz25emR%2BcUvhytkbTeaKGXkRSa9AiBYHkiVHJZ1%2Bh9lcVpa%2F3jcZruCpVAZoV9CU8NriLzqHaF2WwpIVOXiWtKHgx3q6ru9GRVZKm1ZEaoWp523dJq%2FQd1vw%2BxX%2BrklAdkO89uyOi98TNZXm2kBk6SuxNNBwbvFpmaGK5FyuXUkc1cJTJ5ZeKevuAPPmGJYNJBKls96pvTnKKIldV8od1zDoCxhPYk%2FIifB6cafrjUcgvNFQHAxGcdAPOp2Nk9255fcOdXuq7wlHytGE%2F6N2SHtLV5ZE0oV2RXfgiZEnejdiEHa7YdD3h71eMOh9FCIUwtEHi01%2FC9qKzX3g9vL6ZFr9vA1mx%2Bd%2F9NVLX8wfy9%2FZdVLdyuz4JAku44OnUz3E2%2FQzf%2F0LeIoVuHQFAAA%3D)

**tjservice.mcroute** — [Test tjservice/mcroute example.com/mc](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAqHcWoC%2F%2B1Uf2%2BbMBD9KpalSpuaEJofNGOatFbVtK77kabdpCmK0AEX6gkwtU0SFvW77wyhSdd0n2B%2FYZ%2Fvne%2Fde3jDDWZFCga5v%2BGFkksRo7qMuc%2FNL41qKSLknceDr5BRIr%2F9dNMcsY9SG5EnlLJNrqFZpGRpcBd9Cce%2BiBwjBQvDplvEEpUWMuf%2BSYenMpHfVUrIO2MK7fd6USowN85jb45USQ%2B0RqN7Ikt6FuEUdUMx6kiJwtTF%2BESK3DBgugxjmYHImVywSpaKyVXOtiEwTehffdqLUbGlAAY5u5n%2BYAojqWLH9g5KQJjixZOr76gGg6JIq24BiiZhUPnM3OFeMymEmDIjWaSQxGCv0EkcRsJUHSYVSxGWyEgpU7EF7aHA9eu37MiAStAcNdVIpHXF7G05XWKLFQ1p05azCU9nZ4sUUrUlntG0Z3VbMqcTu7SiVnk0KcMrrC7q7vfNYotSSjMTzf3ZhpuqsOLTqHaGoH2QtZc1BjMyklbqwEQFRfLGMu9p2bCkTcvXAqgxG6mbrwsIqYSpuO92%2BApFckfHI8IaqjlwKYjkktwIsHecpSuoNH%2BYd2p1pnhfCoVkXaNKfOjw3zLHYMeB0uKWKa6Bfhh0IpnxBl0bntYJmb4IRIuotdb2t2qxsyfgeYueWfh8R3PGDwhlExrOM94fjbwRn1OfIsmlwkDTF0ypsCHQ4VmZGhHACnahOApqDxItTadU529pthOvucRggNaHGtmf6Z5sjWovyntYnYZRzafDgziy0xL2BYETwNMQF92RdzLuDsMhdMPxOOxiH05P%2ByFEsTfYe5eePViHX6N9tQ7ZgfxAyv2fy%2FO5kPs0PUFxADax7%2Fa9rjvuusNb1yPG%2FmDoeCNvMBocu67vunYWqE0zrA35dN%2BhHK6W3uXEddfnZ%2BG0uB%2B6Py%2BOJ9%2FC6Y24Lu8%2Fn6%2FeFOlYi%2BsP197lO%2F7wB%2FVyyfqiBgAA)

**tjservice.taiwanroute** — [Test tjservice/taiwanroute example.com/play](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABWOcWoC%2F%2B1VbW%2FbNhD%2BKwSBAisiy4rjt6gYsCIturVr0aVe0cIwBEo6y8wkkSGpOFqQ%2F74jacUyHKNfB2xfbJP39txzD88P1EAlS2aAxg9UKnHHc1C%2F5TSm5kaDuuMZ0ODJ8IlV6EgX7794E%2FlVaMPrAl12zj6U8S2rlWgM7C2nYsnCeZOPvIZMsbUh17vAO1Cai5rG5wEtRSH%2BVCUm2BgjdTwcZiWH2oRPMEOhiiHTGowe8qoY2ohQOmw56ExxaVwy%2Blnw2hBGdJPmomK8JmJNWtEoIrY12V0x46%2BO4e5x2sKAUfbDbKBrxPUdkEZbb0auPr3%2B%2BJbIstEEjV%2BuvxIFmVB5aDtkirO0hDcHADdYiTApy3YgmULaDKjYVdhDLlkKJTGCZApweuQnCIsQq7A2IEKREtgdEBytackaz0zC%2FctX5IVhqgDzIu7jxeHet8QWrbGWzSk9Q2aX1Y9z4PwO%2BbYppVBdwiNqrM2BFDVa7E8bYPMcAFk3JfZ627CSrznkxOHAoVibp89Ttms2JyxF0rueHSzbeQj3DMUMYSaqlwEWrWRjvdPWZcpYWYKygmzr7HOTfoD2jSOzL3bbFbr4eprGywdqWmmF64CgyRKFR1fWPg3LlV4IvOrYxVtjUKoXURRQQEXWhjMr3dfllrWaPgZPSVEO%2BxeC56TqKPSvzohM2MjEZBJvav%2BGfrEVXC1btc%2BnA6T8tZ2Ly8KF4qalMaLZAi82aJ78COLKN3oNtw1XgI%2FaqAYeA%2Fq3qCHZs4Nuecdhj%2F0eTTgXPBX4KGTCuxgna21XThe9PAhfdfFLn2C173dJT8vR%2BvXYcOHPqsM5Op6WdDSZTCd0hb3xohYKEo3fzDQKfNMBrZrS8IRt2f4qzxL3QJEKjVbMcyyU3bD2COwmYoY9LchnW%2BgPJskzyxG3O3U0uoDxdD4fTC8hH4zno2hwOcmjwXS6ns7G6fwSgPU29dEKP72fDyf1nBiOBNu1dtDUCar7DfUU7QV9UvnPa9bPzE3sX8TOKkBN%2Fz%2F%2F%2F%2B78cZto%2FL%2FNE2ZdR9FoOojmg2i8iGZxFMUXs3A8O59cXJ7hIYosI6CNZ%2B0B905%2F49Az9s6kN1fyXfXt7ffrXF4t9Ico%2FXZ2O9PTG7MZNe3Z71qcF9u%2F%2FviZPv4DE8yIpcAJAAA%3D)

All three templates have `hostRequired: true`, so per the checklist exception apex-only tests are not required.
