### PR TITLE
Add franklymail.com.mail template

### DIFF
--- a/franklymail.com.mail.json
+++ b/franklymail.com.mail.json
@@ -5,7 +5,7 @@
   "serviceName": "FranklyMail email",
   "version": 1,
   "logoUrl": "https://franklymail.com/icon-512.png",
-  "syncPubKeyDomain": "_dconn.franklymail.com",
+  "syncPubKeyDomain": "franklymail.com",
   "syncRedirectDomain": "franklymail.com",
   "syncBlock": false,
   "records": [

--- a/franklymail.com.mail.json
+++ b/franklymail.com.mail.json
@@ -1,0 +1,49 @@
+{
+  "providerId": "franklymail.com",
+  "providerName": "FranklyMail",
+  "serviceId": "mail",
+  "serviceName": "FranklyMail email",
+  "version": 1,
+  "logoUrl": "https://franklymail.com/icon-512.png",
+  "syncPubKeyDomain": "_dconn.franklymail.com",
+  "syncRedirectDomain": "franklymail.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.franklymail.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx2.franklymail.com",
+      "priority": 20,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.franklymail.com"
+    },
+    {
+      "type": "TXT",
+      "host": "%selector%._domainkey",
+      "data": "v=DKIM1; k=rsa; h=sha256; p=%dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DKIM1"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@franklymail.com",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

FranklyMail is email hosting on a customer's own domain. This template publishes the two MX
records, the SPF include as a mergeable `SPFM` rule, a per-domain DKIM key under a rotating
selector, and DMARC.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Test franklymail.com/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE%2FsfGoC%2F%2B1WbVPqOBT%2BK0xm%2FLSgbbGV1mHGUkAReykVvL6Mw8Q2QOyrSQqtDvvbb6KioHjv3dndWWfWT4Sc55ye55yTJ3kADEVpCBkCxgNISTLDPiIdHxhgTGAchEUEcbjtJREov5i%2FwYjDQfsJYHMAN1JEZthDj67R2tZ7eAk9I2aIUJzEwJDLIEwmyZCEHDllLKXGzs6bDHawl8QVVVa203giwhex52Q3XVQ0E46JN%2BYsQC7yMUEe%2BwWsESZeAIwxDCkqA%2B6QEJ8C4%2BoBsCIVDOxzjpwmlPH1gahHgmNGB4lgnMvbmwqGE4JZwflJZcAYJ1fVJGlR%2Fr2Qyk9DKh%2BEPHXa9npQmo7dLEScC8CxF2Y%2BMkZ87130lSCD88FrjC2KQl6%2BhGxtj%2FzHGgao4GYfMsjNs3qz27Hl%2FVJQJxTul6Z1OoWKqu2X0vqWH%2BBoC6xkypc5s5J4HGKP2ZB5UxxP7MQXX3UIGuMcbIQ8214%2B92G2Iz%2BCxFtLzzZdSxbp3GWQc2Y4RvslksG6oM4S49Hj4H2x%2F9GkH5PgMEQp4ilAMem92EzTsACL60UZ3CcxGr2O3TVnsBxYlEN%2BStFzWs9E%2BWpCkiwd4SU%2B5ewiKk7y0vNqzfV66XsFxHrZVvGfKpKiQbErOiZ27E6n0bk1vzUmwd00wIf6XGqY%2FVbbNHuW2a%2BZwm5NunzdMknRjfpxTbYsuaVdKrGVuY3B3Mtr6nfiIsU%2BOpyfzc%2FYsKm0lFAet%2FdOtKhn9Tp%2BgxQOmTte7S5IqTtRo%2FbpOYnsC3swvImdi%2BNO68iy7xsnztA97iY6uzsmWm236tj3OdaQcxneBVPcvEgseuKas3lwnJ%2FA1ml07LbauN27vVUap73mYWCF2RE5dPX8uxm647MenZnt6EL3cN92mrgXD%2Fudptk3G0D0AU%2FihKAR5b%2BQZYT3mJGMK0KUhQyP4By%2BbvneCIoG8rZRbuVle6MW8ZP2HbyO42alWJm0ddEY%2BZ7oJxayeuN5NR2pfkWX4W5lF%2Bmoou9KXkVVNVXf86rQ1%2F0Vmf5AxTcI9etArQ6nGc5hQcHirVxt4qT8Lifl03F6Eo%2F3pGZ1rpFy6WeKWfoThuGSKSf6ubk9HfG%2FLOH%2FSx1Ym95P3NN%2F57L7Dwm%2F3IiL6zK%2F0r7k9EtOv%2BT0S06%2F5PRvy6l48MMZ8kdQ4MTwVqRaRVYGimyoe0ZV3db03T21%2BockGZIkGCDKnurwwF%2FFq%2B9hoJx5s6o0b7bMuFvk%2BY5T61yezyIND2%2Fzo%2B7e5b2cyuw0MLWY1sHiBz0qwSFlEAAA)
- [Test franklymail.com/mail example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMPsfGoC%2F%2B1XbVPiOhT%2BK0xm%2FCRgW6FCHWa2FIqgXaCCq%2Bs4TGwDxL6kJikvOtzffhNeFBT37oe9c525fiLkPOf0POecPGmfAUdREkKOgPEMEkom2Ee06QMDDCmMg3AeQRzmPRKB7Iv5O4wEHNgrgCMAwsgQnWAPLV2jna338AxaIyaIMkxiYKhZEJIR6dNQIMecJ8w4OnqTwRH2SJwrqlo%2BiUcy%2FDz2Oun9OZrXiMDEe3OWIBf5mCKP%2FwOsGhIvAMYQhgxlgXAg1GfAuH0GfJ5IBs61QI4J42L9TdaD4JizHpGMZ2p%2BX8EwoZjPBT8lCzgX5I51RVlkfy%2Bk9suQ2gchLzu2sxuUJUM3DZHgAnDshamPjIHYexd9K0jvuvca44ChUJSP0IP8wF%2FWMEBzYfYhh8I8qdTOm456mgkqlMHTzLjCxlAr6qeZpHLgBzg6AFuZiuWMWyQehtjjDuTeGMcjh%2FjyqR2KhngG9kLWtpfHfZjtwI8g9XbSc0zXUmU6jykUnDmO0WmGprAiqXNiLD2%2BvS%2F2H016mYSAIcaQSAHKSW%2FHZpKEc7C4W2TBE4nR4HXs7gSDzcCiGRSnFK3TWhNl6b34M6IkTQZ445IIghGTh3njfLvjfbdxv13638lTumrucktTNB3KXdk3ueM0m9Xmg%2Fm9OgoexwFulKdK1ezWbdNsW2a3ZEq7NToX67pJ5%2BdRNy6plqXW9Z9abKVutTf1ZqXiD%2BoizTlrTK%2BmV7xf0%2BpaqA7tkws9alvtpl%2Bl8w6ddrzSY5Awd1SM7MtrGjk3Tq9%2FH3duWs36meU8VS86fbd1Tsr8sUX1UuG44zzNsI46P8PHYIxrN8RiF645mQat2QWsX0Ytt25ju%2F3woFUv27VGYIXpGW245dkPM3SHV202Me3opuzhrtOp4Xbc7zZrZtesAtkNPIoJRQMmfiFPqeg0p6nQhSgNOR7AKXzd8r0BlG0UzWPCKsr2RjPilQKuGrYey%2F2KsTVxu%2BIx8D3ZVCzl9V4%2F0XVP8XInulfMFdRCIVfWhjCn3JeVolrwi8oQbsn1B2q%2BR7B3Bmt7Ts1wCucMLN4q135i2u8S0z4jsZWY7GM2qQjVVDO%2F0tDMXzAMN3QF289PcHnit3Q9%2F4byx9r%2Bv5SGnUn%2B3K1dXYTv%2BvkHLsP%2FlvfLpbm4y4or70trv7T2S2u%2FtPZLa%2F9drZWfCnCC%2FAGUUDnKOaWUU7WephrFsnGs5o9PCmrp5FBRDEWRJBDjq1I8i%2Ffp7Tdp4JmIk%2BsHs9CYkfJNl%2BqHig21Yz2eVm1%2BoTVsTysfdtP%2BsMkqYPE3mxrHtKUQAAA%3D)

---

### Notes on the choices above, in case they save a review round

- **SPF is `SPFM`, not TXT.** `spfRules` carries only `include:_spf.franklymail.com` so an
  existing SPF record is merged into rather than replaced. A customer already sending through
  another provider keeps working.
- **`essential: OnApply` on DMARC only.** Loosening `p=` while watching reports, or adding an
  `rua=` address of their own, is a legitimate thing for the domain owner to do afterwards. MX,
  SPF and DKIM are not marked, because changing one of those breaks delivery rather than tuning
  it.
- **`%selector%._domainkey`** follows the `%dkimkey%._domainkey` form the checklist asks for:
  the selector rotates annually, so it cannot be fixed in a template published once.
- **`logoUrl`** returns `200 image/png`, 17256 bytes.

The first push had `syncPubKeyDomain: "_dconn.franklymail.com"`. The schema accepted it and
`dc-template-linter` reported nothing, and the Online Editor rejected it — a hostname is
required and an underscore label is not one. Fixed to `franklymail.com`; the key record is
`_dcpubkeyv1.franklymail.com`. Both editor runs above are against the corrected template.
