### PR TITLE
add HAST-IT, Webspace und E-Mail

### DIFF
--- a/hast-it.de.hosting.json
+++ b/hast-it.de.hosting.json
@@ -1,0 +1,69 @@
+{
+  "providerId": "hast-it.de",
+  "providerName": "HAST-IT",
+  "serviceId": "hosting",
+  "serviceName": "Webspace und E-Mail",
+  "version": 1,
+  "logoUrl": "https://portal.hast-it.de/brand/logo-hast-it.svg",
+  "description": "Points a domain at the HAST-IT web and mail platform: website, mail exchange, sender authentication (SPF, DKIM, DMARC) and mail client autoconfiguration.",
+  "variableDescription": "dkimkey: the public part of the DKIM key that HAST-IT generated for this domain, i.e. the value of the p= field, without the p= prefix.",
+  "syncPubKeyDomain": "hast-it.de",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "188.34.130.103",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "188.34.130.103",
+      "ttl": 300,
+      "essential": "OnApply"
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mail1.hast-it.de",
+      "priority": 10,
+      "ttl": 300
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "a:smtp.hast-it.de"
+    },
+    {
+      "type": "TXT",
+      "host": "dkim._domainkey",
+      "data": "v=DKIM1;k=rsa;t=s;s=email;p=%dkimkey%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DKIM1",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:postmaster@%domain%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig",
+      "pointsTo": "mail1.hast-it.de",
+      "ttl": 300,
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "autodiscover",
+      "pointsTo": "mail1.hast-it.de",
+      "ttl": 300,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for HAST-IT (Hausdorf & Stritzke GbR), a hosting provider based in
Germany. It points a customer domain at our web and mail platform: website,
mail exchange, sender authentication (SPF, DKIM, DMARC) and mail client
autoconfiguration.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — the signing key is published at `_dck1.hast-it.de`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — not applicable, the template uses no `redirect_uri`
- [x] no TXT record contains SPF content — SPF is expressed as an `SPFM` record
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — DKIM and DMARC, both `Prefix`
- [x] no variable is used as a bare full record value — `%dkimkey%` carries the fixed prefix `v=DKIM1;k=rsa;t=s;s=email;p=`
- [x] no bare variable is used as the full `host` label — the DKIM host is the fixed `dkim._domainkey`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — www, DMARC, autoconfig, autodiscover

Also validated with `dc-template-linter -loglevel error -tolerate info -logos`: exit code 0, no findings.

## Online Editor test results

**Editor test link(s):**

- [Test hast-it.de/hosting beispiel.de/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJsedWoC%2F%2B1Y6W%2FiOBT%2FV6JII%2B2qHIGEI1RIE642A7ThKi2jCjmJQ1wSJ40djlbdv31tjgItOzua3Q%2Bsli9t7Od3%2FPx%2Bfu%2BJV5FCP%2FQAhWLpVQyjYIZsGOm2WBJdQGgS0ZQNxcS75Ab47KR4rfX6Sb3PBARGM2TBtUZAKMKT3e7m9BCaJAQWFGJsC%2FVkGyCPnZnBiKAAi6VMQvSCSTCIPG6D0pCU0ukwiCjwUrsg0mYEsJ3mJ5PbXTLjzmxIrAiFdGVMNAKEKRGAYAc%2BQFgAVKAuFDYRC3NoCsyOwGSewIE7QeSX%2BDZBFCbW%2B3BhuQBP2JJAzFALIGY2MEUW4F6E33pGIyHUmnqb%2FW1r3ervO5uWh9hJrhFYAXbQJI5WSikOGUQImB6sHURsT5E%2FhcvSKs4wNj1kCSGIqBA4qy3uR2AH2IKB2QKZQAyZZWgLDAETIbJBnBBQCqZWmjPgxXBrJiwLDoKenRDmiLpBTLe7YQQdtODxkSW2jNhswmVtZeojCyJoBZFNxNL3V5EuQ55bjW3zvLPPr5wnq9vvB2yZKRZTspLKyFIqI8lMRilLsCxJb4lj2vP5%2FCf1EyIkhGcDcMLcYi0MvaW4Z7V9%2F5dB8RRlUh%2BojYII0SUjonQ0SJbs9qFBEjrd2IPsIkRQIj4N9y3uafbv%2BztFnubUeJ0jlk1OXEABE8zKPMOZy2k5IuCSlsklKUMe6GVY%2FrIhxxeOf0GrjFGMHrQNqOWyp9YObO7HWGXw%2BJGN7N3N8UQcRDq2fRBZBwFykmcuGVtwgOGlEMWgzCOkQSlkOj5DD6OvX9bg%2Fp1YVx7F47k%2BCqF6o7XrOxC7B%2Fi3DPhpYh1xYSNiBayU%2FVMnj28J8YXd7Xj3xh5ZArbP0ISIhOz1rm1t%2FLOvSRTE4Rhtz7OyAXzCS%2FlW8%2FuB6uNW97vIvzfk4su2rlf0J%2B2mMpk%2Bu1N0pc6litapNzTttqp1ihqXVydN9l3XsmQgd1%2FyN72ruYMLatatN2%2BdyUsBw0klbfvP02tqD7LoudlJPw3A8Lr%2FZKfdRoB7PW2hay%2F5zgyrucYsXXGt%2FvODlC9gYxHUCw8zwwfXTfllkb%2B7XlqqU7Nqt0rFyoyWuP4Am8B6Cia6g9sNpauMpvni4ttwOpJMUIWtFk2bKB3C%2FqxoTe%2Fqt2RBdVci%2BcJgVOuYWV%2Fp1Y1i3ynA7EyqZO8vrDjS1Ht3Np3b9bacN3vKg93VWiQObhSkmAPfbC6VWvTSz8vgAqfzTw9ukBvUcuawM7pp4Cp5uh8OKtnBHRg2F2pnaqTn9kVRN9RBK65XSaGVU03U0BYtcJVTjM7FMw6v7cVwdHcb6a2iO5I1wyv0c%2Fnc1Z1lpGu4PejoNa2jVUROBDTBQQTHhP0HNI4Y9WgUw4Toxx5FYzAHuy3bGgPOIMYbwqQslYe1Ga9b8Nfda%2F5BXR3bFucO4s28kHFk01LlZIbdWlJxCmZSzQKYhMWCo0DHLKpqcW8w%2BDwyHJ8MdtTdfwaaNwdLIr59aA2b4Net4YTDf3%2FFH5vQ59v%2FYWU4bEWnlI11f%2FgMZ1ZmvTAjfOqCwh%2FA87bY8pJ0ynB%2BqTGf6%2BWJ1MtTrV8HFPvVieqw7Z9opdtORRusB4PXz1S9UwezN%2BL9R%2BA8JtgweJ4DznPAeQ44zwHnOeA8B5zngP%2FnHPDINMEM2mPAz2WlbD4pFZNSvp%2BVSzmlJMmpjFpQ5fyFJJUkiYcPCV2De31jEPZ%2BgRA7Q7douHq3NtR69Ymn4pY%2B%2BKb0aRdfGC0Me8Dt0Z7cr11VlbL49id2IZ%2BMWRgAAA%3D%3D) — zone apex
- [Test hast-it.de/hosting beispiel.de/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKcedWoC%2F%2B1Ya2%2FiOBT9K1GkkXYFhAABAhXShkdbhkehQGkZVchJDDEkdoid8Ki6v31tHkPpMLOzjw8diS9tYvs%2BTu7xvUe8yAx6vgsYlIsvsh%2BQCNkwqNtyUXYAZQnEFBvK8a87beDxk%2FKt0esn6n2%2BQWEQIQvuLAhlCE%2BPq%2FvTQ2hSH1hQCrEt1RItgFx%2BJoIBRQTLxVRcdsmUDAJX%2BGDMp8Vk0icBA65yTCJpBgDbSXEycVilkQhmQ2oFyGdbZ3KHIMyoBCSbeABhCTCJOVDaZywtoSlxPxLfcyUBfEICryiWKWIwvluHK8sBeMpfKcQctQRC7gMzZAERRfqt17mOS9VGvcX%2Ftoz7yu9Hn5aL%2BElhQSyCJ2gaBlsjRUAGAQKmC6snGdtz5M3hurjN0w9NF1mSDwImkcl2ScSR%2BAH%2BwsEcgEwhhtwztCWOgG8hukccl5ACla1lBNwQHtz4JWmCoGvHpSViDgnZYdUP4AStRH50ja1OaDbgurp19Z4FAbRIYFO5%2BOVFZmtf1Nbgy6Lu%2FPEPwZPt1%2B8T%2FprSdSWjKamMqqTUDN9jjBc4o6qv8XPWy%2BXyJ%2B3jMqRUVAMIwtxhw%2FfdtfzGa%2Bvxu0mJEqWUd9RGJEBszYmonk2SF7t16pD6k%2FvQhfxDyKBIPea%2F9fjGsv%2FYPxqKMivjXY14NQVxAQN8IyqJCqeu5qWAgitWole0BEWiV37p054cnwT%2BFatwRnF6sBZglsOvWovYIk5nW8HzR%2FZ7X8OcL8RJpmPbA4F1kqAgeeqKswUTDK%2BkIAQlkSEjRZ%2FbeBw9DP74tAP3%2F%2BS6jSifr%2FVZCJW20aodQRwv4N8y4KeJdSaEjahFeCv7r0GeX%2BPyhn%2Fb8fGOPfMCHK6hCRH1%2Be3d%2BdrHpw7x%2Bds0IKE%2FRgcb3jqAR0U7P1h%2FOTF%2FPth%2F2TkQYXYkE0uter1cnxnt8nS%2BcOboprBUy0a3dm0YdxWjqxtivzJt8OeakaaDzP0m1%2B7dLCc4X0g7tcbdZLrJYzgtJ21vMb9l9iCNFo1ucjYAw9v%2BzE461wT3esaqbmxy3QgXstdRsuxY%2FcWTmsvjzorU8k9RxwO3jcxmlXu4XVuFSdWq3mllKzVa49oTbABrRqb1CW5da%2FfaaJ7TV5%2BH85FqggpsNlnSREkf9iPdmj%2FU7uiK1R2V5vKDUbVrpj2tV%2Bvo%2FUkepiO1nH6MWWFgFB6daL60a61MzuxpT%2Fa90aQhaWtIMwee2Vhr1WDTz2VADCdzsyeHZAfVrDnsjtrXuEJnj8NBOT14AMPGqtCdd5JLO6bXO4VBM6xVaL6ZLZjo2lg1wU1W63RjC%2Bzf2qvh6OEuqDd1Z5QxOm6%2Bn81lbx6sTrKKW4NuvWp0jbIsCIGmmARwTPl%2FwMKAU5AFIYzLXugyNAZLcFyyrTEQTOL8oXyXl%2FK0R%2BPdKN5TZn%2Bxf9Bix7YlKITEXFcBP5jOZBNZ3QIJzcqChG4XrESGP1manjE1O%2F1GI3yrHs6LhFMWv70VhrsEayq%2FvpsUewx8Uii%2FBo6vt%2Fv9cDpbjR82jdMp9dGqsxsfZ1FFJT4tU9I3c1L6E7juAWJOVT86qnfjW3mP8vsz%2FNJSP0hL%2Fcj97YRrOwH2LcV%2BSoWdSoUP3AkPamoP%2BijYlH%2FQF38FVAeN%2BAvieo5zSXlREhclcVESFyVxURIXJXFREhcl8e%2BUxDO3BhG0x0CcTavpXELVE2qun84Us1oxlVXSul7IqTFVLaqqgAAp2wF8eeUw3vwKItOYPdIro0bS%2Bxyrz%2FBKpXkSRflFBTSW2qI9f1rHen0423hgUJJf%2FwKQvvCx5RgAAA%3D%3D) — with host set