### PR TITLE
Create wepamail.com.email.json

### DIFF
--- a/wepamail.com.email.json
+++ b/wepamail.com.email.json
@@ -5,67 +5,74 @@
   "serviceName": "wepamail Email Sending",
   "version": 1,
   "logoUrl": "https://wepamail.com/favicon.png",
-  "description": "Authorizes wepamail to send email from this domain by adding the domain ownership, DKIM signing, SPF, return-path and DMARC records.",
-  "syncBlock": false,
-  "shared": false,
+  "description": "Authorizes wepamail to send email from this domain using Amazon SES. Adds domain ownership, DKIM signing, SPF authorization, a custom MAIL FROM return-path, and a DMARC policy in one step.",
+  "variableDescription": "%verifyvalue%: Amazon SES domain ownership token; %dkim1%, %dkim2%, %dkim3%: DKIM selector tokens; %region%: AWS SES region for the feedback MX host; %dmarcvalue%: DMARC policy value",
+  "syncPubKeyDomain": "wepamail.com",
   "syncRedirectDomain": "wepamail.com,www.wepamail.com",
-  "warnPhishing": true,
+  "warnPhishing": false,
+  "syncBlock": false,
   "hostRequired": false,
   "records": [
     {
-      "groupId": "wepamail",
+      "groupId": "verification",
       "type": "TXT",
-      "host": "%verifyname%",
+      "host": "_amazonses",
       "data": "%verifyvalue%",
       "ttl": 3600,
       "txtConflictMatchingMode": "All"
     },
     {
-      "groupId": "wepamail",
+      "groupId": "dkim",
       "type": "CNAME",
-      "host": "%dkim1name%",
-      "pointsTo": "%dkim1value%",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
       "ttl": 3600
     },
     {
-      "groupId": "wepamail",
+      "groupId": "dkim",
       "type": "CNAME",
-      "host": "%dkim2name%",
-      "pointsTo": "%dkim2value%",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
       "ttl": 3600
     },
     {
-      "groupId": "wepamail",
+      "groupId": "dkim",
       "type": "CNAME",
-      "host": "%dkim3name%",
-      "pointsTo": "%dkim3value%",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
       "ttl": 3600
     },
     {
-      "groupId": "wepamail",
-      "type": "TXT",
-      "host": "%spfname%",
-      "data": "%spfvalue%",
+      "groupId": "spf",
+      "type": "SPFM",
+      "host": "@",
       "ttl": 3600,
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=spf1"
+      "spfRules": "include:amazonses.com ~all"
     },
     {
-      "groupId": "wepamail",
+      "groupId": "mailfrom",
       "type": "MX",
-      "host": "%mxname%",
-      "pointsTo": "%mxvalue%",
+      "host": "bounce",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
       "priority": 10,
       "ttl": 3600
     },
     {
-      "groupId": "wepamail",
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "bounce",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com ~all"
+    },
+    {
+      "groupId": "dmarc",
       "type": "TXT",
-      "host": "%dmarcname%",
+      "host": "_dmarc",
       "data": "%dmarcvalue%",
       "ttl": 3600,
       "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=DMARC1"
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
     }
   ]
 }

--- a/wepamail.com.email.json
+++ b/wepamail.com.email.json
@@ -47,7 +47,7 @@
       "type": "SPFM",
       "host": "@",
       "ttl": 3600,
-      "spfRules": "include:amazonses.com ~all"
+      "spfRules": "include:amazonses.com"
     },
     {
       "groupId": "mailfrom",
@@ -62,7 +62,7 @@
       "type": "SPFM",
       "host": "bounce",
       "ttl": 3600,
-      "spfRules": "include:amazonses.com ~all"
+      "spfRules": "include:amazonses.com"
     },
     {
       "groupId": "dmarc",

--- a/wepamail.com.email.json
+++ b/wepamail.com.email.json
@@ -1,0 +1,71 @@
+{
+  "providerId": "wepamail.com",
+  "providerName": "wepamail",
+  "serviceId": "email",
+  "serviceName": "wepamail Email Sending",
+  "version": 1,
+  "logoUrl": "https://wepamail.com/favicon.png",
+  "description": "Authorizes wepamail to send email from this domain by adding the domain ownership, DKIM signing, SPF, return-path and DMARC records.",
+  "syncBlock": false,
+  "shared": false,
+  "syncRedirectDomain": "wepamail.com,www.wepamail.com",
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "wepamail",
+      "type": "TXT",
+      "host": "%verifyname%",
+      "data": "%verifyvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "wepamail",
+      "type": "CNAME",
+      "host": "%dkim1name%",
+      "pointsTo": "%dkim1value%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "wepamail",
+      "type": "CNAME",
+      "host": "%dkim2name%",
+      "pointsTo": "%dkim2value%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "wepamail",
+      "type": "CNAME",
+      "host": "%dkim3name%",
+      "pointsTo": "%dkim3value%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "wepamail",
+      "type": "TXT",
+      "host": "%spfname%",
+      "data": "%spfvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=spf1"
+    },
+    {
+      "groupId": "wepamail",
+      "type": "MX",
+      "host": "%mxname%",
+      "pointsTo": "%mxvalue%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "wepamail",
+      "type": "TXT",
+      "host": "%dmarcname%",
+      "data": "%dmarcvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Template for wepamail.com email service. Adds DNS records for Amazon SES domain verification, DKIM, SPF, DMARC, bounce handling, and custom MX when using a subdomain.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Update to existing template
- [ ] Delete a template

## Online Editor test results

**Editor test link(s):**

[Test wepamail.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEPCf2oC%2F%2B1XW2%2FaSBT%2BKyNLeSoQgxMIjiKF5tJFKUk2UG26UYQG%2BzhMsT3uzBhCI%2Fa394xvYELabbUPyYqXxJzbd%2B7HfjIUBJFPFRj2kxEJPmUuiK5r2MYMIhpQ5tccHhiVgndJA1jhIkeCmDIHEiUo09aEyVnytw%2Bhy8IHFJuCkIyHhl2vGD5%2F4J%2BEj%2BJjpSJp7%2B6uerDrUTTIw1qUKLogHcEilSgbnViNuWDfQJICSnEiEYckHhFP8ICoMZPE5UgISSzRA9IJ6Dcekv5Zv0Y6rltw%2BSxEz8YsqpDTi26PSPYQonyF9K%2FPCc3QqEavEEqcWCo03%2Bt0P5Lzm6seEaBiEVYjqsbIRycoOe11bk5IxH3mzIlGCIFIBVFNZ4EKRkc%2BnJaC2sHkMG8%2BpX4MO%2FaKq8%2BcxFgnEB6SHXfCgvpOJX1o5A8WaqdRgA%2BO4iKVl6gg4AHBtPW%2F%2BonplEA8LTQG4gG4I%2BpMSO%2BWjLlUGiOgwsmdKkWVEHXt56FzHY8uYH6aOPq8l7TEDbhMoDsbZSqz2ay2pjSjIrzGCo5169ge9SWklt773JkUFO3mDXyN0bhbEBGIC1ca9t2T8SB4HCXNmiSYOUkdEUDNI92sg9uBkZrBH0OapF2C1E1HFV0vjNZT2LRW0zTx8VGd8NDDdKgeVY52tcddbbXj%2B8aisoquS7NEPbns9M6WuFkpa8O01hOY6xHkLFRywFf4%2Bl%2Bt8DHLVOHQrwI2fgLY%2BK8BrZ8AWr8GKCNviYej2lvCHZcLhZI3sY9VtQ0WOn7sgl3GKBvWbahXyNJ673Zpe8Tj0IGy%2B%2FnkVGWgolo%2BaM8CiQTDVaLmuAHNF8N6jl6OrcD%2F%2FQCTqX5pBnJm3v8rK%2BDftv%2B1AI89GhtFMh7O41GyT%2BooBhKXt2JUn4OrsBNF%2FtxY3C8qBkYAw%2BU436NX%2BQKBR4qnDLLMZs7jUxLlkOXyERU0kPrc5Zp3JdX7XPfO0M8rw65JdOTUG5ZmJBOoSck2reekRkFq5CSrICWKaS9oWiyrQKWqpspFVjUrz8UhiY6%2BxugyZiOEQyJieqT7QXE7UTgubUmdITxVXMBQnyyKZwitKRHjDgxiX7EhxTVakFxnSHVqMaESuYiL%2B7HUAmF6wDetwSwTpQYYuo5OLEteBVzHNa0DWvWsA6juNepmtb2%2F36o67f0mjKxWq962Vt4rNr1zbHqzWNZ1tUc6%2FozOpbHQXb22b7IQ0iqV100WScb68aZ5%2FcE1Xg6u8eaDs14OznpTwZXm6ngZyvQIV3adbFzW5B%2Fq%2B683pOQWZhEVtygLq3wHi4X3o2qVb%2BKrrd16pG%2B4gOVdv3buf%2B8SvY5Yi1eHxX0Fb%2F%2F2um2v2%2Fa6ba%2Fb9rptr9v%2F67rh96OkU3CHVMs1zEazah5U6%2FsDs25be%2FZ%2Bu7bXbLVazXemaZum9h%2BkSlPwhN%2BMq1%2BLRvD%2Bz%2FMPf0%2B417zqXg78Mav3Tw8G7d3rz1%2B%2BtL1PJxcfLrtR%2FLn7Rzg7MhbfAeKePi5CFgAA)

[Test wepamail.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGnBf2oC%2F%2B1XW0%2FbSBT%2BKyNLPG0SfAkhNUJqFugKUbeBUEGLUDSxx8ksjsfMjJMYlP72PeNb7CQt22ofYJUXcM79O1f7WZNkGgVYEs1%2B1iLOZtQj%2FNzTbG1OIjzFNGi5bKo1St4nPCUVLnAE4TPqklSJ1Glrwugs%2FTsgoUfDMYjNCBeUhZptNLSAjdkXHoD4RMpI2Pv71Qj2fQwGWdiKUkWPCJfTSKbKWi%2BWE8bpExGodCUZEuAHpREhn7MpkhMqkMeAEKJYQASoN8VPLESDs0EL9Tyv5LJ5CJFNaNRApxfnDhJ0HIJ8Aw36HxDOvWHlvYEwcmMhwbzTO%2F%2BIPlx9dhAnMuZhM8JyAnwIAqNTp3d1giIWUDdBykNIkJAkaqksYE7xKCCnNVB7kBzqJzMcxGTProS6ESRgfSDhEdrzHujU2GtkD2bxYIF2hoIExJWMZ%2FICFDgZgzNl%2FWaQms4IyFdCE4J8QrwRdh%2BQc4smTEjlY4q5WwRVQ5USVe2T0O3HowuSnKaBbvaSkrgiHuUQzlaZxnw%2Bb60pzTEP%2B1DBiWod28eBIJmlPwPmPpQUFeYVeYzBuFcSwRHjntDsu2dtzFkcpc2aJpi6aR3BgUwi1azXt9daZgZ%2BDHGadkGEajos8XphlJ6EprU6ug6PC3nCQh%2FSIR0sXRWqwzxltRcE2rJR9a5Ks%2FJ68qnnnK385qVsDbNaP5BEjSCjoRTXrMJX%2F1pljHmmyoB%2B1aH5gkPzv3ZoveDQ%2BjWHIvJX%2FmBUnZW79%2FVCgeRVHEBVbY2GbhB7xK77qBtWbahWyMq6c7uyPWJx6JJ6%2BMXkNMVURq1i0DaARJzCKpEJbED9h7A2vdexlf5%2FH2A61T%2BagYJZ9H9lBfzb9u9z4tOFtlUk58E8Hqf7xAAxImB5S4rVOfgc9qIoSLTl%2FbKhAQIyXI3zPURVLBCywHDKSJ7ZPPj8HqVIh7TQiTDHU6FOXqF9V1O%2FL%2FTvMgP3Da0y9IqMR65hWoqRTqIipVvVKEhmSTILklWSUsWsJxQtFk2ChWxmymV2FavIyRGKjh9jCBuyEpIjxGN8rEKTzE4V3te2pcoUnCzGyVCdLgznCKxJHsMunMaBpEMM67Qkee4QqxRDYgVwwS%2FsyVorhNkhX63DVp7YvCfydNS6Yei5KsNU9VfHIF3dareb%2BuHhQbPtdszmyHpnNl2%2Fe9jBvqEfuu3KS8a2F5Btrxn1IlebphfMcSK0pWrztQWUY8nKVdk%2Fa5By%2Fs%2F3z9tAab6A0vxfoLReQGm9OZS12asjmh3DhjfQ1t2OvuMgeN3I0vOZA8vO11rF6vezXJA%2Fq179lr7qWm6F%2FMZLWj8U6VHaAPg7t%2Bz1gC5fRJb3DXiL2N3I3Y3c3cjdjdzdyN2N3N3IzRsJ37ICz4g3xErW1M1OU%2B82jYNr3bAtwzaNVrd72G2%2F%2B0PXbV1XGIiQWRqe4fu1%2BuWqJeb4G368HN%2FcXMhFJ%2Fkovy3248vBQfi1%2F0Qml0%2BLxOr%2BNW%2Bbf%2FedY235DxyuKUXWFgAA)

## How Has This Been Tested?

- [x] Tested in the Domain Connect Online Editor with both apex (`example.com/@`) and subdomain (`mail.example.com`) hosts.
- [x] Verified the generated DNS records include SES verification TXT, DKIM CNAME, SPF TXT, DMARC TXT, bounce MX, and custom MX records.
- [x] Confirmed the template file name follows the pattern `<providerId>.<serviceId>.json`.
- [x] Confirmed `syncPubKeyDomain` is set and `warnPhishing` is not set.

## Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`
- [x] No TXT record contains SPF content — `SPFM` type is used instead
- [x] `txtConflictMatchingMode` is set on the ownership and DMARC TXT records
- [x] No variable is used as a bare full record value
- [x] No bare variable is used as the full `host` label
- [x] No variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record