### PR TITLE
Add insg.io.analytics template

### DIFF
--- a/insg.io.analytics.json
+++ b/insg.io.analytics.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "insg.io",
+  "providerName": "INSG",
+  "serviceId": "analytics",
+  "serviceName": "INSG Analytics",
+  "version": 1,
+  "logoUrl": "https://insg.io/favicon.svg",
+  "description": "Serve INSG analytics from your own subdomain so it is not blocked as third-party tracking.",
+  "syncPubKeyDomain": "insg.io",
+  "syncRedirectDomain": "insg.io",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "proxy.sbda.io",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `insg.io.analytics.json`, a new template for INSG (https://insg.io), a privacy-focused analytics service.

Customers point a subdomain of their own domain (e.g. `stats.example.com`) at our endpoint so the analytics requests are first-party rather than third-party. The template creates a single CNAME to `proxy.sbda.io`, which terminates the custom hostname and issues its certificate. Today customers have to copy this record into their DNS control panel by hand.

The template has no variables: the target is a constant, and the subdomain is carried by the protocol's own `host` parameter. Apply requests are signed (`syncPubKeyDomain: insg.io`); the public key is already published as TXT records at `_dcpubkeyv1.insg.io`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checks that are vacuous here, so they are not mistaken for oversights: the template contains exactly one CNAME and no TXT records, so the SPF, `txtConflictMatchingMode` and DMARC/`essential` items do not apply. There are no variables at all, so the two variable-scoping items and the `%host%` item cannot be violated. The subdomain is supplied through the protocol's `host` parameter; the record's own host is `@`, and `hostRequired` is `true` because this service is only meaningful on a subdomain.

## Online Editor test results

Tested with a subdomain (`example.com` / host `stats`), which produced the expected single record:

```
stats.example.com.  CNAME  3600  proxy.sbda.io
```

Per the PR template, an apex test is not required because `hostRequired` is `true`.

**Editor test link(s):**
[Test insg.io/analytics example.com/stats](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKUdgWoC%2F91S227bMAz9FUGvi1PFbZPUwIAF69b1smJIsvYhCAxZkh0ttuRKdFovyL%2BPTuMm7S4fsCdb5OEheXjWFFRR5hwUjda0dHalpXKXkkZUG591taWdl%2FAtLxBGL28nFxj1yq20UFssNzyvQQu%2Fjx%2BAyeggvVLOa2to1OvQ3Gb2u8sRtgAofXR0tGt6lHLksKbrVxnWSOWF0yVs6%2BgEGyiyJX7pS1JnC1LbyhH7aIivEmkLrvHPEg1Ee2IskCS3Yqkk4Z7AQjsZlNxBTcBxsdQm6zbT10Z8q5JrVZ9vCV4J0STHSmqnBPwhvbAexuqhwjyKAq5SHYpQ66Sn0WxNoS4bST7ejr5%2B2sHx%2BaFR2GoDfmrxiWI%2F1V2fSP5MCoD6HPcZ28w3HfrTGhXvOeeoTTuHeuJ4SdUVttiTe%2BDQqJ45W5Wxbotwb1745uRt%2BexV%2FbwlmO0Ymt46M9ap2OOXQ%2BVUu2JR5aBj%2Fsj3ISliXpZ5jaN6zCLP7%2BubZ4O0E0oO%2FF%2Frd2gsRTOxbgw3TAcJC3kYMHGqgpPeSRokiRgELA0TNjw7FlIMD5z7xtB%2Fs%2B4b0ZT3yoDmjUFH%2BSOvPd1s5h0U8P%2FZBi%2Ft%2BUrJmDfYkIX9gA2DXn%2FKwqg3iNhZdxCesJC9YyxirFlBeXjebo2eOHQDvc7u7%2FUpu7ob%2Fgino4ebSWGq8fmXz%2Ffp1d3yxl1djGGwuMgYWu893fwC3024fnsEAAA%3D)
