### PR TITLE
Add GitResume resume hosting template (gitresume.co.resume)

### DIFF
--- a/gitresume.co.resume.json
+++ b/gitresume.co.resume.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "gitresume.co",
+  "providerName": "GitResume",
+  "serviceId": "resume",
+  "serviceName": "Resume Hosting",
+  "version": 1,
+  "logoUrl": "https://gitresume.co/logo.svg",
+  "description": "Connects your domain to your resume hosted on GitResume.",
+  "syncPubKeyDomain": "domainconnect.gitresume.co",
+  "syncRedirectDomain": "gitresume.co",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "domains.gitresume.co",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for GitResume (https://gitresume.co), a resume-as-code platform: users write their resume in YAML on GitHub and GitResume builds and hosts it. This template connects a user-owned subdomain to their hosted resume via a single CNAME to our fallback target (`domains.gitresume.co`). No template variables; subdomains use the standard `host` parameter (`hostRequired: true`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (n/a: no TXT records in this template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) (n/a: no TXT records in this template)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (n/a: template has no variables; the CNAME target is a fixed value)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description (n/a: template has no variables)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead (subdomains rely on the standard `host` parameter with `hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (n/a: the single CNAME is the service connection itself, not a record users would modify independently)

## Online Editor test results

**Editor test link(s):**
[Test gitresume.co/resume example.com/resume](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIdac2oC%2F91S0W7aMBT9lcivJJCUhLFIk9bRdZ2mUUo7VRNCkYkv4C6xg31DmyH%2BvTaBwFgf9rwny77nnHvv8dkQhLzIKAKJN6RQcs0ZqK%2BMxGTBUYEuc2inkrhNbUhzgyVfOI53VVPSoNY8hR1LnT3u4TXWuZEauViY8hqU5lKQOHBJJhfyh8oMbIlY6LjTOe3dseW2XlsWA50qXuCOSQZSCEhRO5UslcNkTrlwUNbXmu8sTUdgjhROM3HbTleJdFTOvkF1taMZtZqf1prts%2B0tfgyMK1NrGGcY22oMq9KAjBOoSnCNHalUTJN4siFYFdaKwfDy%2B%2Bc93Fw%2FWm8lF6gfZDOFPu%2BPaOzp9nx%2FO9265LcUkBylp%2B6eZvjwQs1%2FWlZ%2B7NF8ykLJskj4gVVQRXNtf%2F7An%2FwhMD0oTA4StjtfCKkg0eakWCo47JqXGfKEPtPjE0sTWhRZlVh6ZoX%2B9kHUCWlmZBTpPxjhkoSldnRuYxdEs3kYzOdeOPd7XtiHmUdTiDxGw8iP6Kzf70YnIX4r4G%2Bm%2BNxA0BoEcmrDepk900qT7XbqGjP%2Fy8VMADRdA0uoBV%2F4Fz3P73t%2B9BBEcRjFQdB%2BF%2FXeh92W78e%2Bb7cAjfWeG5OU04yQFYvuHp9a94i3tFMNP%2F28LlrsJRtlwfVq3nocVYPs6deVWs5u7j6Q7St0yblrmQQAAA%3D%3D)
