### PR TITLE
Add Brandscaling Landings template (Vercel CNAME)

### DIFF
--- a/brandscaling.io.landings.json
+++ b/brandscaling.io.landings.json
@@ -4,10 +4,9 @@
   "serviceId": "landings",
   "serviceName": "Brandscaling Landings",
   "version": 1,
-  "logoUrl": "https://brandscaling.io/logo.png",
   "description": "Conecta tu subdominio para servir tus landings y embudos de Brandscaling (Vercel).",
+  "syncPubKeyDomain": "brandscaling.io",
   "syncBlock": false,
-  "warnPhishing": true,
   "hostRequired": true,
   "records": [
     {

--- a/brandscaling.io.landings.json
+++ b/brandscaling.io.landings.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "brandscaling.io",
+  "providerName": "Brandscaling",
+  "serviceId": "landings",
+  "serviceName": "Brandscaling Landings",
+  "version": 1,
+  "logoUrl": "https://brandscaling.io/logo.png",
+  "description": "Conecta tu subdominio para servir tus landings y embudos de Brandscaling (Vercel).",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for Brandscaling. It connects a customer subdomain (CNAME → `cname.vercel-dns.com`) so their landing pages and funnels are served from their own domain through Vercel. Signed template (`syncPubKeyDomain` set).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A, template has no `logoUrl`

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
[Test brandscaling.io/landings example.com/landings](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEAacmoC%2F91SXW%2FTMBT9K5GfQCRd0ib9iIREVxhCwBgwVZqqKrqxb4tVx85sJ1uo%2Bt9x2oV22ibeebJ877nX5xyfLbFYlAIsknRLSq1qzlB%2FYiQluQbJDAXB5brHFfH%2Fti%2BhcHByfgJwXYO65hT3s8J1XNUcy8%2FMeF%2BOqBq14UqSNPIJQ0M1L%2B3%2BTmZKIrXg2cozVc5UwSVXXgkavP1q7TrG6x70Gg%2BLvGLKeAy9R6%2B9mqOmKF73WlKNpFdV%2Fhmb96oALp%2BV24LOhaIbkq5AGPTJL2XsD7ytuEan0urK1TRSpZkh6WJLbFO2ImeX068fyAHuru9a6xSX1lwrd6XSWdGr92QCJk2PqsIhrBUkHYThbrnzyW8nOjtuXjpTOp54D%2B7D8GHq4YkTv9daVWXGu7nWqMK0n9ttWDxasex2LI5LWgZ8LZXGzLgTbKWxk1tUwvIM7uBYYjSDshSNI2xc1616aoU8fP8JTwYW%2Fu2GTzJGW%2Fa8jRXEk9EKRlEQTwaDII76EExgmARxkvRdKV%2BN8%2Fgkpy%2FE%2BIWgPrUSjUFpOTgqZCruoDFkt1v6ztb%2FWqCLhIEaWQYtvB%2F2h0E4DsL4OhqmyTiNw140SMaj0ZswTMOw1YLGHtRuXXJOM0M2mg7YxeqMfTPqar6ZmVre3M4ErKJ8KM9u%2BMfp7OL2ZzK8n39%2FS3Z%2FAMoeRf2OBAAA)
