### PR TITLE
add Drivethrough, Drivethrough website

### DIFF
--- a/drivethrough.dev.hosting.json
+++ b/drivethrough.dev.hosting.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "drivethrough.dev",
+  "providerName": "Drivethrough",
+  "serviceId": "hosting",
+  "serviceName": "Drivethrough website",
+  "version": 1,
+  "logoUrl": "https://drivethrough.dev/og.png",
+  "description": "Connects your domain to your Drivethrough site by pointing it at your site's Drivethrough address.",
+  "variableDescription": "sitehost is the site's hostname label on drivethrough.site.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "drivethrough.dev",
+  "syncRedirectDomain": "drivethrough.dev",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%sitehost%.drivethrough.site",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Drivethrough (drivethrough.dev), an agent-first website host. The template connects a customer's (sub)domain to their site by CNAME to `%sitehost%.drivethrough.site` — the suffix is fixed in the template so signed apply URLs can only point DNS at our zone. `hostRequired` is true: the record applies under the user's chosen host (typically `www`); apex connections are handled outside Domain Connect.

Validated with `dc-template-linter -loglevel error -tolerate info -logos` (clean).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`drivethrough.dev`; key published at `_dck1.drivethrough.dev`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the sync flow uses `redirect_uri`)
- [x] no TXT record contains SPF content (no TXT records in the template)
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [x] no variable is used as a bare full record value — `pointsTo` is `%sitehost%.drivethrough.site` with the zone suffix fixed
- [x] no bare variable is used as the full `host` label — the only record host is `@` (host-relative, `hostRequired: true`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — set to `Always` on the single CNAME; it is the template's sole purpose, so independent user modification would break the service by definition

## Online Editor test results

**Editor test link(s):** [Test drivethrough.dev/hosting example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGEndWoC%2F91T72%2FaMBD9VyxL1T6UQKBQINKk9dekaSrqqrabhlDkxJfgLrE924FliP99Z1gGrGz7vk%2FWnd%2FzvXd3XlEHpS6YAxqtqDZqITiYd5xGlBuxADc3qsrnbQ4L2vp1P2El4un1HgJvLZiFSGFDnivrhMx32SMUsoTECqzcogswVihJo26LFipXj6bwjzinbdTp%2FK6ko%2FK23jzOwaZGaLfh0islJaTOklpVhnBVMiGJU9vwoLIvS5KaaCWk10mEI8xtgf7ulT3EM84NWNv2UpkRLCng%2BqC0J3nPRFji5tA84lMSnZOCJVAQJcmBF4%2Fyb9pappeFSr%2FQKGOFhW3mrkreQ329sXF8Hh51D1wYdP03nJdxD18rBOJwnKmwAnKU4ZZG0xV1tfbDuZpc3N78hGP4xk%2FcN8g%2BKAxPGo8n7RcmEOkcjuzsPAxbFDsF2FbmZ3hRLFlt6Xq2btHvSkK8qzvD%2BTWi4RvDNYR2qsqdgOVyiUGOZXQsGopmhpXWb2tDnh6wZw19uuFj2Oj2KSfKwM6Vpl6PyKUyEFs8masMNK0pq8KJmC3ZLsXTmGld1Cjf4i0%2B9bJtcrviW9WcOYZBU%2B9fLYt56i2Jzcdj2XA8zsZBd5B2g36WZkHSDfvBYNjvQ%2B98NBhl3b3P%2BKfPevw7HrT22KDWsxa2%2Bf915xeCLYDHzCN7Ye88CEdBOHwIw%2BisG%2FXG7bPRYBwOTzEOQ%2B8DrNv6XeHO7G8LnVxl%2BWXv%2BfNtj394epTP6RMvHyYimXQMvK2Kjr75WJmbT7k%2BVa%2Fp%2Bgd0QHocbAUAAA%3D%3D)

(`hostRequired: true`, so per the instructions only the subdomain/host test is required.)
