### PR TITLE
add motif, Tracking subdomain

### DIFF
--- a/motif.reaktif.io.tracking.json
+++ b/motif.reaktif.io.tracking.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "motif.reaktif.io",
+  "providerName": "motif",
+  "serviceId": "tracking",
+  "serviceName": "Tracking subdomain",
+  "description": "Serves motif's analytics tracker and its event endpoint from a subdomain of your own domain, so both are first-party to your site.",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "dc.motif.reaktif.io",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "m",
+      "pointsTo": "motif.reaktif.io",
+      "ttl": 3600
+    }
+  ]
+}

--- a/motiftrace.com.tracking.json
+++ b/motiftrace.com.tracking.json
@@ -1,17 +1,17 @@
 {
-  "providerId": "motif.reaktif.io",
+  "providerId": "motiftrace.com",
   "providerName": "motif",
   "serviceId": "tracking",
   "serviceName": "Tracking subdomain",
   "description": "Serves motif's analytics tracker and its event endpoint from a subdomain of your own domain, so both are first-party to your site.",
   "version": 1,
   "syncBlock": false,
-  "syncPubKeyDomain": "dc.motif.reaktif.io",
+  "syncPubKeyDomain": "dc.motiftrace.com",
   "records": [
     {
       "type": "CNAME",
       "host": "m",
-      "pointsTo": "motif.reaktif.io",
+      "pointsTo": "collect.motiftrace.com",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
# Description

New template for motif (`motiftrace.com`). One CNAME so a customer can serve the analytics tracker and event endpoint from a first-party subdomain.

```
m.<domain>  CNAME  collect.motiftrace.com  (ttl 3600)
```

Reopens #1560 and #1559.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove

## Online Editor test results

**Editor test link(s):**

- apex, `example.com` with no host: [Test motiftrace.com/tracking example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEVogWoC%2F91STY%2FTMBD9K5YvHNpUaZOm20gcFthKCFgWtsuBqoom9qS1NomztpNuqPrfmfSDLipInDnFmXkzfu%2F5bbnDosrBIY%2B3vDK6URLNe8ljXminMmdA4EDogvd%2FdW%2BhwFOfyhZNowTuZzr4oypX5%2FIRPD82mK1TqQtQJUEkWmFU5ZQuCXJPA2jZfu0ry6CEvHVKWLZfioYqkilnGTZYOoalrLSiQ2Z0weC8mOmMtbo2TG9Kdij1mdUs1W7NwCDLlLHOq8C4ljl9wFrlcECUGjR2T2dICtpSvMm1eORxBrnFQ%2BWuTj9g%2B%2B6gIeZSDC6MMii0kZbHiy13bdXpf3t7%2FemGWmttXeddZ2fH3s41%2FQqd5yjc5Sbnch4Hke%2Fvlrs%2B%2F6FLTM7Ll%2BTgiQY%2BAz3jaex4C51WRtdVok54Eg2F7Z76NLn4bXR5ml1w3t2oVqU2mFj6gqsNKXGmJiOKOncqgQ2cS1IkUFV5SwQtdWnFpfrymJzu7cHBPynv80SKjrHqAjadynCSZpEH0STwwqsw9NIQwPNlOB6FYpwCTF9E9c9B%2Fktiz66htRQxBUSBX%2BcbaC3f7ZZ9cvB%2F00QPbqFBmUAHG%2FmjyPOvvGE09ydxMI6DYDAcjcb%2BtOf7se93GtC6g84t5eNlMvj97PPH6SwYfscI6t5DL9g0X55umnw%2BW0WhrmbP%2BdPXMLPf1unDa777CflbFMF6BAAA) → `m.example.com. CNAME 3600 collect.motiftrace.com`
- subdomain, `example.com` with host `sub`: [Test motiftrace.com/tracking example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFJogWoC%2F91SwY7TMBD9FcsXDjTFbbdNNhKHUlgJVruwbBFIVRVN7UnX2iQOttMSqv47k6ahuypInLkk8cy88Xsvb8c95mUGHnm846U1G63Qvlc85rnxOvUWJPalyXnvd%2FcWcuz6VHZoN1riAdOMP%2BpifSofh%2BfHBnPVSpkcdEEjCp20uvTaFDRyTwB07LD2hWNQQFZ7LR07LEVLFcW0dww3WHiGhSqNpo%2FUmpzBaTEzKatNZZnZFqwt9ZgzbGX8AwOLLNXW%2BaAE62vmTTvrtMc%2BUdqgdQc6A1JQF%2FJNZuQjj1PIHLaVT9XqGuu3rYaYK9k%2FM8qiNFY5Hi923Ndlo392O715R60H43zjXWNnw97NDR2lyTKU%2FnyT9xmPRxMh9st9j%2F80BSan5UtysKOBP4B%2BYwc73kKW0GFtTVUmuoOQbshd87c78OIZetnBFwd8c69eF8Zi4ugNvrKkx9uK7MirzOsEtnAqKZlAWWY10XTUpS3nHhTH%2FPRbfgo8%2FJMHPZ4o2RDXTdTUaDTGMUYBAIbBxWUKQTShB6r0Ml2FajgU6klo%2Fxzpv2T3mX%2FoHOVNA7Hg02wLteP7%2FbJHXv6n0igBDjaoEmgmh2I4CUQUDCZzEcajcXwx6YtxNAzDl0LEQjQy0PlW6o7S8jQnfFbfXH14FO4%2BL20UzaKq%2BrieXs2%2Bvpp80d%2FC%2FHP0%2FW50Pc7M3cC85vtfByRR4o4EAAA%3D) → `m.sub.example.com. CNAME 3600 collect.motiftrace.com`