### PR TITLE
add Prezly, 2 templates

### DIFF
--- a/prezly.com.email-sending.json
+++ b/prezly.com.email-sending.json
@@ -1,0 +1,43 @@
+{
+    "providerId": "prezly.com",
+    "providerName": "Prezly",
+    "serviceId": "email-sending",
+    "serviceName": "Email sending",
+    "version": 1,
+    "logoUrl": "https://cdn.prezly.com/img/logo.svg",
+    "syncBlock": false,
+    "syncPubKeyDomain": "domainconnect.prezly.com",
+    "syncRedirectDomain": "rock.prezly.com",
+    "description": "Verify this domain for sending email campaigns through Prezly.",
+    "variableDescription": "%mailTarget%: Prezly return-path host; %dkim1%/%dkim2%: DKIM selectors; %dkim1Target%/%dkim2Target%: DKIM hosts; %dmarcTarget%: DMARC policy host. All values are assigned per account by Prezly.",
+    "records": [
+        {
+            "groupId": "mail",
+            "type": "CNAME",
+            "host": "prezly-email",
+            "pointsTo": "%mailTarget%",
+            "ttl": 300
+        },
+        {
+            "groupId": "dkim1",
+            "type": "CNAME",
+            "host": "%dkim1%._domainkey",
+            "pointsTo": "%dkim1Target%",
+            "ttl": 300
+        },
+        {
+            "groupId": "dkim2",
+            "type": "CNAME",
+            "host": "%dkim2%._domainkey",
+            "pointsTo": "%dkim2Target%",
+            "ttl": 300
+        },
+        {
+            "groupId": "dmarc",
+            "type": "CNAME",
+            "host": "_dmarc",
+            "pointsTo": "%dmarcTarget%",
+            "ttl": 300
+        }
+    ]
+}

--- a/prezly.com.newsroom.json
+++ b/prezly.com.newsroom.json
@@ -1,0 +1,23 @@
+{
+    "providerId": "prezly.com",
+    "providerName": "Prezly",
+    "serviceId": "newsroom",
+    "serviceName": "Newsroom hosting",
+    "version": 1,
+    "logoUrl": "https://cdn.prezly.com/img/logo.svg",
+    "syncBlock": false,
+    "hostRequired": true,
+    "syncPubKeyDomain": "domainconnect.prezly.com",
+    "syncRedirectDomain": "rock.prezly.com",
+    "description": "Point this subdomain to your Prezly newsroom.",
+    "variableDescription": "%target%: Prezly newsroom hostname assigned to your account.",
+    "records": [
+        {
+            "groupId": "site",
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%target%",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Two new templates for Prezly (prezly.com), a PR & newsroom software platform. Customers connect their own domains for two independent features, hence two service ids:

- `prezly.com.newsroom.json` (`hostRequired: true`): points a customer subdomain at their Prezly-hosted newsroom with a single CNAME. hostRequired because newsroom domains are subdomains in practice and a CNAME cannot exist at a bare zone apex.
- `prezly.com.email-sending.json`: verifies a domain for sending email campaigns — a return-path CNAME, two DKIM selector CNAMEs (variable selector label with the fixed `._domainkey` suffix), and a DMARC policy CNAME.

Only the synchronous flow is used. Every apply URL is signed (`syncPubKeyDomain=domainconnect.prezly.com`, key already published at `_dck1.domainconnect.prezly.com`), and all variable values are derived server-side from the authenticated customer account (newsroom hostname, per-account email infrastructure hosts). They are never taken from the browser.

Both templates pass `dc-template-linter -loglevel error -tolerate info -logos` (also clean in `-cloudflare` mode).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in these templates)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (n/a, no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — **justification:** the CNAME targets (`%target%`, `%mailTarget%`, `%dkim1Target%`, `%dkim2Target%`, `%dmarcTarget%`) are per-account hostnames on Prezly-operated infrastructure that differ per customer and per infrastructure generation, so they cannot be fixed in the template. As mitigation, all apply URLs are signed and the values are computed by our backend from the authenticated account, never accepted from the client.
- [x] no bare variable is used as the full `host` label — DKIM hosts use a variable selector with the fixed `._domainkey` suffix (`%dkim1%._domainkey`), the recommended pattern; all other hosts are fixed (`@`, `prezly-email`, `_dmarc`)
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not set: every record in the selected groups is required for the corresponding feature to function, and each record is independently selectable via its own group.

## Online Editor test results

**Editor test link(s):**
[Test prezly.com/newsroom example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAISjeWoC%2F91T227bMAz9FUNAn2Y7cpKmgYEBa9c9tEOzrMiGDkVgKDLnqLUlV5LTOUH%2BfZTt3Dr0Bwb4wRIPDw8PqQ2xUJQ5s0DiDSm1WokU9E1KYjzAOq9Drgri7yMTViCSTJsY3hvQK8GhSZDwarRq4N11h550AW%2BpjBUyQ8AKtBFKkjjySa4y9UPnCFxaW5q41%2BOpDA%2Fle6LIeg4UmpXLNbXkV7nizyT%2BzXIDPnG89%2FBSCQ0oxOoKWtS0WnyF%2BloVTGApkjY%2FXEkJ3IYn%2FTn0PaRIwO0er7HGKSwFw7UobSOdTJWQ1rNLYTxTLVp2zyqvVpX2Wou8nSmha5ppwRY5XJ%2BwnFmmM7Bn8duUxi6JFnrMGJFJSPfkjHNVSetIUbHSqSHx44ZkWlVlMwsjcKI%2BsXXpBvB5cnn3hbQ%2B4fGTG6jTbmbqSIDDWxzDgNLtfOuTtZKQHOjnfmcgpsAfhlsDnSsdrdONp0ZEIpqcVgdmlkyzwrgd23E8npDMdyyPLc284znmaGXuIM6hYDjuR6GLm%2BM5OfHol9KQON%2BYrTTs1qKocisS9soOVylPWFnmNfZqMIoF0Mo3zsl2k7sWU2bZ0cK%2FI%2BNgp0%2BSlLvmhZvNaMAjOh4Oggt%2BzoNhREfBYhRdBIN0PIgWEA3PI3b05P59jO88utMxgDEgrWDuXV3mr6w2ZLud%2BzjG%2F7c7XBLDVpAmzEH7tD8K6DiI6Cyisfv64WBIL6L%2BB0pjSl0LYGzb7gZ35nhbyPSK5Q9qGH2vs2lJ78zzQ%2FWT5bPrif726%2Bn2aZmt%2BPqlX5br25uPZPsXSxDejUgFAAA%3D)
[Test prezly.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMijeWoC%2F%2B1VbU%2FbOhT%2BK5YlPt0mdQKEkqt9YGOa2AZDCLYrIVS5jmk9nDiy3ZaA%2BO87dt7a3q17%2BbRNfGp6zuPn%2BPF5e8SW56WkluP0EZdaLUTG9UmGU%2FjDH2QVMpXjQec5ozkg8bn3gd1wvRCM%2BwM8p0IGhheZKKa9rzny2nlR711wbYQqcBoNsFRTdaUloGbWliYdDllWhP0FhiKfDh0oNAvPXBXspVTsDqe3VBpeW87nk3e8OlYQCGhx5j%2BYKgrObLimxqEveCY0eDq8Br51WMYN06K0%2Fpr4I9fitkJ2JgyqudGt0q0i5NUjRvOSimlhAKfVfDpD9VOFTjHVgk4kP16j3XHnLqmecruTNmikuZ3rIiipnaGZMvZftJPdiTzaGfrfGJDH705OIbgECUqbFtAQNbCO1oMdkQfmVLPedXp08QqVSgpWeUiIjqRECyrn3CCqOaLGgCKeoZJrRBlT88KiSbWiDN5R6czg9PoRT0F26evBCQOnrUqX%2F1dnR6ev4a8L0VVXwBtQqURhzaXaeBB33EJd7BLyNFjl9mK%2FSd48Vjiu83THq40Qq2%2B1NUa8PUb8nRjxd2O4XHwzxrh1r%2FGupG%2BV9%2BZpgB9Uwcd9Nm4GTRe47ryH0pS8Ke0mAHz5u4yFx7cpa1%2B3fYH6GsBWUk1z40ZFy3u9RnzTMl9j9%2B25f4S3T7ln9IMkiSKakGQvZHNjVQ7jou1OodyZmgzgtbUz9TwNvEtQ%2BOPEcX8%2B7mybzPHPU%2Fe5czR1fr8OhmxC1ynNx677KMwDKBCr5zDs8rm0YkyXtDdlbEzLUlaQfANeIIdW3Ciqoh7EG52XUUu74b31%2Fn2tDeDmzFWBcDU8GsWjg4NoFNySPRrskWw%2FOIwnJNijSZRM9hnPyP7KCvn%2Fctm2RPpC5QasVlC3Jo7kklYGP7lm2qZyvTsbqb9SFn%2Bg9niL%2BPgvVt8NzUbxlib7HXXdDGBsPzfvc%2FM%2BN%2B8f2Lyw4w1d8GxMHSwmcRKQURCRy4ikUZTGJBztJsn%2B7j%2BEpIQ4DdzYWusjbPzVXY%2FPKI0e3i6TvCCZsMs37%2B8%2FXZ2cHS7%2FGx1%2Bmny4om8uPp%2B%2FZeL93cHyBX76AjUDb7zKDQAA)
[Test prezly.com/email-sending example.com/updates](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN2jeWoC%2F%2B1WXU%2FbMBT9K5YlntakSVpalmkPDDapYzA0MTYNVZXruK2FE0e2UxYQ%2F33X%2BS6Mwva0D57S%2Bh6fm3PvPXZusGFxKohhOLzBqZJrHjE1iXAIf9i1yF0qY9xrIickBiQ%2BLWKwrplac8qKDSwmXDiaJRFPlm2s2vLWRlEbXTOluUxw6PewkEv5WQlArYxJddjv0yhx2xfo83jZtyBXrwvmPKFvhKSXOFwQoVm5cprNj1h%2BKCER0OKo%2BEFlkjBq3A01Fv2JRVxBpMEr4NuERUxTxVNTvCY%2BZ4ovcmRWXKOSGy2kqhWhQj2iJE4JXyYacEpmyxUqS%2BVaxURxMhfscIN2x%2B47I2rJzE5YoZFiJlOJkxKzQiupzSu0E13y2N%2FpF88AkIdHk2NILkCCVLoGVEQVrKEtwJaoAMZE0TZ0vP%2FpAKVScJoXEBftC4HWRGRMI6IYIlqDIhahlClEKJVZYtA87yiDOkoVaRxe3OAlyE6LebDCIGjy1Pb%2F4GT%2F%2BC38tSma6XJYBUolT4w%2Bk3cKYrcbmIuB5932utyF2AfJq2K5s7JPlyy%2Fk6Jbq605gu05gkdyBI%2FmsL14MMesDm%2FwdtrX5Z3e9vC1TNis7ca0V7nAuvM7jKZg1WhXCbI0AutrWCheacaLbXXn6iLXhSjfBkhTokis7YlR019s8E%2FrBBdNhmmV4in07QAUxMWxMvJ9MvJGQ5dm2sgYDo%2Faq1zaPSUZwMvVZqnlqeBNu9ynEwft%2FqBZu8sc%2FDp120lLU3b752DoLXhQKjazXiRwOsC4GJXB0RdnwvAZuSLtUkRnJE1FDqOgIQrkYMw7I5aUx3LXh247DvAkzZG%2BVUc7gT1QQO1QcDvZg73BYjAIxs7LXUqc4e4wcsjQHznUixbjIBoPWDDvXCz3r5xtV8u98WUagoYTe4fsiyuSa3xrnbZNdMe695X%2FzrT8vaUInlCL4N8vRuXAewXY4sw%2FWOa0BxfAs%2FGfjf9s%2FP%2FM%2BPBtocmaRTNi0YEXjBxvz%2FG9M98LfT8c%2Bu4evNjAe%2BF5oedZKUybUvINfGl0vzFwfH30tX%2FufTifjxl5cxh82Z18GE8G35aX71L%2F5Gr4cfH%2BRX5wJPaGk9f49geLbcLeUA4AAA%3D%3D)
(newsroom template is hostRequired=true, so per the instructions the apex test is not required for it)
