### PR TITLE
Add entro314.com.hosted-mail

### DIFF
--- a/entro314.com.hosted-mail.json
+++ b/entro314.com.hosted-mail.json
@@ -1,0 +1,41 @@
+{
+  "providerId": "entro314.com",
+  "serviceId": "hosted-mail",
+  "providerName": "Entromail",
+  "serviceName": "Hosted Mail",
+  "version": 2,
+  "description": "Configures MX, SPF, DKIM, and DMARC records for an Entromail hosted mailbox domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.entro314.com",
+  "syncRedirectDomain": "mail.entro314.com",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mxTarget%",
+      "priority": 10,
+      "ttl": 120
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "mx",
+      "ttl": 120
+    },
+    {
+      "type": "TXT",
+      "host": "%selector%._domainkey",
+      "data": "%dkimValue%",
+      "ttl": 120,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none",
+      "ttl": 120,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `entro314.com.hosted-mail.json`, a new template for Entromail hosted mailbox
domains. It configures the four records a domain needs to send and receive mail
on the service: MX, SPF (via `SPFM`), DKIM, and DMARC.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`logoUrl` is not set on this template, so that check is vacuous.

Validated locally with `dc-template-linter`: clean on both the default preset and
`-cloudflare`, with no errors or warnings.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Justification for the bare-variable record value

The DKIM record uses `%dkimValue%` as the whole TXT value. A DKIM record's
content is fixed by RFC 6376: it must begin with `v=DKIM1;` and carry the tag
set as a single string. There is no service-owned prefix that could be hard
coded around the variable without producing an invalid DKIM record, so the
recommended `service-foo=%foo%` shape does not apply here. The `host` for the
same record is `%selector%._domainkey`, which keeps the fixed `._domainkey`
suffix as the guideline intends.

## Online Editor test results

**Editor test link(s):**

- Apex (domain `entro314.com`, no host): [Test entro314.com/hosted-mail entro314.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP4yfGoC%2F%2B1WW1PqSBD%2BK6mp8kmQJBCMWFSdkCBECMhFBS2LGjJDiLlMzCQhYLm%2FfWdAxMvZB5%2F27JZP6fS9e7q%2FmWeQ4CDyYYJB7RlEMclchGMTgRrAYRKTslQ5sUkACoDiOHNtvBUtCU0wKgbQ9Zlkb9WDAfMCmtzuVfRq9Cppb80EayfLcExdEoKaXAAIUzt2o2T7D3QSLlwnjTEVrElBGF1dFASjY1oFAYZIMCxtqAsxtkmMqLAgMeMKb0GFXW4Cp%2BckFxDnhic8l3VoN3xie6C2gD7FO85VOu%2FgtbHVYqF36jYJQ2wnJ59bwPSHGLksdvJmwQN9VnxNDtTun0Gyjnjt1oTxeW6M%2FsWbRtwwoWPCfo%2BCfAxjBydH22a6JHaTNahJYgEkic8IWXwpvDli3bA%2BuqLRYpj6mPJkcvBbo%2FFkfLA5othnFZD46GS2q9fDayZGMIFcjDw3uIF%2Bio%2FeOWNUnvCD8V07sWBiL93QsQji3jXfB%2F8UbIYCGNsH71l9e37SuRDVQxLib4QoAEwp67QLmT7oh1oU%2BWvw8vBSABvmaXbo%2BkPh9SC%2FjvFrWoxyYpJGM3dvEMEYBpRvwd70%2FqPtw974HnB6f2j8P8g%2FTMAJl%2B%2BbvJXziedJ7TvLmawTbKZZI5Z1uoSyUj0XvHpM4XlUt0yzYT5qvYbjPS09t3W2EhvaoHmhaX1dG6gal%2BtOh9FNTbmuzH3UKrXCfsecw7ubno7UdtUkTV89TnI41cT5yHvSUjXYTJBeDVaX3eGVS6z2ctMtNdDgsjRKLTnDZdk1lNBDHbkVy6NseizbXaoscNo38M26Nx1Zq%2Fy2Jzt3fefUmMiJd3dnT1DgX09vUmk6lPp636BSZ3gnK53k0eqsleXjBGN0ibNHSWxkxk10K7bFaXradqp3uSJO10%2BW07oyjamsDYxq68J11CZ2cy%2BVV7JmXMVmYyiOqVmB1TQo93vzgW4uK2ljE21i9KQ%2FpcdPleZ8muq%2Bqt6Q7PZS0tyxvTod50uqh8O2Xrp27FMzd%2Ftj51Z7dLoO7JcfnSraRKQkLa9L%2FWyzOA66Ydsr%2BVprbW3QqWL2RyuyWJmGNtAagM%2BW64QkxjPKvjBhoARqSZwy9AhSP3FncAUPLGTPIB9KNoqUSdkpfwKAcAeEvw778GV03u%2FDRzCYIZuPp8sRuKwo8%2FmpKhZlKFaKlbKqFNXKfF48s2VlYVcVWcVn76D5e4B%2B2JH3C6f5K7im4OXLpn8tKqszTJKEIBf%2BgtvFPZT0hxexRfPfoeLPtv752%2FofmrNvXYv%2Fci1vN%2B3LQ4HdlD%2BQ9gNpP5D2A2n%2FE0jjT3WYYTSDXE8W5WpRVIuSPBbVWqVaUyonSvVMKqvHolgTRV4EpsmuxGf2Onz%2FLgRIj3udtkOVQa6Zcn58NR62RtLIS4djw7fJoLluZt3uGHrEqoOXvwHZg4AafA8AAA%3D%3D)
- Subdomain (domain `entro314.com`, host `mail`): [Test entro314.com/hosted-mail entro314.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANszfGoC%2F%2B1WW3OqOhT%2BK0xm%2BlQvgDdqx5mD2q2olFZtq3Y6TiQRo0AQAoIdz28%2FwUtr270f9tvec%2FpEWCvrmm99yStg2PFsyDCovgLPpxFB2NcQqALsMp8WpGLOpA7IgAD7ETHxXrWgAcMo60Bic83J6hY63Au4Se2OqqPRUdPemwn6QRdhPyDUBVU5AxAOTJ94bP8PGtSdEyv0cSDoo4wwuPuREZpdTc8I0EVCU1f7DcHHJvVRIMypz6XCW1DhkJuQrmc0FlAqdXNpLolr1m1qrkB1Du0AHyR34ayLk%2BZ%2BFw992G5S18Umy31uAd%2Ffx4jw2OzNIg30eeMxOVB9fgUs8dLa9RGXp7nx9T9p0yhxWTCk%2FPfCiYfQtzC72DeTUJ%2BwBFQlMQMYs%2FlCFneZN0e8G%2FpHV4E374c2DtJkYvBTo%2BFo%2BG5zEWCbV0D9i9z0UO8KJ1yNIIOpGq2I8wjtEF%2BcOeOrmKUHYxOT6ZCZC%2BJaOkWpd9W2wa%2BCTZEDffPde1Tbn590LXg1l7r4N0JkAA4C3mkC%2BX5guKrn2QnYvewyYMs9Td%2B7%2FpI5HuRXGB%2FTOuLT8mnoTcnJyIM%2BdIJ0Ek7mzx%2FtX04Ong8e%2BP%2Fp8Pay%2BAMScqn%2B1Oxzm7cOp0LeEY5t3pBFLVhAuVS%2BFlY1P4DXXk3XtLq2VG%2Fr1mq9WJHW1Uasq%2Fc3P1TVaKj3iprqG1aXr2%2FU0kNxZqNWvuUaXW0GJ4%2B3DaS0yxq9sZVLFsOxKs4Gq7UaKs52hBplZ9Pp9e8I1duLbS9fR%2Fed%2FCDU5QgXZNIsuSvUlVu%2BPIjGl7LZC0pzHBpN%2FJjcjgf6Jn66la2JYVWaI5mtJhNzhBz7YfwYSuO%2BZDSMZiB1%2BxO51GVLvZuUFssRxqiDo6Uk1qPmo%2FcktsVxWGlb5UlcEsfJWrdad1pzLKv3zXLrB7GUG0ziVShvZLV552v1vjgMtCIsh07BuJ3dN7RFMaxvva2P1o11eLku3szGYcNWlEcaPXUklQzNTWUYL4KG22838g%2BWWdFiYgytJ3Vp9SxoFJZWGW09mpcWD3kj2s4vnZ7bXuVttZXoW1QpacZgQ%2Bcbraneq3WQYoxYLvXxNOBfyDg5gSrzQ84iTmgzMoUb%2BC5C5hSm4OSQDLiWn%2FInInAPhHhE4XE0vqDnfDQ%2B8sIUmSlKSUrGMwUV0axYypqmibLFeeUqC8tlJauUriTeMlHG0tUZS%2F8et38cl%2FP5U%2B0NTAKw%2BzL4P60tqnGWkgQnFv6F%2B1F%2Br%2BwvqeWMK3Ofa%2Fse4D99gP8ywB1uza84%2B%2FXV%2BQcU9XYj714y%2FDb9prxvyvumvG%2FK%2B59QXvrUhxFGU5julUW5nBWVrCQPRaVaEquFUk6WpbIiXopiVRTTQnDADmW%2B8tfl%2BbsSyDrtsk4yKHqF3rzwUFT0uP%2B0UhNps%2B64y4nRlfQZquh0trBqYPcfXVS1OcQPAAA%3D)

Both runs apply all four records. In the subdomain run the records scope
correctly under the host: `MX mail`, `TXT mail` for SPF,
`TXT mail._domainkey.mail` for DKIM, and `TXT _dmarc.mail`. `essential`
resolves to `OnApply` on the DMARC record and `Always` on the rest.
