### PR TITLE
Add sportsroadmap.com.email-sending template

### DIFF
--- a/sportsroadmap.com.email-sending.json
+++ b/sportsroadmap.com.email-sending.json
@@ -1,0 +1,35 @@
+{
+  "providerId": "sportsroadmap.com",
+  "providerName": "Sports Roadmap",
+  "serviceId": "email-sending",
+  "serviceName": "Email sending",
+  "version": 1,
+  "logoUrl": "https://admin.sportsroadmap.com/web-app-manifest-512x512.png",
+  "description": "Lets your Sports Roadmap campaigns send from your own domain, so recipients see your brand and replies come to you.",
+  "variableDescription": "dkimvalue: the base64 body of your domain's DKIM public key (without the leading p=). mxhost: the bounce-feedback host for your sending region.",
+  "syncPubKeyDomain": "sportsroadmap.com",
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%dkimvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "%mxhost%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Sports Roadmap**, a SaaS platform for youth-sports event operators. It authenticates an operator's own domain for sending, so their marketing email leaves from their address rather than the platform's — recipients see the operator's brand, and replies reach the operator.

Three records, all scoped to a dedicated `send` subdomain plus a DKIM selector, so an operator's existing mail delivery and website are untouched:

| Type | Host | Purpose |
| --- | --- | --- |
| TXT | `resend._domainkey` | DKIM public key |
| MX | `send` | bounce feedback |
| SPFM | `send` | SPF include for the sending provider |

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`logoUrl` verified as returning `image/png` (512×512), on a host that returns a genuine 404 for unknown paths.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `sportsroadmap.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — n/a, this template does not use `redirect_uri`
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value — the DKIM record fixes the `p=` prefix and the variable carries only the key body, so a crafted request can influence the key material but not the record's meaning
- [x] no bare variable is used as the full `host` label — both hosts are fixed (`resend._domainkey`, `send`)
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — n/a: none of these three are records an end user is expected to edit. Removing any of them simply stops the service working, and the operator manages that from within the application rather than in DNS.

## Online Editor test results

**Editor test link(s):**

[Test sportsroadmap.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABNjc2oC%2F%2B1WW2%2FbNhT%2BKwSBYBtmOfIVjoA8OHGbGYm7OraBFEFgUOKRzYQSWZLyJUH223do%2BRK3azFgL8XQB8ESz%2FX7%2BB3SL9RBpiVzQKMXqo1aCA6mz2lErVbGWaMYz5iuJiqjlb3DB5ZhAB1tXMht6YN2C2YhEtjEQ8aEDCzkXOSzg20b%2Bs5bycG6AGOFymlUq1CpZmpiJHrNndM2Oj3F%2FCKvftXR6RLigGkdZCwXKVgXtGr1FT5VvUnKwSZGaLdJTG8Ae12rwpDjvknCMs3ELLebfkhqVFb6qWVOuMJO8wqxihhIhBaQO%2B8IpUtsGIb4x4CWAizBvoA45c1VD4wZwWIJvaNe%2BJPIFkwWEBE3BxIzC%2B0miRVfE5WWmcvCv1jSu%2B4PiC5iKRLyBGvy61K4uSrcJlIC8wwSff5blWSrubJum1IVeQJBCsBjljwRbyGpMmXyLfHY9Awb8n3adZ58LOJrWPc2hb%2BhAO92IVXyRKOUSQu4MmcG%2BP4TSVKGWxrdv1C31n6vx3djjPQN4IcBX7s6LeEhHr9PzDE06fOTPS8nuOwcaqDRDkN8XblLladIgRswl8yx94HiPnlXSvpa2dca3B1K%2BUJetErglo0VrpyUDJ1spCyUEW6NigvflHqTavTx%2FeCrZFant4UExEdFnsiCQ8Qy9qxyC3ZL0SHXw2uFogmmB1IeEO2OX1ih8CRsw7Z18G1mVKGnYuevmWGZ9fO5i7w%2FCn3Yxd5T%2F76n0C8M%2BlfpoBteXY4%2BX436caM3fHfRHU663ebVh27v8kIMry9mw94fj%2B5PCPv58%2FvmkPWeH4cz8Xk599lKwnyqnZICmzldLWwADAeuVj2G7yHjKCkDU4u%2FzBUGG3GmQGlkhXRiypbssMSTKc6vXCNDFq1Y50vZ5OV58V3Z%2FDeUR0Kb8sQzLfwJlkLY5I2wHnTaZxA0Ia0FcdjqBOysUecsacRJXH9zKH7z1PzeqXjYdbC46gSTG1Ev2drS1y%2BFvSVjq8Ut%2Fn%2B3MUcoj8X%2Fw2I%2BUsAx6MU5TmKN%2FOMMkr8YHgo%2F8rY%2BVHCwfyr9p9L%2F%2F0rHO8SyBfAp8271sN4Owk4Qtsa1dlSvRY2zaqfdaDU6v4dhFIYeC%2F6PK6G%2F4F3y9hah%2FHEymwxOi%2BbN%2BCy7XU5aV59GA3aXr4afnkf93uJuKc0NC8PC9c%2Fp69%2FuAxMS3AoAAA%3D%3D)

[Test sportsroadmap.com/email-sending example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB1jc2oC%2F%2B1W227bOBD9FUJAsLuIpciK440F5MGOU6%2BbOo0TF2gbBAYljm0mksiSlG9B9tt3KPkSNW2xwL4U2D4ItjgzZ2YOz5B6cgykMqEGnPDJkUrMOQPVZ07oaCmU0UpQllLpxSJ1ajuHK5pigHNbuJCb0gftGtScx1DEQ0p54mrIGM%2Bme9sm9MJayd46B6W5yJywXnMSMRUfVIJeM2OkDo%2BOEJ9n3quKjhYQuVRKN6UZn4A27kk9WOLjyQKUgY4Vl6YAdt4B1roSuSLVuklMU0n5NNNFPWSiRFr6iUVGmMBKsxrRgiiIueSQGesIpUukKIbYR4FMOGiCdQExwpo92xhVnEYJdCu1sEeezmmSQ0jMDEhENTQbJBJsRcSkRC4T%2F6ZJ97I%2FIDKPEh6TR1iR3xfczERuisgEqGWQyLM%2FPJIuZ0KbDaTIsxjcCQCLaPxIrIVMhCrBN8Rj0VMsyNapV1l8nUeXsOoWib%2BjAOvWSUT86IQTmmjAlRlVwHavSJJQTDvh3ZNjVtLu9ejjCCNtAfiiwOb2xmV72I%2FdJ2oomuTZwY6XA1w2BjVw3PR9%2FLs05yKbIAVmQE08w9oHglnwdpI4z7VdrsHHfSqbyIpWcNyykcCVg5Khg0LKXChuVqg4%2F0WqF1C3128Gr8C0nNzkCWB%2FDs%2FiJGcQ0pSuRaZBbyjaY90%2F1xw0wXhPyj12u%2BUXlii8BDZh2zwzYSdpqkQux3wbI6miqbYzuo2%2Bq4Tfb%2BPvSgCbZkulXRz0e5NB2%2B%2Bd337p3faj4%2B7wotMefmi3G72rdve8w4eXnemw%2B9eDeQ9%2BP1u%2FaQxpd%2F0wnPIvi5lFK4mzUFtFuTo10su1CxQHr%2B5VabCt40gJBWONv9TkCgsxKkeJpHli%2BJgu6H6JxWOc42SFTGm0Yp6v5ZOV58Yr%2BXgbwnYa%2Bm%2BtVlQ3ZrGlnNvjrHXSCoLopO4GfzYCtwFx5J6yxrFbD06jVguOGWPRixPyu0foj47IqgRAo8VwmhQqX9CVdp6%2FVvqGlYKTKhH%2Fbpsq7VZH4qduvqKJb3Q%2FP8NBrZNvjij5m%2BKZ8bNv9H0N5%2F7XEPwagv%2F1EODNo%2Bkc2Jha18APmq5%2F6vono3ozDOpho%2BU1Wvi9Fxz6fuj7th%2F8Cizbf8Ib6OXd47xdd9aHvjrs1P3uOuh87j1c9Jbs6EZ23o8%2BqXdvmfQ%2FP6yvm1cNceY8%2FwPF8yV%2BGgsAAA%3D%3D)

Apex (`@`) and subdomain (`shop`) both tested against `example.com`.

