### PR TITLE
Create 1bw.app.business-hub.json

### DIFF
--- a/1bw.app.business-hub.json
+++ b/1bw.app.business-hub.json
@@ -1,0 +1,1 @@
+{"providerId": "1bw.app", "providerName": "1BusinessWorld", "serviceId": "business-hub", "serviceName": "Business Hub website", "version": 1, "description": "Points a hostname at the member's 1BusinessWorld Business Hub.", "syncPubKeyDomain": "dck.1bw.app", "hostRequired": true, "records": [{"type": "CNAME", "host": "@", "pointsTo": "domains.1bw.app", "ttl": 3600}]}


### PR DESCRIPTION
# Description

New template for 1BusinessWorld (providerId `1bw.app`). The Business Hub service gives member businesses a hosted website; this template connects the member's own hostname (e.g. `www.example.com`) to it with a single CNAME pointing at `domains.1bw.app`. `hostRequired` is `true` — the service is connected on a subdomain (typically `www`), never at the zone apex.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — note: this template has no `logoUrl`, so there is no resource URL to serve

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `dck.1bw.app`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — note: the sync flow is used without `redirect_uri`, so no `syncRedirectDomain` is needed
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — note: no TXT records in this template
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — note: no TXT records
- [x] no variable is used as a bare full record value — note: this template has no variables
- [x] no bare variable is used as the full `host` label — note: no variables
- [x] no variable is used in the `host` field to create a subdomain — note: no variables
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — note: the single CNAME is the service itself; removing it means disconnecting the service, so it is not independently user-modifiable

## Online Editor test results

**Editor test link(s):**
[Test 1bw.app/business-hub 1businessworld.biz/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGbbgGoC%2F91S227bMAz9FUMve5gdyJelroEBS5fugm1ZURQogiAwZIlthNmSJ8lxkyD%2FPsmx53Qb%2BgF7skmKh%2BeQ54AMVHVJDKDsgGolt5yB%2BsxQhsKinZC6Rv7v9IJU4ApXjeYCtL6XqmS2rkFtOYWuq%2BhrwaYpxlLfOTR6n5rCa6HQ3M710RaU5lKgLPQRA00Vr00XoxvJhdEe8TZSG2FBPGI8swGvgqoA9Up7z8l45xMmbv5O0Jum%2BAK7uawId5iM%2FpiM2hzwLfxsuAJL36gGfKSASsU0ylYHZHa1Y%2F5%2BMft23T%2B34Tu3lY7bnXSQHbY%2BgzWmRFk8xfi4PvpoLwXkI%2Bra7zu6LfeMW8d%2FUvD9OKVtWxs8KtnUOR86a6JIpd21BozVv0DWA8qqg3Es%2BKOQCnJtv8Q0Cga5VVManpOWjClGc6uj3FnS2lYtyt%2BrEKebnkgyYsjLi%2FBRzqijzTubPKTpNH6YBhAl0yBJYhoUl8z%2BkSQklxfxRQTxmfP%2BMOQLhnu2OpsGYTixFNCsbMlOo%2BNx7ds1%2Fkdy7KU12QLLiXsZ4Wga4DQI39xFYRYnWYwnaYrDMHmNcYax0wDanAQerCvO%2FYDuZ7WQ8zn7gMtkkVR4uaTf04%2BRYQI%2FheTq9useL0ujr5Whb9HxF76%2Bq1E9BAAA)

Note: `hostRequired` is `true`, so per the stated exception the apex test is not required; the test above applies the template with host `www`.