### PR TITLE
Update syncPubKeyDomain on fingerprint.com.custom-subdomain.json

### DIFF
--- a/fingerprint.com.custom-subdomain.json
+++ b/fingerprint.com.custom-subdomain.json
@@ -3,7 +3,7 @@
   "providerName": "Fingerprint",
   "serviceId": "custom-subdomain",
   "serviceName": "Custom Subdomain",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://fingerprint.com/img/email-assets/fingerprint_logo_with_name.png",
   "description": "Connects a custom subdomain to Fingerprint, verifies ownership, and provisions the SSL certificate",
   "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required. %ip1% and %ip2% are two ingress for the customer. %dcv% is the dcv address needed for each customer",

--- a/fingerprint.com.custom-subdomain.json
+++ b/fingerprint.com.custom-subdomain.json
@@ -8,7 +8,7 @@
   "description": "Connects a custom subdomain to Fingerprint, verifies ownership, and provisions the SSL certificate",
   "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required. %ip1% and %ip2% are two ingress for the customer. %dcv% is the dcv address needed for each customer",
   "syncRedirectDomain": "fingerprint.com,dashboard.fingerprint.com",
-  "syncPubKeyDomain": "domain-connect.fingerprint.com",
+  "syncPubKeyDomain": "fpjs.pro",
   "records": [
     {
       "type": "A",


### PR DESCRIPTION
# Description

Updating the syncPubKeyDomain, to enable easier DNS management

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test fingerprint.com/custom-subdomain a-cool-saas.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMN9fGoC%2F%2B1Xe2vbOhT%2FKkKQv2a7jpN0SWBwQ7dB76MrfYzRrhhZOom12ZYnyQlZyXffkZPUebW3G1y4gxJIpKNzfjrvo9xTC3mZMQt0eE9LraZSgD4VdEjHspiALrUsbMBVTr2H4zOWIzt93zDgoQE9lRxqUV4Zq3LfVIlQOZNFc7wSPakZyOUGwxS0kaqgw8ijmZqoa50hY2ptaYZHRzvKHMl8cgQomfnMGLBmkyF24vFM2jQu8LqgLCaIL8BwLUtb30FPVFEAt4YwslSWPChLrCIbpnkENZNjCYaoWYFKprL0CCsEqd3hdDbEpkAuL%2F8mHLRFXu78iSYxLVmSwdutq68NkIlWVXkq3iQMN4XSOcuyuUeU3jrxOGNklkJBTkYjIg3R8K2SGkRAWrJst2otcBXhSgOxM0VQbw3GkDFCOaWWxoFGCcGnLQfiyLgmTIiatQAQIGoJYDx9EHFBmxf8AgReye3bZaD28sITzKSJYloE%2BxnjAM6r5C%2BYN%2BLlFxOg6%2FAUYZUWhg5v76mdly4xRkheuQB3zglISJWxuPvDpaBCcHOlcFu7AEnWYqJ0wnDh%2FSJK9AjKydnon3dPIMWM5%2BDzFGMHaHjQGn8TRSvYwXdufwR%2FtK0nRntbTcEsw2WIUTMVkM%2B0hSxxvdGtz3QT9W7h0e%2BqgLjx6R0CrJ3OfK5U5hvGzCoyq2vWCsSylllb6FRB%2BZJplhvXGdZIt3tQd2usW%2BrWNdo%2BEsbKEduDKGi7z5IW1bT%2BBg295Wg5WC25CXYuC%2FqD%2FiBAnoBnqhLjDNN%2BrUTjGgdQfpXBRKkJdY6REywxiA3%2BMltp9L3VFXg0rzIrYzZjDUnwmJVlNkc%2FGjxFqO3cLJb9ayM6jUlNODwaC%2B7cJl1cjwdRj487fZ8lyWu%2Fm4jET7qDxB%2F3ugI6ojfoiGijuz7SfP%2BlvzbxxJqGwkrm2ucom7G5oYud2jhgRf%2F3smJdmytLdkqxsetnE%2Bk3sX50OIpNp1jn%2F1aX%2BP%2BZdOdhm3qpsJcKe6mw%2F6rCcDQaNgURM8cWhdGxH%2Fb9dnTV7g7D3rDXC7qdTrv7%2BlUYDsPQ2QLGLq29r9f1%2FJ%2B26%2B%2FVg7Ym1SN9qzjrgb6V6PU4%2F4UU2RzmzSx%2F8kFz8OGxcI9MN8j3Hpmr0O6qtBXLvf5zuMifhdE%2FgPF0iQXPwf1Z1z6W4s%2B562Du48tz4XI0w78ImGQuYZB16uykmy8uOjW6%2Bjjun5oZS8fZzdWf789mxxfn6tOHy5uLV9m16vT6p%2BcXN5N33Td08QMG8VPUmA4AAA%3D%3D)

[Test fingerprint.com/custom-subdomain a-cool-saas.com/metrics](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOp9fGoC%2F%2B1XbW%2FbNhD%2BKwQBf6okS4qb2QYK1E0boFhaLE2KYksNgSbPFjdJVEnKnhP4v%2B8oy5FfM7SfWiAwEPPl7uHdcy%2B%2BPFALeZkxC3T4QEut5lKAfi%2FokE5lMQNdalnYgKuceo%2FXH1mO4vSyFcBLA3ouOdSqvDJW5b6pJkLlTBbtdaN6UQuQmy2BOWgjVUGHsUczNVOfdYaCqbWlGXa7e8Z0ZT7rAmpmPjMGrNkWSJx6spA2TQp8LiiLGeILMFzL0tZv0AtVFMCtIYysjSWPxhKryJZrHkHL5FSCIWpRoJGpLD3CCkFqOpzNhtgUyM3NFeGgLcpyxye6xLRkkwze7jz92QCZaVWV78WrCcNNoXTOsmzpEaV3bjzOGFmkUJCL0YhIQzR8q6QGEZCOLKNObQWuYlxpIHahCNqtwRgyRShn1No50Kgh%2BLzjQNwxrgkTohYtAASIWgMYTx9VXNCWBf8EAp%2Fk9u06UAd54Qlm0oliWgSHGeMA%2Fqgmv8OyVS%2F%2FNgFSh7cIq7QwdHj3QO2ydIkxwuOGAtw5EvAgVcbi7rVLQYXg5lbhtqYAj6zFRDkLw5X3gyjxCZSLj6MP755AShjPwecpxg7Q8aAz%2FSaKTrCH72g%2FgT%2FatROjvWumYJbhMsSomQrIV9pBkaTe6M5Xuo06Xnn0XhWQtJyOEWBDOvO5UplvGDNNZJpncrBacrOxI5G16sZRZxHClEyz3LgGsQG8O0AcbyDvHjHHDeghIEbOHUaDOIjcZ30W12f9rTPkbgsw2Hsz6A%2F6gwBlAp6pSkwzLIKNLS1RDqD8RwYzpWbU0SRnWHCQGPxmttIYCasr8GheZVYmbMHaI8ETVpbZElk1eItQu5larLtZS2ITsdaxNkQeTQR3HEoX6z4%2FCydRBH4oJud%2BLxahP%2FiNh34EIXsZhdFg0JtuddwTDfl%2Feu5BjLHcobCSuc46yhZsaehqr2xOutT%2FJV3a1HDj1n7JHrj5van2a5ExeirCbZvZlMtOi%2Flp%2FRt72Oqe6%2FK5Lp%2Fr8ueqS%2FwZNmwOImFOOg7jcz%2Fs%2B1F8G%2FWG4fnwrBf0Xw7iMHwRhsMwdC6BsWunH%2Bp1PXLMo%2FpvM0rXR%2FX4sFPM9fCwUwv16PADafPEyHR0mFm5MdYNBwdjbBPP1zuxOmhEx8v8uFL%2FiNLThXQM5js5CeipTD1q5NFsxfF05bIqw%2F8jMB9cbFF07hyh24MYBXF9nl69%2BfTm%2Bt2f4vKvy1t%2B9e%2BIDdKrL9ecL6u5uJ91rz9csvus94qu%2FgMCH7flvQ4AAA%3D%3D)