### PR TITLE
Add DKIM conflict matching to shipmail.to.email

### DIFF
--- a/shipmail.to.email.json
+++ b/shipmail.to.email.json
@@ -3,7 +3,7 @@
   "providerName": "Shipmail",
   "serviceId": "email",
   "serviceName": "Shipmail Email",
-  "version": 2,
+  "version": 3,
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.shipmail.to",
   "syncRedirectDomain": "shipmail.to",
@@ -28,7 +28,9 @@
       "type": "TXT",
       "host": "shipmail._domainkey",
       "data": "%dkim%",
-      "ttl": 300
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DKIM1"
     },
     {
       "type": "TXT",


### PR DESCRIPTION
# Description

Adds `txtConflictMatchingMode` to the DKIM record in `shipmail.to.email.json`, and bumps `version` from 2 to 3.

The DKIM record had no conflict matching, so the Domain Connect default of `None` applied: "TXT records do not conflict with any other TXT record". Shipmail generates a new DKIM key whenever a domain is removed and added again, so applying the template a second time adds a second TXT record at `shipmail._domainkey` instead of replacing the first. RFC 6376 section 3.6.2.2 lets a verifier pick either record, so mail signed with the current key fails whenever the stale one is chosen.

Shipmail owns that selector, so `Prefix` matching on `v=DKIM1` can only ever replace a record Shipmail itself wrote.

No records, hosts, or values change. The only behavioural difference is that re-applying replaces the DKIM record rather than adding a second one.

The `_dmarc` record in this template already had the same treatment, so this makes the two consistent. The newer `shipmail.to.newsletter.json` (#1564) sets it on every TXT record.

## Type of change

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the apex SPF uses `SPFM`
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — this is what the PR adds
- [ ] no variable is used as a bare full record value — **not fulfilled, see note**
- [x] no bare variable is used as the full `host` label (all hosts are fixed strings)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

**Note — bare `%dkim%` variable.** Pre-existing and unchanged by this PR. The full value of a DKIM TXT record is prescribed by RFC 6376 and cannot carry a service-specific prefix. The value is signed into the apply URL and the record sits at the fixed, Shipmail-specific label `shipmail._domainkey`, so the variable cannot write anywhere else.

Linter output with `-tolerate warn` is clean, with no findings reported.

## Online Editor test results

**Editor test link(s):**

1. Apex:
[Test shipmail.to/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABliemoC%2F%2B1W%2B2%2FiOBD%2BVyJL%2B9MCzas8skLaQChLKRyvXtlWFTKJE7wkcdZ2AtmK%2B9vPBsqj7Z500kn36k8Yz8yXmW9mPvkJcBQlIeQIWE8goSTDHqIdD1iALXASQRyWOAGFg6kPI%2BEKxnujsDBEM%2ByibQw6v3vhrLT25gxRhkkMLEO45rHbCIm7BJYPQ4Z2N4N03kW5Q0SAcAPe9uCSOEYuL51nJt1HyMNUmA4B5y4hCcgtDcX9gvOEWRcXJ%2FaLHXhxj16UziWWBSLOQ8ylOOHbXEGTxD4OUoqY4vTHivgeoR5TfEKVQ4VbAkqyREgxnIfIOYP44C1x9EHBTOELpDjdTk%2BZTCdKBsMUKQGKERWd8JR5fkSU8HwhInZpSuz9l4H18AR4nkiKe1NxvyCMi%2FNn2S6CY84mRPyN1lrpZS8xoZjnwNLUAuBcEGOo6qZwQBsPrnrneCzxR2mIxDeB6EOYesgSVy9w30AS1R2BDt6zXS1LlEuSIYcHak5QxGnNJechdnkPcneB46BHPAk7oMjHa%2FCmy95mgawuCdbAz9KZeRGk7jED4d%2BzR03tk5LUKfomZuEvzmaLLtwQYyjmGMqB%2FCW2kyTMweZxUwA%2FSIxmx%2B4%2BFvaDLzdrDcWeopJLomMF4hRQkiYz%2FOyfQAojJnf5OfLhLPTxOfYByLPkXJ73VH1SlnXKoCSg12n7PVttN8ff2%2BPO3HCGrYY9vLVts923nWYDD7uNYOjckFq3kkyz23t95SwH5ldXi4fRqMom5WxqLK7nfRVd1QJbx83LtFsJexoZmHRc5Xfl%2FN5YN1SvVfHbtcW1vry5jPrVZKjRiZn%2BWllN1dw25s2y16r5X%2FRv3cuwV40H2veRySaV9E5d3xuwUXadGrrSgy%2BX%2BLq6vNGivkmGHcce2g0gCcVBTCiaMfELudhcYHGaComJ0pDjGVzB45XnzqDshOCfCatg5cV2xTsx%2B3wcmNebdZyW8x2bea7sCZYa6ZuXuj73taLhGUbRrKlGsVZ1zWK1anplV0emW6mcCO4bWvyW4h4n4nS67HAFcwY2r1bgdTFZXSy0pvxku5XfYBieFfhPLekPRea%2FOOf%2Fhqb8San9u8o4iPHmsSDU9F0A3gXgXQD%2BpwIgXkcMZsibQemnq3q5qFaLmjrRDcs0LF0r1cyyWtE%2FqqqlqjJ7xPiuuifx8jh9c4B1q%2B13Ej66W3n0owvXTqziagtOf7T8a6%2FGxp3ORXL3tXxzZap1sPkdThh3eJQNAAA%3D)

2. Subdomain (`host` set):
[Test shipmail.to/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE5iemoC%2F%2B1WW2%2FiOhD%2BK5GlfSrQJARCskI6gfRKw3LrWbZVhUxiwCWJs7aTkq04v%2F3YkEJp2X1a6VzUpziemc%2Beb2Y%2B%2BRlwFCUh5AjYzyChJMMBolcBsAFb4CSCOKxwAko7UxdGwhUMC6OwMEQz7KNNDDrce%2BOsnBXmDFGGSQzsqnDNY78VEn8J7BkMGdru9NJpB%2BUuEQHCDQSbhU%2FiGPm8cngz6T5AAabCtAs4dAnJnNzSUOwvOE%2BYfXr6yn66BS8X6GXpXGHZXMQFiPkUJ3xzV9Am8QzPU4qY4naHijiP0IApM0KVXYYbAioyRUgxnIbIPYD4FCxx9EnBTOELpLidK08ZjUdKBsMUKXMUIyoqESjTfI8o4flCRGyvKbGLk4F9%2Fwx4nkiKvbHYXxDGxfoPWS6CY85GRPxGK63ytpaYUMxzYGtqCXAuiKmq6rq0Qxv2zr1DPJbMBmmIxJlA1CFMA2SLrTe4R5BEdnugnfdkm8sS5ZJkyOGOmlcoYrXikvMQ%2B9yD3F%2FgeO6RQML2KJrhFTjqUthskDUlwRr42XUmQQSpv7%2BB8PecQVv7rCRNih5FL%2Fzm22zQhRtiDMUcQ9mQX2InScIcrB%2FWJfCDxGiyr%2B5DqWh8OVkrKOYUVXwS7TMoxmlOSZpM8EtMAimMmJznl%2Bj7g%2FCHl%2Fj7LYA8RnAv%2FwvKPivLJmVQEuFdXcw8R71oD79fDK%2BmVbd%2F1nL6t45jXHQdt93C%2FU5r3ndviNUxk3F2e6c%2Fucue8c3X4n40aLBRPRtXF9fTrorOrbmj43Yt7Zihp5GeQYcN%2FrWe31VXLTU4M2cX1uJaX97Uom4j6Wt0ZKR%2Fmk9jNXeq03Y9OLNml%2FpjpxZ6jbinfR8YbGSmX9XVXRW26r5roXN9flnD143ljRZ1DdK%2Fcp2%2B0wKSWDyPCUUTJr6QiwkGNqepkJooDTmewCe43wr8CZQVEXVgwipYeTNl8VbUCu6L3nk%2FZPvGORy3SeDL0mApl6YxtUyzYZatmg7LRs2ol6dqQy9bM1OFUwNOfdN6pb1HZPmY%2BB42x%2Btmc8InmDOwfjcRR3PKmmLENeUn8678BcPwIM9%2Fc2ZHpKfyNtv%2FX%2Bv%2FV6qzVeL3BfmVHP%2BT%2BexEe%2F1QEor7IRAfAvEhEB8CcVQgxOuKwQwFEyh9dVWvl9VGWVNHetU2DFszKvWqodbqJ6pqq6rMADG%2BzfBZvFxev1kAXDzqzK33tZxpP9xgRcaN29ZldHpiUOadfFtYrpXRznn7Wj9rgvXfWnwgbdwNAAA%3D)
