### PR TITLE
Add bunni.ee.customdomain.json (Bunni custom domain for profiles and short links)

### DIFF
--- a/bunni.ee.customdomain.json
+++ b/bunni.ee.customdomain.json
@@ -1,0 +1,36 @@
+{
+  "providerId": "bunni.ee",
+  "providerName": "Bunni",
+  "serviceId": "customdomain",
+  "serviceName": "Bunni Custom Domain",
+  "version": 1,
+  "logoUrl": "https://cdn.bunni.ee/assets/logo/bunni-logo.svg",
+  "description": "Serve your Bunni profile and deeplinks from your own domain.",
+  "syncPubKeyDomain": "dc.bunni.ee",
+  "syncRedirectDomain": "bunni.ee",
+  "syncBlock": false,
+  "hostRequired": true,
+  "variableDescription": "dcvuuid: the DCV delegation id of the bunni.ee zone, which lets Cloudflare answer certificate renewals without the domain owner acting again. ownershiptoken: a one-time value proving the connection was started from the owner's own bunni.ee dashboard.",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.bunni.ee",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%fqdn%.%dcvuuid%.dcv.cloudflare.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_bunni-verify",
+      "data": "bunni-verification=%ownershiptoken%",
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Bunni (https://bunni.ee), a link-in-bio service. It lets a
creator point their own hostname at their Bunni profile, which is then served
at the root and their short links under it.

Three records: a CNAME to our Cloudflare for SaaS hostname, a permanent
`_acme-challenge` CNAME delegating certificate validation so renewals never
need the owner again, and a one-time ownership TXT.

`hostRequired` is `true`. Our TLS terminates on Cloudflare for SaaS, which
does not support `APEXCNAME`, so the one-click flow covers subdomains only.
Apex domains are supported by the service through manual DNS instructions.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on two of these:

- The ownership TXT is `bunni-verification=%ownershiptoken%`, and it carries
  `txtConflictMatchingMode: "All"` so re-applying replaces our own record
  instead of stacking another one.
- That TXT is the only `essential: "OnApply"` record. It is read once, when
  the hostname is first verified, and the domain keeps working after the owner
  removes it. The two CNAMEs are permanent: one serves the site, the other
  answers certificate renewals.

## Online Editor test results

**Editor test link(s):** [Test bunni.ee/customdomain bunni.bio/links](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP2HdWoC%2F%2B1VW2%2FbNhT%2BKwQBow%2BxZPkSXwQUWOr0YS3SBq1bbAgCgyaPbC40qZKUNSfwf9%2BhZDm213bbW4GVL5LO%2FXznO9QT9bDOFfNA0yeaW7ORAuyvgqZ0UWgtYwDaPsjfsTXa0VdBg2IHdiM5VNa8cN6shVkzqZ9Vxw5kWpmQ68ZmA9ZJo2nabVNlluaTVWi78j53aafDhY6bEjrMOfCuE6w6lTAKr7HbLDGOAMetzH0Vi37EzEC2prCkTovFZ1IBYVoQAZArqR8cySyWUlmZUpO67jgUvtX8tli8he2%2BzpQKHh9hEQw%2BgJAWuD%2BYnOlfKcMfaJox5aBNV8b5D%2FClQBdEytsCZRtmJVsouD6pXfBNUUiREr8Ccj39jPUqWLKgJVIQk1WKJhl5NBrapFxJviIK8SFTZQqRKWZDt64ESzhYLzPJccDEgoYSSyKl9CtT%2BCpY3XkAAa0Z91IvCVsGMGqZW2F15gF0ShjBfJGXayAbpgogFS3QPsThRmtEJFRaMkecZ9aDqGEO%2BirYC1ehfWhAMLdaGGZFQB4BNVY4mt49Ub%2FNA2%2Bm765uXtMaQfz8JVDRSO3dzBwohyUej8d7JFF%2FmCS79rfCzBlfQ8RXTCnQSzgN2sq%2BCN2KW%2FtRtGJ8ifkB15ib9TeyzH6bHeWoWYoUl9k2cJR51vCkloaZIFovW6cwt0L0P%2F3U6ExJ7m%2BY5yvE%2BMaIkONKKdQDboP2koV1ea%2Bv8lxtT2q637Vp4Mb8GdJ7LOGUrAtpnsutdgI%2Fl9YU%2BVw2LjmzbO3CzdA43x153zfud3v%2FkKSGLci6%2BxP18ER9PNEAT3R5dILLaf%2FBc5L1%2BIh1FwMYijFPWD%2B7XIzEBLq8xwYLlEGSdVmf19JeRkPDcqmNhbnDJ%2FOFhWbT1oXycs5K9iwSfM4CaIiPQy2m%2FDvldH1zNcDs5%2Fd9yrXpXPCAVgCADtlk1M%2B64ygbMh4NYMwjxvqTqDfoD%2BGyO5pk48HR3Xp%2B537ncj0b2jEdrlTJto7uvsL%2BfUdn7I%2FPOqw%2B48OQ438zxX%2FYkR8TlnpdG1CO1%2FUckq8s7X9m6I8FR3Np7Hb3bdzzn%2Bz%2Fyf7%2FJ%2Fvx9%2BPYBsScBeNe0htGyThKRrNklPb66aAbJ93eZf%2FyIknSJAl9gPM1ME%2F4zzn%2B29DH29njYpghwJ8vfveZM9nHN7nib7pvB%2BqmM7ko%2F4Cy83o7vC3Ll3T3F4MbVEp5CwAA)

Subdomain test only, as `hostRequired` is `true`.
