### PR TITLE
Add Superfluidity template

### DIFF
--- a/superfluidity.ai.domain-verification.json
+++ b/superfluidity.ai.domain-verification.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "superfluidity.ai",
+  "providerName": "Superfluidity",
+  "serviceId": "domain-verification",
+  "serviceName": "Superfluidity Domain verification",
+  "version": 1,
+  "logoUrl": "https://www.superfluidity.ai/icon.svg",
+  "description": "Proves you control this domain so you can claim its listing on Superfluidity.",
+  "syncPubKeyDomain": "superfluidity.ai",
+  "syncRedirectDomain": "superfluidity.ai",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "superfluidity-verify=%verification%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "superfluidity-verify=",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new template for Superfluidity.ai, a procedural catalog of software products where listings are curated from systematic web crawls. The template publishes a single TXT record at the apex containing a verification token, which lets a non-verified owner prove that they control a domain, thus allowing them to take ownership of a product listing.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test superfluidity.ai/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL7YeGoC%2F91TbW%2FaMBD%2BK5GlfhqBhJdCIlVa12qo6ujKyqZpCEUmNuG2xA62E8gQ%2F31naMeL6Pp9n3LxPY99z3N3a2J4lqfUcBKuSa5kCYyrO0ZCooucq1laAANT1SmQ2t%2F8A80QT54OEZjWXJUQ8y2byYyCcEuuYAYxNSDFHnGO79xuGc4JA3%2B1jUK%2FRlKZyK8qRebcmFyHjcZyuayf1tmAWIq6LhNkM65jBfn2rpA8YvlcO5UsHIQYJVPHzEE7u1odLXcpKpw4pZA5YLSTgjYgEkcK56jculVTifixmN7zalf7edMs6gtnoHhs%2FoXDvFRMk3C8JqbKrUGj7yNMzKU2%2BPPe6qGGnrJ3HldXF4fOXSDYGLSq5XkYrcyNFLMUYjOgJp6joIFkfGsJn8GKnIU85155Djlcay4MUNuRz%2BI6z9OKbCabGvktBY%2F2eia153FAHF9RnDdej2W2l4ZRomSRR%2FCCz6mimbYz%2BcIcH1EnL9wxsfHR0OCZ32wRWwgkQioeafxSUyhUbFTBayQrUgMRXdL9EYsjahVg3RqzeMtpH8Ruat%2Fqg3370PyIxVYH2K0IuoHfa%2Fd8t%2BNPW2672eu6Pdqauu1O0GSXjAaBxw727LU9fHvR9saebdJmUkOX%2F2uBOBWalpxF1OKaXvPS9XquF4z8IGx3Qq9Z93w%2F6PnvPC%2F0PCuIa7OTvcbJOZwZMq2m8%2BpbY3r9Y9Ff3t1%2Fur1ZJKuFKPvDj7Pk189uP4BsIBbDpw%2FDK7L5A2tTlHxUBQAA)
[Test superfluidity.ai/domain-verification example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALLYeGoC%2F%2BVT7W7aMBR9lchSf43Q8FEokSoNrftsu7GNSp0qFBn7Bq6a2KntQDPEu%2B%2BatIMi2j3AfiX2Pcc%2B597jFXOQFxl3wOIVK4xeoATzWbKY2bIAk2YlSnRVkyNr%2FK1%2F5Tnh2c9dBJUtmAUK2LClzjmqcAEGUxTcoVZbxCF%2BcL5hBHsMWlr%2FF7caLNMzfW0yYs6dK2x8fLxcLpv7Oo9RaNW0ixmxJVhhsNicFbMRyQcbVLoMCOKMzgI3RxvUWgOr6xJXgcg45gE6G2RoHapZoFXwTG7Tu6mUGJXTC6hq7Yeb5lE%2FQKIB4V7DUV0baVl8u2KuKnyDxjdjKsy1dbR46%2F1wx%2FfZdY%2Brs6Pdzh0R2DlqVSeK6O%2FBvdMqzVC4K%2B7EnAxdaQmblkCKD%2Bwg5LH2wnXEAWtBOeR%2BIt%2FUsCiyiq0n6wb7rRUkWz%2BTxmMcCAcPnPIGTaHzrbUpTZZWM6PLIsEnTsENz63P5RP79hl98sS%2FrQ%2BYbNKyDQ%2Ftt9od5gXhTGkDiaUvd6Uh586U0GB5mTlM%2BJJvt6RIuHdC%2Bi1V6ZT9eag6vY%2BiXxuJv353DokU3g76B9LmMEinYhD225007LZ6%2FXAKnWnYkTAV3VRG%2FX5v58m99CT%2F%2Feae9%2FjgzNaTBjX8f%2FBJGbF8ATLhHtuO2r0wOg2jwbg1iLvd%2BCRq9k4HnX7%2FTRTFUeRNgXW19RXlaDdB7LIYXozw%2FiaPquH1ODs9%2F%2FIRBvjpXrW%2Bu%2Fvh%2B9GF%2BHD%2B62SY3vG7M7b%2BAwaFNe9qBQAA)