### PR TITLE
CartQu, 2 templates

### DIFF
--- a/cartqu.com.custom-domain-apex.json
+++ b/cartqu.com.custom-domain-apex.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "cartqu.com",
+  "providerName": "CartQu",
+  "serviceId": "custom-domain-apex",
+  "serviceName": "Connect a CartQu store apex domain",
+  "version": 1,
+  "logoUrl": "https://cartqu.com/images/logo.png",
+  "description": "Connect this apex domain and its www alias to a CartQu store and prove ownership.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "cartqu.com",
+  "syncRedirectDomain": "api.cartqu.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%target%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_cartqu-verification",
+      "data": "%verification%",
+      "ttl": 300
+    }
+  ]
+}

--- a/cartqu.com.custom-domain.json
+++ b/cartqu.com.custom-domain.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "cartqu.com",
+  "providerName": "CartQu",
+  "serviceId": "custom-domain",
+  "serviceName": "Connect a CartQu store domain",
+  "version": 1,
+  "logoUrl": "https://cartqu.com/images/logo.png",
+  "description": "Connect this domain to a CartQu store and prove ownership.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "cartqu.com",
+  "syncRedirectDomain": "api.cartqu.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_cartqu-verification",
+      "data": "%verification%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two signed CartQu templates for connecting merchant custom domains.

- `cartqu.com.custom-domain.json`: a tenant subdomain CNAME plus tenant-bound TXT ownership proof.
- `cartqu.com.custom-domain-apex.json`: an apex A record, `www` CNAME, and tenant-bound TXT ownership proof.

The templates use CartQu's published RS256 signing key at `_dcpubkeyv1.cartqu.com` and a live CartQu logo.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] TXT values are tenant-bound ownership tokens; Cloudflare's synchronous flow does not support `txtConflictMatchingMode`
- [x] record-value variables are signed, server-controlled values
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not applicable: CartQu verifies ownership before activating routing

## Online Editor test results

- [Subdomain template: itremo.com/testweb](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEzBfGoC%2F%2B1UUW%2FaQAz%2BK9FJfSqBhFFgkSatayt16orajqlbKxSZxMC1yd317gKjiP8%2BHwFCS7W9TtOeotj%2BbH%2Bf7Vswi7nKwCKLFkxpOeUp6s8pi1gC2j4V9UTmrLb19CCnSHZCvuuC7Ab1lCdYAgpjZe6nMgcuKt8GIoXAxHrglWCPgjV62%2BgpasOlYFFYY5kcy286I9TEWmWiRqNqpsFzGKNpuJi6EmOCpmgSzZVdwbeF7ISbdXrPytd1QaSeI4WenAkqPeGq7nqei%2BRTJpNHFo0gM1harorhBc5Py1ZfKeP8N5hyTTW3EaB4%2FUXURBp7g08FhZFUVheUmRBSp4ZF9wtm52olUu%2F48mwdTr8fnfKSC2v6kn4PLOgx2gOyWkvqvAuCZW2L7X%2FvV8i4rO6TqnzEE1hpQ0qBBZdo1%2Fwi3WBZY89SYFw1NyDYhhe3GnO5w4lsFo2d4ZAMYy0LFfMNSoGG3Li92uDvdxMMNhnutynIVFJ0xqSc466Og9WaVIRcVMmzrOCvMb5L6Fv5iII5RnwsaOaxoS%2FYQuNmAnmRWR7DDCpTmsSgVDYnAQx5qcT%2BdES50RXxtaxvdFxJW2NxmjgxuLuVbnMUBOmw44dhu%2Bu3WqPQHwKC3x01g2arhUkIsHN2%2Bwf5u8PbGwwag8JycBd1nM1gbthyb3PWrN7anPo%2B1T%2FJ%2FhcTH9RoO%2F9P9V%2BbKj0OBqaYxuCiqW7bD7p%2B2OyH3eioFQWtejt432mHh0EQBYGjQglL4gt6I3ZfB3b35ey2p%2B4mF%2B3DWda9PoeTu6Pp8enXH0%2B3D5e9n%2Be3kneeHxr94dH1B7b8BYXedJFFBwAA)
- [Apex template: example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE3BfGoC%2F%2B1Ua2%2FaMBT9K5GlfioJIbxCpEl97Kk%2BtFV0Yq1QdEmcYDWxU9uBMsR%2F33UDBNpu%2FbhN6hdw7r3Hvuf4XC%2BJpnmRgaYkWJJCihmLqfwSk4BEIPV96UQiJ41t5hJyrCSnmPtWYlxROWMRrQCl0iK3Y5ED4zYU9KEu2OAE5zTSFljVDhYiJLVMrVXhEDKjUjHBSdBqkEyk4lpmCJ1qXaig2azbarIcUqqapsYpeIrQmKpIskI%2Fwren6SlTu2dYwGOLaWXN53MLMgbK0uJZT1hjWFNLzDl2NGWFY%2FgseHSSieiOBAlkilaRr%2BXkjC7eVwyeSGfyVzRmElvZVkDBnL0qzAoZKxLcLoleFEasYwxPhdK4PDJXIBjXaijw84AVs84BxrRGadquu2psUaeXxxcfaiRSfILVIFOqf4MejoY1Nqw6tPFCWMIieJQVRQYNZqPd8N5241WD%2FBSchjWpMcI23OkDoOXomvj6LFylUpRFyDb1BUjIlbHlBnm7Bx1vsLfErI0kZt0aeI7reE7LBCuuJhxVXtgVffxotZqZqaoIry28xtiaKvwRd5QTQ42lHA0SKvwHXUqUTcsSjZCXmWYhzKEOxVEIRZEtUAmFWTxi%2F3p5NRZHtap1%2B7WgDRLGkRGCmTHr034CCfXsjuf17U5v4tsDv0ftbs91Y99tR52kvTOxz2f51Zmtr4QqRblmYAbwOJvDQpHVC15b06i8tibyguD%2FAaPK%2F2s%2Bf%2Fb%2Fq175Z%2BmOGzhfb0Z8M%2BJfNyI%2BwQpmNA7BlHmu17Nd3255w5YfdDuB23Va7sD3O4euG7iuIYKsKtpLfIl332ByM7i6B3p63R%2BNDrPR4hzan246rWQ2ST6ec52fqc%2FsR9qNT75P%2FHdk9Qs8cCug%2BQgAAA%3D%3D)
- [Apex template with host: itremo.com/testweb](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALjLfGoC%2F%2B1U72%2FaMBD9VyJL%2FVQSEhMKRJq0ruu0qSprJ%2FZDqlDkOi5YTWzPdkgZ4n%2FfuQmEFqZ%2BXaV%2BIpzvne%2B9e%2BcVsqxQObEMJSuktFzwjOkvGUoQJdr%2BLgMqC9TZnoxJAZnoDM6uS4gbphecshpQGisLP5MF4cInij20CRucFIJR6xGvruABQjPP5Xo1DiALpg2XAiVRB%2BVyJr%2FrHKBza5VJut22rS4vyIyZrssJlJgBNGOGaq7sI3x7m51zs3uHR0TmcWu8qqo8knNiPCv3eoIcx5p5shLQ0ZyrwPFZCvohl%2FQeJXckN6yOXJW3F2z5sWbwTDp3%2Fo1lXEMr2wyiePAkC06lzgxKblbILpUT6xTCc2ksfL53I5BcWDOR8PeIq0V8BDFrQZpeGK47W9TZ%2BPTyvEUCxWdYS%2FSM2X%2BgJ78mLTatO%2FRhIPyOU%2FIoK4hMLHGFdsNPyk3XHfRHCpa2pKYA23DnVrNCNrybqywztmK3EJhpWaqUb1CKaFIYZ84N%2Fma3wHRT4WZbAkJOHheKRjgIAxxELljzdmFa%2B2J3ANNH27UsXVZNvrFzg%2FHdLb6V90wgR5PPBJglNfBLbKlBQqtLMEVR5panpCJtKKMpUSpfgioGTuGKp6MW9Yq0SjQ6tyRaiTsozagThbvFiwdhyCg%2B8fu4H%2FkxYdgfRfHQx3cxjWOa4WE22tnh%2Fe1%2BcYv3psSMYcJy4jbzNK%2FI0qD1ARM2nMCEwR6vA1N4PQTrPWnoHdqTA3xf8tP%2Fzn7agYV88%2BybZ1%2BTZ%2BFhN2TBspS4bBxCS%2BHQj%2FAkGiW9YdLDQR%2Bf4LB%2FHIZJGDo%2BULBmv4L3ffdlRyfV4OdVcf6je3Hdnw8%2BDfGk1w1v5%2Brzw%2BWgf46%2F5le66OLxMY%2Fid2j9F0y%2FQd9bCQAA)
