### PR TITLE
Add groundlio.com.connect.json — Groundlio domain connect template

### DIFF
--- a/groundlio.com.connect.json
+++ b/groundlio.com.connect.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "groundlio.com",
+  "providerName": "Groundlio",
+  "serviceId": "connect",
+  "serviceName": "Connect your domain to Groundlio",
+  "version": 1,
+  "logoUrl": "https://groundlio.com/favicon.ico",
+  "description": "Points your domain and www at your Groundlio website (Render-hosted, auto-SSL).",
+  "variableDescription": "No variables — the target records are fixed.",
+  "syncBlock": false,
+  "shared": false,
+  "syncPubKeyDomain": "groundlio.com",
+  "syncRedirectDomain": "groundlio.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "216.24.57.1",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "groundlio.onrender.com",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Domain Connect template for Groundlio (groundlio.com), a website builder for local
service-area businesses. This lets customers who already own a domain at a supporting
registrar (GoDaddy, IONOS, etc.) point it at their Groundlio site with one click instead of
typing DNS records by hand. The template is fixed-target — no variables — pointing the apex
(`A`) and `www` (`CNAME`) at our hosting origin.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — we use `redirect_uri` in our apply flow
- [x] no TXT record contains SPF content (`"v=spf1 ...`) — N/A, this template has no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, no TXT records
- [x] no variable is used as a bare full record value — N/A, this template has zero variables; both records are fixed
- [x] no bare variable is used as the full `host` label — N/A, no variables
- [x] no variable is used in the `host` field to create a subdomain — N/A, no variables
- [x] `%host%` does not appear explicitly in any `host` attribute — N/A, no variables
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A here: both records are the site's actual hosting target (apex + www), not independently user-editable content like a DMARC policy

## Online Editor test results

Check template and Test apply both pass with 0 errors, resolving to `A @ -> 216.24.57.1` and
`CNAME www -> groundlio.onrender.com`.

**Editor test link(s):** [Test groundlio.com/connect example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHYwe2oC%2F%2B1TbWvbMBD%2BK0KfNmanfknc1jBY2o5SuobSFxh0wSjWJRG1JU%2BSkzgh%2F32nxEka6NjXftgXW9Ld89zdc3craqGsCmaBpitaaTUTHPQNpymdaFVLXgjVyVVJvb1xwEp0ptc7M5oM6JnIYQPLlZSQ28Nr63%2B5fSeNqjXhqmRCEqvIW5oZaCOUpGno0UJN1LMuEDi1tjLpyclRPidjhtxKdvCDSA4m16KyGzS9V0JacxSJSU7m8zlhbQL7sGQOIyMskE8PILE6f6qMBe4RVlvlPz7%2B%2BNxxmTEt2KiAq6M4A0V2BkN%2B1VEQdomdArFMT8ASDbnS3BCmgYzFArhjMo3MLwqVv9J0zAoD%2BDJFB76%2FtiiavqyobSonXR9xLi08fnON2JT3pPAahUkn6nZ6p50QDdaiXkkQrL099HLQv%2Ft%2BgKMExwQHUZXUGwHabu%2B5hmuPLpWE7JDYEAXfyIoEsGA4P9Ci2jB4csRVJnb%2BFdOsNG7GdsiXI%2Bhwh32h1EUUE6k0ZAb%2FzNYaS7G6RnXKurAiY3N2eOJ5xqqqaDBBg1akOFZObufPKceZZX9VzaMZz12Gwo3xKOH8PIHQP42S2O9yGPnn4zzxw7OIsThO4m4UvVmKdzfm%2FbU4aATGgLSCuSnvF3PWGLp%2Bp3dtAdvetSX8s28fpJqhh93%2F34%2BP0w9cNMNmwDPm3KIgSvzgzA%2FDp7CbRnHaCzpxL4yD8EsQpEHgCgBjt0WucC%2FfbiQtb56a5vJ2%2BfM2eV7e8YvF70q9LhfTQXiu%2B8Fiklwtxw%2Bv191eqL7S9R%2BhyOZrawYAAA%3D%3D)

`syncPubKeyDomain` (groundlio.com) signing verified end-to-end: public key published at
`_dcpubkeyv1.groundlio.com` (`p=1,a=RS256,d=...`), server-signed apply links verify against it.
