### PR TITLE
Add template novafit.lat.gym-website

### DIFF
--- a/novafit.lat.gym-website.json
+++ b/novafit.lat.gym-website.json
@@ -1,0 +1,30 @@
+{
+    "providerId": "novafit.lat",
+    "providerName": "NovaFit Studio",
+    "serviceId": "gym-website",
+    "serviceName": "NovaFit Studio website & client portal",
+    "version": 1,
+    "logoUrl": "https://novafit.lat/icons/icon-192.png",
+    "description": "Connects a fitness studio's custom domain to its NovaFit Studio website and client portal.",
+    "syncBlock": false,
+    "shared": false,
+    "syncPubKeyDomain": "novafit.lat",
+    "syncRedirectDomain": "novafit.lat",
+    "hostRequired": false,
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip%",
+            "ttl": 3600,
+            "essential": "Always"
+        },
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "novafit.lat",
+            "ttl": 3600,
+            "essential": "Always"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for NovaFit Studio (https://novafit.lat), a gym & boutique fitness studio management SaaS in Mexico. The template connects a studio's custom domain to its NovaFit website and client portal: A record on the apex (variable %ip%) plus CNAME www → novafit.lat.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

## Online Editor test results

- Test WITH host: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACtxd2oC%2F%2B1UW2vbMBT%2BK0bQ7WGxI6eJaxsG63qhpTSsXcceQjCKpSRisqRJcjw35L%2FvOM2VJOx1g4Hx5Vw%2Bne8753iOHCu0II6hdI60UTNOmbmnKEVSzciYuwCcqLVx9UkBoagPzlvuvK%2BupFyB3zIz4zlbZk7qwq%2FYyHJA3XiOJnqrMO%2BdlwvOpPO0Mo4ISJsxY7mSKA1bSKiJ%2BmYEpE%2Bd0zZtt3eKa%2FNcSbu8%2B2HSCbScQDplNjdcuyUEulJSstxZj3iQJZm1nl0W8N56eWmdKjyqCsKl55THIe5EmUTS%2FUKDhmAt889C5T9QOibCMrBMiWF0%2BwkBX8rRA6uvl4cciNsEPDPKDdR4ImSqrHtmP0u%2BCwzxylCL0sEcuVo3%2Bl6uYuH1U9M2xaWzLwo%2Bz7g%2BA4tzoON5hHELgQzAhJNG2EtRkdqiRWuDdNW%2FfLzZolVVtY%2B3X98fYIeLFnpVkmXbkofQpDXXgrO3flBWqCBXxfZcW%2BalscuRmBhV6oyvszUxpLDN3K5xBkeAhmukwRYKbFw3liQOkl4QdjtB2Omipkg%2BkcqwzMKTuNKAEM6UIHVRCsczUpGtieYZ0VrUwMmCF%2FD22yDfJn6HACWOgGX%2F1D3tMpo3hHizRhdJdDGKkrGfjEbE70aj0E9whP046lEad5M4iuOdzTyytKeX8lDcY107Mg0rUjANwSGxkyPxl9EatmB%2B%2FjfrH2kWbKslM0Yz0oR3cCfycQzXSxinIU57YdA57%2BEk%2FIBxinHDBf4BbyTnsNG7u4wMLcVdFAr12v4e3p1LY2%2Fwk%2FilbmfT6LG%2BfjTlw9M9j7pX4%2BojWvwGfvNEGR4HAAA%3D
- Test WITHOUT host: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAERxd2oC%2F%2B1TXWvbMBT9K0bQ7aGxaztuEhsGy9KtjG4h%2FVg3VoJRJCUVsyVNkmPc0P%2B%2Bq3w0CUvYax8GxpZ1zz2651zdBbKsVAW2DGULpLScc8r0Z4oyJOQcT7kNIIhaL6EhLgGKhhD8xK13ayvKJcQN03NO2DJz1pR%2BzSaGA%2BtL5GCit4Z5bzxScCasp6S2uIC0OdOGS4GyqIUKOZPfdAHpj9Yqk52d7RR3xokUZvn2ozQOlJhBOmWGaK7skgINpBCMWONhD7IEM8YzywLeGo9UxsrSo7LEXHhWehxwR8rEgu4XGjiBjSAfCkl%2BoWyKC8Ng5xFrRre%2FABhVkyvWXCwP%2BctcB7hhlGuo8QjkURp7w35XfJcY8FJTg7KHBbKNcv7211hYvndtk1xYcyfh94SrE9ixFnxsd8KwhcAGUMKxM7Zf1Lgx6Ln1wjQY9r9%2B3LLVdb3Pt1%2FfP2jHzy30JAXLtyWPoUkbrSVnq35QVsqAyHJ7LqxmWlYq55sshTUujbuvm%2FyHAwTjDcMDcmuu3CrtBel5ECVxEMUJckXxmZCa5Qa%2B2FYahFtdgbVlVVie4xpvtyjJsVJFAxoMRIFv33axuuHOdoothuX%2BcXsm5ZQ4BdzNy3mcdpJu2PbTZJL6yTRN%2FN60S33CKA7bExa1k2hnBA9M5%2FHp27p4qC0H2r1WsWr3WsfRVr8SFeMW3Iv%2FzXglzYBpM3jOaI4dLA7jjh%2F24LmLelkUZVEniDtJJ%2B2dhmEWhk4DzO5K3AImcncW0ahbT0%2B%2FN9ekW7N7O6q%2BPF38bA8ur6NuPbitL0d34eX9lZ09zX%2F036HnP3nWFHzOBgAA

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, no TXT records
