### PR TITLE
Add configuration for Adhoc custom domain service

### DIFF
--- a/adhoc.inc.custom-domain.json
+++ b/adhoc.inc.custom-domain.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "adhoc.inc",
+  "providerName": "Adhoc",
+  "version": 1,
+  "syncPubKeyDomain": "adhoc.inc",
+  "syncRedirectDomain": "www.adhoc.inc",
+  "syncBlock": false,
+  "serviceId": "custom-domain",
+  "serviceName": "Odoo by Adhoc",
+  "logoUrl": "https://raw.githubusercontent.com/ingadhoc/ansible_notebooks/7aa78c7ca9f9b0ff86be1d8be58b91a5de6a83c7/docs/assets/adhoc-isotipo-violeta.png",
+  "description": "Points a host of the customer domain to their Odoo instance hosted by Adhoc. The host is supplied by the caller, so both www.customer.com and odoo.customer.com are covered. Odoo does not support more than one subdomain level, so the host is never fixed in the template.",
+  "variableDescription": "database: name of the customer instance on the Adhoc platform. The CNAME target is always <database>.adhoc.inc, so the variable is limited to the instance label.",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%database%.adhoc.inc",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for Adhoc (adhoc.inc), an Odoo hosting provider.

Our customers point a custom domain at their Odoo instance running on our
infrastructure. Today they create the DNS record by hand following written
instructions, which is our main source of onboarding friction.

The template creates a single CNAME. The host is supplied by the caller rather than
fixed in the template: Odoo does not support more than one subdomain level, so both
`www.customer.com` and `odoo.customer.com` are valid targets and the template must
not be able to produce `www.odoo.customer.com`. `hostRequired` is set accordingly.

The only variable is the instance label. The platform suffix is fixed in the
template, so the CNAME target can only ever be `<instance>.adhoc.inc`.

We recommend Cloudflare as the DNS provider to all of our customers and are
onboarding this template with them.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checklist:

- The template contains a single CNAME and no TXT records, so the TXT-related items
  (`txtConflictMatchingMode`, SPF content) do not apply.
- `essential` does not apply either: the single record **is** the service, there are no
  auxiliary records the end user would remove without breaking it.
- The only variable, `%database%`, is not bare: it is followed by the fixed platform
  suffix (`%database%.adhoc.inc`), which limits it to the instance label.
- The `host` field contains no variable — the host comes from the `host` request
  parameter, as the guidelines recommend.

## Online Editor test results

**Editor test link(s):**

[Test adhoc.inc/custom-domain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB%2BFc2oC%2F91UbW%2FbNhD%2BKwSBfpolS7ZsKcI2LGu3tSjatUH2ggWBcRJPNheJVEnKjhf4v%2FcoRbaTDPsB%2ByToXp977jk%2BcIdNW4NDnj%2Fw1uitFGjeCZ5zEBtdhlKVfHJ0fISGAvmld5F5i8ZKrXgeT7jdq%2FJTV7zH%2FRvdgFTPKnj3FQppsHTHgN1uFz4P%2BrHW5R3PK6gtkgXNVpbYAyo763QTiCH76HvE9KvQmhV7NmKr9Vr%2FZmrybJxrbT6dGtiFa%2Bk2XdFRaqmVQ%2BXCUjdTqdY9jCkoK4saV0o7LLS%2Bs9MUIM3KtISL6qKIqipbFhiLrMBFVlzEsBC4hGxeplOhSzsFa9HRxxcLpNVOtjrYSl2jg7BVa8Il0JZGtq7njX%2FSUjnLgG20dUxXzG2QDYOiYcOozGlvlob1M0plHagS%2BxQUx5lDdr0ZjExaZru2reXg7mtCXaOZMEskabdhnvqxj%2BeAgRJMU%2F1nVkOpmvaMIhzaC42WET99B20cazTFuA0ophWStXhEXeMW676hO8OlyGpYJe8Jmh%2BNXKMCQ68oMBJoA2%2BesCTAQQEWc6Zo2S9oOjKih4I9HczXrLRpBl5ef7z88BNzYNbY44B6B3vLvh1Lf38S4hHzCMbH17KRnu1hF6eWNRRYe%2BR%2BwCv80pHCSazOdKReErs2wvL85oG7fetl2uN4DKffH%2Fxx9Rq41vT7aoTz6sldOEc6ni%2Bj6HB7mPB%2FiOfVqfQtaWo8KLwH4hL96k49aNX0sza6a1dyTGnBQGP90Y%2FJN0%2Byb8f0mz7fN3mEdhbJPRy5VqSAlaUvuM7gOHzT1U6uYAcnkyhXQLLcE3pLXqr0khg1nPMA2vc8G%2BtfOZnwlSj9INI%2FEkmSpMtSiEAk2SJI0ioOQMRJMJvNI5jNkzhdzs8etBcv3X89OE%2F4RDp15ST4F%2BayFxM%2FHG4nxO3%2FbSbavYUtihX4yFk0WwZRFkSL6zjLk2W%2BWISLNJvH82%2BiKI8iPwZaN0z5QPo4VwZP6vjO%2FjW7v%2FoZLmLRzb788eHydZVievd78bayn%2F98J%2F9%2Bq3%2FZxte77%2FjhK5xKnlKeBgAA)

Parameters: `Domain: example.com` · `Host: www` · `database: example`
Result: `www.example.com.` CNAME 3600 `example.adhoc.inc`

Apex test not required: `hostRequired = true`.
