### PR TITLE
Add Pag Ninja custom domain template

### DIFF
--- a/pagninja.com.custom-domain.json
+++ b/pagninja.com.custom-domain.json
@@ -1,0 +1,34 @@
+{
+    "providerId": "pagninja.com",
+    "providerName": "Pag Ninja",
+    "serviceId": "custom-domain",
+    "serviceName": "Domínio personalizado",
+    "version": 1,
+    "description": "Conecta um subdomínio à Pag Ninja e cria os registros de validação do hostname e do certificado TLS.",
+    "variableDescription": "%ownership%: token de propriedade emitido pela Cloudflare for SaaS; %certificate%: token de validação do certificado TLS",
+    "syncBlock": false,
+    "syncPubKeyDomain": "pagninja.com",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_cf-custom-hostname",
+            "data": "%ownership%",
+            "ttl": 300,
+            "txtConflictMatchingMode": "All"
+        },
+        {
+            "type": "TXT",
+            "host": "_acme-challenge",
+            "data": "%certificate%",
+            "ttl": 300,
+            "txtConflictMatchingMode": "None"
+        },
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "customers.pag.ninja",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a signed Domain Connect template for Pag Ninja custom subdomains. It creates the Cloudflare for SaaS ownership-verification TXT record, TLS-validation TXT record, and the CNAME to `customers.pag.ninja`.

The TXT values must remain bare because Cloudflare for SaaS issues opaque values that cannot be prefixed. The synchronous request is signed through `syncPubKeyDomain`, so callers cannot alter those values.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: this template does not include `logoUrl`.

Also passed:

- `dc-template-linter -loglevel error -tolerate info -logos`
- `dc-template-linter -cloudflare -loglevel error -tolerate info`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A: no `redirect_uri` is used
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [x] no variable is used as a bare full record value unless necessary — the two bare values are opaque Cloudflare for SaaS validation tokens and the request is signed
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records users may need to change independently — N/A: every record is required for routing or validation

## Online Editor test results

[Test pagninja.com/custom-domain example.com/pay](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC88dmoC%2F%2B1U0W4TOxD9FctSn8gGN02TdBES0N4L6NKo0CAQpYomtjdx67X32t6kaZV%2FZ7zJppsWEI8g8ZLseGY8c84czx0NMi80BEnTO1o4O1dCureCprSAqVHmCtrc5rS19Q0hx1h6BlMyjG50eenmissqi5c%2B2DwRNgdl7n2brBObfy0Zk8IoSwrpvDWg1S0Ii6FztJU1NN1vUSE9d6oIlU2PrZE8AClz4suJaF5SfTGybYdIgolArCdOTpUPDr%2BEJHOsI6CK7le%2FB5YIS2bWB4O9YRpaXLqgMsWxHzJ6d96OTQHeNtHyZKehPbsw2O1MFXspCfZamlgDKSqckgLwW%2BYqKBFBaiDH2pYi0%2BAkyawj5wDnz8jetlqQzVt%2B0OmD3iK1S8NfacuvaZqB9nJ9clZO%2FpPLkzX%2Fj6YY8X6Q%2F5fKSZxWcCVmOcmtE56mF3c0LIs4p9Hn0SYYjTHPks1Ya7rQKSDALhN4GIKm6QFj%2BHUTcGqZVjycQuAzZaanVsS7X2pNV60flAKey4TPQGtpps0yTbJ%2BsdAQVdOsdDx8efrPfa0XUdRWmeBHditchNJGytpmI%2B26zupy1aK3eOH4nq1L7K6mWd4APiPZYLnifonG1NmyGKs6pQAHuY%2BvrU6%2B2Mm%2BrNMvqnw0twzHs62RVIKJ%2FgY1MaJh1jHYu5oa6%2BTY4z%2BE0sl6%2BHmpgxrDAu6PBB9DUeglQvXoxTsfCsOsX%2FN3hNFeY95M7WGzzbmNBY8kqLg0%2BgeDI9GHo6Tfh27SHXRYMhHdXjI5zHq9vhCHbCAaK%2Bh76%2BlnO2hnHNJ7aYICXUlxAUtPV4%2FkWAPcleMuuMc8%2FwHw6jewAbgL6Kcv4DeDdNnCx%2FRXl391%2BbvpEheyh7kUY4iRHdbpJWyQsP6ow9L9Tnqw3%2B4Ojg577AljKWMRiPRhjfQO93RzQ9Ozf98sbtSJuXrz9DpcZbfv%2FPGXJ8Mle9358Gn26ct7CIPuYcYHH%2FXiOV19A58Pb4nMCQAA)