### PR TITLE
add PhotoView.io, website routing templates

### DIFF
--- a/photoview.io.website-apex.json
+++ b/photoview.io.website-apex.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "photoview.io",
+  "providerName": "PhotoView.io",
+  "serviceId": "website-apex",
+  "serviceName": "PhotoView.io website",
+  "version": 1,
+  "logoUrl": "https://photoview.io/brand/photoview-logo-horizontal-transparent.png",
+  "syncPubKeyDomain": "photoview.io",
+  "syncRedirectDomain": "photoview.io",
+  "description": "Connects a domain apex to a published PhotoView.io photography website.",
+  "variableDescription": "%ipv4% is the signed IPv4 destination recommended for this domain by PhotoView.io's hosting provider.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/photoview.io.website-subdomain.json
+++ b/photoview.io.website-subdomain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "photoview.io",
+  "providerName": "PhotoView.io",
+  "serviceId": "website-subdomain",
+  "serviceName": "PhotoView.io website",
+  "version": 1,
+  "logoUrl": "https://photoview.io/brand/photoview-logo-horizontal-transparent.png",
+  "syncPubKeyDomain": "photoview.io",
+  "syncRedirectDomain": "photoview.io",
+  "hostRequired": true,
+  "description": "Connects a subdomain to a published PhotoView.io photography website.",
+  "variableDescription": "%cname% is the signed CNAME destination recommended for this domain by PhotoView.io's hosting provider.",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds Domain Connect templates for routing domain apexes and subdomains to published PhotoView.io photography websites.

The `%ipv4%` and `%cname%` values intentionally occupy the complete record target. Vercel can return a domain-specific required target, and PhotoView cryptographically signs the exact value for each request using the RSA public key published at `_dcpubkeyv1.photoview.io`. A fixed prefix cannot be added to an IPv4 address or CNAME target.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

The templates contain no TXT/SPF records and no records users should modify independently. Their sole A or CNAME routing record must continue to match the target verified by PhotoView and Vercel.

## Online Editor test results

**Editor test link(s):**

[Test photoview.io/website-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANxMcmoC%2F91TUWvbQAz%2BK%2Bag7GFxcnVcNzUMlrV9KBsjdO3argQj%2B5T4wPYdd%2Bekbsh%2Fny5tmoR1%2BwEDP8jSJ92nT9KKOax1BQ5ZumLaqIUUaK4ES5kulaNfXPalYr232HeoCcsmPvrzLWrRLGSBm8Ql5lY6DEHj0y70Tl7wiiTQAo2VqmHpcY9Vaq5uTUXg0jlt08Fgn8ogN9CInSv08LBURj6rxkEVOopbDQYb19fN3DPommLS5l%2Bxu1A1yObP5jziGoU0WLi%2FYQTawkjtNjTZuWoaAtsAArFJCHy7gVPk0G1eSVuiCA663dSbG9Blt%2B2871sHIyGv8OKg%2FpHUi%2FgokDZwJQZWzhsqdzVZxAHxcLIBjwuIr6prbAQFZ8oQlhJe%2BeTdwfMfbFAqnzkPtqP0r%2FsKRliWPq6Y67Qf0ZjcHkrmZz94JRtnb9QbKfI5R%2BMZJpyvp%2BseI%2BEx2xWaklZbDfEJaL2wTzR3VcmaG9XqTG7xNC6orV%2FBbebjQep0m%2FvIvO1pePs06dMXHdPHPBFSSRnMvFrgWkPNONNij9Vt5WQGS9i5RJGB1lVHvC1FqdqhAM3LunoBBDggc%2F%2BxPQV6LBOFZy797o9O8xOIOIaz2UkexmfAQyhyHh4nw3yGw1EuhvHeMb13aP84pZ1%2BaC3ttwR%2FJeNqCZ1l6%2FW0R1r%2BB23QhC0sUGTgYRGPkpCPQh7fRDwdxkS3z8%2FiJEo%2Bcp5y7rugk3hpb0VbsD9%2FNniYXUY4xh%2B33aW6%2BcbPb0ezL3eT0Vi013fJhMPo4Vfk7st7G39i698ACnr%2FDwUAAA%3D%3D)

[Test photoview.io/website-apex example.com/portfolio](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG5NcmoC%2F91TXW%2FaMBT9K5Glag8jYAKFEmnSuvWl6ja1XbduqlB0E98Sa4lt2Q40Rfz3XdNSgtbtB0zKA9x77vE592PNPNamAo8sXTNj9VIKtOeCpcyU2tNfXPWlZr2X3BeoCcsuQ%2Fb7S9ahXcoCt4UrzJ30GIPBh33qlbroGUmgJVontWLpsMcqvdDfbEXg0nvj0sGgK2WQW1BiH4oDPC61lY9aeahiT3lnwKLyfaMWQUGrissmv8D2TNcg1Z%2FmAuIahbRY%2BL9hBLrCSuO3MtlHrRSBXQSR2BZEwW7kNQVMk1fSlSiiA7dbvoUFU7Y75%2F1gHayEvMKzA%2F4jaZbjo0i6yJcYOblQRHd%2BuRxHpMNLBQEXkV5d16gEJe%2B1JSwVPOvJ24Pn37io1KFyEe1GGV4PDFY4lt6tmW9NGNEphQOUfr4Pg9dSeXejX0RRzHsaz2jC%2BWa%2B6TFqPGZ7ojn1atdDfABaL%2ByTzD2r0dbf62rb1YXVjcnkrpDmBrULu7ijuDvgmO9I7josFAzCQnA66dOXDOljQRr1TVvMQv%2FAN5bsedtgj9VN5WUGK9iHRJGBMVVLThxlie2wJeppgbviBXigUPfRTm96LBNFsCLDVeDxbDYteBIXfIjxeHIyiUFMp%2FE9Px7mfDLCREw7Z%2FbaCf7jyF7pLDpHJyAhHNJptYLWsc1m3qMu%2F4%2B%2BaAccLFFkEPAJTyYxP4n5%2BCbh6Wia8oRMHA%2BT5C3nKefBDp3Rk8817Ul3Q9jVrxWeN7PbnzioitMre3Z70s6S0vy4uXqcXegRfCrtl2tffvj6%2BR3b%2FAZCg%2FoeQwUAAA%3D%3D)

[Test photoview.io/website-subdomain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD9NcmoC%2F91T207bQBD9FWsl1AfixDgXg6VKpVCiEopoBFVbFFlr7xCvau%2Ba3XVcN8q%2Fd9aJcxGgvvfN4zkze86ZmSUxkBcZNUDCJSmUXHAG6jMjISlSaTCEqssl6WxztzRHLLmz2W%2FbrAa14Ak0hRXEmhtwdRkzmVMudvlXip0NHEELUJpLQcKTDsnkXD6oDMGpMYUOe719Pr1YUcF2v1wLd1Op%2BB8pDM1cg3ldUAXCdAsxtwxqkdyV8QTqyzWpFwotYgqMK0jMW5hUajOF5xJBKNWoEjqEgU4UL0xDnVxIIbCBdqizNcAxEsOijDOuU2DOgf7mhbmiRVq3XnStGVRxGmdwedD9KBFo4ZHDtWNScDSfC%2Bx3cXv%2B5ZODPAwX1CId1CDzHATD7JNUCMaKDZm4PiDwTjtWFRdzp52xfd92UEyT8HFJTF3YsTXPbEzA8IPdCsmF0fdyRw1%2FGoNz6488bzVbdQhOBKJdtxka1poLvykuH3SR665tVVUYzJUsi4i3JThKmmu7o23x40H1rC1%2FbOoxbNjYuPno4m4lkLlMaNdbVyA1dE8qiKyL1JQK2onmZWZ4RCu6%2B8WSiBZFVqMSjVls%2FNKX9YsbAYwaisEbr%2B%2BZ1CERS6wybo8nGD49wWkSuHTk%2B%2B6gH5y5pzD0Xa8PAX70gyQY7F3ja5f6r1s88Bm0xhvh1F7aeVbRWpPVatZBz%2F9nfbgfmi6ARdQifc8fud6p6w3ufQ85hyfDrjcIghP%2F2PNCz7Nq8LbWipe4N%2FsbQ8Q4v%2BL963R8lh9PnnuiP55kVxcff%2F74Or0cTp7Hdzff9fUvNQxuHt6T1V%2FznizScQUAAA%3D%3D)
