### PR TITLE
Add LightHost mail template

### DIFF
--- a/lighthost.it.kr.mail.json
+++ b/lighthost.it.kr.mail.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://lighthost.it.kr/logo.png",
   "description": "Configure DNS records for LightHost mail hosting and ZeptoMail outbound authentication.",
   "syncBlock": false,
-  "syncPubKeyDomain": "_domainconnect.lighthost.it.kr",
+  "syncPubKeyDomain": "domainconnect.lighthost.it.kr",
   "syncRedirectDomain": "lighthost.it.kr",
   "records": [
     {
@@ -39,61 +39,6 @@
       "type": "CNAME",
       "host": "autodiscover",
       "pointsTo": "%autodiscover_target%",
-      "ttl": 300
-    },
-    {
-      "type": "SRV",
-      "name": "@",
-      "service": "_autodiscover",
-      "protocol": "_tcp",
-      "target": "%srv_target%",
-      "priority": 0,
-      "weight": 0,
-      "port": 443,
-      "ttl": 300
-    },
-    {
-      "type": "SRV",
-      "name": "@",
-      "service": "_imaps",
-      "protocol": "_tcp",
-      "target": "%srv_target%",
-      "priority": 0,
-      "weight": 0,
-      "port": 993,
-      "ttl": 300
-    },
-    {
-      "type": "SRV",
-      "name": "@",
-      "service": "_pop3s",
-      "protocol": "_tcp",
-      "target": "%srv_target%",
-      "priority": 0,
-      "weight": 0,
-      "port": 995,
-      "ttl": 300
-    },
-    {
-      "type": "SRV",
-      "name": "@",
-      "service": "_smtps",
-      "protocol": "_tcp",
-      "target": "%srv_target%",
-      "priority": 0,
-      "weight": 0,
-      "port": 465,
-      "ttl": 300
-    },
-    {
-      "type": "SRV",
-      "name": "@",
-      "service": "_submission",
-      "protocol": "_tcp",
-      "target": "%srv_target%",
-      "priority": 0,
-      "weight": 0,
-      "port": 587,
       "ttl": 300
     },
     {

--- a/lighthost.it.kr.mail.json
+++ b/lighthost.it.kr.mail.json
@@ -5,7 +5,7 @@
   "serviceName": "LightHost Mail",
   "version": 1,
   "logoUrl": "https://lighthost.it.kr/logo.png",
-  "description": "Configure DNS records for LightHost Stalwart mail hosting.",
+  "description": "Configure DNS records for LightHost Stalwart mail hosting and ZeptoMail SMTP relay authentication.",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.lighthost.it.kr",
   "syncRedirectDomain": "lighthost.it.kr",
@@ -100,6 +100,20 @@
       "priority": 0,
       "weight": 0,
       "port": 587,
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "%zepto_dkim_selector%._domainkey",
+      "data": "%zepto_dkim_value%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "k=rsa;"
+    },
+    {
+      "type": "CNAME",
+      "host": "bounce",
+      "pointsTo": "%zepto_cname_target%",
       "ttl": 300
     }
   ]

--- a/lighthost.it.kr.mail.json
+++ b/lighthost.it.kr.mail.json
@@ -8,6 +8,7 @@
   "description": "Configure DNS records for LightHost mail hosting and ZeptoMail outbound authentication.",
   "syncBlock": false,
   "syncPubKeyDomain": "_domainconnect.lighthost.it.kr",
+  "syncRedirectDomain": "lighthost.it.kr",
   "records": [
     {
       "type": "MX",
@@ -97,7 +98,7 @@
     },
     {
       "type": "TXT",
-      "host": "%zepto_dkim_host%",
+      "host": "%zepto_dkim_selector%._domainkey",
       "data": "%zepto_dkim_value%",
       "ttl": 300,
       "txtConflictMatchingMode": "Prefix",
@@ -105,7 +106,7 @@
     },
     {
       "type": "CNAME",
-      "host": "%zepto_cname_host%",
+      "host": "bounce",
       "pointsTo": "%zepto_cname_target%",
       "ttl": 300
     }

--- a/lighthost.it.kr.mail.json
+++ b/lighthost.it.kr.mail.json
@@ -1,0 +1,113 @@
+{
+  "providerId": "lighthost.it.kr",
+  "providerName": "LightHost",
+  "serviceId": "mail",
+  "serviceName": "LightHost Mail",
+  "version": 1,
+  "logoUrl": "https://lighthost.it.kr/logo.png",
+  "description": "Configure DNS records for LightHost mail hosting and ZeptoMail outbound authentication.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "_domainconnect.lighthost.it.kr",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mx_target%",
+      "priority": 10,
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "mail",
+      "pointsTo": "%mail_target%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig.mail",
+      "pointsTo": "%autoconfig_mail_target%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig",
+      "pointsTo": "%autoconfig_target%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "autodiscover",
+      "pointsTo": "%autodiscover_target%",
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "@",
+      "service": "_autodiscover",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 443,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "@",
+      "service": "_imaps",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 993,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "@",
+      "service": "_pop3s",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 995,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "@",
+      "service": "_smtps",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 465,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "@",
+      "service": "_submission",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 587,
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "%zepto_dkim_host%",
+      "data": "%zepto_dkim_value%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "k=rsa;"
+    },
+    {
+      "type": "CNAME",
+      "host": "%zepto_cname_host%",
+      "pointsTo": "%zepto_cname_target%",
+      "ttl": 300
+    }
+  ]
+}

--- a/lighthost.it.kr.mail.json
+++ b/lighthost.it.kr.mail.json
@@ -5,7 +5,7 @@
   "serviceName": "LightHost Mail",
   "version": 1,
   "logoUrl": "https://lighthost.it.kr/logo.png",
-  "description": "Configure DNS records for LightHost mail hosting and ZeptoMail outbound authentication.",
+  "description": "Configure DNS records for LightHost Stalwart mail hosting.",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.lighthost.it.kr",
   "syncRedirectDomain": "lighthost.it.kr",
@@ -18,9 +18,9 @@
       "ttl": 300
     },
     {
-      "type": "CNAME",
+      "type": "A",
       "host": "mail",
-      "pointsTo": "%mail_target%",
+      "pointsTo": "%mail_ip%",
       "ttl": 300
     },
     {
@@ -42,17 +42,64 @@
       "ttl": 300
     },
     {
-      "type": "TXT",
-      "host": "%zepto_dkim_selector%._domainkey",
-      "data": "%zepto_dkim_value%",
-      "ttl": 300,
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "k=rsa;"
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "mx -all",
+      "ttl": 300
     },
     {
-      "type": "CNAME",
-      "host": "bounce",
-      "pointsTo": "%zepto_cname_target%",
+      "type": "SRV",
+      "name": "",
+      "service": "_autodiscover",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 443,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "",
+      "service": "_imaps",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 993,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "",
+      "service": "_pop3s",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 995,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "",
+      "service": "_smtps",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 465,
+      "ttl": 300
+    },
+    {
+      "type": "SRV",
+      "name": "",
+      "service": "_submission",
+      "protocol": "_tcp",
+      "target": "%srv_target%",
+      "priority": 0,
+      "weight": 0,
+      "port": 587,
       "ttl": 300
     }
   ]


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for LightHost Mail (`lighthost.it.kr.mail`).

The template configures customer DNS for LightHost mail hosting and ZeptoMail outbound authentication:

- MX routing for the customer's apex domain
- Core mail CNAME records for `mail`, `autoconfig`, `autoconfig.mail`, and `autodiscover`
- ZeptoMail DKIM TXT and bounce CNAME records using runtime variables returned by ZeptoMail during domain provisioning

ZeptoMail returns a domain-specific DKIM selector/value and bounce CNAME target, so the template uses variables for those values. The DKIM host is constrained as `%zepto_dkim_selector%._domainkey`, and the bounce host is fixed as `bounce`.

SRV records for autodiscover, IMAPS, POP3S, SMTPS, and submission are intentionally not included in this Domain Connect template because the Online Editor rejected the SRV host composition. LightHost still provides those optional SRV records in the manual DNS guidance email sent to customers.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value unless necessary
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template

## Online Editor test results

**Editor test link(s):**

[Test lighthost.it.kr/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEOgeGoC%2F%2B1X70%2FbMBD9VyJLfFob3B9jbSakwUAaY63QViQGQpFxrqnXNI5sp7Qg%2Fved09CENLBN%2BzKmfmrqe%2Ffs8728U%2B6JgVkSMQPEuyeJknMRgDoJiEciEU7MRGrjCuNOFWmsw0M2Qzj5YgGfEIAhDWouOGSJMyaiYqkKdgar8ByUFjImXqtBIhnKcxUhbGJMor3d3crmuxbhJnGIiQForkRismTyUcZjEaYKnKPhN0cBlyrQzlgqp9jRHsixZCIOHRYHziUkRtpzODI1NzLFJZaaCcRGcGaJXXv%2BZcwPI8mnxBuzSMNq5Sy9OYXlkUROu32QPXAZx8CNu3llNuUrBAIPZtZJm7D83MS7uidmmdgLG1zgugXh8wd7%2BVLERo8k%2Ft2ZLXzDVAhmJ%2BuKkEqYJd4kbRBj8Bo7lD401kwfhweD44Isb88TPlwqMf6aA29L8uzm3Rq6Iur%2FBfPzpH%2FKFwjNJeqthvEx9DLn6GJUMO7cWfX4wVTMfA0RNlaqHddfKWEKSytRZlgFOWdRCmV6fFoYq95IcDNghk9QnQMZ2P3OFIzFgtRC8phHpvtKs%2Ffk%2BdKtsDlUil4dicf4VtbVfP3QIHcyBr9Q5HUjVzmmw4KhW4DL5azYB59CJdPEF4%2F4hCk209ZRHjOvnqReP%2BZeEfu8lrNdsIpxK%2BCSitaQ6kuEsHrd%2FWbG74ErenkJXiMTC%2B%2B1O6137XYFkcnDhldddZL9wcnJ4cmPg%2BFhODr%2BNjo9%2Fl5klLtnc3iUagOq13ezeHag7OawmSKMpQJf4y8zaJPEMypFL5ulkRE%2Bu2XFUsB9liTREnuvMYrMFTeKV1b%2BoVD4RrPK%2Bn5qTH7ArSCEnRBw06LjDu83odPba3YZ7Tb7tMuafK%2FHex0YjylrlebNM%2BOoZuYUigStrZ0zO1QOolu21OSh5lXJS8rTy1Vt7ldU9k%2FXsunN%2F1lZ%2F1NFpdH0Omtajca8otzbaofhC8b2ajq2nqh5Tc8Z779W0HUDp%2FLWzLdmvjXzrZlvzfyVmzl%2BB2g2h8BnFtam7b0m7TVpf9R663W7Hu24%2FX6fdvbeUOpRas8P2qyKvMcvgvK3AGnLz6eti91owmR4Dv3W28vTIf3ybhLJs%2BNIdM%2BPFnBxfnkj7jq3%2B%2BThJ3TVrV0uEgAA)

[Test lighthost.it.kr/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIsgfGoC%2F%2B1XYU%2FjOBD9K5ElPm0b0pZjS1ZIwIJ0HNsK3RaJBaHIONPUVzeObKe0IP77jZO0CWlg93RfWNQqUhPPm2eP%2FfJGeSIGZomgBoj%2FRBIl5zwEdR4SnwgeTcxEauNy404Vaa3DQzpDOPlmAX8iAEMa1JwzyBJnlItyqA52Bnl4DkpzGRO%2F0yJCRvJKCYRNjEm0v7tbm3zXItwkjjAxBM0UT0yWTL7KeMyjVIFzOvzuKGBShdoZS%2BWUM9oFOZaMx5FD49C5gcRIuw5HpuZepjhEUzOB2HBGLbFr17%2BM2YmQbEr8MRUa8pHL9P4ClqcSOe30YXbDZBwDM%2B7mltmUvyHkuDCzTtqEFesm%2Fu0TMcvEbtjgGsctCO%2BP7OZLHhs9kvi4M1sEhqoIzE52Klwqbpa4k16LGIPb2PO859aa6evweHBWkhXH84IPhyqMP%2BfA3ZIs23m3ga6MBv%2BD%2BXXS%2F8oXcs0k6q2BcRV6m3N0PSoZdx6teoJwymeBBoEHK9WOG%2BRKmMLSSpQaWkPOqUihSo93C2PVKzgzA2rYBNU5kKGd71LBmC9II6SI%2BWR6qDT9Ql4v3QqbQa3ofEksxreyqea75xZ5lDEEpSLvWoXKMR0WFN0CXCZnG4KKlEyTgK9yEqroTFtXWWXfvki%2FW%2BXf5gT4vJb1atCtJVTUtIbUXyaENevvFzN%2BDVzTzVvwBrlYeL%2Fb63zudmuITCY2nJ%2BukxwOzs9Pzv85Hp5Eo7Pvo4uzH2VG9RRtDhOpNqD6B24WzxaU7RweKo9iqSDQ%2BE8N2iXxjUrR02apMDygD7QcCllAk0QsUQMao8hcc6U4t%2FSjUukbh1XV%2BUuDCkJmRcFtp4D7jjfusYM29Pr77T3q7bUPvD3aZvt91u%2FBeOzRTqXvvNKWGnrPS2WC1tbaqW0wx%2BKBLjV5bnhtirKKpGplm3OW1b37eja9%2BgOW9tGqqrSs37euvG0WVRV%2B19go3zC73%2Brk1h23qOs1Q36PRd21sGtvjX5r9Fuj3xr91ug%2FsNHj94OmcwgDaqFdr7vf9vrtTnfkeX52uV72%2B5Q92BpAm7zQJ%2FySqH5DkK7866JzvSsmVEZXcND54%2BZi6H37PBHy8kzwvavTBVxf3dzzx97DIXn%2BFyfJKIBuEgAA)