### PR TITLE
Add Car Show HQ (thecarshowhq.com) white-label templates

### DIFF
--- a/thecarshowhq.com.whitelabel-apex.json
+++ b/thecarshowhq.com.whitelabel-apex.json
@@ -1,0 +1,16 @@
+{
+  "providerId": "thecarshowhq.com",
+  "providerName": "Car Show HQ",
+  "serviceId": "whitelabel-apex",
+  "serviceName": "Car Show HQ white-label domain (root)",
+  "version": 1,
+  "description": "Points your root domain (yourclub.org) at your Car Show HQ show pages.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/thecarshowhq.com.whitelabel-apex.json
+++ b/thecarshowhq.com.whitelabel-apex.json
@@ -4,6 +4,7 @@
   "serviceId": "whitelabel-apex",
   "serviceName": "Car Show HQ white-label domain (root)",
   "version": 1,
+  "syncPubKeyDomain": "thecarshowhq.com",
   "description": "Points your root domain (yourclub.org) at your Car Show HQ show pages.",
   "records": [
     {

--- a/thecarshowhq.com.whitelabel.json
+++ b/thecarshowhq.com.whitelabel.json
@@ -1,0 +1,17 @@
+{
+  "providerId": "thecarshowhq.com",
+  "providerName": "Car Show HQ",
+  "serviceId": "whitelabel",
+  "serviceName": "Car Show HQ white-label domain",
+  "version": 1,
+  "hostRequired": true,
+  "description": "Points a subdomain (like show.yourclub.org) at your Car Show HQ show pages.",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "thecarshowhq.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/thecarshowhq.com.whitelabel.json
+++ b/thecarshowhq.com.whitelabel.json
@@ -5,6 +5,7 @@
   "serviceName": "Car Show HQ white-label domain",
   "version": 1,
   "hostRequired": true,
+  "syncPubKeyDomain": "thecarshowhq.com",
   "description": "Points a subdomain (like show.yourclub.org) at your Car Show HQ show pages.",
   "records": [
     {


### PR DESCRIPTION
# Description

New provider: **Car Show HQ** (`thecarshowhq.com`), a SaaS platform for car show organizers (registration + live voting). Organizers on the paid tier can white-label their pages on their own domain; these templates power the one-click DNS setup for that.

Two templates for the same service:

- `thecarshowhq.com.whitelabel.json` - CNAME for subdomains (e.g. `show.yourclub.org`), `hostRequired: true`
- `thecarshowhq.com.whitelabel-apex.json` - A record at the zone apex, target filled via `%ip%`

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A - no `logoUrl` in these templates)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set - `thecarshowhq.com`; public key published at `_dck1.thecarshowhq.com` (TXT, `p=1`/`p=2` parts, RS256)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` - neither is set
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (N/A - no `redirect_uri` usage)
- [x] no TXT record contains SPF content (no TXT records at all)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (N/A - no TXT records)
- [x] no variable is used as a bare full record value unless necessary - `%ip%` in the apex A record is bare by necessity, justification below
- [x] no bare variable is used as the full `host` label (both hosts are `@`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` where the end user may need to modify records without breaking the template (N/A - each template is a single pointing record that *is* the service; removing it is disconnecting the service)

**Justification - bare `%ip%` as record value:** A-record data is a complete IP address; prefixing is not possible for address records. This follows the common pattern for apex A templates.

## Online Editor test results

**Editor test link(s):**

- [Test thecarshowhq.com/whitelabel myclub.org/show](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALnVe2oC%2F91SXW%2FTMBT9K5afQGsiN%2BvaLhISg6IxPrYyxmdVRY5z2xgS27WdVmnV%2F46dEFq0TbzzZNn3nHPPub47bKFUBbWA4x1WWq55BvoqwzG2OTCqTS43%2BSpkssS9P%2FVrWjo8fkk1%2Bujq6PUHVzSg15xBw93k3EJBUygOhfsk1MCCBocyWVIuHHwN2nApcNzv4VwaewurimtwslZX4ORqwaZV%2BhbqSUt50GoGhmmubKOEp5ILaxBFpkrbRuhJwX8C8pywlpVmRZWGUi%2BfImqRf0DHRj0MKboEEzptDUzqzOB4tsO2Vk2q64v3r3Br2F2f%2B2E1Pe%2Fkw%2F6sLXB8OiRkP9%2F38FYKSA6yc%2Be%2Fy1bWnbWDvFdyt6WWlUp4R1FU09L4f%2BzIs2P2vKPPWr7vy5dCakiMO6mtNHQzLqvC8oRu6OEpYwlVqqidTeOqTuZ%2BetF%2B8W97GbX0H%2BF7OMmYd8z91izOF8MRRCxIAUgw6I%2BjYDxanAYpowMSpWcRDIZHW%2FjYlj66iH9PD4wBYTl1VvBFsaG1wfv9vOcm%2BV8Gc99v6BqyhHpoRKJhQMZBP7ojUUzG8dkodFbG%2FeEJITEhPgsY2ybduU053hH84%2BTm6w28SFe56rNPxedperv4LhZXk%2B07NblU2y%2Ffzi%2FFm9G2EvIZ3v8C7hZYE2QEAAA%3D) - renders `show.myclub.org. CNAME 3600 thecarshowhq.com` (`hostRequired: true`, so no apex test for this template)
- [Test thecarshowhq.com/whitelabel-apex myclub.org/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALJifGoC%2F91S24rbMBD9FSNY6JLYyM7FjqHQdtv0SrvbLC3bEMxEniRabEsryUndkH%2Bv5JCNSy8f0CePZ%2BacOWc0e2KwlAUYJOmeSCW2PEf1NicpMRtkoPRG7DYPARMl6T%2FWP0Jp%2B8kVKG9m696bG1vUqLacYYvdbbjBApZY%2BCDx%2B7n6O9Jre%2F222ctFCbzynighzKVFbVFpLiqShpahqdh1vXyPzcu2688Sc9RMcWlaFLkWvDLaa0StPMf5OMBlWFEvA6HWlx6YY0tXlmP1JKxRB5ZWIRMq1ySd74lppPPw3KY3QhsbPnO7aUfdCvt7weWFzRhTkHQwpvSwOPTJD1FhdqZZWKknG2VzknKmtNFaiVpm%2FNQuQUGp3TOdgPMucnGCzomLuXRRRAcBDcJwEMTEieDrSijMtP2CqZW1YVSNfVLWheEZ7OCcylkGUhaN1axt1bL9ar06vqSznoMBG3aHddz3SZYzJ5u7y2AJHbFkEvujYQj%2BcLma%2BBNg1I%2Fy4WoUJzQeTsLOpf3tEv99bOcdotZYGQ6FU13soNHkcFj07T7%2FHzf2tTVsMc%2FAtLqjsU8TP4xuwygNaRqNg2iURJO4R2lKqTOD2hxd7u1NdK%2BBTO%2F0VuoeJl95b4bxhxf8vlh9eX1fXYUz8eluFb37nL%2B6mU6n39hTcvgJTEtD9D4EAAA%3D) - renders `myclub.org. A 3600 203.0.113.7`
- [Test thecarshowhq.com/whitelabel-apex myclub.org/show](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAILWe2oC%2F91S22rbQBD9FbEQaKilSLJjW4JCQ%2FKQ0jYkJC5tjRGj1dRekLTb3ZVt1fjfOyvXsUIvH1AQrOZyzpy57JjFSpVgkaU7prRciwL1u4KlzK6QgzYruVl9D7is2OA5fgcV5bNr0N4jxb3bBwoa1GvBscNuVsJiCTmWPijcnqK%2FI70u1%2B%2BSvUJWIGrvlZbSnhNqjdoIWbM0Ioa25vdN%2Fh7bmy7rzxILNFwLZTsUu5eitsZrZaM9x%2FlcwHl42eSB1MtzD%2BwhpS%2FLsXoKlmgCotXIpS4MS%2Bc7Zlvlergi90oaS79v3Wy6Uk%2BSzDOhzshjbcnS4TgM94v9gP2QNWYnmgVJPbZRtUcpJ0pXnqyllo3KxBGiQENl3KqO4HkfvTjC5wc82UI5Kw6HQRhE0TCYMCdGLGupMTP0gm00tWN1gwNWNaUVGWzg5Cp4BkqVLWk3FCW2lyOoDxv9pbcAC2T16%2FUGMWBZwZ164Y4kniYQQv7Nj6KE%2B6NoBH6CfOInfMST8WScQ4y9o%2FvbUf777l6OE43B2goonfhyA61h%2B%2F1iQKP975qi3RtYY5GB7bTHYz%2Bc%2BlH8FMZpRN80iCdJEo9eh2Eahq4hNPbQ6Y4upH8b7OIqGjVRXc8e1M3nL9eb6mObTx7Fh69FjheNurxd5%2BPtp1m8vZu9YfufHPcErFQEAAA%3D) - renders `show.myclub.org. A 3600 203.0.113.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
