### PR TITLE
add motif, Tracking subdomain

### DIFF
--- a/motif.reaktif.io.tracking.json
+++ b/motif.reaktif.io.tracking.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "motif.reaktif.io",
+  "providerName": "motif",
+  "serviceId": "tracking",
+  "serviceName": "Tracking subdomain",
+  "description": "Serves motif's analytics tracker and its event endpoint from a subdomain of your own domain, so both are first-party to your site.",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "dc.motif.reaktif.io",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "m",
+      "pointsTo": "motif.reaktif.io",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for motif (`motif.reaktif.io`), a revenue analytics product. One CNAME so a customer can serve the analytics tracker and its event endpoint from a subdomain of their own domain, making both first-party to their site.

```
m.<domain>  CNAME  motif.reaktif.io  (ttl 3600)
```

Synchronous flow only, signed, no variables.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Ticked as vacuous: this template sets no `logoUrl`, so there is no resource URL to serve. 84 of the 1049 templates in the repo are the same. Happy to add one in a follow-up if you would rather every template carry a logo.

Also linted with the repo's command plus both stricter modes:

```
dc-template-linter -loglevel error -tolerate info -logos motif.reaktif.io.tracking.json   # 0
dc-template-linter --merge-or-fail motif.reaktif.io.tracking.json                          # 0
dc-template-linter -cloudflare motif.reaktif.io.tracking.json                              # 0
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove

Notes on the ones that are vacuous here: the template has a single CNAME, no variables, no TXT records and no `redirect_uri`, so the SPF, `txtConflictMatchingMode`, variable-scoping and `syncRedirectDomain` rules have nothing to apply to. `essential` is left unset because the one record is the whole service: removing it does not degrade the template, it disables it.

The record host is the literal label `m` rather than `@` plus `hostRequired`, since `hostRequired` is not supported by Cloudflare (DCTL5006) and `@` without it fails `--merge-or-fail` (DCTL1012). Customers who want a different label use a manual CNAME instead.

## Online Editor test results

**Editor test link(s):**

- apex, `example.com` with no host: [Test motif.reaktif.io/tracking example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALyneWoC%2F91Sy27bMBD8FYKXHmq5lCy7loAe3EeAJGiSokZQwDAEmlw5jClSICm5iuF%2FL%2BlHlaIJeu9JxO7samZ2dthBVUvqAOc7XBvdCg7mkuMcV9qJcmiAbsJXaDz43b%2BhFZwRvmzBtILBYcoZyjZCrfvyCTw%2FNZBtVlxXVCgP4WCZEbUTWnnIdz8AFh3WvrGIKio7J5hFh6VgfIUj4SyCFpRDoHithX%2BURleI9ouRLlGnG4P0VqFjaYCsRivtHhA1gEphrItqalyHnD5irXAw9JRaMPZAJ%2FYKOsU%2BSs02OC%2BptHCs3DWra%2Bg%2BHzXkmLPhC1YZYNpwi%2FPFDruuDg58upl9%2FeJbD9q64F4wNPC3c%2F2y3c5JnI8mhOyX%2BwF%2B0gqKfu3Su3emAD%2BpPyIMma76%2Ff61NrqpC3HGe8G0suHQ58nFH6PL8%2BwC4%2FBHsVbaQGH9l7rGeA3ONN6EqpFOFHRL%2BxJnBa1r2XmC1nf9ir91q1Nqwt2po%2F%2FQPMAFZ4GrCLEapfEq5WQSQZatorQcT6IsYWWUZmw8YWk2mibls4C%2BFuBXkto7Btb6aAnqSeCZ3NLO4v1%2BOfDu%2FU96%2FKEtbYEXNMASkkwiMo1iMo9JnkzzOBmOJzFJp28JyQkJKsC6o8adz8XzRODHhrB3YxXf26tbKTfybtp%2Bu7ow9%2B%2Flk3m8ub34Mb9c8%2BtqPs5mH%2FD%2BF%2BZQ28hwBAAA) → `m.example.com. CNAME 3600 motif.reaktif.io`
- subdomain, `example.com` with host `sub`: [Test motif.reaktif.io/tracking example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPuneWoC%2F91Sy27bMBD8FYKXHmq5lOKngB7SJCjiommQumgBwxBocuUwlkSVS8lVDP97V37UCZqg954o7e4sZ4az4R7yMpMeeLzhpbO10eCuNY95br1Juw7kqj2N5Z0%2F%2FRuZw3GCygiuNgp2KO%2BkWplieSofhqeHBsNqoW0uTUEjGlA5U3pjCxr5SgBAtlv7BpksZNZ4o5DtloKjimbGI4MaCs%2Bg0KU19JE6mzN5WsxsyhpbOWbXBduXOgwtW1h%2Fz6QDlhqHPiil8w3zdj%2BLxkOXKNXgcEcnJAVNoT5kVq14nMoMYV%2B5rRafoLnca4i5Vt0XrHKgrNPI49mG%2B6ZsHbi4Of98Ra17i751rzW05Y9T%2B7Ld3mc8PhsIsZ1vO%2FzRFpCc1s7JvSMF%2BCXpEaGrbH7aT3bQz9LZqkzMEUKaZY7tWx%2FBs2fo%2BRE%2B2%2BHbe82ysA4SpFP6ypES7yqyIq8ybxK5lqeSVoksy6whmkhd2vK3%2BuKQne6en5Ze%2FkN9hydatZRNGzC5CIc9JXpBpMaDoDda9IPRoK%2BDtJdqJYa9QSTCJ1F9LcqvZPaZd4BIOTOSePDzbC0b5NvtvEM%2B%2Foey6OVR1qAT2U5GIhoEYhSEYhqKOBrHYb%2FbJ4Zi9FaIWIhWCKDfy9xQSp7mg38XH%2FUtnkVXl%2BFDfTEpf0weH4bLu5%2FfwIWT8fXdct1M3y2%2F1P1w9J5vfwOQsnUAhAQAAA%3D%3D) → `m.sub.example.com. CNAME 3600 motif.reaktif.io`

The `_dc1` public key TXT under `dc.motif.reaktif.io` is published and resolving:

```
$ dig +short TXT _dc1.dc.motif.reaktif.io
"p=1,a=RS256,d=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAulwL8VJeH7Vm..."
```

Reopens #1559, which closed automatically when I deleted the fork. Same file, same content, checks were green there.
