### PR TITLE
add Citevine, Google Search Console verification

### DIFF
--- a/citevine.com.verify.json
+++ b/citevine.com.verify.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "citevine.com",
+  "providerName": "Citevine",
+  "serviceId": "verify",
+  "serviceName": "Google Search Console verification",
+  "version": 1,
+  "description": "Creates the Google Search Console verification TXT record Citevine needs to enable search-performance reporting for the domain.",
+  "syncPubKeyDomain": "citevine.com",
+  "syncRedirectDomain": "citevine.com",
+  "syncBlock": false,
+  "variableDescription": "verificationCode is the Google Search Console site-verification token issued for this domain.",
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "@",
+      "ttl": 600,
+      "data": "google-site-verification=%verificationCode%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "google-site-verification=",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for Citevine's Google Search Console verification flow. It writes a single TXT record at the apex so a customer can authorize the record at their DNS provider instead of pasting it by hand.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver — no `logoUrl` is set in this template

Also validated against `template.schema` (draft-07) locally: valid. The Go linter was not run — no Go toolchain on the machine that prepared this PR; happy to re-run and report if that blocks review.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `citevine.com`; the RSA-2048 public key is published as multi-part `p=N,a=RS256,d=...` TXT records at `_dcpubkeyv1.citevine.com` (live now)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`citevine.com`) — the synchronous flow uses `redirect_uri`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set — `Prefix` on `google-site-verification=`, so an existing verification token belonging to another service is not clobbered
- [x] no variable is used as a bare full record value — the record is `google-site-verification=%verificationCode%`
- [x] no bare variable is used as the full `host` label — `host` is the fixed apex `@`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` — the owner may remove the record after verification without breaking anything

## Online Editor test results

**Editor test link(s):**

- Subdomain (`example.com` / host `blog`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANyTc2oC%2F%2BVUbW%2FaMBD%2BK5GlfirpEggNRKq0vqhrV7VFHetWVShy7Etwm9iRbSgU8d93CTBgZe2%2BT0KCe3nu7rnn8IxYKMqcWiDRjJRajQUHfclJRJiwMBYSDpgqSON37IYWmEtOl1GMGNBjwaAGjUGLdLp2LrO%2FKJXl4HwDqtnQOVXSKDTrZMGoFUoiBE1T%2FYr8BuFgmBZlHcFmGnBC49ghOB%2BXcvo%2F%2B44GpjR3VmM6EoBjAeWApAkCTI13S9Cp0gWVDBBSKm2FzBx01b24KqiQBxWdqWS9UXIF07Pa93Y%2FVcYdcIGN7Xs5J7lizyRKaW4AOVMtqnnOtvhusjlVHBzxHneDTdytBVj1DBJBZgR8SQYrrNkslmNI9DgjmVajcq3dWg47LSvpcJloDJWxaHyu%2FDYn0aHnoUjUUnRm9VTumzGO9v7ksVfBJxYHT3PB7DW1bIj7vsYQ1ulpSMVkd8oy9k4zxIExIK2gOB%2B5lcdlmU%2FJfDBvkFclIV6THuDoK4VgQvH%2BVwItaSa5ytCqVxOLFaakmham%2Bp%2Bs0I9b8MEK%2F7goMGi8EbKK0YRxSP1mK2gfhp2u9zebVJOLTCoNscFvakcaC1g9wrspRrkVMX2haxdnMa0oI1GDUWyF6m6JKBd%2FxiW7j9T75zk3TyLmrFqQqB8Q3mx3PO65SdClbtBudd0kTEOXBqHfookfhszfeFh2PTo7n5ZtkXaKPh80ULH%2FmT8en6Fj4DGtcpte89D1Oq7X7vvdKMBP56CLA7Q6%2B54XeV7FAYxdrGSGd7d5ccQ%2FlxN195C3PpUX%2B%2B306Xvx4%2FjrzVN%2B1b54OO%2B%2F9k5egm54n13e3wZHZP4LniomIFMGAAA%3D

The apex case (`example.com`, no host) was also run in the editor in the same session and produced `example.com. TXT 600 "google-site-verification=<token>"` with no errors, but that run's share link was not captured before the session was reset. Say the word and I will re-run it and post the apex link too.
