### PR TITLE
add Tailor AI, Tailor AI Custom Domain

### DIFF
--- a/tailorhq.ai.redirect-domain.json
+++ b/tailorhq.ai.redirect-domain.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://app.tailorhq.ai/images/logo.png",
   "description": "Points a subdomain at Tailor AI, so campaign links and hosted landing pages are served on your own domain.",
-  "variableDescription": "host is the subdomain being connected, for example \"go\" in go.example.com. target is the Tailor AI hostname it points at.",
+  "variableDescription": "host is the subdomain being connected, for example \"go\" in go.example.com. It is pointed at Tailor AI's shared hostname, cname.tailorhq.ai.",
   "syncBlock": false,
   "syncPubKeyDomain": "tailorhq.ai",
   "syncRedirectDomain": "app.tailorhq.ai",
@@ -15,7 +15,7 @@
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "%target%",
+      "pointsTo": "cname.tailorhq.ai",
       "ttl": 300
     }
   ]

--- a/tailorhq.ai.redirect-domain.json
+++ b/tailorhq.ai.redirect-domain.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "tailorhq.ai",
+  "providerName": "Tailor AI",
+  "serviceId": "redirect-domain",
+  "serviceName": "Tailor AI Custom Domain",
+  "version": 1,
+  "logoUrl": "https://app.tailorhq.ai/images/logo.png",
+  "description": "Points a subdomain at Tailor AI, so campaign links and hosted landing pages are served on your own domain.",
+  "variableDescription": "host is the subdomain being connected, for example \"go\" in go.example.com. target is the Tailor AI hostname it points at.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "tailorhq.ai",
+  "syncRedirectDomain": "app.tailorhq.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Tailor AI** (`tailorhq.ai` / `redirect-domain`).

Tailor AI is a performance-marketing platform. Customers connect a subdomain of their own domain (e.g. `go.example.com`) so campaign links and hosted landing pages are served on their brand rather than ours. Today that means hand-copying a CNAME into their DNS provider; this template lets the provider write it for them.

The template is a single CNAME on the connected subdomain, pointing at our shared ingress hostname `cname.tailorhq.ai`. `host` is its only variable, so an apply URL can decide *which* subdomain is connected but never *where* it points.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`logoUrl` verified: `HTTP 200`, `image/png`, 35830 bytes.

Also run through `dc-template-linter`, including `--merge-or-fail`: no findings.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Two notes on how the template meets these:

**Rule 6 — bare variable as a full record value.** No variable is used this way. An earlier revision of this PR had `pointsTo: "%target%"`, which `dc-template-linter --merge-or-fail` flags as `DCTL1040`. The destination is now the literal `cname.tailorhq.ai`, so the only thing an apply URL can choose is the subdomain being connected. We put the hostname in a variable originally so it could change without a new template version; naming it outright is the better trade, and a guard in our own backend now withholds the one-click path if our fallback target ever stops matching what is published here, rather than letting a link write a CNAME to a host we no longer serve.

**Rule 10 — `essential`.** No record here needs it. The template writes exactly one CNAME, and that CNAME *is* the connection; if the customer edits or removes it, the custom domain has genuinely stopped working and treating that as a template conflict is the correct outcome.

`txtConflictMatchingMode` and the SPF rule are ticked as not-applicable — the template contains no TXT and no SPF records.

## Online Editor test results

**Editor test link(s):**

[Test tailorhq.ai/redirect-domain example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHQ1cmoC%2F91TXW%2FaMBT9K5Zf9rAAoYQ2RJo01k5ata2rKvqwtQhd4ktwm9ip7UAp4r%2FvOkBJ22l731Ni33OPz7kfa%2B6wKHNwyJM1L41eSIHmXPCEO5C5NvOHNkgePIcuoCAoH9VBNjynkEWzkCnWSQaFNJi6ltAFSHWIvs5jp5V1umBne9wCjZVa8aQb8Fxn%2BtrkhJ87V9qk04GybDcEdWQBGdqOB7ZLlVG%2BQJsaWbqag19qqZxlwGw13Uph4Njz6wGzmqVQlCAzxXKp7gmrBJtr61CwnP6lyljpH2FgkHkXFNCKrXRlmF4qtqVte%2BlgJExzPHshwXMxaZmbY0PFFD1xqpWiKqEI2IwE4SNJyZHd8kzfckYwsrW7bKe6aLPzmqr0rkhG08o7y%2BycJG7FKypzwFL%2FadbLq7QrlX7KdXrPkxnkFrc3l9X0K652XXjddA%2B42nX0GfKqFQTzD1%2FhQ0U4mgFnKuKmFG2E5cnNmrtV6Xt%2FejH8%2FnkHp%2BNHP1V1m0aajm80U9g5moFeGG7Gm4A%2FaYWTA%2B2YWr6X1CjVgT%2FT9J8ZXZUTuc8owUBh%2Fajvc29eJI%2F32Tc%2BnU4OTIb1%2Ba0%2BL4rGRxucWPqCqwzu7RdV7uQElnC4EumESpevyIOlKHG%2BLY3abkktXYCDf9Ql4BORejfS795xOB3EEZ60BoP%2BtBXF4aAVQy9u9Xu92aAbdUXUjxub%2FIcl%2F%2FsmN%2BuK1qJyEvyODvMlrCzfbMYB1fi%2FM0VTYIGWfwIeeBQeHbfCuBVGo26c9KMkitrHdDfovQ%2FDJAy9EbRu63NNE9KcDX56kl%2BNnpbXdz8EigdlplgsoPtN3tn4y8XsPhv%2Bir4NHl02O%2Fr5gW9%2BA7F%2F03idBQAA)

Subdomain apply (`domain=example.com`, `host=go`) produces:

| Name | Type | TTL | Data |
|---|---|---|---|
| `go.example.com.` | CNAME | 300 | `cname.tailorhq.ai` |

The template takes no variables, so the apply URL carries only `domain` and `host`.

The apex case was also run in the editor even though `hostRequired=true` makes it optional: with `host` empty, the editor rejects the apply with *"Template requires a host name"*, which is the intended behaviour. A CNAME at a zone apex is not valid DNS, so this template deliberately has no apex path. No test link is included for it because a rejected apply does not produce one.
