### PR TITLE
add CadêncIA, Blog CadêncIA

### DIFF
--- a/cadenciaoficial.com.br.cadencia-blog.json
+++ b/cadenciaoficial.com.br.cadencia-blog.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "cadenciaoficial.com.br",
+  "providerName": "CadêncIA",
+  "serviceId": "cadencia-blog",
+  "serviceName": "Blog CadêncIA",
+  "version": 1,
+  "logoUrl": "https://cadenciaoficial.com.br/cadencia-logo.svg",
+  "description": "Aponta um domínio personalizado para a hospedagem de blogs da CadêncIA.",
+  "variableDescription": "%routingTarget%: hostname do edge de hospedagem da CadêncIA",
+  "syncBlock": false,
+  "syncPubKeyDomain": "cadenciaoficial.com.br",
+  "syncRedirectDomain": "cadenciaoficial.com.br",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%routingTarget%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Domain Connect template for CadêncIA custom blog hosting.

The template creates exactly one CNAME record for the customer-provided hostname. The CNAME target is supplied at runtime through the signed `routingTarget` variable. In production, CadêncIA supplies `blogs.cadenciaoficial.com.br`, using the same value already produced by its existing DNS instructions builder.

The synchronous apply request is signed with RS256. The public key is published at `_dcpubkeyv1.cadenciaoficial.com.br`, as declared by `syncPubKeyDomain`.

The template does not create TXT verification records and does not introduce a separate domain-verification mechanism. HTTPS activation remains handled by CadêncIA's existing HTTP-01/TLS monitoring flow.

For Cloudflare onboarding, we will explicitly request that the resulting CNAME be created as DNS-only. Proxy state is not represented by a standard Domain Connect template field.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality in a backwards-compatible manner)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Validation completed:

- JSON schema validation passed.
- Mandatory Domain Connect linter passed.
- Cloudflare validation completed with informational notices only.
- The Online Editor result contains exactly one CNAME and no TXT records.
- `https://cadenciaoficial.com.br/cadencia-logo.svg` serves the actual SVG resource.
- `_dcpubkeyv1.cadenciaoficial.com.br` resolves publicly with the two RS256 public-key TXT fragments.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Bare `routingTarget` variable justification

The complete CNAME `pointsTo` value intentionally uses `%routingTarget%`.

CadêncIA's existing DNS contract accepts a complete environment-specific FQDN, rather than a variable label beneath a fixed suffix. Tests in the application also exercise routing targets outside its primary domain. Adding a fixed suffix to the template would create an invariant that the application does not guarantee and could make automatic instructions diverge from the existing manual DNS instructions.

The value is not selected by the end user. It comes directly from CadêncIA's server-side `buildDomainDnsInstructions` result and is included in the signed Domain Connect request. Any modification to `routingTarget` invalidates the RS256 signature.

The bare variable is therefore necessary for this use case and follows the documented exception for values that genuinely cannot be constrained with a fixed template suffix.

### Non-applicable checklist items

This template creates no TXT records, so SPF and `txtConflictMatchingMode` requirements are not applicable.

The only CNAME is required for the hosted blog to function. It is therefore not a record the user may modify or remove while keeping the service functional, so `essential: "OnApply"` is not applicable.

The template uses the Domain Connect `host` parameter with `"host": "@"`; it does not use a variable to construct a host label and does not reference `%host%` directly.

## Online Editor test results

**Editor test link(s):**

[Test cadenciaoficial.com.br/cadencia-blog example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGdDf2oC%2F%2BVT227aQBD9FWulPAUTGwMhliqVJq2a5tKG0oeUImvsnZhN7V13d01CEP%2Fe2QAhlCb9gL7Y2pk5Z87c5sxiWRVgkcVzVmk1FRz1KWcxy4CjzASoG0Hfopmpsplq1niKuoSSUOwY%2BI86CBBkdtont0E9FRlucfhpofKNb4V8R0bvT%2FgUtRFKsjhsMPKrb7qg0Im1lYkPDv4u6snsO0TTTF0ujibTorKPZKxfKWnBq0uPq%2FIxIZdCeRVlUxIK8QCcXqDBA2%2BiTIUccqRg9Jx043HYVtp0UkELSAs82cq0p1VthcyHoHO0e7Gjs5Iqpswe8hwd6fMUsNMDM5MZNSf7yeIbKAwuLV%2Fq9AxnJ6oEIV%2Bbj4sdIBcaM%2FvvaKdugL9qCqeJWV1TNkIqzQ2LR3NmZ9XjlC%2F7F%2B9X4fR86%2FZACWnNUO3WTE5raWzdIFiMFw32oCQmG9IxDWetC%2B%2BB9g%2Bdng37altyYq0Ssca46ZTG7ekaPdqCj9f40ZKA3luy1g7TfKEZTqrIpdKYGPqDrTWuW1LWhRUJ3MHGxLMEqqqYUWWGvES%2F2y653PRVQRwsrF4viti0rsESnrlyhTulqJchcp76nV4L%2FTZ2I%2F%2BolUZ%2BELY7vN1Lj7q88%2Bw4Xz%2Fh1250ewZoDEpLYHdDxR3MDFssxg2ax39TLO2RgSnyBFxoK2h1%2FaDnh%2B1h2I2jKG5HzcNu2Ipa%2B0EQB4GrCY1dVj%2BnjXq%2BS%2BzQltH3obyehBdng8%2FyeHZ%2BdXv%2F6bqzX9rbSA8%2Bfjj%2F2sdJ2rsJr96wxW8skduyngUAAA%3D%3D)

This template has `"hostRequired": true`; therefore the official PR-template exception applies and an apex test is not required. The test uses `example.com` with host `blog` and runtime value `routingTarget=blogs.cadenciaoficial.com.br`.

Expected result:

```text
blog.example.com. CNAME blogs.cadenciaoficial.com.br.
```
