### PR TITLE
add MonCoach, MonCoach — site en marque blanche

### DIFF
--- a/moncoach.io.site.json
+++ b/moncoach.io.site.json
@@ -1,0 +1,33 @@
+{
+  "providerId": "moncoach.io",
+  "providerName": "MonCoach",
+  "serviceId": "site",
+  "serviceName": "MonCoach — site en marque blanche",
+  "version": 1,
+  "description": "Connecte un domaine à une plateforme MonCoach : site vitrine, réservation en ligne et espaces de gestion, avec vérification de propriété.",
+  "variableDescription": "ip = adresse du edge MonCoach ; token = preuve de propriété générée par la plateforme",
+  "syncRedirectDomain": "moncoach.io",
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "*",
+      "pointsTo": "%domain%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_moncoach-verify",
+      "data": "%token%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **MonCoach** (`moncoach.io`), a French white-label coaching platform. The `site` service connects a customer's own domain to their MonCoach site: apex A record to the platform edge, wildcard CNAME for the app/booking subdomains, and an ownership-verification TXT record. Template variables (`ip`, `token`) are generated server-side by the platform when building the apply URL.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver — no `logoUrl` in this template

Also validated with `dc-template-linter -loglevel error -tolerate info` (exit 0; only infos: DCTL1029 no syncPubKeyDomain — justified below — and DCTL1021 `_moncoach-verify` not an IANA label, expected for a provider-specific verification record).

# Checklist of common problems

- [ ] `syncPubKeyDomain` is set — **justification:** apply URLs are generated exclusively server-side by our platform (no user-editable parameters), and `warnPhishing: true` is set so registrars display the confirmation warning. We plan to add `syncPubKeyDomain` + signed apply URLs (key published at `_dck1.moncoach.io`) in a version 2 once our signing endpoint ships.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — only `warnPhishing` is present
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (`syncRedirectDomain: "moncoach.io"`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (`All` on the `_moncoach-verify` token record)
- [ ] no variable is used as a bare full record value — **justification:** the apex `A` record value is `%ip%`, the address of the platform edge. An IP cannot carry a fixed prefix; the value is not user-supplied (our backend injects the current edge IP when building the apply URL). Kept as a variable rather than hard-coded so an edge re-IP does not require a registry-wide template resubmission.
- [x] no bare variable is used as the full `host` label — all `host` fields are fixed (`@`, `*`, `_moncoach-verify`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set on records the end user may need to modify independently — not applicable: all three records are required for the service to function

## Online Editor test results

**Editor test link(s):**

- Apex: [Test moncoach.io/site example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABJLdGoC%2F%2B1VS28aMRD%2BK5alXFIgC7sJsFWkRElbRS2oSukzRcjYA1js2hvbS0IR%2F73jXZ4pufWQQ06enZlv9puHxwvqIM0S5oDGC5oZPZMCzI2gMU214prxSU1qWtmYuixFV9rR6sob0WLBzCSHAmMlBtqonviS33kjqEfEOxFQJGXmPgcyTJjiEw%2BbgbFSKxrXK1SA5UZmrvimV1op4AjLFRE6ZVIBRgsCCFADpEhgpE0KZPOzuPzPTDqD3hViCv%2B2p8Z8VM8gkWNEgyNgM8bBEgFkDNabK4TNgJNZiTJyJHkJQxesRWZkaXHlUfP0mZFsmMD1HnWZkXPChAFrgYicgBjvsHxLnJ4ik3MMCvkMnglPxuWpVnTKA12ZIQnbyd8Xf674LQhpsGDXRa3%2BaeYDM%2BrzRNqJVGMaO5NDhU60dbdwnyMOOzliiUUlxtBGWBrfLaibZ76bl7T0RfHCz4WWytmexs8jmR2hxrmExmEQLCsbzFX3svNuizt%2Bgis7%2Bgy296O3RQ7WeVRxVuRojhbBHPNBijruxkDp0eHgjBLJXYc57rPtaFEkkSR02V9W6B%2BtYLDNso%2Fx1iWDR4Y3A2pcp1sCKI2NzrOBXPtjC1hq%2Fe1ZI%2B%2F2oP019o56WWZeqofNWjOqtRu10CsL7l6f8lVi1XDUZnXeGDYF9TxxULWBgcWTudzAumtpnjg5YNjQjUrwAcuyZI5pWbRi2P3mqfJWXmxrt8tmt34DwX1e0t%2Fs4DQatiMQ1bNm2KpG7Wa92uaiUQ1ZaxhBO4z4aLSzJg5skAN7YltUfzuUkywpmvPA5pYuDwzQivvxlvt%2Bl14i93KAV8yfH%2BCDrX9JGfUrOO6vo%2FQ6Sv9hlHDnWXxfxYB5t0bQOKsGrWpw1gta8WkdSdZap%2FVWu%2FEmCOIg8NzxVS6zW%2BA23N2DlF%2BGH067UTfMpuzXyc%2Fk%2FXc968HJbWs6%2FfL15JtufpSfsiBKNL85p8u%2FVCcJo%2FEIAAA%3D)
- Subdomain (host=`coach`): [Test moncoach.io/site example.com/coach](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB1LdGoC%2F%2B1V227bMAz9FUFAX7okc%2BI0Fw8FVjQb1hXpiiLdBV0RKBKdaLMlV5LTZkH%2BfZSd%2B9LHAX3ok2ySh%2BYhj%2Bg5dZBmCXNAoznNjJ5KAeZC0IimWnHN%2BKQmNa2sXVcsxVDa1%2BrcO9FjwUwlhwJjJSZam%2FZiyc%2B8EdSbxAcRUCRl5iEHMkqY4hMPm4KxUisa1StUgOVGZq54p%2BdaKeAIyxUROmVSAWYLAgjQAqQgEGuTAll%2FLCq%2FM5XOYHSFmCK%2B60tjPquvIJFjRIMjYDPGwRIBZAzWuyuETYGTaYkyMpa8hGEI9iIzsvS48qj58pmRbJRAb6d0mZFTwoQBa4GInIAYb1X5jjj9Gys5xaSQT%2BGZ9GRcnmpZTnlgKDMkYVv8ffNnit%2BAkAYb1it69c8wH5lR1xNpJ1KNaeRMDhU60dbdwEOOOJxkzBKLRsyhjbA0uptTN8v8NM9oGYuP770utFTODjS%2BHsnsCC3OJTQKg2BRWWPOr876Hza44z1cOdFnsIPvgw1yuOJRRa3IeIYewRzzSYo%2BbufApyeHwokTyV2fOe7Z9rUoSCQJXdwvKvSPVjDcsLzHfKuWwRPDmwE1rtNNAXwp%2BrHReTaUKxDOgaXWX6EV%2FG4Hf79KcLfMgAaZ%2Bdd62K61m7VuoxZ6Y8HC21O%2BpFgN4y6r88aoLaivGCWrDQwtnszlBlbzS%2FPEySHD0a5Ngg9ZliUzJGjRi2l3x6jK%2B7nitOzkdkXb3RwK7glKf88FxCfATxpV0WixarPdCquddktUuzxsxSKIoR6OtpbGgX1yYGvstdhfGOUkS4p5PbKZpYsDmlqSOK7t0dgd34ulUcp7SWJf3vucDorixZG7r%2BCVeFXaq9L%2Bv9JwY1r8T4sh87GNoNGqBp1q0BoEneikHjXrtWYrbIWNN0EQBYEngH%2F3kuIcd%2Bn2FqX608fR1ddb9fmy3%2BuNBTu7vPgNFyP1DVd7Vyr29kfn15c4vu7C7Sld%2FAV76mCAOQkAAA%3D%3D)

Both tests applied the expected three records (apex A → edge IP, wildcard CNAME → apex, `_moncoach-verify` TXT → token).
