### PR TITLE
Add FunnelCockpit funnel template

### DIFF
--- a/funnelcockpit.com.funnel.json
+++ b/funnelcockpit.com.funnel.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "funnelcockpit.com",
+  "providerName": "FunnelCockpit",
+  "serviceId": "funnel",
+  "serviceName": "Funnel domain",
+  "version": 1,
+  "logoUrl": "https://app.funnelcockpit.com/images/logo.svg",
+  "description": "Connects a customer-selected domain or subdomain to a FunnelCockpit funnel. DNS providers apply the record relative to the domain and host supplied by FunnelCockpit.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "funnelcockpit.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "connect.funnelcockpit.com",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the `funnelcockpit.com.funnel` template for connecting a customer-selected funnel domain or subdomain to `connect.funnelcockpit.com`.

The portable flow uses the standard Domain Connect `host` parameter and creates one CNAME relative to that host. `hostRequired` remains enabled because generic providers such as IONOS cannot create an apex CNAME. FunnelCockpit only signs an empty-host request when Cloudflare is discovered; Cloudflare ignores `hostRequired` and flattens the standard apex CNAME as documented in its Domain Connect implementation.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check.
Comment on any point which is not fulfilled. See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — not applicable; this template does not use `redirect_uri`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — not applicable; this template has no TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — not applicable; the CNAME is the core service record

## Online Editor test results

**Editor test link(s):**

[Test funnelcockpit.com/funnel example.com/offer](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKo1eGoC%2F91TUW%2FaQAz%2BK9G9QsKlQIFIk8boWnVVWdd1UzWEInMx9LYkl91d6DLEf5%2BvIQPWTtrznk72%2Bftsf7Y3zGJWpGCRRRtWaLWWCerLhEVsWeY5pkKJb4W0gVAZa%2F8OmEJGAHb%2BFDKpQ%2BjboF5LgQfwvfMI4iUqA5nT7xq1kSpnUdhmqVqpTzqlqAdrCxN1OlAUwbM6OjKDFZqOCw%2FMekUsCRqhZWGfmNhEEUJY44EnSmNVhto3mJILk11mT2nPlIudYRWFHjXj1VkD72z60Wu6JsKiSCvPPqCnUSid0EPayTU6CufeEUKeeA%2FKWMpBCElpF9VxgsApU%2BXiTUo2i5aQGqw9N%2BXiCquzWqCXx%2BCob%2FF7KTWS1FaXBK0LMiyabZitCqf1ZDq%2BfrsLJ%2FO1G6CSuTV3ikxRqxS8lMBamkKX8%2B1822Y%2FVY7xnn5OcjfF4Q%2Bg7cGDssiplkvUZK60KotYNqACNGTGrVkDnx3h5w3BbMfgcstVrjTGhl6wpcam26xMrYzhEfauRMRP46FSDf0Sz3Ml8noJmwoTsPCPSrRZnAhXvHTL3eOnQwiF8Je9cOH3wrDrA4bg8wEsF9Dv94ej4cG5%2FPWeXjyYP2REYzC3EtxdjNNHqAzbbudtkvR%2F7o%2B2wcAakxhc7Ak%2FOfX50OejOz6M%2BCgKe0F30B2MTlqcR5y7RtDYut8N7c3hxjBxjueL%2B%2B5nOanUVXombofp%2FXUGX1udL63Ldxc33ff9Xv5h3LtIxq%2FY9hct8%2B4lEwUAAA%3D%3D)

The generic editor correctly requires a host for this schema-valid template. Cloudflare's documented implementation ignores `hostRequired` and applies CNAME flattening when FunnelCockpit sends an empty, signed host specifically to Cloudflare.
