### PR TITLE
Add Bloom website hosting template

### DIFF
--- a/getbloom.cloud.website.json
+++ b/getbloom.cloud.website.json
@@ -5,7 +5,7 @@
     "serviceName": "Bloom website hosting",
     "version": 1,
     "description": "Connects a subdomain to a Bloom-hosted website and adds Bloom's ownership check. This template does not change email or nameservers.",
-    "variableDescription": "%verification%: Bloom's random domain ownership token",
+    "variableDescription": "%verification%: Bloom's exact domain ownership challenge",
     "hostRequired": true,
     "multiInstance": true,
     "syncPubKeyDomain": "domainconnect-keys.getbloom.cloud",
@@ -14,14 +14,14 @@
             "type": "TXT",
             "host": "_bloom-verification",
             "data": "bloom-site-verification=%verification%",
-            "ttl": 300,
+            "ttl": "300",
             "txtConflictMatchingMode": "All"
         },
         {
             "type": "CNAME",
             "host": "@",
             "pointsTo": "sites.getbloom.cloud",
-            "ttl": 300
+            "ttl": "300"
         }
     ]
 }

--- a/getbloom.cloud.website.json
+++ b/getbloom.cloud.website.json
@@ -7,7 +7,6 @@
     "description": "Connects a subdomain to a Bloom-hosted website and adds Bloom's ownership check. This template does not change email or nameservers.",
     "variableDescription": "%verification%: Bloom's exact domain ownership challenge",
     "hostRequired": true,
-    "multiInstance": true,
     "syncPubKeyDomain": "domainconnect-keys.getbloom.cloud",
     "records": [
         {

--- a/getbloom.cloud.website.json
+++ b/getbloom.cloud.website.json
@@ -1,0 +1,27 @@
+{
+    "providerId": "getbloom.cloud",
+    "providerName": "Bloom",
+    "serviceId": "website",
+    "serviceName": "Bloom website hosting",
+    "version": 1,
+    "description": "Connects a subdomain to a Bloom-hosted website and adds Bloom's ownership check. This template does not change email or nameservers.",
+    "variableDescription": "%verification%: Bloom's random domain ownership token",
+    "hostRequired": true,
+    "multiInstance": true,
+    "syncPubKeyDomain": "domainconnect-keys.getbloom.cloud",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_bloom-verification",
+            "data": "bloom-site-verification=%verification%",
+            "ttl": 300,
+            "txtConflictMatchingMode": "All"
+        },
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "sites.getbloom.cloud",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds Bloom's website-only Domain Connect template for connecting a customer-selected subdomain to a finished Bloom-hosted site.

The template creates only:
- a fixed-prefix Bloom ownership TXT record; and
- a CNAME to sites.getbloom.cloud.

It is host-required and single-instance: the standard `host` parameter scopes each customer subdomain, and its CNAME at `@` has one target. It does not include MX, SPF, DKIM, DMARC, NS, registrar transfer, or redirect parameters.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern providerId.serviceId.json
- [x] resource URL provided with logoUrl is actually served by a webserver (not applicable: this template does not provide logoUrl)

# Checklist of common problems

- [x] syncPubKeyDomain is set
- [x] warnPhishing is not set alongside syncPubKeyDomain
- [x] syncRedirectDomain is set whenever redirect_uri is used (not applicable: no redirect_uri)
- [x] no TXT record contains SPF content
- [x] txtConflictMatchingMode is set on the ownership TXT record
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full host label
- [x] no variable is used in the host field to create a subdomain
- [x] host does not appear explicitly as a variable in any host attribute
- [x] essential is set to OnApply where applicable (not applicable: both records are required for this website connection)

## Online Editor test results

**Editor test link(s):**

[Test getbloom.cloud/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALzygWoC%2F%2B1UW0%2FbMBT%2BK5YltIc1VVIgZJGQBmVCGwM21l1RFTn2aWuR2mnstISq%2F33HSa%2Bj2l6naU%2FJ8bl95%2FuOPacWxnnGLNB4TvNCT6WA4q2gMR2CTTOtx22e6VLQ1tp7w8YYTc%2BdE48NFFPJoc6ZQWok1lqfbseSpZeMtLFSDTFqCoWRWtE4aFEBhhcyt7VNu1op4NYQRkyZCj1mUhGr0axrea4GiHVJpgRhQpjG%2B8IQPVNYeyRzwkfAH9qkN5KGrIYlQoMhSlv0MjUEAlg%2FI7ogCgE77JjcdgBZIVmawcUOuAN0y4HkzNkH8bopPDJuyRLsNgKWZYBtsKDDfQeTUhaAhNmiBOSqUvxDmV5BdVGnYoemBm9I8B6gMu1nehTAdSEMje%2Fn1Fa547n3rbfsgUZSh3vbWNEpmGXobHyOu52A093RMN7aDMMPfd%2F9P1rUZZBJbq%2BZ5SMU8VoL1%2Fgsy%2BiitcbRvTm7frNB8tptj5bKmp5G03XdM8%2Bm06K%2FaNEnrSDZzNhvLUnBGOQZdYQ2rxdw2WQ2m6ExLHSZJ3KVkrOCjY3b7VXy%2FU52f5V%2BX%2Bf365Xc0IXHgnuI1nodvxP6URBSh00OlS4gMfhltixgpeS4zKxM2IxtjgRPWJ5nFY5i0Islf5VLNXdkj1ztZqY%2FSPYM4ZJKZLJFE8Hd9NLdzhRCDgEfeIPBIPWOIuF7UcpDL2AhBEevgiCNtu%2F5%2Fldg%2F3Xf0QCMAWUly%2BrFmLHK0MWe5VjOvTPj71bj75qn38L9%2Bi%2FlPyElXnvDpiAS5iId%2BZ4feUHYC07iThh3%2FHbon0R%2B9NL34%2BYhRJGaMef4Gmy%2FA%2FRLaCZ5enb1%2BXJ8%2FF1NzPnxw9fgfXXYlT8mPXb57m7yqfrYuX3q8uiULn4CobK8tYAHAAA%3D)