### PR TITLE
add Letter, Custom publication domain

### DIFF
--- a/letter.pub.publication.json
+++ b/letter.pub.publication.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "letter.pub",
+  "providerName": "Letter",
+  "serviceId": "publication",
+  "serviceName": "Custom publication domain",
+  "version": 1,
+  "logoUrl": "https://letter.md/icons/icon-192x192.svg",
+  "description": "Connect a customer-owned subdomain to a Letter publication.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "letter.pub",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "sites.letter.pub.",
+      "ttl": "3600"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for Letter publication subdomains. It uses the signed synchronous flow and creates a CNAME at the required customer host pointing to `sites.letter.pub.`.

The signing public key is published at `_dcpubkeyv1.letter.pub`. The template intentionally requires a host because the first-phase automatic flow supports customer-owned subdomains; apex domains continue to use Letter manual setup.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

The official linter passes with `dc-template-linter -loglevel error -tolerate info -logos letter.pub.publication.json`. The logo URL returns HTTP 200 with `image/svg+xml`.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

The TXT, variable, and `essential` checks are not applicable because this template contains one fixed CNAME record only. `syncRedirectDomain` is not required because the flow does not send `redirect_uri`.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

[Test letter.pub/publication example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJWfdmoC%2F91Sf2%2FaMBD9Ksj%2FloSQQAqRJo3Rdtq6omll%2B2MIRY59oRZJnNlOUob47jsnMOiq7QNMyg%2FZd%2B%2FuvXe3JwbyMqMGSLQnpZK14KA%2BcBKRDIwB5ZZVQvq%2FIwuaYyb51MbwXoOqBYMWgJmZYNQIWZwjR8C80kbmvYuUHpc5FTazBqUtJhr2SSY38qvKEPFkTKmjweBII%2BcDwWSh268znPrP%2BLq63mABDpopUbaNsZUsCmCmR3usbQrKkU0BvKerpOvZMxKjnYZLSq6lvSvYu0yyLYlSmmnobj5XyT3sbjrGf1jzJLX5Aj8qoQBdMKpCjAImFdckWu2J2ZWtA4vZw%2B0xHY9vralSFEYvJR61MKDdc11LxRjrQxB6HjmsD33yUxYQnyuvUfiJEDxTnCK4TObnFk3T4GGjZFXG4gQpqaK5tsM%2BgVcv0OsTfNXibV%2BxKaSCWOOfmkrBSWReZUbEtKHnK85iWpbZDmlqjGKV1wYU3UZ07Dg19F%2Fyrfo%2BiTmzjIXdsvR6PE2CAJw0mPjOiIYjJ0mvPWc8TDifUsZgxC8W9vUq%2F31lX%2FgGWkNhBLUzmGUN3WlyOKz76OF%2FJgknrmkNPKY20%2Ff80PEm%2BCy9IBqGUXDthpNJ6HtXnhfhKqIK0KYTucftuNwLcpVut9%2F8%2BvHx%2Fe1dIAez%2BX2qv4%2BXwWJx04w%2BTsOiuTN6qPJwzt6Qwy9bdVX3fQQAAA%3D%3D)

`hostRequired=true`, so the PR template apex-test exception applies.
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->