### PR TITLE
Add lofty.com.email-cloudflare template

### DIFF
--- a/lofty.com.email-cloudflare.json
+++ b/lofty.com.email-cloudflare.json
@@ -6,11 +6,27 @@
     "version": 1,
     "logoUrl": "https://static.chimeroi.com/servicetool-temp/2023910/17/crm/lofty-Logo.svg",
     "description": "Lofty customers can use their own domain name to send email",
-    "variableDescription": "cNameRecordName1-3 / cNameRecordValue1-3 are the DKIM selector CNAMEs issued by AWS SES for this domain; dmarcValue is the DMARC policy; loftyIpA1 / loftyIpA2 are the click-tracking gateway IPs.",
+    "variableDescription": "cNameRecordName1-3 and cNameRecordValue1-3 are the DKIM CNAME host/target pairs AWS SES issues per domain; mxMail is the SES custom MAIL FROM subdomain; dmarcValue is the DMARC policy; loftyIpA1 and loftyIpA2 are the click-tracking gateway addresses.",
     "syncBlock": false,
     "syncPubKeyDomain": "lofty.com",
     "syncRedirectDomain": "lofty.com",
     "records": [
+        {
+            "type": "A",
+            "groupId": "tracking",
+            "host": "@",
+            "pointsTo": "%loftyIpA1%",
+            "essential": "OnApply",
+            "ttl": 3600
+        },
+        {
+            "type": "A",
+            "groupId": "tracking",
+            "host": "@",
+            "pointsTo": "%loftyIpA2%",
+            "essential": "OnApply",
+            "ttl": 3600
+        },
         {
             "type": "CNAME",
             "groupId": "sending",
@@ -33,18 +49,11 @@
             "ttl": 3600
         },
         {
-            "type": "SPFM",
+            "type": "MX",
             "groupId": "sending",
-            "host": "@",
-            "spfRules": "include:amazonses.com",
-            "ttl": 3600
-        },
-        {
-            "type": "TXT",
-            "groupId": "sending",
-            "host": "_dmarc",
-            "data": "%dmarcValue%",
-            "txtConflictMatchingMode": "All",
+            "host": "%mxMail%",
+            "pointsTo": "feedback-smtp.us-west-2.amazonses.com",
+            "priority": 10,
             "ttl": 3600
         },
         {
@@ -53,20 +62,30 @@
             "host": "@",
             "pointsTo": "inbound-smtp.us-west-2.amazonaws.com",
             "priority": 10,
+            "essential": "OnApply",
             "ttl": 3600
         },
         {
-            "type": "A",
-            "groupId": "tracking",
-            "host": "@",
-            "pointsTo": "%loftyIpA1%",
+            "type": "TXT",
+            "groupId": "sending",
+            "host": "_dmarc",
+            "data": "%dmarcValue%",
+            "txtConflictMatchingMode": "All",
+            "essential": "OnApply",
             "ttl": 3600
         },
         {
-            "type": "A",
-            "groupId": "tracking",
+            "type": "SPFM",
+            "groupId": "sending",
             "host": "@",
-            "pointsTo": "%loftyIpA2%",
+            "spfRules": "include:amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "type": "SPFM",
+            "groupId": "sending",
+            "host": "%mxMail%",
+            "spfRules": "include:amazonses.com",
             "ttl": 3600
         }
     ]

--- a/lofty.com.email-cloudflare.json
+++ b/lofty.com.email-cloudflare.json
@@ -6,7 +6,7 @@
     "version": 1,
     "logoUrl": "https://static.chimeroi.com/servicetool-temp/2023910/17/crm/lofty-Logo.svg",
     "description": "Lofty customers can use their own domain name to send email",
-    "variableDescription": "cNameRecordName1-3 and cNameRecordValue1-3 are the DKIM CNAME host/target pairs AWS SES issues per domain; mxMail is the SES custom MAIL FROM subdomain; dmarcValue is the DMARC policy; loftyIpA1 and loftyIpA2 are the click-tracking gateway addresses.",
+    "variableDescription": "cNameRecordName1-3 and cNameRecordValue1-3 are the DKIM CNAME host/target pairs issued per domain by our mail platform; dmarcValue is the DMARC policy; loftyIpA1 and loftyIpA2 are the click-tracking gateway addresses. The SES custom MAIL FROM label is fixed at \"mail\".",
     "syncBlock": false,
     "syncPubKeyDomain": "lofty.com",
     "syncRedirectDomain": "lofty.com",
@@ -51,7 +51,7 @@
         {
             "type": "MX",
             "groupId": "sending",
-            "host": "%mxMail%",
+            "host": "mail",
             "pointsTo": "feedback-smtp.us-west-2.amazonses.com",
             "priority": 10,
             "ttl": 3600
@@ -84,7 +84,7 @@
         {
             "type": "SPFM",
             "groupId": "sending",
-            "host": "%mxMail%",
+            "host": "mail",
             "spfRules": "include:amazonses.com",
             "ttl": 3600
         }

--- a/lofty.com.email-cloudflare.json
+++ b/lofty.com.email-cloudflare.json
@@ -6,7 +6,7 @@
     "version": 1,
     "logoUrl": "https://static.chimeroi.com/servicetool-temp/2023910/17/crm/lofty-Logo.svg",
     "description": "Lofty customers can use their own domain name to send email",
-    "variableDescription": "cNameRecordName1-3 and cNameRecordValue1-3 are the DKIM CNAME host/target pairs issued per domain by our mail platform; dmarcValue is the DMARC policy; loftyIpA1 and loftyIpA2 are the click-tracking gateway addresses. The SES custom MAIL FROM label is fixed at \"mail\".",
+    "variableDescription": "dkim1-3 are the DKIM selector tokens issued per domain by our mail platform; cNameRecordValue1-3 are the corresponding CNAME targets (their target domain varies by provisioning path, so they cannot carry a fixed suffix); dmarcValue is the DMARC policy; loftyIpA1 and loftyIpA2 are the click-tracking gateway addresses.",
     "syncBlock": false,
     "syncPubKeyDomain": "lofty.com",
     "syncRedirectDomain": "lofty.com",
@@ -30,21 +30,21 @@
         {
             "type": "CNAME",
             "groupId": "sending",
-            "host": "%cNameRecordName1%",
+            "host": "%dkim1%._domainkey",
             "pointsTo": "%cNameRecordValue1%",
             "ttl": 3600
         },
         {
             "type": "CNAME",
             "groupId": "sending",
-            "host": "%cNameRecordName2%",
+            "host": "%dkim2%._domainkey",
             "pointsTo": "%cNameRecordValue2%",
             "ttl": 3600
         },
         {
             "type": "CNAME",
             "groupId": "sending",
-            "host": "%cNameRecordName3%",
+            "host": "%dkim3%._domainkey",
             "pointsTo": "%cNameRecordValue3%",
             "ttl": 3600
         },

--- a/lofty.com.email-cloudflare.json
+++ b/lofty.com.email-cloudflare.json
@@ -1,0 +1,73 @@
+{
+    "providerId": "lofty.com",
+    "providerName": "Lofty",
+    "serviceId": "email-cloudflare",
+    "serviceName": "Lofty Sending Email Domain",
+    "version": 1,
+    "logoUrl": "https://static.chimeroi.com/servicetool-temp/2023910/17/crm/lofty-Logo.svg",
+    "description": "Lofty customers can use their own domain name to send email",
+    "variableDescription": "cNameRecordName1-3 / cNameRecordValue1-3 are the DKIM selector CNAMEs issued by AWS SES for this domain; dmarcValue is the DMARC policy; loftyIpA1 / loftyIpA2 are the click-tracking gateway IPs.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "lofty.com",
+    "syncRedirectDomain": "lofty.com",
+    "records": [
+        {
+            "type": "CNAME",
+            "groupId": "sending",
+            "host": "%cNameRecordName1%",
+            "pointsTo": "%cNameRecordValue1%",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "groupId": "sending",
+            "host": "%cNameRecordName2%",
+            "pointsTo": "%cNameRecordValue2%",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "groupId": "sending",
+            "host": "%cNameRecordName3%",
+            "pointsTo": "%cNameRecordValue3%",
+            "ttl": 3600
+        },
+        {
+            "type": "SPFM",
+            "groupId": "sending",
+            "host": "@",
+            "spfRules": "include:amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "groupId": "sending",
+            "host": "_dmarc",
+            "data": "%dmarcValue%",
+            "txtConflictMatchingMode": "All",
+            "ttl": 3600
+        },
+        {
+            "type": "MX",
+            "groupId": "receiving",
+            "host": "@",
+            "pointsTo": "inbound-smtp.us-west-2.amazonaws.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "type": "A",
+            "groupId": "tracking",
+            "host": "@",
+            "pointsTo": "%loftyIpA1%",
+            "ttl": 3600
+        },
+        {
+            "type": "A",
+            "groupId": "tracking",
+            "host": "@",
+            "pointsTo": "%loftyIpA2%",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds `lofty.com.email-cloudflare.json`, a template for Lofty's sending-email-domain setup on Cloudflare-hosted zones.

Lofty already ships `lofty.com.email.json` in this repository, in production use through an **unsigned** synchronous flow at another DNS provider. This new template keeps the same records and variable names, and adds three things that could not be retrofitted onto the existing one without breaking it:

- **`syncPubKeyDomain`** — Cloudflare requires synchronous apply requests to be signed. Adding this field to the existing template would make every provider start verifying signatures and break the currently-unsigned integration that depends on it.
- **`groupId`** — records are split into `sending` (DKIM, SPF, DMARC, SES custom MAIL FROM), `receiving` (apex MX) and `tracking` (apex A records), so a customer whose mailbox stays with another provider can apply only the sending records instead of handing over inbound mail.
- **`essential: OnApply`** on the records an end user may legitimately change afterwards.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (HTTP 200, `image/svg+xml`)

Also validated with `dc-template-linter -loglevel info` (exit 0) and with `-cloudflare` rules (exit 0; only informational notes that Cloudflare ignores `syncRedirectDomain`, `txtConflictMatchingMode` and `essential` — those fields are kept because other providers honour them).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — both SPF entries use the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (DMARC)
- [ ] no variable is used as a bare full record value — **exception claimed for the DKIM targets, see below**
- [x] no bare variable is used as the full `host` label — DKIM hosts are `%dkimN%._domainkey` (fixed suffix)
- [x] no variable is used in the `host` field to create a subdomain — the SES custom MAIL FROM records use a literal `mail` host
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify

## Exception claimed for rule 6 (DKIM record values)

The DKIM record targets use bare variables (`pointsTo: "%cNameRecordValueN%"`) because **there is no fixed suffix we can hard-code**: the CNAME target domain is decided by our backend configuration, not by a single constant. (The host side now spells out the fixed `._domainkey` part per review.)

Our platform issues DKIM CNAMEs through two paths:

1. **SES Easy DKIM** — target is `<token>.dkim.amazonses.com`
2. **BYODKIM** — target is `<selector>.dkim.<configured domain>`, where the domain comes from a deployment setting (currently `lofty.me`) and differs per environment

Writing `%dkim1%.dkim.amazonses.com` into the template would therefore produce a wrong DKIM record for every domain provisioned through the second path, silently breaking mail authentication for those customers.

The remaining variables (`loftyIpA1`, `loftyIpA2`, `dmarcValue`) are supplied by our backend so the values can change without a template revision. All variable values originate from our provisioning code, never from user input.

If maintainers would still prefer a scoped variant for the Easy DKIM case, we can submit a separate template for it.

## Online Editor test results

**Editor test link(s):**

[Test lofty.com/email-cloudflare example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACbIe2oC%2F%2B1YbU%2FjOBD%2BK1YkpDtd0yZpS18QEhzsSWi37IrldpdDqHJtp%2FU1iYPttATE%2FfYbu%2BkbdEuBL12pUtU0fplnZvzM%2BFEfHM3iNMKaOe0HJ5VixCmTZ9RpO5EIdV4mInZKs4lzHMNC55OZgmHF5IgTZpezGPPIJZHIaBhhyebTi5vQV5ZQnvTRB7McnQp4JLB0xKTiInHafgmA%2B%2BJvGcGWgdapalcqSmPNSZkMeMyk4MapSmFcCxG5JoZK4AXVlu9V%2FEaFyLhi3Xc%2Fga2yGvUBgjJFJE%2B1hSm8IZnSAmwqRHCCMsWQHjAukRgniFrfUALeIy2QAseRDdK4iyXHvYidLtmkQx77bhVB9MYOOv141oF9ESNaSLAxZIlCXKmMUZQyOUXo5UhkEtmEmKMIhYwPEDFpu2BESPoNRxlbNAyDkqlUTFJ5cn7c%2BYA0ln2mFfptEsHkdQph%2FGXKINmTNKk2O1OsByWkhDGamxQkQsNDyhxhFPI78FNlIfz4%2FQDRGEtiPYEQJuF1ji9OUCoiTvIDZPN9lh77CEOipm%2FB3GdYNnS1xGRooPtAuTEGHEohFMVU2RAmT8ifkSBDpx3iSLHJyJes95HlBVWWeWmmLxjlElK8coG0CVRO%2B%2FrB0XlqeHgMw30pstTSduoQDA6E0jByZPgueKLVpYDXvVlgezBhXE00x4adn5PjNI1MHWgN79V9z3ssvRsmeB2MPfwlKDWpsDnSnuXlXrk7IcOQ5U%2Bgn1Ft751gwSvAgveCVV8BVv0ZWOfHeqSi7hdsh4zRHhyqq2KdljPljpnSblDGMb4XiSH0tHVyITm0y7bvbYQNlGV8tI4rPOmJLKGrkfF4NfLmlLr8cbk%2BGV3bC0xLxRrbY5j1BpvfO30ikhDqXXewhqad9DuC2pqIoleR%2B%2BuXvzrrXTGZUWl4kUVM2cyQKKOs%2FfQQ3ma8OPRX2b95LDkwxbrzznMDiZr2JnaH4bplxbYCZ%2BpFl9v1i81i7tOcFmAvxRLHylzZU8vXS6ZvpravHfPbWt%2FM8qzbmeX1oAyfoAbfi3NBMdcq%2B55frjXMnO0xZjyjY1yjXh97g1wS3ajHCmdpTdWaDSzuJDaLnzWcTTaWDcST8iqArUMjX5Gc3w%2F8MM2p1rWeH9az9PZ2GI37934arwLeaOMa4KrZ7zWTfpZynSlvKNJY1cIg90YyqA%2Flv8ldMFgFvNHGnwHPqs16f2jvYf8ApYcJEO%2FAMRTk%2FURI1lXwxDoDNdbWMoP7NM4izbt4jOdDlHSxqUFgrIJZsLl8VyYT%2BXY0r%2FdFWixwvwSNgRhOclNNVdLYbxGfuIw2sVvzesRtMYzdoNfar%2FZwPWj26IKyfCY5X9CW89JZ1U4en1zEK2OY0Xf7Y5jehUUcL5bK0oVYRPyW%2BtquzBxHoBjVusS8WMqrEvOW%2Bv%2FVEvNiq1mVmLf0p61PjFVbRVaKC74Id1NFtxDgssTa9nAX2t%2BGEnJ7Q13VJSfCtQj2qUh9fk9uf9tfCuhoMRbQpD5aqUbRf9iq7C0vw6XQluvwl43upgRafyeeduJpJ5524mknnnbiaSeeduJpJ542FE83YAGPGO1isyzwgn3Xa7p%2BcOn5bd9veyCamkGtVv%2FD89qeZ8KAsptE%2FfAIkSz81%2BWM7vMWPk1vs3hQUfTk7DzMr%2F4Jg8Y3%2F6zqVb5fRd9jqa%2FyZoWTQ%2BfxfxMwOFIFHQAA)

[Test lofty.com/email-cloudflare example.com/alert](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF7Ie2oC%2F%2B1aC2%2FaSBD%2BKytLke50YGxDCCGqdGnSO1UpbZrmqp5ahBZ7DXvYXnd3DSFR7rffrG3eBhuC1HJCigLex3wz43l8XvOkSeKHHpZEaz5pIWdD6hD%2B1tGamsdcOdZt5mul6cR77MNC7Z2agmFB%2BJDaJF5OfEy9su2xyHE9zMlsen4T%2BkQChwY99EYtR9cMPgJYOiRcUBZoTbMEwD32F%2FdgS1%2FKUDQrFSGxpLZu96lPOKNKqUoqXDLmlZUNFcuwquemUTHPKjb3K7H65XcgSxfDHkA4RNichjKGSbWxIyEZyBTIxgGKBEGyTyhHbBQgJ9YNBaA9kgwJUBzFRip1Mae465HrBZnOgPpmuYrAeiUHXd%2B8bcE%2Bj9iScZAxIIFAVIiIOCgkfILQHSMWcRQ7RN0Kl3H%2FAtnKbXfEZtz5jL2IzAuGQU5EyBJXXr2%2FbL1BEvMekQL9kliQXE4glL5EKKT4TipXq50hlv0SEkwJHSsXBEzCB%2BdjhJFLH0BPEbnw5dcL5PiY27EmYEJiXuvy7gqFzKP2%2BALF%2Fn4bXpoIg6MmV9ZMZ1g2KEuO7YGC7kHIjTDgOA6YIojQVcCMA%2Fu1x%2ByB1nSxJ0gycht1b8g4DZXFuFTTd8ShHFycuYDHDhRa8%2BuTJsehisNLGO5xFoVx2E4UgsE%2BExJGflfxzmggxT2Dy5OpYScwoVQNJMUqOj8El2HoqTyQEq6rdcN4Lr0YxtoOJr75C1AiybAZ0kkclyd6JwmGARkvQa%2BE2skLwawtwKyXglW3AKuuA2t92YyU5v2cbJcQpws3tSx8GeqRKI%2BIkGVLxz5%2BZIEK6EnppIxTKJdN0yiEDSFL6HBTrNCgy6LAyUbGo2zk4iF1%2F%2BV%2BszM6cS1QJRVLHN%2BGaW2I%2Ffsgr1jgQr7LFpZQtINeizlxTnjeVsH96faP1mZVlGdE6N5FHhGxZ2wvckhz%2BSbsJjy96VvJbz%2BXNJginVnlaYOjJrWJPGBotyTdluJgj3A5UaVD403zFWOm2Cw2QGiIOfaF6tsT8V8X5LcnAF9ThHYKUUz8tO6p5aeWDn9WDf7Pz1np3LluGqZeO1NzcbVR45EzwjXH6GGjP%2Ba2PDv1BY7Cmqg1zjB74FgtXik9RTbqCmIp0VLgWKGhKewxfeybbjh2pKx1Tfc0Cr9%2FH3ij3qMZ%2BlnAhTZuAK6q%2FUYj6EUhlZEwBiz0Rc21xsaQW6cD%2Fk%2FwYPWzgAttXAc8zbtY%2B1dxRzYvUPgqgBC80FQw0l7AOOkI%2BMQyAl7WlDyCzupHnqQdPMKzIcfuYJWNELsCZkHmYtcMEiI3Cdc0%2B%2BdDYy4TSlAmbBWcVOWWe%2B7gBnHq5YZtueXamWGXu2a9UbZdt%2BGcn1u2VTXmeOYKAc1hmkuJlFVhnpd681pjprF8IMZM%2BmRqUG7yzJqlvmT8Lnn3Ezrp0gNiKTb5KDfP1%2FtolxJxkD7KLUnrfbRLNTsMH8VULXWQkrVseVFSOGfrIks7CMuXjC5IR39ym7NKa8KEU6sT1rtSD1aa7oG0jQXbVowCzmuiTLaL%2FsUxiz%2BEdF2wMStfD9vQdgmeLY4U7UjRjhTtSNGOFO1I0Y4U7UjRjhTtp6JobRCDh8TpYLXWMqx62WiUTeveMJum2Txt6Of1unFm%2FmYYTUNpIyE1E9Of4u%2FJAW9ypvo0ffEYj86d0C5RvLnz2SW%2BlErKP5zNPJvdkX%2BkJ7P5B7OZ57I7NvT0VDb%2FUDbzTHbHDjl%2FIptZeNa8CSh8Lv%2BsrtTp7Mo7zTSH5uTqi6mR8TCQTbiLiJiG1H5obi7kLoG3H3aZq9ou4bkfUper2i5BvIlL5QKaBipGsNagFAEoRGZyKEIuzrfV7P2mrZVaSFxOH9sgvpjvC2KoEpIW5GM%2F%2Bb%2F2k6w3y3tpL7FEfQ9NprigPbeagsA%2FruEUVPDHtZ2CCu67%2BRSEfWkLKg6zj0ZUEG27drSF0Bc2pf0iteHJUEt%2BMAlPTOrpJ%2F1VpSoi2vxvGLSPV29qf3r45tPn4PXHD0EfP9xc1ei1Xfkc9B6vx7f9OmV%2FDv7ujW4br7Tn%2FwBymnoN5yoAAA%3D%3D)
