### PR TITLE
add Einblick, Email sending

### DIFF
--- a/einblick.xyz.sending-domain.json
+++ b/einblick.xyz.sending-domain.json
@@ -1,0 +1,55 @@
+{
+  "providerId": "einblick.xyz",
+  "providerName": "Einblick",
+  "serviceId": "sending-domain",
+  "serviceName": "Email sending",
+  "version": 1,
+  "logoUrl": "https://app.einblick.xyz/images/favicon.svg",
+  "description": "Authenticates an Einblick Workspace sending domain with SPF, DKIM, a custom MAIL FROM domain, and optional click tracking.",
+  "variableDescription": "%mailFromRegion% is the AWS SES region; %dkim1%, %dkim2%, and %dkim3% are the constrained DKIM selectors returned for this sending domain.",
+  "syncPubKeyDomain": "domainconnect.einblick.xyz",
+  "records": [
+    {
+      "type": "MX",
+      "groupId": "sending",
+      "host": "send",
+      "pointsTo": "feedback-smtp.%mailFromRegion%.amazonses.com.",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "type": "SPFM",
+      "groupId": "sending",
+      "host": "send",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "type": "CNAME",
+      "groupId": "sending",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com.",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "sending",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com.",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "sending",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com.",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "tracking",
+      "host": "links",
+      "pointsTo": "links1.resend-dns.com.",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Einblick email-sending template. It configures a custom AWS SES MAIL FROM domain, SPF, three constrained DKIM selectors, and an optional Resend click-tracking CNAME.

The template passed the official linter in both standard and Cloudflare compatibility modes, including remote logo validation.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

The `syncRedirectDomain`, `txtConflictMatchingMode`, and `essential` checks are not applicable: this template has no redirect URI, direct TXT/DMARC records, or independently editable policy records.

## Online Editor test results

**Editor test link(s):**

- [Test einblick.xyz/sending-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJAdf2oC%2F%2B1WbW%2FbNhD%2BKwQBf5okS7LjOhr6wWiSJkidFUmGFAsCg6LONmFJFEjKiRNkv31HWfJL5iZFhwJdYX2RfUfecw%2Fv7qGeqIGsSJkBGj3RQsm5SECdJTSiIPI4FXzmPSweqbPyXbAM19Lj2oseDWouOFSbNOSJyCduIjMm8rWz2YXWlNSL0DsHpYXMaRQ4NJUT%2BadKcdXUmEJH7TYrCm8zi7bI2AR0e8wwpMw9PbcxEtBcicJUceigNFPIjeBISROWkyZRciPVTBeMQ4NPlkmSe2Gm5OrziUOOzs%2BGDmGEl9rIjAwHZ5%2FIyeUfw3oluvKEyAqKpYRXYY1ifIbRPEuHKcHiFI62UmpZ0idKZpcwQUuLCE0wSTK4uSJXx1dEVebfSSuZiSxoOcsfYWsJV%2F3ptAhTUO1C4hoxRQ5JlS%2BySYEbqTQGMqWy9rFUuBZhtpnaFPUi55%2FL%2BBwWR8sSRXTpxLg5xvFelF0BlyrRNLp9omZR2CIOv6B9omRZbJYcbVOpTW2wDSNFbvS1RMsYIInxmFydmcJ7eR4ey9gjsgLtcZnZJI3BNuj0fN%2B2nZBKmAW2iP%2FsrHLAcg2%2FKQtdjC%2FLFJAARY5pmUC0BUc3gn64GAyPX49a18gbLQ9tBottpo3fvl7h9R2g4Rug4Y8A7bwB2vlvoM3srFFTRNLbQJUp8BTYFN0k34Fx9%2BxQxIfRulvvnLqvrZI9MNQ4qMq9QmoSGYlmfcEUy7TVwWbn7dbWu2bvLbW%2Ft7u4Wly696CNG1h31QjWyhgL7NMYQ2uM4zi0T2PsWCPnvGMfavmISS4VjDS%2BGY41HqBRJSBsmRoxYvdsbUr4CKUyXSB9jV4M9WJY86X61iORMMP%2BNZSr3L95Gh06Srg9LWFLGcQw7ofgu0EYcLf7rnfo9lmPuzzo9%2BEg7iaBn2zcIrtumFfvkXXVQGsr8MzeFIP0ni00fd7osusv119jPH%2BPahCQnTpA%2FmZp2pBFrj8rvWaIaoJNc22Pac135XxjRv8fVJuR2Ul15fwlqDZCsJPqyvlLUG0Evyb3ttj%2FVLTuHLw49mK7F9u92O7Fdi%2B2P1hs8VtZszkkI2aXhX7Yc%2F2%2BG3Svg050EEZBzwt6vV6395vvR75veaDILrk%2B4Rf15rc0ffxrcDjttz8eHPLTi8lpOhA3B377IT1%2FF0N46scfIWgfTdLLR9V9T5%2F%2FAeSFW%2B8nEQAA)
- [Test einblick.xyz/sending-domain example.com/mail — sending group only](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO8df2oC%2F%2B1WbW8aORD%2BK5YlPnV32RcK6Z76gV6CFOVIqyQVqBFCxjbgY3e9Z3tJaJT77TfeFwJcmlStTrpUWSEBM%2BPnmceeGe8dNjzNE2I4ju9wruRaMK5OGY4xF9ksEXTl3W6%2BYmfrOycpxOKT2gsezdVaUF4u0jxjIlu4TKZEZA%2FOZhVYE1QHgXfNlRYyw3Hg4EQu5GeVQNTSmFzH7TbJc283i7ZIyYLr9pwApMw8vbYYjGuqRG5KHNwvzJJnRlCQpBHJUJMoGkm10jmhvOFHVZLoRpgluvw0cNDx2enQQQTRQhuZomH%2F9A80uPg4rCPBlTEkSyqSIFrCGkXoCtA8K4coQWYJP95LqWVFD5RML%2FgCLC0kNIIkUX90iS5PLpEqzb%2BhFluJNGg51Y%2BwVdGVf6IWIoqXq0C4Bk6RcVbmC2oSTo1UGoBMoax9LhXEAs2%2BUpui3mT0UzE745vj6ohiXDkBNwMc7%2BDYFadSMY3j6ztsNrk9xOEY7Asli3z3yMG2lNrUBlswUmRGX0mwzDlnM9gmV6cm9w73wyMp%2BQqquPaoTG2SxkAZRF3ft2UnpBJmAyXi3zvbHOC4ht%2BVhc7nF0XCQQAGjUnBeLxHh3dAfz%2FvD0%2BeRq3PyJtWm7bim32ljd9%2BPaHrB0jDZ0jD%2F4I0eoY0%2BjnSpnceWBNg0vtEpSnwFLcpuix7hGNy72Dg59OHap04dV3bSXZLYMbx8ri3TLYIm2Smolyz3QRYnBNFUm2HYgNzvYczaYCuK6RJDXUAs1%2FqJUjh3nBt3MC6y2qxVkJIYJ%2FGGFrjbDYL7dMYI2uklEb2wVa0WGRS8amGbwK9D7tsVMGBtkiMmJIb8mBidArzNNnAHmnwAtRBR2fViLbJe%2FXmMGLIv9p3K%2BC7%2B9bBU0btVgp76FHkRx0WcLdHetztUD90Z92AurTnd8gRfdslEd%2B5bx67i568cfbPl2ttrwNi75V%2BckM2Gt%2Fv1OTV%2BOpJ6ev3MEAC9OjoQH%2BTJGlUg%2Bj%2Fs86m92qlTbntdPeB8G3EM%2F39cjQ33fRtzduIX0ZzMyy%2BrXkb8dI0TxyY8a8j7HWEvY6w1xH2QkcYvNdpsuZsSmxo6Idd1z9yg85VEMVv4RN4Ya979C544%2Fux71stMLUq1Xfw9rf73oeJ6i0Sdj5uh%2FTzyESdsz837eD2ZLwciPl8%2FmE1Gv81Wg%2Ferb8cr97j%2B38AZvDkdfgPAAA%3D)
