### PR TITLE
Add Laicos branded links template

### DIFF
--- a/laicos.com/laicos-links.json
+++ b/laicos.com/laicos-links.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "laicos.com",
+  "providerName": "Laicos Links",
+  "serviceId": "links",
+  "version": 1,
+  "logoUrl": "https://laicos.com/favicon.svg",
+  "description": "Connect a domain for branded Laicos links",
+  "syncPubKeyDomain": "laicos.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "connect.laicos.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_laicos",
+      "data": "laicos-verify=%verification%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a Domain Connect template for Laicos branded links (CNAME to connect.laicos.com plus verification TXT).

## Notes
- Feature is behind DOMAIN_CONNECT_ENABLED on the Laicos worker until this lands.


Made with [Cursor](https://cursor.com)