### PR TITLE
Add mosspub.com.website template

### DIFF
--- a/mosspub.com.website.json
+++ b/mosspub.com.website.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "providerId": "mosspub.com",
+  "providerName": "moss",
+  "serviceId": "website",
+  "serviceName": "moss website",
+  "description": "Point a domain at a website published with moss.",
+  "variableDescription": "No variables. %domain% is the built-in for the domain being configured; the trailing dot pins both records to the zone apex, because moss publishes a whole site rather than a subdomain.",
+  "records": [
+    {
+      "type": "A",
+      "host": "%domain%.",
+      "pointsTo": "45.76.13.224",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "www.%domain%.",
+      "pointsTo": "45.76.13.224",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **moss** (`mosspub.com`), a desktop publishing tool. The template points a domain at a site published with moss: two A records, the zone apex and `www`, both at moss's publishing host.

The desktop app already shows these records for the user to copy by hand. This template lets a DNS provider apply them instead, so the user signs in and approves one screen rather than transcribing two records into a form.

The template has **no caller-supplied variables** — every value is a constant. It therefore omits `syncPubKeyDomain`; the justification is in the checklist section below, as the rule requires.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

  *No `logoUrl` is set — we do not currently serve a stable logo asset, and we would rather omit the field than point it at a URL that 404s. Happy to add one if it is required.*

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [ ] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected

  **Not set. Justification:** this template has no caller-supplied variables. Every record value is a fixed constant, identical for every user; the only substitution is the built-in `%domain%`, which draft-03 §9.2.2 distinguishes from named variables "supplied by the caller in the apply request". Signing exists to stop a crafted apply link writing an attacker-chosen value into a user's zone (the spec's worked example is a hijacked `%ip%`). Here there is no value to choose: a forged link can only point a domain at moss, which is exactly what the button does anyway, and `%domain%` can only name the zone the DNS provider has already authenticated the user against.

  Neither listed alternative fits. `syncBlock: true` would restrict us to the async flow, and the synchronous one-click is the entire feature. `warnPhishing: true` is deprecated in draft-03 §6.1, which says it "MUST NOT be set in new templates".

  We also cannot sign meaningfully. moss is a **desktop application** — there is no server in the apply path by design. Signing would mean shipping an RSA private key inside a binary users install, where it is extractable; a key anyone can extract is worse than no key, because it carries the authority of `syncPubKeyDomain`. We would rather be honestly unsigned than nominally signed with a published key.

  If this is not acceptable, we are glad to discuss — but we would want to understand what signing protects here that a zero-variable template does not already guarantee.

- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow

  *`redirect_uri` is not used, so the field is not required.*

- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)

  *No TXT records in this template.*

- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description

  *`%domain%.` and `www.%domain%.` are the absolute-apex form from draft-03 §6.3.2, not a caller-chosen label — `%domain%` is a built-in and resolves only to the domain being configured.*

- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead

  *The opposite: the absolute `%domain%.` form pins both records to the zone apex regardless of the `host` parameter. moss publishes a whole site rather than a subdomain, so an apply carrying `host=www` must still configure the apex and `www` — see the second test link, which produces records identical to the apex run.*

- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

  *Both records are load-bearing — removing either takes the user's site offline — so the default `Always` is correct here.*

## Online Editor test results

**Editor test link(s):**

- Apex (`domain=example.com`, `host` empty) → `@ A 45.76.13.224`, `www A 45.76.13.224`: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACDZfmoC%2F%2B1TXWvbMBT9K0LQpznGcRIn9RiskLF2JaWDUhghmGvrJlGxLSPJcbKQ%2F74rx2naUQp7GoM9Wb4f55z7tecWiyoHizze8w1qI1XJ477HK602UqC%2BETzmhTKmqlM%2FUwU%2Fu%2B6gwM5JVoN6IzNs4xtMjSTMZ%2BuLUHZ2CjSZlpVtOfm9kqVlwIQqQJYM3LuLZUSeS7NGwRpp18zh%2BASwAS0hzXH6CuhOsZPD%2BOziiHfBpGF2jSytZW57RLBUujV0fCnKcsUyVS7lqtYoPrZOq0HmziGUZZUsDUsVCdCYKS0IULVRP1WJDCrcegSTQW2wlfgs27hS1ipH1lajgZIcOVCZzNTpUYKrqAPm8XzP7a5yTbsi81oZS89TLS6ycu0yD4rMw5E%2Fjvz%2BwA%2FDIXmszXk8iILg4L0F0jSN%2F6dAi4PHXZHJWd%2BC5teCUB5ugbYIu%2F3oeOi10qquEnmKr0BDYdymnTLnr1IXp9w5545RrkqlMTH0BUsz4bHVNXq8qHMrE2jgbBJZAlWV70igIS9BvG5geVzAz27rwMI7tXo8EZnTKN0mi2AZLrPRpIciwt6wH0x6EF2OetEAMwyicTqGlL97LW%2FfxblHaAyWVkLulOYN7Aw%2F%2FDa4TjwN7h%2BRv%2FBo3P8H8BcHQKdkYIMiARcWBmHUI%2Br%2B8CG4jIMg7kd%2BNBmE4eAD%2FQSB04%2FGHivb0%2BW9vDlePpjb2a4%2FmRS3y%2B%2BmHk%2Fl0zd9%2Ffj4FYOpvJ5Ns6vd7Eu0fbpZ%2FvjED78ANs%2BH7FMGAAA%3D

- Subdomain (`domain=example.com`, `host=www`) → **identical output**, `@ A 45.76.13.224`, `www A 45.76.13.224`: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMnafWoC%2F%2B1T22rbQBD9lWUhT5UUSbacWKXQYrclhYZSUgI1Roy0Y3tB0qq7Kyuu8b93VrbjuIRAn0qhT1rN5cw5c9lyi1VTgkWebvkatZGq5mnk8UartRSobwRPeaWMado8KFTFT65bqPDgJKtBvZYF9vEd5kYS5qP1SSg7OQWaQsvG9jX5FyVry4AJVYGsGbj3IZZR8VKaFQrWSbtiDicggDVoCXmJ0zOgW8WODhOwiz3eBZOG2RWyvJWl9anAQunecKiXo6yXrFD1Qi5bjeJ177QaZOkcQlnWyNqwXBEBjYXSggBVH%2FVT1cigwQePYApoDfYUH2kbJ2WlSmS9Gg2U5IoDyWSmzfcUnKIDME9nW243jWvaOzKvlLH0PGpxkY1rl7lTZB4mwdUoiAZBHA%2FJY23J08EoDHfecyBd1wV%2FCjTfedyJzE785jS%2FHoTy8AFoi%2FCwH6c69LPUqm0yeUxpQENl3LIdk2dn2fNj%2BqzPd3XlslYaM0NfsDQZnlrdosertrQygw5OJlFk0DTlhmga8hLKeRvr%2FRq%2BdbsHFl5Q7PFMFI6mdPs8FGIxHo0H%2FjiHxB8W45EPeYQ%2BFtcjTK6SOI8S%2FuLNPH8dZ51CY7C2EkpHtuxgY%2Fjutwke%2BO%2Fj%2FxEFc4%2Fm%2Fn8Mf30MdFkG1igycJFxGI%2F88NqPBnfRME2SNEyCKBkM48GrMEzD0ElAY%2FfitnSFT%2B%2BPVz8%2BwuSmneL0fnMZWrVMxOJ9eP%2BtS%2BLJZbX8UMbmU7T6%2FjWafH7Dd78Al3Hmp2UGAAA%3D

