### PR TITLE
Create lucaledger.net.app.json

### DIFF
--- a/lucaledger.net.app.json
+++ b/lucaledger.net.app.json
@@ -1,0 +1,17 @@
+{
+  "providerId": "lucaledger.net",
+  "providerName": "LucaLedger",
+  "serviceId": "app",
+  "serviceName": "LucaLedger App (white-label)",
+  "version": 1,
+  "logoUrl": "https://app.lucaledger.net/favicon.svg",
+  "description": "Point a subdomain (for example app.yourdomain.com) at your branded LucaLedger app. SSL is issued automatically.",
+  "variableDescription": "your app subdomain",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "lucaledger.net",
+  "syncRedirectDomain": "app.lucaledger.net",
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "portal-proxy.lucaledger.net", "ttl": 1800 }
+  ]
+}

--- a/lucaledger.net.portal.json
+++ b/lucaledger.net.portal.json
@@ -4,19 +4,14 @@
   "serviceId": "portal",
   "serviceName": "LucaLedger Client Portal",
   "version": 1,
-  "logoUrl": "https://app.lucaledger.net/icon-512.png",
+  "logoUrl": "https://app.lucaledger.net/favicon.svg",
   "description": "Point a subdomain (for example portal.yourdomain.com) at your branded LucaLedger client portal. SSL is issued automatically.",
   "variableDescription": "your client portal subdomain",
   "syncBlock": false,
   "hostRequired": true,
-  "syncPubKeyDomain": "_dc.lucaledger.net",
+  "syncPubKeyDomain": "lucaledger.net",
   "syncRedirectDomain": "app.lucaledger.net",
   "records": [
-    {
-      "type": "CNAME",
-      "host": "@",
-      "pointsTo": "portal-proxy.lucaledger.net",
-      "ttl": 1800
-    }
+    { "type": "CNAME", "host": "@", "pointsTo": "portal-proxy.lucaledger.net", "ttl": 1800 }
   ]
 }

--- a/lucaledger.net.portal.json
+++ b/lucaledger.net.portal.json
@@ -8,7 +8,6 @@
   "description": "Point a subdomain (for example portal.yourdomain.com) at your branded LucaLedger client portal. SSL is issued automatically.",
   "variableDescription": "your client portal subdomain",
   "syncBlock": false,
-  "warnPhishing": true,
   "hostRequired": true,
   "syncPubKeyDomain": "_dc.lucaledger.net",
   "syncRedirectDomain": "app.lucaledger.net",

--- a/lucaledger.net.portal.json
+++ b/lucaledger.net.portal.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "lucaledger.net",
+  "providerName": "LucaLedger",
+  "serviceId": "portal",
+  "serviceName": "LucaLedger Client Portal",
+  "version": 1,
+  "logoUrl": "https://app.lucaledger.net/icon-512.png",
+  "description": "Point a subdomain (for example portal.yourdomain.com) at your branded LucaLedger client portal. SSL is issued automatically.",
+  "variableDescription": "your client portal subdomain",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "hostRequired": true,
+  "syncPubKeyDomain": "_dc.lucaledger.net",
+  "syncRedirectDomain": "app.lucaledger.net",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "portal-proxy.lucaledger.net",
+      "ttl": 1800
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New provider template for the LucaLedger white-label app. Points a customer subdomain (e.g. `app.yourdomain.com`) at their branded LucaLedger app via a single signed CNAME to `portal-proxy.lucaledger.net`. Companion to `lucaledger.net.portal.json`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (n/a — no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (n/a — no TXT records)
- [x] no variable is used as a bare full record value (n/a — no variables)
- [x] no bare variable is used as the full `host` label (n/a — no variables)
- [x] no variable is used in the `host` field to create a subdomain (uses the `host` parameter)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` where appropriate (n/a — the single CNAME is essential and must not be removed)

## Online Editor test results

**Editor test link(s):[Test lucaledger.net/app lucaledger.net/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABuTdGoC%2F91TYW%2FaMBD9K5E%2FtRqBJNCSRZo0NqqpKmsr2n2YKhRd4gOsmTi1ndAM8d93JqO0o5P2eRISiu%2B95%2Bd3dxtmcVVKsMiSDSu1qgVHfclZwmSVg0S%2BQN0t0LLOc%2FUaVoRmE6pPdnWqGdS1yHFHhLI8nByBvVFZeifrpbDoS8hQnhK4Rm2EKlgSdphUC%2FVNSyItrS1N0uuRYPe1m94cSFwVXVMviM7R5FqUdifBbpUorAeeqTKuViAK72SutIdPQC9Fz6k1qtJtrZur1akH1nNHXqah4Mi9F3Yd3Lu7m3jC0M9UVIXKEtcKciSbrrMPWkAmcfzKx06R6AcjLpamyD9Jlf9gyRykwQ5bKmOn%2BFgJjZSe1RW2qNsqu8Jm3BLfaIfDTJETLbfPqOOoCEkIpblhycOG2aZ0%2Ffh8Pfp6wdrL6fOja6%2BLzdwr%2BiyVtiB9avhTcyxnLTUnjINgO9t22E9VYHq4YUbd%2BKvl37e1A7LQqipTsWeVoGFl3BTu%2BQ9%2FCsz2Cg87CXe7WBRKY2roH2ylcR%2FgqpJWpLCGwxHPU2LJhswaqpLKcRxFO62tQQ4W%2Fj2MDkt57uwLtwMYx4DzuO%2F3Iz70B8PwvZ8NI%2FQDzoMo5HA2BHyxUm8v3PFSvQoQjcHCCnCrMpJraAzbbmcdCvO%2FfBh130CNPAWHjILo3A9iPzi%2FD%2FvJWZychd1oEISD4bsgSILAvQCNbZ%2B6oUl5OSPs8ZJPxKS4ub1ZjwdzO2hEP36Sl2Ic1aP6uxx8uXqcZsvyJjYXH9j2F%2BYCUj8lBQAA)