### PR TITLE
Add corpusrank.com.gsc-verify template

### DIFF
--- a/corpusrank.com.gsc-verify.json
+++ b/corpusrank.com.gsc-verify.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "corpusrank.com",
+  "providerName": "CorpusRank",
+  "serviceId": "gsc-verify",
+  "serviceName": "CorpusRank Search Console Verification",
+  "version": 1,
+  "logoUrl": "https://www.corpusrank.com/logo.svg",
+  "description": "Adds the Google Search Console DNS verification record so CorpusRank can read Search Console data for this domain.",
+  "variableDescription": "%token%: the Google Search Console verification token issued for this domain and Google account (the value after 'google-site-verification=')",
+  "syncPubKeyDomain": "dc-keys.corpusrank.com",
+  "syncRedirectDomain": "corpusrank.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "ttl": 600,
+      "data": "google-site-verification=%token%",
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `corpusrank.com.gsc-verify.json` — Google Search Console domain-ownership
verification for CorpusRank.

CorpusRank is an SEO/GEO analytics product that reads a customer's Search Console
data. Setting that up requires proving domain ownership to Google, which today
means the customer copying a TXT record into their DNS by hand. This template lets
their DNS provider write it instead.

One TXT record at the apex, carrying the verification token Google issues per
domain and per Google account.

The signing key is already published — reviewers can verify it:

```
dig +short TXT _dcpubkeyv1.dc-keys.corpusrank.com
```

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Note on `txtConflictMatchingMode`

Set explicitly to `"None"`, which is deliberate rather than an oversight.

Google supports **multiple simultaneous verified owners** on one domain, each with
its own `google-site-verification=` TXT record at the apex. A `Prefix` match on
`google-site-verification=` would let this template remove the records belonging to
other owners — another agency, another tool, or the customer's own second Google
account — silently revoking their Search Console access.

So this record is explicitly one that must **not** be unique per content prefix, and
`"None"` is the safe value. Duplicate applications of this template are handled on
our side instead: we issue one token per (domain, Google account) and reuse it, so
re-applying writes the identical record rather than a second one.

### Note on `essential`

Set to `OnApply`. A customer who stops using CorpusRank should be able to delete the
verification record themselves without a provider treating it as a template conflict.
Losing the record simply un-verifies the property at Google, which our own daily
ownership check detects and reports back to the customer.

## Online Editor test results

**Editor test link(s):**

- Apex: [Test corpusrank.com/gsc-verify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACubgWoC%2F%2BVUa2%2FaMBT9K5GlqZtKIIHyilRppbC2Y7CqpRVdhZCxncQi2JnthDLEf981LQX62LTP%2BxTH95x7j8%2B99hIZNksTbBgKlihVMueUqQuKAkSkSjOtsJgWiZyhwnO0j2eARqfr%2BBXEIaaZyjlha2KkiZszxcPFNvCK41wzrEjsnEqhZcKcW0vgBBsuBdCAr%2B0q8AsokZG8UQnQY2NSHZRK8%2Fm8uC%2BvZEFFnUfApUwTxdN1pgCdUKodEzPnTMoICr2o2%2B5fO%2FlObUcxyEwdLZ0dsQTbAKYv2RQb7IRSQQGuHSpnmIuilY8Vx5OEtfekfDByysSH4A9y9qSs4Q7XOmP0ZRUHC7rJgQmRmTDOR5s3x0kGW6FhyjmI1gBXc8Pc3dTHB59sbxaCXGaTLlu01zlBIiXulC108VXzLfaKUQ72mGf0m6hWIskUBSFONCugRzs1Cu6XyCxSOwSD4QCgsdQGfj7D0hhobs3zoHXgp52g92Q%2FOWg5DwY8CxNOTA8bEnMR9SS16ftSMAAwrZkwHNu5%2BS5O0jRZoNVoVUC%2FID7eyhpB1c152AOGy8CeDvOkEFaRklk65ht8ihWeaXthNsz7Pepow71Hdr3WbH86w%2FlwMDlt3p3EvX7tS%2BjH1SzuDMOWe3eUp2FT3X6dddyfsta9QFYpj4RUbKzhi02m4HBGZeDpLEsMH%2BM53m5RMsb2iHAwDVGo9tJv8XgDrd9%2Fc%2FlfdO52b0yJNYXbR8Cre7jJKlW3QXHoHpXZxG0268zFzWrNI5UK9Sbezpvy9ovz7quybc2bbV6NCtCn%2F9sBGDyNc0bH2OLKXrnmeg3Xrw18P%2FDLwVGl6Deqdb986HmBZ4UYps2jL0uYvd2pQ98uz3pSLERaj4f6XLCOpO1eq9sfqB%2BeadVKh3EDn%2FtJ3r29OUar3wgyg3lUBgAA)
- Subdomain (`host=shop`): [Test corpusrank.com/gsc-verify example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF6bgWoC%2F%2B1UbW%2FaMBD%2BK5GlqptGaMJbIVKltaXtaAebWtbSVQgdtkM8QpzZTihD%2FPedKbTQl037vk%2BJfffcPffc%2BebE8Ekag%2BEkmJNUyVwwrlqMBIRKlWZaQTIuUjkhhUdrByboTY6X9ku0o01zlQvKl8CRpm7OlQhnT4YXGOeKg6KRcywTLWPuXFuAoGCETBCGeG3%2FAr9AYjmS31SM8MiYVAd7e9PptLhNb886FXU%2BQizjmiqRLiMF5JAx7ZiIO2dSjjDRs7zNzpWTb%2BR2FMfIzNHS2SBLwRqAPUczMOCEUmECoR0mJyCSoqUPSsAw5s0tKjtGjnmyE%2FyBzhaVpbsjtM44e57FgYStYwClMkuM887GzSHO8Co0XDm7o6WDq4Xh7mbog933tjezhH7Nhhd81lzGRIqMumM%2B08UXzbe%2Bl5wJlMc8er%2FqdRRLOiZBCLHmBfIgpybB3ZyYWWqHoNvromsktcHDR%2Fw1Bptb8zxsHeppJ%2Bgt2isFLebeoGZhLKhpg6GRSEZtyWz4jkw4OnCteWIE2Ln5khymaTwji%2F6iQH6hffBEq49Z1%2FXwe8DHwFfFrBjqSKZ4GimZpQOxxqSgYKLto1mj77bg%2FTX%2B7iEAnpfc7cVJb9rrDo8bt4dRu1M7Df2omkUnvfDIva3kadhQ1%2BeTE%2FenrF20iGUsRolUfKDxCyZTWKRRGWo7yWIjBjCFpytGB2BLxQI1WjHbc92Th5e4qupvgv8L1c1GDhi12gi7D8qVeqVK97kLPgzdCmUld1iuDd06lLwGZ8zzS%2FWN9fL68nlzwWx36dWuL%2FoFbNl%2FIVAIHEMNOWcDsL4lr1Rzvbrr17q%2BH%2FjloFwp%2BtXKvl%2F64HmB59lKuDYP2sxxEjdnkNyf3fSg9LlxAd99P2xXm5%2FoPrByNb%2BBWevHlUiGrdPz6rh0EtIDsvgN%2FTtszGoGAAA%3D)

Both were run against the exact file in this PR. Apex yields
`example.com. TXT 600 "google-site-verification=<token>"`; with `host=shop` the
protocol appends the label on its own, yielding `shop.example.com.` — the template
contains no `%host%`.

Also linted clean with [`dc-template-linter`](https://github.com/Domain-Connect/dc-template-linter)
(no findings; the `-cloudflare` profile reports only the informational
`syncRedirectDomain` / `txtConflictMatchingMode` / `essential` unsupported notes,
which are provider capability limits rather than template defects).
