### PR TITLE
Add wildventures.ai / linkdomain template (Syndicate)

### DIFF
--- a/wildventures.ai.linkdomain.json
+++ b/wildventures.ai.linkdomain.json
@@ -1,0 +1,28 @@
+{
+    "providerId": "wildventures.ai",
+    "providerName": "Syndicate",
+    "serviceId": "linkdomain",
+    "serviceName": "Branded short links",
+    "version": 1,
+    "description": "Connects a customer-owned subdomain to the customer's dedicated Syndicate link endpoint: a CNAME pointing the subdomain at the endpoint, plus an ownership-verification TXT record used to issue the TLS certificate. Only ever applied on a subdomain (hostRequired), never the apex.",
+    "variableDescription": "target: the label of the customer's dedicated link endpoint; the CNAME destination is always <target>.up.railway.app. verify: the TLS ownership-verification token; the TXT value is always railway-verify=<verify>.",
+    "syncPubKeyDomain": "wildventures.ai",
+    "syncRedirectDomain": "syndicate-betterman.netlify.app",
+    "syncBlock": false,
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%target%.up.railway.app",
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_railway-verify",
+            "data": "railway-verify=%verify%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for Syndicate (provider domain `wildventures.ai`): connects a customer-owned subdomain to the customer's dedicated link-tracking endpoint. Two records: a CNAME pointing the subdomain at the customer's endpoint (`<target>.up.railway.app` — the variable is constrained to the endpoint label, never a free-form destination), and an ownership-verification TXT (`railway-verify=<verify>`) used by the host to issue the TLS certificate. `hostRequired` is set — the template is only ever applied on a subdomain, never the apex.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A, no `logoUrl` in this template

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected — set to `wildventures.ai`; signing key published at `_dck1.wildventures.ai` (TXT, `p=1`/`p=2` chunks)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `syndicate-betterman.netlify.app`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — set to `All` on the verification TXT so a re-apply replaces a stale token
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — TXT value is prefixed (`railway-verify=%verify%`), CNAME target is suffixed (`%target%.up.railway.app`)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`) — hosts are fixed (`@` and `_railway-verify`), no variables
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — not set: both records are structural to the service; user modification would break the connection

## Online Editor test results

**Editor test link(s):**

[Test wildventures.ai/linkdomain example.com/get](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOwqfmoC%2F%2B1VbW%2FbNhD%2BKwSBYBtma3KcWrbWFktfBhRb2jXxgAFBYJzIU0yYJlWSsmMH%2Fu87Sn5Nl%2B3rMOyTzOPdc%2Fc8dzw%2F8oDzSkNAnj%2FyytmFkug%2BSJ7zpdJygSbUDn0Cinf21x9hTu78ZmWkEjG0wz26hRLYBGplZtLOQZnDxTbkjQMjUTI%2FtS6w6OjJZ4HOK2t43utwiV44VYXmzN9aY1AEz4CJ2gc7R9e1SxMR6qLNwYJlYYr7%2B288owxNXZLtS2xyMTSyssqEnPDefry8es%2BaozL3DcQBE0Jj2Pl3WKVrKsKwmNz5qaq6VLQqIzZVysZ%2FjJlDYZ1ktae8VJPyvsYGZfzrDRPoQuuOCftk9IohATCoKq3InyDgKP23U%2BvDNX6plUP5XYeZxjliQYUPSZQMnIJC47sTuQK4eyR20VNDgZrZ8nlxTiT5sfFrRaEekCYtM0W09RJWnr1s0V8ndZU4UNGYUP0Ja5RY5Xuuz2gU7AxNmybKtQBN%2Bhzgt5BtzOrVy%2Fb7OpL1KyN%2Bq4tfcPWuHau%2FGs7odE3cqA1h7%2BZ3%2Fe8WGAK6OZjEYNCEHGvfhr3RVsx4XoL22OHH2vM8uJpsbW89z28feVhVcZQbqXjrTsef4vuIQvqxpeNZK9bZE7HIKQTN8%2F4gTTedPRbpcUCanCpBFxIC0MUThc7a79kxJv18CPRoSq1EuIIgpjTbV1bGJJda883dpsPX1uDkwOiOEuz0wgegbYCJsPNDQcSDDvfO1tVE7UIqcDD3cWnsgm9Pou924bdNPB1bRaJBqi%2FZYrReRuuWJFlF0e9lJRQlihFKSEsxLMuin6XnF9ATMOSxdnVvrMOJpy%2FE5u8aNK91UBNYwsEkxSQ%2BrxVR9XRLKb5unmnXUstwK%2FOuur9pXYdPpIjcVdx3WYa9NC1H3RQy6F68SHvd4kJm3d75CxyWF9kwG46Otuczy%2FXZDXrSBfSeohTopqHx4fDNV4O0ZfVkkJITlk%2BG6R%2FF%2F%2Feyv%2BvQPP7f2v9ka2lBeFignED0PE%2FPB9102O31x%2Bdp3s%2FyNE3IRvS%2BT1M6RCb019XK8Ejb4nhP8MH05zVki88LsZ4%2BiB8GN%2BUs05eXrri5Lmbwafr5%2Fe9uYPtyPfrwim%2F%2BBIZUUHYZCQAA)

Note: template has `hostRequired: true`, so per the instructions the apex test is not required — the editor correctly refuses an apply without a host ("Template requires a host name"), which was verified during testing.
