### PR TITLE
add GymPillar, Gymnastics studio website

### DIFF
--- a/gympillar.com.website.json
+++ b/gympillar.com.website.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "gympillar.com",
+  "providerName": "GymPillar",
+  "serviceId": "website",
+  "serviceName": "Gymnastics studio website",
+  "version": 1,
+  "logoUrl": "https://gympillar.com/shots/logo.svg",
+  "description": "Points your domain at your GymPillar studio website and proves you own it.",
+  "syncPubKeyDomain": "gympillar.com",
+  "syncRedirectDomain": "gympillar.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_studio-verify",
+      "data": "studio-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "studio-verify="
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "5.78.92.126",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for GymPillar, a platform for gymnastics studios. It points a studio's own domain at their GymPillar website and proves they control it.

Two records: a TXT carrying a per-domain verification token, and an A record to the platform. One template serves both an apex domain and a subdomain via the standard `host` parameter.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`dc-template-linter -loglevel error -tolerate info -logos gympillar.com.website.json` exits 0.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published at `_dcpubkeyv1.gympillar.com` (two parts, `p=1`/`p=2`, RS256), verified by reassembling from DNS and checking a signature made with the private key
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — the synchronous flow returns the studio to their settings screen
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set — `Prefix` on `studio-verify=`, so re-adding a domain replaces the previous token rather than leaving two at one label
- [x] no variable is used as a bare full record value — the TXT is `studio-verify=%token%`
- [x] no bare variable is used as the full `host` label — `_studio-verify` is fixed
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` on the A record — a studio repointing their apex should not read as a template conflict

One note for reviewers: the linter emits `DCTL1021` (`_studio-verify` missing from IANA definitions) at info level, so `-merge-or-fail` returns non-zero and this will not auto-merge. The underscore prefix is deliberate — it keeps the verification record from colliding with a real hostname — and matches existing accepted templates such as `8s.io.ownership-verification.json` (`_8s-verify`). Happy to change it if you would rather.

## Online Editor test results

**Editor test link(s):**

Apex domain (no host):

[Test gympillar.com/website northshoregym.ca/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGxremoC%2F%2B1UW2%2FaMBT%2BK5GlPg1CLlwC0qRW3Vq1U1vW0bVShSJjO8FrYme2A80Q%2F33HUEhhVNvbNGlP8fG5%2BPu%2Bc04WyLC8yLBhaLBAhZIzTpm6oGiA0ioveJZh5RKZo8bWeY1zCEbnVT5cucGlmZpxwlZpczbRHMptb%2Bt4gbXhRDvalJRLp46cMaW5FGjgN1AmU3mnMsiYGlPoQau1A6Slp9Lolo1y9SyFZMo0UbwwqwJoKLkw2qlkqRwqc8yFg83a3CLeA%2BBgQR3Ljq3yHDkXDjeuZVAJMiwnn1j1YVXqgCo25JZRrhgxbwaBUyqq0eBxgUxVWDlGDyNwTKU2YMRrQE3QgSeV5YQNhvud6%2FdHRj4xcQRuY0CfsOt5cHw2p1IkGSfmChsy5SK9ktS%2BMFQs4c%2FoYMiLb%2F8FtGxsAZ7U8I5t91e6jiSYHbcXuf3A9YPuLhamNROGY9u8G3FSFFmFluNlA%2F2QgsW1CGMguJFKSGWm0FPFQDSX4PpVOKVKlkXMN0kFVjjXdlA36Y%2B%2F5o83BR6RPa80swaeED8IKUvanW465b2o%2F%2B0p8%2FwgFzJsd4rvyALlKdRjsYYvNqUCHYwqWQPlZWZ4jOe4vqIkxpYh8NLghSf2myvWg%2F9nzf0tvB2lY0qsDNwuXHtCMSYRaVIvCZvtwPObk6Tba%2FodL%2BzQTi%2BZePjV%2Bh7c7cMLXDfidWdPsjmuNFruzcoL2%2BOa4Jtz8jfRb%2BdyOW7ATP3v2b%2FVM9hojWeMxtjGBV7QbXpR0%2FdHnjcIwoEXud0waof9d2B7nqXAtFlzW8B%2Bv95s9DG9uA0T4cubr2f%2Bl%2FCyii6vs%2FuH%2FulzwO9JeU7C289nl%2B1z0rqDP%2BNPOB0D9SoHAAA%3D)

Applied records:

```
_studio-verify.northshoregym.ca.   TXT   3600   "studio-verify=abc123def456ghi789jkl012mno345pq"
northshoregym.ca.                  A     3600   5.78.92.126
```

Subdomain (`host=register`):

[Test gympillar.com/website northshoregym.ca/register](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJJremoC%2F%2B1UW2vbMBT%2BK0bQpyWO77nAYKWFrnTdQpuNlRCMYsm2WltyJTmpF%2FLfd5Q016bsdYw92To3ne%2F7ztECaVpWBdYUDRaokmLGCJXXBA1Q1pQVKwos7USUqLV1fsUlBKOrphyu3OBSVM5YQldpczpVDMptrbt4jpVmibKUrgkT1i5yRqVigqOB20KFyMR3WUBGrnWlBp3OQSMdlQutOibKVrMMkglViWSVXhVAQ8G4VlYjamkRUWLGLazXx23HRw1YmBPLoKOrPEvMucW0bRA0PBnW0xvaXK5KnWDFhNxRwiRN9LtB4BSSKDQYL5BuKkPH6OcIHLlQGg7xuqE28MDSxmDCGoP9wPzxTIsnys%2FArTXw40eOA78v%2BkLwtGCJvsU6yRnPbgUxNwwlTdkLOhny6ju%2BAS1b2wbPd%2B19MuqveB0JOIZ2t2f3Pdv1osNeqFKUa4aNeN%2F4eVUVDVpOli30S3Aa70iYAMANVVxInYOmkgJpdoJ3t4KFKU3NfGVS1FXMNskVlrhUZmA3ZcZv60w2hca7SmBbcWiMeJq4nk9oGoRRlrNur%2F%2F4VDiuV3LhB2H1jEzjLIO6NFbwxbqWwIuWNW2hsi40i%2FEc70wkibFBDDgVeOGKY7H5ehEOxbb3YJ5U%2FY99HkgQk8Twwswm9lLPJf2ItlMXu%2B0gDNJ2f%2BoHber3kyDoYh%2F70729Prn0pzf7rUL70p8Xc9wotDwaplf4b%2FG%2BO09%2FA5jtHC8nLZi9%2F5r%2BW5rCi6DwjJIYm3jP8aK202u77shxBp4%2FCCK723WCsP8Bzo5joFCl1xgX8D7svwyoiark8%2F1Vdjkn8uISy4cHFuL7H1cNjfKb8DlPH%2B%2BcodONvvjX8NL%2BBi%2B9x596BwAA)

Applied records:

```
_studio-verify.register.northshoregym.ca.   TXT   3600   "studio-verify=abc123def456ghi789jkl012mno345pq"
register.northshoregym.ca.                  A     3600   5.78.92.126
```