### PR TITLE
Add SanityCheck domain verification template

### DIFF
--- a/sanitycheck.dev.domain-verification.json
+++ b/sanitycheck.dev.domain-verification.json
@@ -1,0 +1,21 @@
+{
+	"providerId": "sanitycheck.dev",
+	"providerName": "SanityCheck",
+	"serviceId": "domain-verification",
+  	"serviceName": "Domain Verification",
+	"version": 1,
+	"syncPubKeyDomain": "sanitycheck.dev",
+	"syncRedirectDomain": "sanitycheck.dev",
+	"description": "Verify domain ownership.",
+	"logoUrl": "https://sanitycheck.dev/logos/mark-dark.svg",
+	"records": [
+		{
+			"type": "TXT",
+			"host": "@",
+			"ttl": 3600,
+			"data": "sanitycheck-domain-verification=%verificationToken%",
+			"txtConflictMatchingMode": "Prefix",
+			"txtConflictMatchingPrefix": "sanitycheck-domain-verification="
+		}
+	]
+}


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for SanityCheck's domain ownership verification. The template provisions a single root TXT record (sanitycheck-domain-verification=%verificationToken%) so customers can prove they control a domain before automating tests through SanityCheck (sanitycheck.dev).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test sanitycheck.dev/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHXBc2oC%2F%2B1V227iMBD9lcpSnyCQQKElUqVtu%2Br9pha6lBYhYxviJYkt2wRSxL%2FvONAFuvSC1Md9IU7mjGfmzJlhggyLZIgNQ%2F4ESSUSTpk6o8hHGsfcpCRgZFCgLEH5v%2BZrHAEc3WeAIwsAo2Yq4YRlrlREmMdOwhTvcYINF%2FECMff%2BmWG2HlYx4KLtyfcAn8bkdti9YOkMuzYnC7pjlCtGzAcwyjRRXGZRfJQFTbdmaW6JUQxRAy4LAAxFXzRUCKDAGKn9YvHNZUWL0MUIq4FD4aegkz74QXyhqEb%2B0wSZVNoK6806GAKhDbz8gKMxcG%2B56rqQDzZ4NVFnDWn728tvdTFg8ba9Z2yORNwLOTFX2JCAx%2F0rQW3IW8V6fLweMrd9HhRN29M8ehEx6yyqaufnXYUL2BiDZliBiGhRIJz6Sgxlh7%2FiJVY40lZXr55PK67tV98nZM%2F%2FlGoN4sFLCavXG1JeVgJVTniv1UrDVknE4kTjszj5ddpIgsd73NhHNm3ej4ViHQ1PbIYKSDFqyPIoGoaGd%2FAILz5R0sFShilUqcEK4d72Lp5J1fbuiw3bKN8VRXQosVRxOz%2BVamnH65Y9h3g9z9nBdM%2FBrFtzyjVW6RFa89wSWZrHd8b184lctI5pzWLDsRX%2BQTjCqUbTaTsPbfzPySonoFSNE0Y72MJKbqnquHuOW6mXyr6745e8Qs3brVbdnOv6rmvrYdrMmJpk52wisGRj%2B0yw4rgbsuzjmglAG5L3zoxmk2mncmo3lVX7mk017%2BySZ2Ht0nr%2B1o4%2Fo9m%2Bsf35CiFe35x3u42j49%2BHvZMKxfcyd9g8lMf1UYtdH8dnh3JvQE5ucjc3%2BgNC5l2eiWITdsCj8A0MbVLFjKGpFW8I%2F3IgPSsjCJOJCL4vbzv0WKQHfNCM6OnL2NOXt4NdZl4UvssNKpd6zM8vmpXyeBQ8HFwT2PR%2FABFIDlYACAAA)

[Test sanitycheck.dev/domain-verification example.com/dev](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOO9c2oC%2F%2B1V224aMRD9lchSnsKCs4RLV4rUkpYkbXMRlyQlQcisDTgstmWbhQ3i3zteSIGINCD1sS%2BsL2c8M2fODDNk2UhFxDIUzJDSMuaU6UuKAmSI4DYJBywcZimLUebP9TUZARzVU8CZA8ClYTrmIUtNqRwRLryYad7jIbFcihViaf01xRzcbWLAxLhVcAz4RIS34%2B4PliywW2NyoBqjXLPQ%2FgVGmQk1V6mXAKVOk4NFmAdyIsDrgKssACPZl00dAWhgrTJBLvfmsZxDmNyI6KFH4Sdr4j7YgX%2BpqUHB4wzZRLkMGw8NuBhIY2HzGZbWwrv5IsYQD7FkM1BvC2mnh%2Bu7hhwycejemdozKXoRD%2B0VseGAi%2F6VpM7lrWY9Pt0OWd597BTN2%2FMMepGCdVZZtTPLqsIDbEpAMywbytEqwQXPfS3HqsNfTRTRZGSctF6NHzes26%2Fmj6l9OxXAZsLu7rhvv3e7zbPqc6V3XqCkro4qDxVVbUxa7LoqLiuqPAzPb45ubswpcsHzvpCadQx8iR1roMbqMcug0TiyvEMmZHVEww5RKkogVwO34O5tBcVCsEsh7Va4vSLeUEaHho4v7vqo7GNc7OKCh4s09E5OMPbK1C%2FBNsz7RVYolEtkrS%2FfaduPO3OjhMwYJiwnrge%2BRBOSGDSftzNQzv%2FEbCEGNGtIzGiHOKSP%2FaKHyx4uNHw%2FOPkU4FIWlyD%2B8hHGAcYuJWbsgqxZuk7bgyg2dd%2BYaE66EUsPt%2FQCknfHScgajaZSPwsDnY95r9VKopYvhTw35FLE9xfNePCrTpqOv3d6Nm1T16JzN7mc7rdMrmV51yyzW4fY04dF3yfoJ7SYP47zXQjZU1A7D7Ed2QGL7D9gaJ8sFgzNnX4j%2BNcD6TkZLaOH4%2FWxhwritlbT1%2FkHeXEvTDOHZS7uV%2FGzvfPrfqn8%2FVsJl2rjl7MuncDg%2Fw3nukjYDwgAAA%3D%3D)