### PR TITLE
Add Netivo template for synchronous Domain Connect setup

### DIFF
--- a/netivo.co.ke.netivo.json
+++ b/netivo.co.ke.netivo.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "netivo.co.ke",
+  "providerName": "Netivo",
+  "serviceId": "netivo",
+  "serviceName": "Netivo Sitemap Hosting",
+  "version": 1,
+  "syncBlock": false,
+  "logoUrl": "https://studio.netivo.co.ke/static/img/netivo-logo.svg",
+  "description": "Hosts a sitemap for the domain at nse.<domain>/sitemap.xml, served over HTTPS.",
+  "syncPubKeyDomain": "netivo.co.ke",
+  "syncRedirectDomain": "studio.netivo.co.ke",
+  "records": [
+    {
+      "type": "A",
+      "host": "nse",
+      "pointsTo": "167.233.254.126",
+      "ttl": "3600"
+    }
+  ]
+}


### PR DESCRIPTION
# Add Netivo template for synchronous Domain Connect setup

Adds the Netivo template for synchronous Domain Connect setup.

Netivo hosts websites and their SEO sitemaps. Customers whose DNS provider supports Domain Connect can provision their sitemap subdomain (`nse.<domain>`) with one click.

The provider signs the synchronization request using the RSA public key published at `_dcnetivo.netivo.co.ke` (RS256).

The template creates the following DNS record:

* `nse.<domain>` → `167.233.254.126` (TTL: 3600)

The synchronous flow is used (`syncBlock: false`), so the provider's synchronous endpoint verifies the signature and `redirect_uri`.

## Type of change

* [x] New template
* [ ] Bug fix (non-breaking change which fixes an issue in the template)
* [ ] New feature (non-breaking change which adds functionality to the template)
* [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

## How Has This Been Tested?

* [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
* [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`netivo.co.ke.netivo.json`)
* [x] Resource URL provided with `logoUrl` is actually served by a webserver (`https://studio.netivo.co.ke/static/img/netivo-logo.svg` returns HTTP 200)

## Checklist of common problems

* [x] `syncPubKeyDomain` is set (`netivo.co.ke`)
* [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
* [x] `syncRedirectDomain` is set (`studio.netivo.co.ke`) — the synchronous flow signs a `redirect_uri`
* [x] No TXT record contains SPF content — this template contains no TXT records
* [x] `txtConflictMatchingMode` — not applicable because there are no TXT records
* [x] No variable is used as a bare full record value — there are no variables; `pointsTo` is the fixed hosting IP
* [x] No bare variable is used as the full `host` label — `host` is the fixed label `nse`
* [x] No variable is used in the `host` field to create a subdomain
* [x] `%host%` does not appear explicitly in any `host` attribute
* [x] `essential` — not set; the single A record is the purpose of the template and is not intended to be modified independently

## Online Editor test results

Steps performed:

1. Load the template in the Online Editor.
2. Select **Check template**.
3. Fill in a test domain (for example, `example.com`) and host.
4. Select **Test apply template**.
5. Select **Copy Markdown**.

**Editor test links:**

* **APEX (domain test):** [Test netivo.co.ke/netivo example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJLOdWoC%2F91SYW%2FaMBD9K5G%2FLglOgADRNqkV2jpRMdRSdRtCkRtfwTSJI9uBZoj%2FvjMpBTT2B%2FYpzt27u%2Ffu3pYYyMuMGSDxlpRKrgUH9Y2TmBRgxFr6qfRfgLjvuTHLEUvG%2ByzGNai1SOGk5Bg8wzr3Amex0rmR2ohigbA1KC1kQeIAS%2Boivc5k%2BkLiZ5ZpcEkmF%2FJBZdhgaUyp41ZLm4oL6Z8ywxgzIm2JfNFq4p6t8%2FXaDuCgUyVKsx9C7GDtMEe%2FEXmWyjFLcLjMmSgcZpxCg%2F%2Bx%2Bf3ceoP5r3nmOlYRcEciZedmOp3c%2B6ThPKmeRlAP9zV%2Fb80i7oALBal5x1yQgVCESMU1iWdbYurSLu4Kw0skbfvq%2FRGkKIyeSgwEUc8P220%2F7Hb8IIwwaYzdVTuilOzmO5f8lgUkx65zXMeBAbwyvDrg7Pw4Al8LJasyEQd8yRTLtXXGoXJ2Vjo%2F1M4IsRPFopAKEo1fZiqFEoyq8JJ5lRmRsA07hniasLLMaiSoMYstzmUXjXUa2ZwZ9m%2FJVrFLEp5aosL6sD%2FodoN22Pb6nYB7nacw9PoRTb1ByKMBPnqU0RNLX7L7RVsfFwVaQ2EEsxu%2Fyjas1mS3m7u4tP9ABp5VM3R7wiwspGHk0b5He9MgjMNO3KV%2BFAyioPuB0phaBga0acRt0QWn9yc%2F4cdtT5WCfwl%2BjVd3bDS8fgwm3zerCX2YbobV18dRr%2Ba3q81EfiK7PwgkRWOPBAAA)
* **SUBDOMAIN (host set):** [Test netivo.co.ke/netivo example.com/nse](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALjOdWoC%2F91T7Y7aMBB8lch%2Fj3xCEojaSlT9uKqnE%2BrRVhVCkRMv4JLEqe3kDhDv3jU5DmjpC%2FQXyu6Md2Z32BENZV1QDSTZkVqKljOQnxhJSAWat8LJhbMG0nvp3dMSseT%2B0MW6AtnyHM4op%2BIF1nrgOIvW1q1QmldLhLUgFRcVSXykbKr8bSHyNUkWtFDQI4VYiq%2BywAdWWtcqcV2lG8aFc64Ma1Tz3OXl0u3qtuE5qjUDGKhc8lofhhAzWFnUUs9CFkJaegUWEyXllUW1VSlwXnWfb9xnmPNUFj3LOAJmCZRs3U6nkweHdJonTfYZNu8OnL%2B3ZhBfgHEJuX7BXLGBUIQIyRRJZjuiN7VZ3BjLKxRt3lWHIwheaTUVWPCj2An6fScIB44fRNjU2uyqH3ke2c%2F3PbIVFaSnV%2Be4jqMCeKJ4dcDZ5Z8jllI0dcqPlJpKWioTjiN5dsGeH%2BmzA9%2FM5ctKSEgV%2FlLdSDSiZYP3LJtC85Q%2B0lOJ5Smt62KDMhV28ZVL81UXIHOWTh2jmv7bvPHeIynLjV5uEhlkACzwmD3qDyJ7sGC%2BnY0Gmb2I8yEdDeMoX4zOwn0t%2BFcDfrEyUAoqzalZ%2F7h4pBtF9vt5D9f3%2F7jBOyuK%2F4CUGmTgBZHtDW0vnvpBEoRJMHQiPx4E4Y3nJRhAtABKd%2F52mInzNJAQ4nAjf7T97aT2siVTdzcT%2BitUGdsu1nej6vt7V%2F4cxh8%2FfBu%2FJvvfRDcYxqMEAAA%3D)