### PR TITLE
update KonvoAI Custom email domain return path (v3)

### DIFF
--- a/konvoai.com.email.json
+++ b/konvoai.com.email.json
@@ -3,12 +3,12 @@
 	"providerName": "KonvoAI",
 	"serviceId": "email",
 	"serviceName": "Custom email domain",
-	"version": 2,
+	"version": 3,
 	"syncPubKeyDomain": "konvo.to",
 	"syncRedirectDomain": "konvoai.com",
 	"description": "DNS records for sending email from your domain with KonvoAI (Resend / Amazon SES).",
 	"logoUrl": "https://k2.konvoai.com/favicon.svg",
-	"variableDescription": "dkimKey: Resend DKIM public key (the base64 value after p= in the resend._domainkey TXT record); region: SES region parsed from the send MX record.",
+	"variableDescription": "dkimKey: Resend DKIM public key (the base64 value after p= in the resend._domainkey TXT record); region: SES region parsed from the konvo MX record.",
 	"records": [
 		{
 			"groupId": "dkim",
@@ -20,7 +20,7 @@
 		{
 			"groupId": "outbound-mx",
 			"type": "MX",
-			"host": "send",
+			"host": "konvo",
 			"pointsTo": "feedback-smtp.%region%.amazonses.com",
 			"priority": 10,
 			"ttl": 3600
@@ -28,7 +28,7 @@
 		{
 			"groupId": "outbound-spf",
 			"type": "SPFM",
-			"host": "send",
+			"host": "konvo",
 			"spfRules": "include:amazonses.com",
 			"ttl": 3600
 		}


### PR DESCRIPTION
## Description

Updates `konvoai.com.email` (v2 → v3): the return-path record host moves from `send` to `konvo`.

We now create every Resend domain with a [custom return path](https://resend.com/docs/dashboard/domains/custom-return-path) of `konvo`, because Resend's default `send` subdomain collides for customers who already delegated `send.<domain>` to another nameserver or service. Only the two return-path record hosts change; the DKIM record and all variables are identical to v2.

Records created on apply (v3):

- DKIM `resend._domainkey` **TXT** → `p=%dkimKey%` (per-domain key from the Resend API)
- `konvo` MX → `feedback-smtp.%region%.amazonses.com` (priority 10)
- `konvo` SPFM → `include:amazonses.com` (renders `v=spf1 include:amazonses.com ~all`)

All record hosts stay relative, so the template applies correctly to an apex domain (`example.com`) and to a sub-domain via the `host` parameter (`example.com` + `host=mail` → `resend._domainkey.mail`, `konvo.mail`).

Synchronous flow only. Apply URLs are RSA-SHA256 signed; public key published on `konvo.to`.

## Type of change

- [x] Update to an existing template (version bump 2 → 3)

## How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) for both apex and sub-domain
- [x] Template file name follows the pattern `providerId.serviceId.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://k2.konvoai.com/favicon.svg`)

## Checklist of common problems

- [x] `syncPubKeyDomain` is set (`konvo.to`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`konvoai.com`) — synchronous `redirect_uri` is signed by the service
- [x] no TXT record contains SPF content — uses `SPFM`
- [x] N/A — no DMARC/TXT uniqueness records in this template
- [x] variables are not bare full record values — the DKIM TXT fixes the `p=` prefix (`p=%dkimKey%`)
- [x] `%host%` does not appear in any `host` attribute
- [x] no variable used to create arbitrary subdomains
- [x] N/A — no DMARC `essential` records

## Online Editor test results

Validated in the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) with the documented Resend sample variables (`dkimKey` from a live `resend._domainkey` TXT, `region` `us-east-1`). Template check passed with no warnings; apply preview shows the expected `resend._domainkey` TXT, `konvo` MX, and `konvo` SPF (`v=spf1 include:amazonses.com ~all`) for both the apex and the sub-domain case.

**Editor test link(s):**

[Test konvoai.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACyyeGoC%2F%2B1VW2%2FiOBT%2BK5alSjMql5CkNGTVhwBdhjIwpcC0UFXIJA64JHGwnXCpOr99bUgLdDqzTyuNVn2KnXOOz%2Fed6xMUOIwDJDC0n2DMaEo8zJoetOGcRilFpODSEOZeRR0USlXYUkKnKQUcs5S4eGuCQ0SC%2Fb9Mt5ZwQUOwFQKPyk8kdVLMOKERtA2pv47c62TSwuv6Tpx5LwgKd9Ib7BGGXXEsf0XnYe4yEovtg7De6QGpTJnHgU8Z4DjySDTNEPhMglnThGVYwJKIGcgIgU83WKmDInBCtKER6F32Pheki4BO6YAF8vmZEDG3i8W5XjhAUfSR5EyjAk%2Bnih5iBE0CXD9C5s1JKFnaIPNSbzXbIE4mAXHBHK%2FBJzHDYII4LpsgRUGCAfIFZiC%2BABKoErKtYWG8w65s%2Bnf9jO3nv%2BRhKj3ZCnV2BjFiHHs72uqFLWbQvsuMFLcsWNC%2Bf4JTRpN4m00FVgrFOlZZlG7kZUa5kJefUKgcIIGkKL44yVieKGMhI2aUNe05d%2Fg0TcSEJpGXD1d7D%2B27vYMtSFV2lESC96n85WPsTZA7z%2FNQxIWTHbuTAtqmiWP%2BWqiEMiLW0C5p%2F%2B6fx%2F4eQO%2F67%2FbPEKTKTRJgGR1IIjdIPGy%2F9bn38vCcg1KEx%2FuQPsjQvFQtXiHZbTgzyxzJ0xbZmLzoy5ShkKuOfLG8PzJ9eLG9h%2BqcxVtd282G33a0Rq23aPSaE6Pevaw63YHjmI2OU69VSbdVnXZr0UTvjDaPo15pNbgORvGyVV2gxWy%2Bmp4PB98RNa6MVVGMutfVLxt31B1ctg1ncm7O1%2BXWzPx2urk8nWuds%2BU85s5jxXG1hjGqhybBj5bVHMZ3Z3c3ong1%2BrpIy5ZYVpxOpf%2B9PZzdTh67jeXXW4%2BV3cXt9ZWR1B3XL33TBsNR%2FYvR98yAM1%2Bbtwe%2BUyzRMrqNN91m3ek6VUVzl3HFMuF5jLjIl6CKN5lGlOExl18kEiYzKViCczBMAkHGaIn2vzx3jOI4WMv0cCmVb8mKPyrwaDezflvg%2F9sgH1RyDo49V1UgUf1Squi6f66ZeVO39Lxp4PM8qiA97yJD08tnvl7RrYMl8c7%2BeG9N7OsfcxluQZAar06wRGsOn1XHHk6GLDMvbZll43gqvBZG4Zct%2BnZC%2FEE0jyrwDc%2F0Qs6hEnh3AoEfKAj%2BsOQ95OQg%2B2iuj%2Bb6aK7%2FoLnkNuQoxd4YKTVdesprVl6r9EvntqbZulUwzZLEeiovmqbQYy52ZJ%2FkxjzcldBaVUu0tbKcTtWLtNrGIZWh2Xctp81GVjrwqmdmWsPEGrDhBXz%2BB2Gi%2F6oxDAAA)

[Test konvoai.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFSyeGoC%2F%2B1VW2%2FiOBT%2BK1akSjMqhARCChn1IZQupQwUCvRCVSEnccAliVPbCZeq%2B9vXJmmBaUf7thqt%2BhTH5xyf7zvXF4WjMA4gR4r1osSUpNhDtO0plrIgUUogVl0SKoV3UQ%2BGQlXpSKHdFgKGaIpdtDVBIcTB7i7XPUsYJyHYCoFHxCcSOimiDJNIsSpCfx25%2FcTpoHUzE%2BfeVU6UTHqNPEyRyw%2Fl7%2Bg8xFyKY759UGn2hkAoE%2Box4BMKGIo8HM1yBD4VYNYkoTkWsMR8DnJC4Ns1kuqgBOwQbkgEhufD76pwEZAZGdNAPD%2FnPGZWqbQoq3soSj4UnEmksnQm6UGKoROg5gEyb4FDwdICuZdmp90FceIE2AULtAbf%2BBwBBzJkGiCFQYIA9DmiID4FAqgU0q2hOs2wS5vR3Shn%2B%2F2HOMyEJ0uizs8ghpQhL6MtX9hiBt273Ehyy4OlWA8vyoySJN5mU4IVQr6OZRaFG%2FEzJ4yLnw8oZA4gh0IUnx7lLI%2BkMRcRq5ia9lrYf5ok3CFJ5BXD1c5D927nYAtSlh3BEWcjIq58hDwHuosiC3msHmXsjlS4TRND7L1QMaGYrxVL1%2F7dP4v9HYBh%2F6%2FuRwhC5ToJkIiOgiM3SDxk%2Fepz5%2BXxtaAIEZruQvooQvNWtWgFRbeh3Cx3lDfNFt0Uv9mItMGQya58s344MH98s3%2FIHpBusrjLq2675XdtrXU2fG4N206lOThv2IOxbRutnt08a%2BBBpzEbnEVOuTfZPE2G%2BmrcDybxstN4hs%2FzxWp2cj%2B%2BgaRyWVmV%2BGTQb1xs3MlgfN6t2M6JsVibnblxdbw5P15ovepyETP7qW67WqsyaYYGRk%2B1Wvs%2BvqveXfPS5eTnc2rW%2BLJu9%2Bqjm%2B79%2FNZ5GrSWP289arrPt%2F3LStK0XV%2B%2F0sb3k%2BZFZeQZAaO%2BtuiOfbukExPexptBu2kP7IakmWVeskxYEUHGi7oi445nEaFoysQX8oSKjHKaoIISJgHHU7iEuyvPncI4DtYiTUxIxVui8g8KPcpm14dCV%2FNsvVf7%2FzbSe2VdUKaeK0sRy%2BYxTLfqmVq9iOpOuWhUfbfoeNVa0TTL0PBNAxp6dW9jfLJMPtsZh82AmIg7x1DOWztYwjVTXmUL74%2BKPEXZpjhMy%2BGseC8T9beN%2B%2Bvc%2BMP4HtTkZ4TTUzGmdPDpgAJ%2FwyD4A9P5WBBz7qvvvvruq%2B%2B274TO5TBFHlTKFXLWtksarWiVh%2FpJ5amW1pNNUzD0OvHmmZpmmSAGM8Iv4g9u79hlePRKm1dVa9vwgFOuxG6jDWjz1oleKVrt63NqDyuly8SZz6r1k6V138ARgCuhm8MAAA%3D)

## Service provider contact

- Website: https://konvoai.com
- App: https://k2.konvoai.com
- Signing key DNS: `_dcsig.konvo.to` (TXT on `syncPubKeyDomain`)
