### PR TITLE
Add genex.games templates: game (subdomain) and game-apex (root domain)

### DIFF
--- a/genex.games.game-apex.json
+++ b/genex.games.game-apex.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "genex.games",
+  "providerName": "Genex",
+  "serviceId": "game-apex",
+  "serviceName": "Connect your root domain to your Genex game",
+  "logoUrl": "https://genex.games/genex-logo.svg",
+  "version": 1,
+  "description": "Points a root domain (for example example.com) at the Genex game you chose, adds the record Genex uses to confirm you control the domain; HTTPS is issued and renewed automatically, with no certificate record for you to manage. No other DNS records are changed.",
+  "variableDescription": "%cname%: the Genex edge hostname this domain should point at. %token%: the random half of a per-domain ownership token Genex issues when you connect the domain (the record is written as genex-verify=<token>); it is re-checked daily, and removing it stops the domain serving.",
+  "syncPubKeyDomain": "genex.games",
+  "syncRedirectDomain": "api.genex.games,api-dev.genex.games",
+  "records": [
+    {
+      "type": "APEXCNAME",
+      "pointsTo": "%cname%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_genex-challenge",
+      "data": "genex-verify=%token%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    }
+  ]
+}

--- a/genex.games.game-apex.json
+++ b/genex.games.game-apex.json
@@ -3,7 +3,6 @@
   "providerName": "Genex",
   "serviceId": "game-apex",
   "serviceName": "Connect your root domain to your Genex game",
-  "logoUrl": "https://genex.games/genex-logo.svg",
   "version": 1,
   "description": "Points a root domain (for example example.com) at the Genex game you chose, adds the record Genex uses to confirm you control the domain; HTTPS is issued and renewed automatically, with no certificate record for you to manage. No other DNS records are changed.",
   "variableDescription": "%cname%: the Genex edge hostname this domain should point at. %token%: the random half of a per-domain ownership token Genex issues when you connect the domain (the record is written as genex-verify=<token>); it is re-checked daily, and removing it stops the domain serving.",

--- a/genex.games.game.json
+++ b/genex.games.game.json
@@ -3,7 +3,6 @@
   "providerName": "Genex",
   "serviceId": "game",
   "serviceName": "Connect your domain to your Genex game",
-  "logoUrl": "https://genex.games/genex-logo.svg",
   "hostRequired": true,
   "version": 1,
   "description": "Points a subdomain (for example play.example.com) at the Genex game you chose, adds the record Genex uses to confirm you control the domain; HTTPS is issued and renewed automatically, with no certificate record for you to manage. No other DNS records are changed.",

--- a/genex.games.game.json
+++ b/genex.games.game.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "genex.games",
+  "providerName": "Genex",
+  "serviceId": "game",
+  "serviceName": "Connect your domain to your Genex game",
+  "logoUrl": "https://genex.games/genex-logo.svg",
+  "hostRequired": true,
+  "version": 1,
+  "description": "Points a subdomain (for example play.example.com) at the Genex game you chose, adds the record Genex uses to confirm you control the domain; HTTPS is issued and renewed automatically, with no certificate record for you to manage. No other DNS records are changed.",
+  "variableDescription": "%cname%: the Genex edge hostname this domain should point at. %token%: the random half of a per-domain ownership token Genex issues when you connect the domain (the record is written as genex-verify=<token>); it is re-checked daily, and removing it stops the domain serving.",
+  "syncPubKeyDomain": "genex.games",
+  "syncRedirectDomain": "api.genex.games,api-dev.genex.games",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_genex-challenge",
+      "data": "genex-verify=%token%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for [Genex](https://genex.games), a platform where people build and publish browser games. A creator connects a domain they own and their game serves on it.

Two services because DNS forbids a CNAME at a zone root:

| serviceId | For | Routing record |
|---|---|---|
| `game` | a subdomain, e.g. `play.example.com` | `CNAME @ → %cname%`, with `hostRequired: true` |
| `game-apex` | a root domain, e.g. `example.com` | `APEXCNAME → %cname%` |

Each writes exactly two records: the routing record, and a `_genex-challenge` TXT we re-resolve ourselves to confirm the creator still controls the domain. **Nothing for HTTPS** — certificates are issued and renewed via HTTP DCV, so there is no `_acme-challenge` record for the end user to keep.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — published as a TXT record at `_dck1.genex.games`, and signature verification was tested end to end against that record before submitting
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — both API origins are listed, so one template serves our production and development deployments
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the ownership TXT (`All`)
- [x] no variable is used as a bare full record value — the TXT is `genex-verify=%token%`, and only the random half travels in the query string
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not needed — neither record is one an end user would modify; removing the TXT deliberately stops the domain serving, which is the takeover defence

## Online Editor test results

**Editor test link(s):**

- subdomain (`genex.games/game`, `example.com` / `play`): [Test genex.games/game example.com/play](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGbgeWoC%2F%2B1UbW%2FbNhD%2BKwSBAC0mKbIjv7Yd1i1F0g0JssYr2gWBQZMniY1EqiRlRwvy33eU5bemRb8WwwAD1r3f89zxHqiDsiqYAzp9oJXRSynAvBV0SjNQcB9lrARLg63pEmU0nnkjqi2YpeSwDvCmrapz%2FE0rBdyRRteGCF0yqYjTa7FNQrqwXFv3Dj7X0gAmc6aGgC7BWKkVnfYCKsByIyvXyvRKS%2BUsYcTWiy7rs1QbAvcM4QBBSE3UCRHX5XPCHHE57NX0PRCOZSEgTAjbmg1wbUTnVVuwvlmuVSpNuQ7QyhldtM7rwi%2FI%2BWx2dU2kxZ%2BtQRCmBCZSsPLftUMvJzkriiYgK%2BlyojAlGCdT1LptTd%2B%2Br4AFS6ZYBhG51ERjIUNOL687N8RsANtmKgMRIW9LZiRbFHB6wM8RVwjxaLqHGUQGxLPsLajHfjvmbK7rQpDKc4o8ReTI6TtQXbRBOLokOStSolOkvAITdpF6pXBEuaxIG9FVammwZJWjpuOs3YEdZ%2BTZHtnYyMpI59CbWdKuXYiTl2nz6mWb9ufnL4h03s9AyHPgd0isYNITuua6xOVUmXeyTld2v1K7jirzVNlG8at68Qc0p63tyZJ7h3cgcAW527qwSkZ7bgHKoYBldBjaTYdObx6oa6p29S9fX7zpNhvFX%2Fwratd2pncTQqVzBZ2eDOP4MdjGzj7MdpHzNSc49KIAnDtaBHNs0%2F6GrG5qPuO9w3eXFpK7C%2BZ4jvgvtPB5XxfFQcXbx4D%2BoxXMd%2F3fYvYN9r0XtGvHvy2UMqPrai43MRUzrLT%2Bimyibw7CbzfxN%2BsEKLcMeEX70RHqgOdKFzprXVpI3iXu9U%2BSwXA0nrAFF5B%2BKVOPRGZKG5hb%2FGeuNrC5I2VdODlnK7ZTCT5nVVU0CNyiFUs8Hdy6vQ3ejvJv9LpHakDngnsipL%2BKrJ%2F2odcbhosk6YXJSXISjidpPxyL3mAyGo4Wo2S0d1%2B%2Fcnq%2FcmMPJwHWgnKSFe2AV6yx9PHJLnVgvtyl6BDdwUJ9l%2FMfDvRtgKv4%2FyD%2FA4PEt2%2FZEsScedd%2B3B%2BG8TjsxbNeMu1PpoNxNBoOBpPkpziexrEHANatsT%2FgJdi%2FAfT3%2Fq%2FJW7m81vxDtkjujlfOni%2F%2FEpP3x3%2Be6k%2Fq%2FO%2FR2Uf36c37s%2BOPr%2Bjjv9e1E1UTCQAA)
- apex (`genex.games/game-apex`, `example.com` / `@`): [Test genex.games/game-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMfgeWoC%2F%2B1UbW%2FbNhD%2BKwSBAC1qefJL7MRdh2WN0Q5p3KwxthRBYJzJk8RVIjWSsuMG%2Be87ynIsry22jxswwIDFu%2BdenueOfOAeizIHj3zywEtrVkqi%2FVnyCU9R4303hQId7zy5ZnQm55vgJLNDu1ICtwHkiqBs2xv0a6M1Cs82prLMGuOZNAUozbzZ2up0LCSg2BVap4zmk16HS3TCqtLXZ35llPaOwUGOZ4mxDO%2BBaODuvytM8ZyBZz7DVvJQjInMOOwwkNLVbovCWNmgKocudCWMTpQttgFGe2vyGryt%2BZK9nc%2Bvrply9HMVSgZaUiKN6%2FBdeUJ5JSDPNx22Vj5jmlKi9Sohq3%2BqGToPFahgARpS7LKZYYYKWXY%2Bu25gRNgitQ06RdkNAoFVsMzx%2FECcI6GJ4tGkxRlliozo%2BuAhO%2FXbiOYyU%2BWSlUFQ0qnLjrz5hLqJtkTHFCyDPGEmIb1LtFETadaa5pOpktURTaVaBsfWGVkazeqJ7zVjz1piUyNrq7wnNDhWb1pEY1fJ5tX3ddofnr9kygecxUhkKD6RsBJUEHSrdUH7qNMAct6Url2pXj6dBqncRouranmBm%2FPa98VeB8AHlIoa808QKFW3BevQOZK46h6GNtPhk9sH7jdlWPSzq%2BnN69nZ5TTcmHpZ52Y%2FGjJ6n%2FPJYBTHj52noPnNnDxhTHRYbMWgaec50sDJI8HDru%2BdSs24QsZ7T9cryZXwl%2BBFRsQvjaybyfODinePHf7ZaFzsG7%2Bj7DvSrauzb4e%2BUmuqcqF2%2BBIsFC68FrvI24PQu13sLQ%2FfNfNwqD8aBT2KTJvcpJsAqakESNzrD4bHo%2FHJKSyFxOSvZx4YqFQbiwtH%2F%2BArS7m9rbDDiyr3agFr2JukWEBZ5hsi7MhLJb4%2BqW2L%2FMe91t9otqVmhy%2BkCCqo8PSBiE%2BTUT%2BJesd9jIbjBKOlAIhG4%2BF4uBzAiE6tR%2FQr7%2Bu3HtL9HNA51F5BXo92DRvHH7%2FYoobKP9yivxX830f4rkNL%2BP8Y%2F%2FNjpHvvYIVyAQHWj%2FujKD6JevG8N5wMepPBcbffPx6enryI40kcBwbo%2FJb8A70C7fvPfxc%2Ffby4%2Fm4wnM7hczn%2B7eKm986dvR%2FcT%2BHFm8Fp%2F9fZhz9W09nql9XHV%2FzxTwNltBvzCAAA)
- apex template applied to a subdomain (`genex.games/game-apex`, `example.com` / `play`): [Test genex.games/game-apex example.com/play](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPgDe2oC%2F%2B1UbWvbSBD%2BK8tCoCWSkGzHsdxruVxTcseRXGhdrlwIZr07kpZKu%2Bruyo4a8t87K8ux3Kbc11IKAmlmnnl7ZjT31EFVl8wBnd%2FT2ui1FGD%2BEnROc1BwF%2BWsAkuDR9MVymi88EZUWzBryWHrgKaQ1UN9j36tlQLuSKsbQ4zWjghdMamI01tdF474AOi7BmOlVnSeBFSA5UbWrpPptZbKWcIOYjzLtCFwx7AN2L0jrqvnhDniChgE98kIL7SFgDAhbGc2wLURPaqxYH1VXKtMmmrroJUzuuzA25wvyJ%2BLxfU7Ii0%2BtgFBmBIYSMHGfzcOUU5yVpZtQDbSFURhSDBOZqh1jzl95T4DJqyYYjlE5EoTjYkMOb9618OwYQNYNlM5iMgTxIxkqxLOD8g54gpbPJoPegaRA8F2nbegHuvtSbOFbkpBak8o8hSRI6c%2Fguq9DbajK1KwMiM6Q75rMGHvqTcK51PImnQefaaOBks2BWp6zrqJ7zkjzwZkYyEbI51DNLOk27QQxy6z9uVvXdhXz18Q6TzOQMgL4B%2BRWMGkJ3TLdYX7qHIPsk7XdpipWz6Ve6psq%2Fh1s%2Fob2vPO9s1ee8BbEBILc48QVstoAAtQDgWso0PXfjp0fnNPXVv7RT%2B7fvPh9dXZ5Rv%2Fx3TLutD70aDSuZLOx9M4fggenRYfFmjxY0JhuSUDp12WgANHi2CO7eresdSPy0e8c%2Fh7ZaXk7pI5XmDjl1p0xZTlQcbbh4B%2B1gqW%2B8JvMfqu6cGvsy8HT0OLUm50Uy%2FlzqdmhlXWX4yd982B%2B%2B3O%2F2YbAOWOAa%2FoPnomHfBC6VLnHaRryUPiZDSenExPZylbcQHZ1zL1nchcaQNLi2%2FmGoOxnWkgoFVTOrlkG7ZXCb5kdV222LhFK6Z4emLbEunve86%2FU%2ByA1YAuBfdMSH8CV6fxhIk0DceQJeEkhVU4G6%2FG4SzOptnJbHzKeTw4pk%2Fc2e8d1MN5gLWgnGRlN%2BYNay19%2BGaj%2Bna%2B3qioj%2FHUWv0v8z9m57cBbuWvmf5cM8WLYNkaxJJ56CgeTcN4FibJIknmyWQex9HJNJmNR8dxjILvAqzbEnCP92F4Geh7%2B8fZ%2Bwn%2FJ00%2F1fGpWv%2F73%2BjiOK1OUndxPBufLyZnpqg%2FfyrKdPKSPnwBCUssZhUJAAA%3D)

Both were run with `cname = cname.genex.technology` and a sample token.

## Notes for reviewers

**`hostRequired` is set on `game` and deliberately absent on `game-apex`.** `game` writes a CNAME at `@`, which cannot be applied to a zone root; `game-apex` uses `APEXCNAME` and is apex-capable, so the pair covers both cases without either template being able to write an illegal record.

The ownership TXT is re-resolved daily rather than trusted once. Three consecutive positive failures retire the domain and stop it serving; an inconclusive lookup counts for none, so a resolver outage cannot take a working site offline.
