### PR TITLE
Add InstaRep website template (instarep.io / site)

### DIFF
--- a/instarep.io.site.json
+++ b/instarep.io.site.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://instarep.io/brand/instarep-apple-icon.png",
   "description": "Point your domain at your InstaRep website.",
   "variableDescription": "",
-  "warnPhishing": true,
+  "syncPubKeyDomain": "instarep.site",
   "syncRedirectDomain": "portal.instarep.io",
   "records": [
     { "type": "A", "host": "@", "pointsTo": "76.76.21.21", "ttl": 3600 },

--- a/instarep.io.site.json
+++ b/instarep.io.site.json
@@ -1,0 +1,16 @@
+{
+  "providerId": "instarep.io",
+  "providerName": "InstaRep",
+  "serviceId": "site",
+  "serviceName": "InstaRep Website",
+  "version": 1,
+  "logoUrl": "https://instarep.io/brand/instarep-apple-icon.png",
+  "description": "Point your domain at your InstaRep website.",
+  "variableDescription": "",
+  "warnPhishing": true,
+  "syncRedirectDomain": "portal.instarep.io",
+  "records": [
+    { "type": "A", "host": "@", "pointsTo": "76.76.21.21", "ttl": 3600 },
+    { "type": "CNAME", "host": "www", "pointsTo": "cname.vercel-dns.com", "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect service template for **InstaRep** (https://instarep.io), a website builder for local service businesses. It points a customer's domain at their InstaRep website — apex `A` + `www` `CNAME` — applied only through the DNS provider's own interactive consent screen (synchronous redirect flow, `syncRedirectDomain: portal.instarep.io`).

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — "Test apply" succeeds for an apex domain and a with-host case
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`instarep.io.site.json`)
- [x] `logoUrl` is served by a webserver — https://instarep.io/brand/instarep-apple-icon.png returns `200 image/png`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — RS256 public key published as a two-part (`p=1`/`p=2`) TXT at `_dcpubkeyv1.instarep.site`; verified a signature from our private key validates against it.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` (removed now that the template is signed)
- [x] `syncRedirectDomain` is set (the template uses `redirect_uri` in the synchronous flow)
- [x] No TXT record contains SPF content (the template has no TXT records)
- [x] No variable is used as a bare full record value (the template has no variables — fixed `A`/`CNAME` values)
- [x] No bare variable in `host`; `%host%` does not appear in any `host`
- [x] No `essential`/DMARC records the user must modify

## Online Editor test results

Both links below were regenerated from the current signed template (with `syncPubKeyDomain: instarep.site`).

**Editor test link — apex (`acme.com` / `@`):** https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF5Bh2oC%2F%2B1TXWvbMBT9K0Gvsx3lY4lrGCxdupGVtSXL6EoJ5lrSUoEtaZIS44X8910136Njj30ZCGzpnnt07rlXa%2BJFZUrwgmRrYqxeSS7shJOMSOU8WGESqUl0CN1AhVAyCcGpMBhxwq4kE885TiLR4egPbOteFDvASlgntSJZJyKlXuhvtkTgk%2FfGZe32yc3twoLih5MYjClFLJlWiVELZOLCMSuNf2Yjd1oq32r00ra4rkCqFuy2BxH1VkQSVICVUJRifMYR9DeK3S2La9GMn1lO3diXiJCp4NIK5g8go62HMjl3DhHackeyxzXxjQmOjPD4STuPv%2B%2BDt0G1m2ncDgcJrm4HFwa8R1t6A0o30SH3w83oy9Uxv67rcwam0PUEDWaijLlyCdPVGdV8E5FfWon8KGyOPu5rAIbp25zdFfi3sHppcrkHG7BQuTAx%2B7THY958n%2FhISLhLLpS2Inf4Bb%2B0WIO3SxGRall6mUMNxyPO8tDgBqU5jCLFuWdqO1DBMw4e%2Fu5XRHLOgj4ZpjJ924PeRdGJKRQQ91mfxmnKeDzsUsp5HwYFK05G%2FIXpf2HGj%2BYI54TyEsIIj8oaGkc2LzRsJ37bsJ38fzXr9euYR9jw%2F1147S7go3KwEjyHAOvS7iCmadyls06a0V7WoUl6MbxI0zeUZpQG8cL5bXlrfIOnr48MV1dfr28rmtaXD9du3Hflj5%2Ff7eXEdW674r6cfHxoT6vZJ%2Fl5NnlHNr8BX7eH8yIGAAA%3D

**Editor test link — with host (`acme.com` / `blog`):** https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIZBh2oC%2F%2B1TbWvbMBD%2BK0FfZ7uKE%2BfFMFiyjtGGpiVrKSUEI1tKKmZLQlJikpD%2F3lNenHhk7Gs%2FDAS27u45Pffc3RZZVqicWIbiLVJarjhl%2Bo6iGHFhLNFMBVwir3KNSQGh6M45J0yBxzC94hnbYwyHRJXpj9jGK0uPASumDZcCxU0P5XIhX3QOge%2FWKhPf3Fy8fJNqImhl8YlSOfN5JkWgxAIyUWYyzZXdZ0NPkgvbWMulblBZEC4a5HitSJQHEoFjQTQnac5uazkc%2F7XInpbpiK1v91ku1TiVCCETRrlmma2ClNSW5EFdOYiQmhoUT7fIrpVTZADmd2ks%2FH5z2jrW5lnCtdsJ4IRNOOCwFmRpdTDeeRX2%2B3jw8OOML8uyniEToHoAAmcs96kwQSaLWqrZzkMbKVhyJjYDHU81kAzgB8zxiRQ6BLeFlkuV8BNAEU0K46bmBJ2esbMTeHpAuzf5QkjNEgNfYpcaarF6yTxULHPLE1KSs4lmiWv0Giga8EKaunbiMFhHYpRY8nfpPJTQzNHkbkBJSmmY4b7f6UUtv52mkd%2BfR5HP2s3uvNumbUzxxbRfWYQr417XiRnDhOXETfQgL8naoN2V%2Fh1rgP4F9Tr%2B1cDPUdDMgyH435XP1hVYPENWjCbEhYY47Pi454f4udmLcSuOcNBvtjpR7wvGMXYULDP2UOIWdvRyO9EDHYmeuu%2Bq8cuEjsP528%2Ffw86m%2FzoapG%2BbX8PHIaHmvtxg8Si%2Fot0HiaG8pUoGAAA%3D
