### PR TITLE
Add Clawnify website template (clawnify.com / website)

### DIFF
--- a/clawnify.com.website.json
+++ b/clawnify.com.website.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "clawnify.com",
+  "providerName": "Clawnify",
+  "serviceId": "website",
+  "serviceName": "Clawnify Website",
+  "version": 3,
+  "logoUrl": "https://app.clawnify.com/logo.svg",
+  "description": "Connects a subdomain to a Clawnify-hosted website: a CNAME to the Clawnify edge, plus a CNAME that delegates SSL certificate validation to Cloudflare so renewals need no further changes.",
+  "variableDescription": "dcv is the fully-qualified hostname being connected (e.g. www.example.com). Cloudflare publishes this hostname's ACME challenges under our zone's fixed delegation host, so only the leading labels vary.",
+  "syncRedirectDomain": "app.clawnify.com",
+  "syncPubKeyDomain": "dc.clawnify.com",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "sites.myclawnify.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%dcv%.7bc45adc451e4364.dcv.cloudflare.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Clawnify (`clawnify.com` / `website`), a hosting platform for
small-business websites. It connects a subdomain the customer already owns to
their Clawnify-hosted site with two CNAMEs:

- the connected host → our hosting edge (`sites.myclawnify.com`)
- `_acme-challenge` → our Cloudflare delegated-DCV host, so the certificate is
  issued and **renewed** without the customer touching DNS again

`hostRequired` is `true` — apex connections stay on our manual instructions,
and the template contains no `APEXCNAME`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`https://app.clawnify.com/logo.svg` returns `200 image/svg+xml` (SVG, 560×160).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `dc.clawnify.com`; the RS256 public key is
      published as two `p=`-indexed TXT parts at `_dcpubkeyv1.dc.clawnify.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `app.clawnify.com`
- [x] no TXT record contains SPF content — the template has no TXT records
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [x] no variable is used as a bare full record value — `%dcv%` carries only
      the leading labels; the delegation host
      (`.7bc45adc451e4364.dcv.cloudflare.com`) is fixed in the template, so the
      record can only ever point into our own Cloudflare DCV delegation
- [x] no bare variable is used as the full `host` label — both hosts are literals
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — n/a; both records are required for the service to function
      and removing either breaks it, so neither is marked `OnApply`

## Online Editor test results

**Editor test link(s):** [Test clawnify.com/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO%2FsemoC%2F%2B1U227UMBD9FcsSAkSSpt1Ll0hIlJZLgVaUixCqqpVjT7JWHTu1nWxD1X9nvLfuLkWCN4R42ZXtMzPnzJnMDfVQ1Yp5oNkNra1ppQB7LGhGuWJTLYsu4aai0ertlFWIpYeLV3xxYFvJYRY0hdxJTLa63YKTrytAC9ZJo2nWi6gypfliFQIn3tcu29lhdZ2sM9gJkMS1JUYKcNzK2s%2Bi6aHRGrh3hBHX5MJUTGriDR6XReOJcR4EWZDLwtPpwcnLgPITWOEIiBIiUqvG3UEmzBMBCkrskSOfPr0nHKyXheR4QVqmpGCBSUh2qEwjCsUsEGeIBQ1TphzRgMW1IUVjsZwlfMJ0CS4JTWBWslzB0YYkwVsi3Yxb0SjVxVcN1ikkpglSNPaU5CB1SfhcPD48gqRMyHQ6TeCaoaUQuvY4WedUN7mSbgIhM6ZfpnroyMEhSkVaSkFgRhqNThPTWPLd6AAo5DXWWPQhqA3BUVBptOpmTBUwESgplgOKRmVdUOg6zT%2BCkBZpHs3MQYHb7i5wH5r8HXQrlOD3gV4owy9pVmBnIaKBx0e4ajA%2Fzp%2B3Dd5hKWOFo9n5DfVdPZu%2FYCadw%2FH4PAy0kdq7zwaPYSpcUnVb1bzHiewN0%2FQ2%2BlWiMeMVxKvObaZ9gD4%2BSPZz3h8wgT%2B70O8N%2Bwneoq6lKz%2FVuriNaOj6%2BE7GBc78silr7t7RQNvxUFrT1GO5DKmZZZUL3%2FUy%2BHwj%2BmIZfj6LD0V4uzglG0BkJEttLIwd%2FjPfWFj2umqUl2M2ZXdXgo%2FRX9WhAIevmPFnH%2FR8Lcx54wfEfsOFiI4FD3Jk2DQjzoejvaejGCDdjftiJOK8n%2FJ4wPf3hqNCDPcFW1tb9620%2BxfXRkvBOdBesrCaDtSUdY7e3jMNCzlb05BsyNvq6p%2FOxV%2Bj%2FiLC4frv6L%2FkKH76jrUgxiwg99K9YZyO4t3dz%2BnTrDfI%2Br1k0O8Nhr0naZqladAAzs%2BbcIO7YX0rUHF9MuyXl%2B3J8f712%2FrbF3V1tKPfnV3y3tdXta%2B%2BnQGcnr0WH%2FI3l8%2Fo7Q8u6H88gAgAAA%3D%3D)

<!-- hostRequired=true, so the apex test is not required; the link above is the
     subdomain case (example.com / host=www). -->
