### PR TITLE
Add AZBrand website hosting configuration

### DIFF
--- a/azbrand.ca.web.json
+++ b/azbrand.ca.web.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "azbrand.ca",
+  "providerName": "AZBrand",
+  "serviceId": "web",
+  "serviceName": "AZBrand website hosting",
+  "version": 1,
+  "logoUrl": "https://azbrand.ca/logo2.webp",
+  "description": "Connect your custom domain to your AZBrand website.",
+  "syncPubKeyDomain": "azbrand.ca",
+  "syncRedirectDomain": "azbrand.ca",
+  "variableDescription": "txt_token: Cloudflare custom hostname verification token",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "cname",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "edge.azbrand.ca",
+      "ttl": 300
+    },
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%txt_token%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
New template for AZBrand (azbrand.ca) website hosting. Automatically configures customer custom domains (CNAME -> edge.azbrand.ca) and Cloudflare for SaaS verification (TXT _cf-custom-hostname -> %txt_token%).

Public signing key is published in DNS at `_dcpubkey.azbrand.ca`.

## Type of change
- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

## How Has This Been Tested?
- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern <providerId>.<serviceId>.json
- [x] resource URL provided with logoUrl is actually served by a webserver

## Checklist of common problems
- [x] syncPubKeyDomain is set — this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] warnPhishing is not set alongside syncPubKeyDomain — the two must not appear together
- [x] syncRedirectDomain is set whenever the template uses redirect_uri in the synchronous flow
- [x] no TXT record contains SPF content ("v=spf1 ...") — use the SPFM record type instead
- [x] txtConflictMatchingMode is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. @ TXT "%foo%") unless necessary — prefer @ TXT "service-foo=%foo%"; if bare, justify in the PR description
- [x] no bare variable is used as the full host label — the non-variable parts are fixed to limit misuse (e.g. %dkimkey%._domainkey, not %dkimhost%); if bare, justify in the PR description
- [x] no variable is used in the host field to create a subdomain — use the host parameter or multiInstance instead
- [x] %host% does not appear explicitly in any host attribute
- [x] essential is set to OnApply on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results
Editor test link(s):
[Test azbrand.ca/web example.com/demo](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF0kgWoC%2F%2B1T226bQBD9FbRSngIOJgmxkSo1lz5UbS6N3KpNZKFld7BXAZbsLk6w5X%2FvLDbBJOl7HvqEmMvZc%2BbMrIiBvMyoARKtSKnkQnBQXzmJCF0mihZ8wChxXzJXNMdKcnp3ZnOY0KAWgkHT8QRJF%2BlXOpjTwoAzl9qIYoZ1C1BayIJEQ5dkciZ%2Fqgzr58aUOjo46F4%2FsMlggAAldnHQTInSNJ3kXBYFMOPUslIOq7SRucNlTkXhGLmJviIwsAzrgt1UyTeoL5ra12Jt%2Fha4UAj9fsWCKkGTDC56bMyziY18gCJyzjNZ8TSjClpaVniBM3FQt0gFo7bJacq3T55lkj2QKKWZBpfY%2Blt4rJAFztaoCmNISCquSXS%2FIjMlq7IZO7OwiGHq0k78%2FOr08gvZAODvZ%2BueFIXRE4m%2FwGcw6GkxBud%2B6Ptrdxd0l2WHPfk96ZBjlnobcV4rzhpEDcXk3ssw9nbecO2M0LQ0E8xcUsPmuAuXkjebkmVkPV27ZCkLiDupU8RsTYBnitsKAybzjgeHXOJfwz0WbU9JFc213eq2%2B77XPm377zcAU7fzzwaJpSJmhVQQa%2FxSUylojcirzIiYPtEuxFlMyzKrkbnGLEKgSa8sKTY3sSW8ndS%2FHXFJzJlVIKwjY5aw4SGMPDoOE%2B8oDHwvOR6BFw5pkAY89NNwvHOpb2%2F47an2BwhaQ2EEzRoznmitydouRc%2F7rYR3vB%2F0ZX0wHVMXl%2BK%2FIx%2FJEbw4TRfAY2pLAz8IPX%2FkDcOJH0RHx9HReHByPAoPT%2FZ9P%2FJ9yx602WhZ4W3uXiX5Q5ORrwN2d1vdXN%2FN61myDE7Fj2VyXZpS5WJ%2FEjzu55X%2B%2Fkt%2FIuu%2Fjv6Qy%2FYGAAA%3D)