### PR TITLE
Add sikkasoft website builder template

### DIFF
--- a/sikkasoft.com.verify.json
+++ b/sikkasoft.com.verify.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "sikkasoft.com",
+  "providerName": "Sikka Website Builder",
+  "serviceId": "verify",
+  "serviceName": "Sikka Website Builder - Domain Verification",
+  "version": 1,
+  "logoUrl": "https://sikkasoft.com/logo.png",
+  "description": "Verifies domain ownership so Sikka can issue an SSL certificate for your website",
+  "variableDescription": "host and value are provided by AWS Certificate Manager and are unique to your domain",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%acmhost%",
+      "pointsTo": "%acmvalue%",
+      "ttl": 300
+    }
+  ]
+}

--- a/sikkasoft.com.verify.json
+++ b/sikkasoft.com.verify.json
@@ -8,6 +8,7 @@
   "description": "Verifies domain ownership so Sikka can issue an SSL certificate for your website",
   "variableDescription": "host and value are provided by AWS Certificate Manager and are unique to your domain",
   "hostRequired": true,
+  "syncRedirectDomain": "sdp.sikkasoft.com",
   "records": [
     {
       "type": "CNAME",

--- a/sikkasoft.com.verify.json
+++ b/sikkasoft.com.verify.json
@@ -7,7 +7,6 @@
   "logoUrl": "https://publicweb-sikka-logo.s3.amazonaws.com/2024-sikka-ai-official-logo-usa.svg",
   "description": "Verifies domain ownership so Sikka can issue an SSL certificate for your website",
   "variableDescription": "host and value are provided by AWS Certificate Manager and are unique to your domain",
-  "hostRequired": true,
   "syncRedirectDomain": "sdp.sikkasoft.com",
   "records": [
     {

--- a/sikkasoft.com.verify.json
+++ b/sikkasoft.com.verify.json
@@ -4,7 +4,7 @@
   "serviceId": "verify",
   "serviceName": "Sikka Website Builder - Domain Verification",
   "version": 1,
-  "logoUrl": "https://sikkasoft.com/logo.png",
+  "logoUrl": "https://publicweb-sikka-logo.s3.amazonaws.com/2024-sikka-ai-official-logo-usa.svg",
   "description": "Verifies domain ownership so Sikka can issue an SSL certificate for your website",
   "variableDescription": "host and value are provided by AWS Certificate Manager and are unique to your domain",
   "hostRequired": true,

--- a/sikkasoft.com.verify.json
+++ b/sikkasoft.com.verify.json
@@ -8,6 +8,7 @@
   "description": "Verifies domain ownership so Sikka can issue an SSL certificate for your website",
   "variableDescription": "host and value are provided by AWS Certificate Manager and are unique to your domain",
   "syncRedirectDomain": "sdp.sikkasoft.com",
+  "syncPubKeyDomain": "sdp.sikkasoft.com",
   "records": [
     {
       "type": "CNAME",

--- a/sikkasoft.com.websitebuilder-www.json
+++ b/sikkasoft.com.websitebuilder-www.json
@@ -1,15 +1,14 @@
 {
   "providerId": "sikkasoft.com",
   "providerName": "Sikka Website Builder",
-  "serviceId": "websitebuilder",
-  "serviceName": "Sikka Website Builder",
+  "serviceId": "websitebuilder-www",
+  "serviceName": "Sikka Website Builder (www)",
   "version": 1,
   "logoUrl": "https://publicweb-sikka-logo.s3.amazonaws.com/2024-sikka-ai-official-logo-usa.svg",
-  "description": "Connects your domain to the website you built with Sikka's website builder",
+  "description": "Connects the www version of your domain to the website you built with Sikka's website builder",
   "variableDescription": "target is the unique CloudFront address for your specific website",
-  "hostRequired": true,
   "syncRedirectDomain": "sdp.sikkasoft.com",
   "records": [
-    { "type": "CNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 }
+    { "type": "CNAME", "host": "www", "pointsTo": "%target%", "ttl": 300 }
   ]
 }

--- a/sikkasoft.com.websitebuilder-www.json
+++ b/sikkasoft.com.websitebuilder-www.json
@@ -8,6 +8,7 @@
   "description": "Connects the www version of your domain to the website you built with Sikka's website builder",
   "variableDescription": "target is the unique CloudFront address for your specific website",
   "syncRedirectDomain": "sdp.sikkasoft.com",
+  "syncPubKeyDomain": "sdp.sikkasoft.com",
   "records": [
     { "type": "CNAME", "host": "www", "pointsTo": "%target%", "ttl": 300 }
   ]

--- a/sikkasoft.com.websitebuilder.json
+++ b/sikkasoft.com.websitebuilder.json
@@ -1,0 +1,15 @@
+{
+  "providerId": "sikkasoft.com",
+  "providerName": "Sikka Website Builder",
+  "serviceId": "websitebuilder",
+  "serviceName": "Sikka Website Builder",
+  "version": 1,
+  "logoUrl": "https://sikkasoft.com/logo.png",
+  "description": "Connects your domain to the website you built with Sikka's website builder",
+  "variableDescription": "target is the unique CloudFront address for your specific website",
+  "hostRequired": true,
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 },
+    { "type": "CNAME", "host": "www", "pointsTo": "%target%", "ttl": 300 }
+  ]
+}

--- a/sikkasoft.com.websitebuilder.json
+++ b/sikkasoft.com.websitebuilder.json
@@ -9,6 +9,7 @@
   "variableDescription": "target is the unique CloudFront address for your specific website",
   "hostRequired": true,
   "syncRedirectDomain": "sdp.sikkasoft.com",
+  "syncPubKeyDomain": "sdp.sikkasoft.com",
   "records": [
     { "type": "CNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 }
   ]

--- a/sikkasoft.com.websitebuilder.json
+++ b/sikkasoft.com.websitebuilder.json
@@ -4,7 +4,7 @@
   "serviceId": "websitebuilder",
   "serviceName": "Sikka Website Builder",
   "version": 1,
-  "logoUrl": "https://sikkasoft.com/logo.png",
+  "logoUrl": "https://publicweb-sikka-logo.s3.amazonaws.com/2024-sikka-ai-official-logo-usa.svg",
   "description": "Connects your domain to the website you built with Sikka's website builder",
   "variableDescription": "target is the unique CloudFront address for your specific website",
   "hostRequired": true,

--- a/sikkasoft.com.websitebuilder.json
+++ b/sikkasoft.com.websitebuilder.json
@@ -8,6 +8,7 @@
   "description": "Connects your domain to the website you built with Sikka's website builder",
   "variableDescription": "target is the unique CloudFront address for your specific website",
   "hostRequired": true,
+  "syncRedirectDomain": "sdp.sikkasoft.com",
   "records": [
     { "type": "CNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 },
     { "type": "CNAME", "host": "www", "pointsTo": "%target%", "ttl": 300 }


### PR DESCRIPTION
# Description

Adds three Domain Connect templates for Sikka Website Builder (`providerId: sikkasoft.com`), letting a dentist connect a domain they already own to the website they built in Sikka's website builder without manual DNS work:

- `sikkasoft.com.verify.json` — publishes the CNAME AWS Certificate Manager needs to issue an SSL certificate for the connected domain.
- `sikkasoft.com.websitebuilder.json` — connects the domain's apex (root) to the CloudFront distribution serving the dentist's site.
- `sikkasoft.com.websitebuilder-www.json` — connects the `www` subdomain to the same CloudFront distribution.

These are split into separate apex/`www` templates (rather than one combined template) because a single template with both an apex CNAME (`hostRequired: true`) and a fixed `www` record produced incorrect duplicated records (`www.www.<domain>`) when applied together — see test notes below.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — set to `sdp.sikkasoft.com` on all three templates; public key published at `_dcpubkeyv1.sdp.sikkasoft.com` (TXT, live)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `sdp.sikkasoft.com` on all three
- [x] no TXT record contains SPF content — templates contain only CNAME records, no TXT records at all
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — no TXT records present, not applicable
- [x] no variable is used as a bare full record value — not applicable, no TXT value records used
- [ ] no bare variable is used as the full `host` label — **exception, justified below**
- [x] no variable is used in the `host` field to create a subdomain — `host` values are either fixed (`@`, `www`) or provided directly by ACM, not user/dentist-chosen
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not applicable; these records are core to the service (removing them breaks the SSL cert or the live site), so none are safely user-removable

**Justification for bare `%acmhost%` in `sikkasoft.com.verify.json`:** the host label here is entirely determined by AWS Certificate Manager at certificate-request time (a random per-request validation string) — there is no fixed, predictable prefix Sikka can hardcode. This mirrors how other ACM/CA-driven domain-verification templates in this repo are structured, since the CA — not the service provider — controls the record name.

## Online Editor test results

**Editor test link(s):**

`sikkasoft.com.verify.json`
- [Test sikkasoft.com/verify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI1Fg2oC%2F91UbW%2FaMBD%2BK5alfoJAApS0kfaBtpPW9WVstOumCkUX21CrSZzZDmmK%2BO87JzDareoPmPjA%2Be6eu%2BfesqZWZEUKVtBoTQutVpILfc5pRI18fASjFrbHVEa7f4zXkKEznTkzuROJkVaQk1KmaEM3I%2FRKMtGEWAktF%2FVe%2BR6UeORMZSBz8t2hJAMrVY5YDGKcFAVdmqqlutUpxniwtjBRv1%2BUSSpZJRKv4es5j54Z9iCDZ5VDZRz7%2FsAfjLYOID21wPAS0sbZKw30zGqJmbgwTMuiyRvRloYwhLe0VJUjkwdZEKNIWwKDnEhjSkFQmM0uCRPattwFWShNalVqUrWFulJAS0hScfYq0YMyFgNwsoLUhdKCbHvNSVKTyd2MnL6IewU5LLFfDuF8y1z%2BQphVbbaWret5nbNvgkstmG0764bKi97fg3WO0zK5EPW7bhhHaW5odL%2Bmti7cIE%2BvJ1cf0eQqwOcBsMyJB25blMytuVFbdVOa01uL0xv6%2Fma%2B6VKckIj3cec4gh0D8QS4l2Kbe5sApaVWZRHLnX8BGjLjdneHvH8Fne%2Bw99TJW4LuGUPCgsGQi8XocLy1NSwb41P9HB4d91DnoVLyZhlNz%2B0TdczlMldaxAb%2FwZYaQVaXokuzMrUyhgr2Ks5iKIq0xkINWjH8vw3M28N4zQmhYMGp32Ozb2mXxpy5Vkh3e2MIj5KQMS9I%2BLE34sz3kkMeeqPDYDwe4S8cBy%2Bu%2Bs2Tf%2FOW97MQxojc4iHhc5JWUBu62cy7OJf%2Fu0JcFgMrwWNwbvhtGXv%2BkReEN0EYDYPoMOz542AQHHd8P%2FJ9x18Y21a6xt15uTX062WZ315MPj3Ozj9Xw5PponP5E778uOqEz%2F3lctox0%2BQiyM786mnygW5%2BAxE%2FMquvBQAA) (apex, Host blank)
- [Test sikkasoft.com/verify example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJlFg2oC%2F%2BVU227aQBD9ldVKeSp2zM2ApT7kVrXKpRdIUzVC1ti7wArb6%2B6ubRzEv3fWJiW0UX6gT6xn5pw5c2NLDU%2FzBAynwZbmSpaCcfWJ0YBqsV6DlgvjxjKlnT%2FOO0gxmE6tmzzwSAvDyXkhEvRhmOaqFDFvKEquxKI%2BGN%2BCEodcyhRERr5blIjBCJkhFkm0fQXdDk3kUt6rBDlWxuQ6OD3NiygRccUjp9Hr2AhX911I4UlmUGmr%2FrTn9Qb7ABCOXCC9gKQJdgoNri6XmIlxHSuRN3kD2srgmrBWlqwyVLISOdGStCXEkBGhdcEJPqbTGxJzZVrtnCykIrUsFKnaQm0poARECb88SrSS2iABIyUklkpxsu81I1FNzh6m5OIF7y1ksMR%2BWYSNLTLxC2FGttlatbbndRZ%2F40woHpu2s3aoLHf%2FHqwN%2FFJE17x%2BMwx5pGKaBo9baurcDvLi7uz2Cl22Avw8gTi1zxO7LVJkRs%2Fk3tyUZu3G4PT6nreb7zoUJ8TDA%2B8cR%2FCsgG8A95Lvc%2B8TVFWFH0slizwUz5AcFKTaru8z%2BPEIPX%2BGPzZ4%2FNzLtJYQorjb6zO%2BGAz9va%2FR2jg39dNoPHHR5qBRsGYltWu3ilr9YplJxUONv2AKhSCjCt6haZEYEUIFBxOLQ8jzpMZyNXqR%2Ft82Zu15HGly25oxNVjXW4oOze3QkMW2I8JeIUCf%2B%2F7Yc0bR0HcG40XfgYnfc7o9YIuYedE4jl7c96vH%2F%2BpVH02Fa80zg1eFlrOkglrT3W7ewQn9F4Xi6mgoOQvBRuL%2Fje94Y6c7mnVHQb8XeBN3OOj63ck7zws8z5bAtWmL3eImvdwhWo2eip%2FDD%2BvVYFx%2BjWaT8%2BuPN33j3deXftZLZ%2FlqUz6sP1fej83Ve7r7DceB0YXDBQAA) (Host=`www`)

`sikkasoft.com.websitebuilder.json` (apex, `hostRequired: true`)
- [Test sikkasoft.com/websitebuilder example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABZGg2oC%2F91U227TQBD9FWslxENj167jNlhCojduhVJ6EYgqiia7Y2ep7XV31zFplH9n1kmatqDyTl6inTlzOWdmPGcWy7oAiyyds1qrqRSoPwiWMiNvbsCozAZclax37zyFksDswrm9bzg20qJ30MiCfAQzqKeSY5eiXXrHT53%2FSDFFbaSqWBr1WKFydaULQk%2BsrU26vV0340JySu13HfoOEZg4gBLuVAWtcf1u74Q7%2FRUApK%2byTHIJRQf2GwOBmeZUSaDhWta2q8YOVVUht8abqUZ7QpUgK88qz07QW1FxLs%2FxsV4r7cTrKLw09%2B4N1SloCeMCjx6VsKBztJ40XdKmkrcNeoeFasRbrSrrgRAajfEypZddmBq5pObXFSjzRBl7jreN1EgiW90gCTur%2BDkKMnF71DXuJijq4OkUHfCsGZ%2Fg7FkY5VFaGJZez5md1W5ah6f7n49X5en5xq2EkpU1l4qeL5bMXpDVWhpXHIaL4aLHaCQ42mQbkubruvgLaPVwVXGVtm1beuRaNfVIrkNq0FAat6Hr4OtH0cN1%2BHUXT89lN84gou4HYy4wGwTcaZ05rYOKAK5FmVdK48jQP9hG41rTsimsHEELG5PgI6jrYkaMDHkp%2F5%2F6VMvlXhIRYIEezzexkazHRoI7ntKdT5gNOIQZ95N%2BX%2Fh9Abv%2BK4jAF9EgwUGym2RJ9uAw%2F3q1z57jI81p7bCydCRk2S9amBm2WAx7pP%2F%2FzpH2xcAUxQgckr4cu3448KO9y2gvjftp1A%2FiMI6SeCsM0zB0VNDYJes57c%2FDzWE7Sb7%2Fs4ru2vzi4Gu5dXL1%2Fp3Zspn98in60U75R%2Fk9O5vUx7OTOH%2FNFr8BJkCcJ38FAAA%3D) (Host=`www` — `hostRequired: true` exempts this template from a separate apex test)

`sikkasoft.com.websitebuilder-www.json` (fixed `www` record)
- [Test sikkasoft.com/websitebuilder-www example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALdJg2oC%2F91Ua0%2FbMBT9K5YltE00wemTRNoHBntpgvEUDFRVTnzTGpI4s51mXdX%2FvuukpbBN7PvyJbHv8b3nnHudJbWQlxm3QKMlLbWaSwH6s6ARNfLhgRuVWj9ROe08Bk94jmB64cLkGmIjLZB3lcwwhjADei4TaFLUbTRug15d11vAS2nIa4S%2BQewctJGqoFHQoZmaqiud4ZmZtaWJ9vbKKs5kgkW8hqvnEL7p%2BTznP1XBa%2BOY73VZt78GcOmpNJWJ5FkD9irDfTOfYiUBJtGytE01eqiKAhJriJ0BQS5kTYSolCxUpYlQOZcFsapFrOljiDixltTSzkij7ZV5DMePJs25ljzO4OhZVcv1FCyRbdmqkN8rIIeZqsQHrQpLuBAajCGp0i0LU0IiUc%2BmgnN3USTnIKRG%2BkcNSddKUfq%2Ft9MBT6v4CyxehGEepYWh0d2S2kXpWnZ4cnD8HkMzZaxrctPVUsnCmkuFGzutjh3ctRb71WNsNV51KPYEJtt8YzR9Uxl%2BcJxCWNdcJ8avqVZVOZEbfMk1z42b1M3Ju2dHx5uzd9R9tzzcSgTNw%2BNEQLrvJ87T1HnqFwhw5OS0UBomBt%2FcVhp1Wl1Bh%2BZVZuWE13y7JZIJL8tsgVoMRjH%2Fn94U7XS33ghuOS5eJrE1q0MnInEipbtDIRvus%2BFo4Il%2B2vX6LIi9EHqBx%2FrAknAoIBimT27nX6%2FuP%2B%2Fk1nGcLygsXhBcHmQ1Xxi6Wo076P5%2FLxInxvA5iAl3MPxtDD227wWjy2AU9cOo3%2FMHbNQbBLuMRYw5LWBsK3uJE%2FR0duj99XV8c3PGk7MMjuH%2B2%2BL84by3%2B%2FE23L04VZ%2FCU3bbz7tXMfsanr2lq19DDB0AhgUAAA%3D%3D) (apex, Host blank)
- [Test sikkasoft.com/websitebuilder-www example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJVNg2oC%2F%2BVUbW%2FTMBD%2BK5alCRBNlnRLaCPxYesYmsoGYhsbTFXl2JfWLI2D7TQrVf8756RdV0DjB5AvUe6eu3uee8mSWpiVObNAkyUttZpLAfpM0IQaeX%2FPjMqsz9WMdh6dF2yGYHrp3OQGUiMtkONK5uhDmAE9lxyaFHXrTVunV9f1FvBcGvISoa8QOwdtpCpoEnZoribqWucYM7W2NMn%2BflmlueRYxGu4eg7hmwOfzdhPVbDaOOb73aB7uAYw6aksk1yyvAF7lWG%2BmU%2BwkgDDtSxtU40OVFEAt4bYKRDkQtZEiMrIQlWaCDVjsiBWtYg1fXQRJ9aSWtopabS9MI%2Fu9LFJc6YlS3M42alqmZ6AJbItWxXyRwVkkKtKnGpVWMKE0GAMyZRuWZgSuEQ9mwquu4uCfwYhNdI%2FaUi6UYrS%2F32cDvipSoeweBaGeZQWhiZ3S2oXpRvZ4OLo%2FB26pspYN%2BRmqqWShTVXCg17rY49tFqL8zoIgtVo1aE4Exhv842w6ZvK8MBwC2FdcyfxRKuqHMtNSMk0mxm3rJvgu53o0Sb8ronHz5aNM4iweVjKBWQ9n7vOZq6zfoEAR1FOCqVhbPDNbKVRrdUVdOisyq0cs5ptTYKPWVnmC1Rk0Iv5%2F%2BxQ0e44EvFbMYJZhobniWzb1qFjwZ1W6a4pDqAHgMvMIp56h2HU93pxFHvRYdDncdzFfNGTO%2F3rEf%2FzOnd6j8sGhcVrQctRXrOFoavVqINz%2BF%2B04v4YNgcxZg6Jv5LYC3pe%2BOYq7CVBnIQHftztRlH%2FdRAkQeDkgLGt8iXu09NNoqG4PbsJP5wMh5fHD7FeXPH3H%2FuD3vmNOL%2Fu3n65%2BP6t4Kdfj2N5a97S1S%2BSM917mgUAAA%3D%3D) (Host=`www`; Online Editor preview shows a doubled `www.www.dochyre.com` — known tool rendering quirk, not a real application issue)