### PR TITLE
Create azbrand.ca.web.json for AZBrand hosting

### DIFF
--- a/azbrand.ca.web.json
+++ b/azbrand.ca.web.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "azbrand.ca",
+  "providerName": "AZBrand",
+  "serviceId": "web",
+  "serviceName": "AZBrand website hosting",
+  "version": 1,
+  "logoUrl": "https://azbrand.ca/logo2.webp",
+  "description": "Connect your custom domain to your AZBrand website.",
+  "syncPubKeyDomain": "azbrand.ca",
+  "syncRedirectDomain": "azbrand.ca",
+  "variableDescription": "txt_token: Cloudflare custom hostname verification token",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "cname",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "edge.azbrand.ca",
+      "ttl": 300
+    },
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%txt_token%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
New template for AZBrand (azbrand.ca) website hosting. Automatically configures customer custom domains (CNAME -> edge.azbrand.ca) and Cloudflare for SaaS verification (TXT _cf-custom-hostname -> %txt_token%).

Public signing key is published in DNS at `_dcpubkey.azbrand.ca`.

## Type of change
- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

## How Has This Been Tested?
- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern <providerId>.<serviceId>.json
- [x] resource URL provided with logoUrl is actually served by a webserver

## Checklist of common problems
- [x] syncPubKeyDomain is set — this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] warnPhishing is not set alongside syncPubKeyDomain — the two must not appear together
- [x] syncRedirectDomain is set whenever the template uses redirect_uri in the synchronous flow
- [x] no TXT record contains SPF content ("v=spf1 ...") — use the SPFM record type instead
- [x] txtConflictMatchingMode is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. @ TXT "%foo%") unless necessary — prefer @ TXT "service-foo=%foo%"; if bare, justify in the PR description
- [x] no bare variable is used as the full host label — the non-variable parts are fixed to limit misuse (e.g. %dkimkey%._domainkey, not %dkimhost%); if bare, justify in the PR description
- [x] no variable is used in the host field to create a subdomain — use the host parameter or multiInstance instead
- [x] %host% does not appear explicitly in any host attribute
- [x] essential is set to OnApply on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results
Editor test link(s):
[PASTE COPY MARKDOWN LINK HERE]