### PR TITLE
Add onpack.link resolver template

### DIFF
--- a/onpack.link.resolver.json
+++ b/onpack.link.resolver.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "onpack.link",
+  "providerName": "Onpack",
+  "serviceId": "resolver",
+  "serviceName": "Onpack barcode resolver",
+  "version": 1,
+  "syncBlock": false,
+  "hostRequired": true,
+  "description": "Points a hostname at Onpack, the free GS1 Digital Link resolver, so printed barcodes resolve under the brand's own name. The certificate is issued automatically once the record is live.",
+  "syncPubKeyDomain": "onpack.link",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "saas.onpack.link",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Onpack (onpack.link), a free hosted GS1 Digital Link resolver. The template writes a single fixed CNAME pointing the brand's chosen hostname (e.g. `scan.brand.com`) at Onpack's ingestion host `saas.onpack.link`, so printed GS1 barcodes resolve under the brand's own name. The certificate is issued automatically (HTTP DCV) once the record is live, so no further records are needed.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver — N/A, the template has no `logoUrl`

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A, the sync flow does not use `redirect_uri`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead — N/A, no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, no TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — the template uses no variables at all; the CNAME target is fixed
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead — the record host is `@`, the subdomain comes from the `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — the single CNAME is `essential: Always`, since removing it breaks the service entirely

## Online Editor test results

**Editor test link(s):**
[Test onpack.link/resolver brand-example.com/scan](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHwYc2oC%2F91TbWvbMBD%2BK0Jf9qF2psRN6xkG6xujbEvLlsFKCeEiX1IRW9IkOa0X8t93tuempR37PjAyopfnnnvutOUBS1tAQJ5tuXVmo3J0lznPuNEW5HpQKL3m0aNrAiWF8qvWSXaPbqMkthkOvSk26PbmZ9FsAU6aHNmTODq9MppnQ8qptTwtDMFmSyg8RvzO%2BPAVf1bKIeEHV5EtRy%2BdsqHN4tdG6eAZsCZUUzUGgXXlIhbukC0dIvv4bcjO1UoFKNhn6ueRQcS8YdYRBuY9Pd97WaWp4RZl4UDnbzwz95o1VQZsSlaJLqilkqQeU54%2BXxEMVMGUEMhcFDUzWmIL4VAalzdxhdrggHf9XleLT1ifU4LSLzTvUjzPbrc81LZR8mxy8uWCd8rQ9UMzmVaCqaGrB%2FCD5xghFDxLjoSIOHqPOiggAz8p7qH2fDfbRfyX0Tjf15qRxj2ftu8YH4B2BAfSlPvSXoKm28qZys5Vn2nBQembXeoxbl8BmfUotx1Mw0KttHE49%2FSHUDns511WRVBzuIe9KZdzsLaoibQnL8G8FEh3m%2FeHZQ4B%2FqnPPJcNcdWs8jARYpjgMl7IcRofpulxnKbLJMZUwBiSQxBJ%2BuRVvPJg%2FvIwnqv32kh2s4iU%2FL86ooF72GA%2BhyZ0JEZHsUhjMZ4Oh5lIstHhYJwm46PRgRCZEE0T6EPX4pZ24%2BlWcJtfvR2dTUAc1PmNO55enP5Y21V5tbbfvZ3od%2FUmPb05FpeXqXnPd78Bl4XckeEEAAA%3D)

Apex test not included per the exception: the template sets `hostRequired: true` (a CNAME cannot coexist with apex records; the service is subdomain-only by design).
