### PR TITLE
Add adsu.ai.tracking template

### DIFF
--- a/adsu.ai.tracking.json
+++ b/adsu.ai.tracking.json
@@ -1,0 +1,27 @@
+{
+    "providerId": "adsu.ai",
+    "providerName": "Adsu",
+    "serviceId": "tracking",
+    "serviceName": "Adsu first-party tracking",
+    "version": 1,
+    "description": "Serves Adsu's first-party tracking script from the gym's own subdomain (e.g. track.yourgym.com) and proves domain ownership, so ad-click attribution survives browser tracking protections.",
+    "syncPubKeyDomain": "adsu.ai",
+    "syncRedirectDomain": "app.adsu.ai",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "cname.adsu.ai",
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_adsu-verify",
+            "data": "adsu-verify=%verifytoken%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "adsu-verify="
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **Adsu** (adsu.ai) — gym ad-click attribution. The template serves Adsu's first-party tracking script from the customer's own subdomain (`track.yourgym.com`) via a CNAME to `cname.adsu.ai`, plus a prefix-scoped ownership-proof TXT (`adsu-verify=%verifytoken%`) at `_adsu-verify` under the applied host.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

*(The `logoUrl` check is N/A — no `logoUrl` in this template.)*

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`adsu.ai`; the public key is published at `_dcpubkeyv1.adsu.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.adsu.ai`) — the synchronous flow uses `redirect_uri`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the verification TXT (`Prefix`, `adsu-verify=`)
- [x] no variable is used as a bare full record value (`adsu-verify=%verifytoken%` is prefix-scoped)
- [x] no bare variable as a `host` label (hosts are `@` and `_adsu-verify`)
- [x] no variable in the `host` field to create a subdomain (the `host` parameter carries the subdomain; `hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not needed — both records are integral to the service; removing either breaks tracking or verification

## Online Editor test results

**Editor test link(s):**
[Test adsu.ai/tracking example.com/track](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOyQf2oC%2F%2B1UbW%2BbMBD%2BK8jStE0DSihJCNKkdV2nvShd1kXqpCpCxjaJV8DMNklZlP%2B%2BcwKFvmlfN2mfiM%2FPc77nnrtskWZ5mWHNULRFpRRrTpn8SFGEMFWVizmyb8PnOAcYOoELiCom15ywPVZLTK55sezCPayVcqm0U2Kpa6uHXDOpuChQNLARZYpIXur9GX2DHExZhvxcPUq3DnArlSK39IpZyzoHqNgUlqoSKnLMC%2BsFc5fugeLWopKAcYnIX1q4oJYRBW80UCBCNSte2pYSFqYOyTi5trDWkieVKQvygjBDSaTYgMquFkilGTEg5ZoO1AWZVclnVr%2FbJ7%2FTS3N5wSiXQOiuy9LtICuh9AX7WQEGeqtlxWwEcCGpQtHVFum6NK09PT%2BZnjVwOL4xRgleaDUXcCQFGNBLqnWGouOR5%2B3s2wzz7%2FOOHxusA57wtIYoxRo3hTfB188OXy2uWfGsnxJ%2B3uhTUaTQMz3FmqygK1NBzRszyVJ%2Bgx6FNHd3X0G7xc5Gv0TB4k70Agpqm8VuMEwsM0521e%2B9gONSiqqMeUuCocG5MqPd0q%2Fu8Bdtgqsmw2I%2Flq1KE%2FeSSRown4R0gIN0xCbJMRnTIfZZmA5IkCBTLl8WQrJYwRfrSrLWtrzKNI%2FxBnchSmKwO6tBnYJbeOKhpcVheVpRjRdPWmqjmBIjkptdHE684WjkpQ6ehMQJwgF1cJiMHDoeDvxJEAThcdBb6nu7%2FsRW32szU4oVmuPMrHi2wbVCuweD1ajoD5Z7T1Lf%2BD82%2Bu9TvLBhyP7b98%2FaB9uu8JrRGBus7%2FkjxwudQTD3%2FcgLIj90w2EY%2BuNXnhd5nlHAlD5o38LW9%2FcdzXL1IzuaLcfSD5T6pEbJB4zn06PLwHv%2F9e34Un2heJ6xs8nUg%2F%2B430Tn5GF4BwAA)

Applied records from the test (domain `example.com`, host `track`, `verifytoken=0b9f4e2c8d1a4f6e9b3c7d5a2e8f1c4b`):

| Name | Type | TTL | Data |
| ---- | ---- | --- | ---- |
| track.example.com. | CNAME | 3600 | cname.adsu.ai |
| _adsu-verify.track.example.com. | TXT | 3600 | "adsu-verify=0b9f4e2c8d1a4f6e9b3c7d5a2e8f1c4b" |

*(hostRequired=true, so per the template instructions the apex test is not applicable.)*

*Note: this PR is maintained by an automated agent on the provider's behalf; the editor run above was performed live in a browser session.*

