### PR TITLE
add CursusMail, Mail

### DIFF
--- a/digitalgex.com.mail.json
+++ b/digitalgex.com.mail.json
@@ -8,6 +8,7 @@
   "syncPubKeyDomain": "keys.digitalgex.com",
   "syncRedirectDomain": "cursusmail.digitalgex.com",
   "description": "Configure CursusMail sending and authentication records.",
+  "variableDescription": "spfDomain is the SES custom MAIL FROM label; region is the SES region; dkim1, dkim2 and dkim3 are the SES Easy DKIM selectors; clickTrackingSubdomain and clickTrackingCnameTarget are returned by the domain tracking configuration.",
   "records": [
     {
       "groupId": "outbound",
@@ -50,7 +51,10 @@
       "type": "TXT",
       "host": "_dmarc",
       "ttl": 3600,
-      "data": "v=DMARC1; p=none;"
+      "data": "v=DMARC1; p=none;",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
     },
     {
       "groupId": "click-tracking",

--- a/digitalgex.com.mail.json
+++ b/digitalgex.com.mail.json
@@ -4,7 +4,7 @@
   "serviceId": "mail",
   "serviceName": "Mail",
   "version": 1,
-  "logoUrl": "https://cursusmail.digitalgex.com/brand-kit/svg/cursus-logo-mono-white.svg",
+  "logoUrl": "https://cursusmail.digitalgex.com/brand-kit/svg/cursus-logo-dark.svg",
   "syncBlock": false,
   "syncPubKeyDomain": "keys.digitalgex.com",
   "syncRedirectDomain": "cursusmail.digitalgex.com",

--- a/digitalgex.com.mail.json
+++ b/digitalgex.com.mail.json
@@ -4,6 +4,7 @@
   "serviceId": "mail",
   "serviceName": "Mail",
   "version": 1,
+  "logoUrl": "https://cursusmail.digitalgex.com/brand-kit/svg/cursus-logo-mono-white.svg",
   "syncBlock": false,
   "syncPubKeyDomain": "keys.digitalgex.com",
   "syncRedirectDomain": "cursusmail.digitalgex.com",

--- a/digitalgex.com.mail.json
+++ b/digitalgex.com.mail.json
@@ -1,0 +1,63 @@
+{
+  "providerId": "digitalgex.com",
+  "providerName": "CursusMail",
+  "serviceId": "mail",
+  "serviceName": "Mail",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "keys.digitalgex.com",
+  "syncRedirectDomain": "cursusmail.digitalgex.com",
+  "description": "Configure CursusMail sending and authentication records.",
+  "records": [
+    {
+      "groupId": "outbound",
+      "type": "MX",
+      "host": "%spfDomain%",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "groupId": "outbound",
+      "type": "SPFM",
+      "host": "%spfDomain%",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "ttl": 3600,
+      "data": "v=DMARC1; p=none;"
+    },
+    {
+      "groupId": "click-tracking",
+      "type": "CNAME",
+      "host": "%clickTrackingSubdomain%",
+      "pointsTo": "%clickTrackingCnameTarget%.awstrack.me",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the CursusMail transactional email Domain Connect template.

The template configures:

- Amazon SES custom MAIL FROM MX record
- SPF using the SPFM record type
- Three Amazon SES Easy DKIM CNAME records
- DMARC policy
- Optional click-tracking CNAME record
- Signed synchronous Domain Connect flow

Provider ID: `digitalgex.com`  
Service ID: `mail`  
Redirect domain: `cursusmail.digitalgex.com`  
Public key DNS: `_dcpubkeyv1.keys.digitalgex.com`

# Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`
- [x] No TXT record contains SPF content; SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record
- [x] No variable is used as a bare full record value
- [ ] No bare variable is used as the full `host` label

The dynamic `%spfDomain%` and `%clickTrackingSubdomain%` host values are intentional. They represent domain-specific SES MAIL FROM and tracking subdomains returned by CursusMail. The apply request is cryptographically signed by the CursusMail backend.

- [ ] No variable is used in the `host` field to create a subdomain

The dynamic SPF MAIL FROM and tracking subdomains are required because they are generated per domain by the CursusMail backend and passed through the signed request.

- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

# Online Editor test results

## Apex domain

[Test digitalgex.com/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMm2fGoC%2F%2B1X227bOBD9FUKAn2o5uqS5KMiD66RANnXrTRxs0SAwKJJ2CEuiQFKO3SD77TukZVlKbbcB9iHdzZPlmeGcOXOj9OholuYJ1syJHp1cihmnTF5QJ3Ion3CNkwmbd4hInXal%2FYxTsHZ6hVSF6mOegE4xOeOE2YNpQ1Ral3YzJhUXmRP5bScRE3EjE1Dea52raG%2BPWJfmfKeJvhdLnFF3yvWemk1KO9c4cCmW0w4IDeIiIx8SQaZONMaJYkvJoIgv2eJMgFvAdaZsoTo%2FcDOGV4xyyYiuTLeGAwcoU0TyXFsyTk9kYz4pJEPrrCDFMsqzCYLIES70Pcs0J9icQAAjJFUdkxEsOY4TdtZwqPLxMgzEFYKj6Pr8GpFCaZGifvfiE%2Fp49aWPEhyz5AS8TYzTmuVScoLolKd%2B2%2F4ENg7zFCIMga5Mz7FaoLPLiz7EmwB7IdUJIgkn06HEZAoErouYLmMxHhqqXgbVHWI5Ydo6lUwXMmMUxQsLUJ7TpTkiZZ5sFgz7MhFOdPvoTKQocttBotCxKDIKBnqR2%2Fb5Cs%2F3Qml4blXJaZmuFDzTaihAMWaMxoDkqlTnndYyCa0OTvF3kSmmytJpDT0XHnieaWkuJNcL6Efvqb07hOvBx%2F62IGouQX5VJAwoOTwjSUFZ1AygiWMKssbofe72z2sgtn6tzmiZR2jdJuGV3vxsp%2FlSwOAngMG%2FDRj%2BBDB8IWCKJVkjDr8O13ijSrmuGMUag2p2etbvXvX8E5SfZiJjJ8Zqrs1oQ8vrPtbkHnq4L6jxOpBszOebTUrd2iWYMaXM%2FGOz7r5k3TxPFs86wQ6WuxqV7RnbPJvPRqG1bUxhHB6UBenAXq7n8O6p7UB62Wg9k3eQnNUyZHMMFwUrU18GA0%2BWwIhb%2B%2FrUlGVf5fsZO%2FCcY4lTZa6dFcZtA%2BRuhXLrmGeL81KMakjNQbOPjXC5F4wE7hCGlXZ9I7azZKSaKb38U0qDujRYScO6NDTSzZWxZkb4g0mtLMZIOqYEfJIJyUYKfjEsU%2BgALQu4ytIi0XyEH%2FBaRMkIm0aCiinQgg%2FYovWFmS3vXku86vPmlqxS8Ktrsg0zREzVuGnawCc%2B81noEp%2Fsu%2FvB%2B9DFOB67x8yjx3GIjw99XHt12PxiseHlYd1f9cHpJg94oZwnMziN6d5IdHYK5ffRxi2M%2FsZJ0iT5qmithr4kVrVkc1GWRNfa3Wvy9%2BAY7OQY%2FCc4hjs5hr8Xx8YIVhfsrlv1NRCpLuEd1bJbu6Iit12dr6Ied224rt%2F2%2F9v%2Bf9v%2Fb%2Fv%2Fbf%2F%2F%2F%2Fa%2F%2BdzBM0ZH2JgFXnDgekeuHwz9o8g7jvywc7R%2FsB%2BE7zwv8jwTv2k3S%2B0RvjvqXxzwRcaL6f1g8P6w%2BOOmN%2FxTzT5cxnM2G3zyD284%2Byb%2Buv5e6Hc0zqenztM%2FZlkCvEUUAAA%3D)

## Subdomain

[Test digitalgex.com/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKe4fGoC%2F%2B1XbU%2FqSBT%2BK5MmfFpa%2B%2BICYvzAAjeSu%2FW6wr1xYwwZOkOd0Ha6M1MUjfvb90xboFXQNdkP3g1fLJ45c57znNf2yVA0TiOsqNF9MlLBl4xQMSJG1yAsZApHIX2wAh4bzc3pBY5B2%2BhnQmbSxyyCM0nFkgU0vxjXRKV2qbekQjKeGF2naUQ85N9FBId3SqWye3QU5Cb1fauOfjQTOCHmgqkjuQxLPVMbMAkWCwuEGnGVBL9FPFgY3TmOJC0kl9nsK10NOJgFXGNBV9J6xU0rXlHCBA3URnWvO3CBUBkIlqqcjNHnyZyFmaBoGxUkaUJYEiLwHOFM3dFEsQDrGwhguCDS0hHBguFZRAc1gzKdF24gJhFcRePhGAWZVDxGfm%2F0O%2Fpy9c1HEZ7R6BSshdpoRbOQnCKyYLHTzB9u7of%2B5SEMjq5Vh1iu0ODryAd%2FI2DPhTxFQcSCxUTgYAEExtmMFL5oC7WjfgLZnWARUpUbFVRlIqEEzVY5QHlPleooKOOUR0GzLwNhdG%2BejFDwLM0riGdqxrOEgIJapXn5XMPvOy4V%2FG5sgtPQVclZouSEw8GcUjIDJFPGKrUaRRAaFo7xI08klWXqlIKa81q2rUuaccHUCurRfm6%2B7cL48ou%2Fz4mKSZBfZREFSgZLgigjtFt3oI6jE7LF6F%2F0%2FGEFJM9fw5oWcYTSrRNen%2BvHfpofBXTfAXT%2Fa0DvHUDvg4AxFsEWcXI92eJNN4fbjBGsMBwtzwZ%2B76rvnKL0LOEJPdVaD0q3NpS88rEK7qCGfU601UtB5%2Bxht0p5tjUJalRK3f9Yj7tvSS9No9WLSsgby1y3yv6I7e7NF63Q2Nem0A73MgexYC5XY3j73DQgvHS67clbCM56GNIHDIuClqEvnSlHfU5iyvI71c4pU7%2BO%2BQuGYD3FAsdSr541zk0N6HaNdFNA3ZZYH8XZNKu%2BqOeyFhbzQUtgl1Aslelocd5TWqqoVMU%2FpdStSt211KtKPS3dnaFcTQtfqVTSo5WEoVPBwoQLOpXwxDBUoRKUyGClxVmk2BTf462IBFOsCwoyJ%2BEUbMA0rQ7OpNjBmrhVpqws%2BvrI3MTh387MJjRUoNPHdAW3nU6r1cZt87jzK%2Fyhx8Sc2fOO6Z20W3PS9tquiyvvEbvfMna8SdSLrdpJveger6TxrDup1u77GS%2FPoBgctHM2o79xFNXZfjp%2B63FQMtwUaWWEvmC8VXl7iv48ZN33ybr%2FG7Le%2B2S9n49srU2LrfyqUXfs48%2FCaLPC38hfsWRrnMS%2B7ftpMnTbhK1%2FWB%2BH9XFYH4f1cVgfh%2FXxwfWhP7bwkpIp1qqu7bZMu2M67sTpdJ1213Es%2B8Q5sY9%2Fse2ubWsOughzek%2Fw1VP93jGGfySD76wXeo%2F9%2BHEcjrn%2FI7j46%2Fyc%2Fel0nOP4%2FHruO%2FjHaDhrj86M538ACN46OcsUAAA%3D)

# Security

No private keys, credentials, or customer data are included in this template.

The signing private key remains exclusively in the CursusMail backend. The public key is published at:

`_dcpubkeyv1.keys.digitalgex.com`