### PR TITLE
add Destevo, 2 templates

### DIFF
--- a/destevo.com.helpdesk.json
+++ b/destevo.com.helpdesk.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "destevo.com",
+    "providerName": "Destevo",
+    "serviceId": "helpdesk",
+    "serviceName": "Destevo Help Center",
+    "version": 1,
+    "logoUrl": "https://destevo.com/icon.svg",
+    "description": "Points a subdomain such as support.yourdomain.com at the Destevo help center, so your support articles are served from your own domain.",
+    "syncPubKeyDomain": "domainconnect.destevo.com",
+    "syncRedirectDomain": "app.destevo.com",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "cname.destevo.com",
+            "ttl": 3600,
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/destevo.com.widget.json
+++ b/destevo.com.widget.json
@@ -1,0 +1,22 @@
+{
+    "providerId": "destevo.com",
+    "providerName": "Destevo",
+    "serviceId": "widget",
+    "serviceName": "Destevo Widget Domain Verification",
+    "version": 1,
+    "logoUrl": "https://destevo.com/icon.svg",
+    "description": "Adds the TXT record that proves you own this domain, so the Destevo live chat widget is allowed to run on it.",
+    "variableDescription": "token: the per-domain verification token shown in the Destevo dashboard under Brands > Domains. 32 lowercase hex characters.",
+    "syncPubKeyDomain": "domainconnect.destevo.com",
+    "syncRedirectDomain": "app.destevo.com",
+    "multiInstance": true,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_destevo",
+            "data": "destevo-verify=%token%",
+            "ttl": 600,
+            "txtConflictMatchingMode": "None"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Two templates for Destevo (destevo.com), a multi-tenant live chat platform:

- `widget` adds the `_destevo` TXT record that proves domain ownership, which is what authorizes our chat widget to run on that domain.
- `helpdesk` points a subdomain (e.g. `support.example.com`) at our help center so a tenant can serve their support articles from their own domain.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Both templates also pass `dc-template-linter -loglevel error -tolerate info -logos` with exit code 0. The only remaining info-level note is `DCTL1021 missing from iana definitions` for the vendor-specific `_destevo` label.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Note on `txtConflictMatchingMode`** (left unchecked on purpose): our TXT record is explicitly set to `"None"` because it must *not* be unique. A single domain can host more than one of our tenants' brands, each with its own verification token at the same `_destevo` label, and multiple TXT records at one label are valid DNS. With `"All"` or `"Prefix"`, applying the template for the second brand would delete the first brand's token and silently break a live widget. Leaving a stale token behind is the strictly safer failure. `multiInstance: true` is set for the same reason. Our verifier looks for its own token among all TXT records at the label, so extra records are harmless.

## Online Editor test results

**Editor test link(s):**

- widget, apex: [Test destevo.com/widget example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAChLemoC%2F%2BVU207jMBD9FcsST9tLmrZpG4mVWLoP7AqEWGBBqKpce9p4Se1gO2mzVf99x%2BkdIfEB%2B5Sx5xz7zJmJV9TBPEuZAxqvaGZ0IQWYK0FjKsA6KHSD6zmt7VM3bI5QOtwkMWHBFJJDRVlIMQN32DwFk99Vmgz1nElFHsHIqeTMSa2QUoCxPopbNZrqmX4wKVIT5zIbN5tHYpqSa9WwxQxJuM2NzKojYnohhCUuAXL%2FdE8McG0ELpkjXjxYUuqc6IXCPWmJqFTUiNUVZacxlQUQ7kmbYghCWZrqBeBZmphcEa2IdA0vmRnJJikMT1Q4%2FQoqrg7NwNQ395DiqFpSQYhNvBipTu4XzCYTzVB5rtBu8s0whVV93bpmG6QdEi%2FHcGaBJLD0ag3jDv3zomyp%2BG0%2B%2BQnlhuE7WQXomgLuGqd99fA7EBLtcnsCy7J3sHmeOnmlrGOKY0udyaFGNxZbGr%2BsqCsz32p0HtGJtg4XY7GfEsEcO8xUvXKjPD%2BrjDjDvHPY7SgIMFq6S62mqeTumjmeSDW71sKffaMV0PVoXaN%2FMRofbh%2FVtiUiCJYM5xm2srdCMJoZnWdjucNnaNnc%2BpnfMV9OqKMd94X6uNLpF0ErbHe6Ua8%2FYBMuYPp%2BTb08OVPawNjil7nc7P2qTByzBTtsCT5Gs9MSq7GYxSvee6k2%2F9CnXn6q7NjkseC%2Bdul%2F2mgatYEFvfpEtFv1TiSgPpi2RD1kg0nQGQRRp9s7egA%2BeBs%2BfAIO1oO1oJxk%2Fn%2B%2BSBestHS9HtWwDf9LrThBlhUgxszDwiCM6kG%2F3gruwzAOunHYb3QHURT1vgRBHARePd65KX2F83Q8SXR%2BVwx7gyR7vBss%2F%2FBfb5N06KIf%2Fbf%2BrXpqfn9mTXyPOg%2BXpXt9Pqfrf66GLi%2FgBQAA)
- widget, subdomain (`host=app`): [Test destevo.com/widget example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIpOemoC%2F%2BVUbW%2FaMBD%2BK5alfhqBEF4KkTqJrtLWba3aqmydKhQZ%2BwCrwU5tJ0AR%2F33nhNeq0n7APtnnu8f33HNnr6mDeZYyBzRe08zoQgow14LGVIB1UOg613Na27tu2RxD6VXlRIcFU0gOJWQhxRTc4fA0mPwu3eRKz5lU5BcYOZGcOakVQgow1u%2FiZo2meqqHJkXozLnMxo3GEZmG5FrVbTFFEB5zI7PyipgOhLDEzYA8Pj0SA1wbgSZzxJMHS1Y6J3qh8ExaIkoWNWJ1CdlxTGUBhHtQVQzBUJamegF4lyYmV0QrIl3dU2ZGsnEKVycsnH4BFZeXZmCCKg8pjqolZQixM09GqpP8gtnZWDNkniuUm1waprCqz1vVbJ20IuLpGM4skBksPVvDuEP9PCm7UvwuH%2F%2BAVYXwnSw3qJoC7uqnffXhDyAkyuX2AJZl78LmeerktbKOKY4tdSaHGq0ktjR%2BXlO3ynyrUXmMnmnr0EjEfkoEc%2BwwU0GpxurirBTiDP3OYbe7YYi7pfui1SSV3N0wx2dSTW%2B08HffagV0M9rU6BvukkP2UW1bIgbBkuE8w5b2lgjWg8bU6DxL5A6SoWpz68d%2BB34%2BQY928OcSj2bJ1tthM2q1O93zXp%2BNuYDJe5t6knKqtIHE4spcbvaqlVImbMEOR4InmCJdYU0WvZjivaKqekk7RetVRR%2Br%2Bk92x3IngnsJpH%2B%2BEevwEDrjYNwP%2B0G722oFfRa1Aj5pd6P2hAH02NFX8MEv8eFncNIEsBaUk8w%2F7kG6YCtLN5tRDRvyn5WM82RZASJhPjIKo24Q9oJm%2BBhFcbMfd9r1ThPpRp%2FCMA5DXwCmrapf43QdzxXNHwZ3w9RMzO2fty70Xi%2FT6Of5y%2F2TnHTG98vXQqcvX4tv3xvD4eCCbv4CksoB1fQFAAA%3D)
- helpdesk, subdomain (`host=destek`): [Test destevo.com/helpdesk example.com/destek](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ5MemoC%2F91TXW8aMRD8K5Zfe4A5CIGTKjVKUjWtkkZpIrWN0MnYC7i9s43tI1DEf%2B%2F6yCWQpup7n%2FyxM%2BPd2fWGBihtwQPQbEOtM0slwV1ImlEJPsDStIUpafIUuuIlQunZLogBD26pBNSUORQWaT%2Bfrw%2Fh5AMCyCnoAA4xS3BeGU2zbkILMzN3rogiIVifdTp773eUMLrtlzMk4bVwyoaaSK%2BN0sETTnw1kabkSuNOzAn3uFprXGivTeV2oShFeCBhDqTJKKZMRJ1RQrwhEd1QCXdBiQJQ3wGJFYEkU4ciNco8aPIoHAtea3FdTT7B%2Bqy%2Biw7WG0xdgwjtQz8j%2FAakchh6InBrX8DmxocbWFSIQ4ODqyChSDFOeprdb2hY2%2Bjv6dXJ5fkjHI%2FvYsNqZ24NHoXGLrwQDgG97g0YSyh4j%2FUrHs3%2FrE%2BsLdZ0O94m9JfRkD%2B%2FNk4eK0IcrDiODexl2UxMbP7MmcrmqmFZ7njp44A1%2FPsDgXGjcN9IxNfVTBsHuceVh8pBU35ZFUHl%2FIE%2FX0mR85g2JusxikJ%2FWqN3k%2FiUo%2BSB%2F9ubXIqYt4rTPejDUZr2hy2YcNHqT0fD1lAeD1sSepJNRconrLf3U175RH%2F5Ky%2Fte7Uh23GCXv6PdWH7PcevlfOITlk6aLFhq8tu0zTrdrN%2B2j4a9YbHvTeMZYzFOlBwV%2BYG52R%2FQujXO2PL4mLJjPq%2BXk0H36784svp%2B4ktPmqmWP9yNFuch9UPrthbuv0N93hFWv4EAAA%3D)

Record names produced by the three runs: `_destevo` (apex), `_destevo.app` (host set), and `destek` CNAME to `cname.destevo.com`.
