### PR TITLE
Add EstateFunnel website template

### DIFF
--- a/estatefunnel.com.website.json
+++ b/estatefunnel.com.website.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "estatefunnel.com",
+  "providerName": "EstateFunnel",
+  "serviceId": "website",
+  "serviceName": "EstateFunnel Website",
+  "version": 1,
+  "description": "Connects a domain to an EstateFunnel website without changing its nameservers or unrelated DNS records.",
+  "syncPubKeyDomain": "estatefunnel.com",
+  "syncRedirectDomain": "server.estatefunnel.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "35.203.0.42",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new EstateFunnel website template that connects a customer domain without changing its nameservers or unrelated DNS records.

The template points the requested domain to `35.203.0.42` and creates a `www` CNAME pointing to the domain apex.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A — this template does not define `logoUrl`)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (N/A — this template contains no TXT records)
- [x] no variable is used as a bare full record value (N/A — this template contains no variables)
- [x] no bare variable is used as the full `host` label (N/A — this template contains no variables)
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (N/A — both records are required to provide the connected website)

## Online Editor test results

**Editor test link(s):**

- [Test estatefunnel.com/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJobgWoC%2F%2B1T227iMBD9FcuvhMgEyiXSSq160VbdZWmLVO0iFJl4ALfBTm2HlEX8%2B465I9H3PuxTnPE5M2fOjJfUwSzPuAMaL2lu9FwKMPeCxhSsw%2FC4UAqyMNUzGuzvu3yGeHq7RtytEXhrwcxlCmtyCSMrMek%2BeoZCXvagORgrtaJxLaACbGpk7tb%2F9FojNHWWcCL0jEtFnCZckZNE22qklG6qC0fSKVcTqSZEIlFhZS8CSxBtSKEM%2BH4Fuek%2BEwOpNsKGXuhCpb1i9ACLm3Wh8xZ41BMIiUS3x23Sh2fg2%2Fw0HiypW%2BTegisMT7V1eLz0nmqpnO1r%2FK1fhBGrhyxsRHjhXEbjOmOrYE%2B97l79vD3Qy7I8TXB5TBuuAvpXK0gOGobo7r63D46Dh63ObUY8TYwu8kTu8Dk3fGb9cuyYgxPqcMcdUOoryonSBhKLX%2B4Kg6qdKSCgsyJzMuElP4REmvA8zxYo0OItpjg1SW1WxjcluOOfGhTQRKReoVyvLb9grCY6VYiAVxvtSFTbrAXViEVt3u5EYlQfH63yZ6t%2BfpkPNoG1oJzkmReblXxh6erMpLY9bCa17eLU%2Ba%2FXxTDAwf8fxZcYBT4vy%2BcgEu5hWLJZZe1qrdlnUczacdQMO60Wq9crjMWM%2BR6w9Ka5Jb7G43dIxw%2Bv7FfDSJnBS5H9yN%2FGld9PI3i%2B6%2FE%2F3crHa9Z7%2B%2F7%2B3n90i%2FtvdPUP7AFK1hoGAAA%3D)
- [Test estatefunnel.com/website example.com/homes](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD4cgWoC%2F%2B1TXW%2FaMBT9K5ZfCZkTKKBIk1r1c6oG04ZUbQhFJr6A1cTObIdAEf991xQoVPS9D3tKfH3Oued%2BeE0dFGXOHdBkTUujF1KA%2BSZoQsE6DE8rpSAPM13Q4HDf5wXi6e0WcbdF4K0Fs5AZbMk1TKxE0UP0DIU8HUALMFZqRZMooAJsZmTptmd6rRGaOUs4EbrgUhGnCVfkRGiXjdTSzXXlSDbnaibVjEgkKszsTWAKog2plAFfryA3%2FV%2FEQKaNsKE3ulLZj2ryCKubbaLzLfConyAkEt0B9yofnoHv9GkyWlO3Kn0LrjA819bh76XvqZbK2aHGY%2BsijFkrZGE7xgvncpq0GNsEB%2Bp1%2F%2Br77Ru9rutTgctj2ngT0BetIH3zMMbuHmpbchw87HzuFOcae4XHmdFVmco9qeSGF9ZvyJ4%2BOuGP9wKjnYLPLWdKG0gtfrmrDPp3poKAFlXuZMpr%2FhYSWcrLMl%2BhVYu3qHPaLvW6PHt3gjv%2BYbsCmorMW5V%2BDycX0TTqRd1mC7JWs83anWavI9pNyLpZFE%2FEFOLu0WJ%2FtPjnV%2Ftd08BaUE7y3LvOa76ydHNmeLticHjhu4K2x%2FB0MJ%2B0rHGAe%2FF%2FSJ98SPguLV%2BASLnHxizuNFmvGXWGLE6iKIlY2Gn30FiDsYQxXwjmf61zjS%2F4%2BO1S8%2FKs7PL38%2BB%2BMnD56rrzUKjG%2FV39Z%2FE4fHgC%2BDK9G%2F7ljUG1rL%2FSzT9MzWbdWAYAAA%3D%3D)