### PR TITLE
Add blogdat.ai.custom-domain template

### DIFF
--- a/blogdat.ai.custom-domain.json
+++ b/blogdat.ai.custom-domain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "blogdat.ai",
+  "providerName": "Blogdat",
+  "serviceId": "custom-domain",
+  "serviceName": "Blog custom domain",
+  "version": 1,
+  "logoUrl": "https://blogdat.ai/images/blogdat_logo_2_light.png",
+  "description": "Points your blog subdomain to Blogdat with a CNAME (DNS only / grey cloud).",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "blogdat.ai",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "blogs.blogdat.ai",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Blogdat (`providerId` `blogdat.ai`). Customers connect a blog hostname (e.g. `blog.example.com`) with a single CNAME pointing at `blogs.blogdat.ai`. `hostRequired` is `true` — the service is connected on a subdomain, never at the zone apex. Sync pubkey TXT is already published at `_dcpubkeyv1.blogdat.ai`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — `blogdat.ai`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — note: Cloudflare requires signed apply URLs and ignores `syncRedirectDomain`; redirects are signed, so this field is omitted
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — note: no TXT records in this template
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — note: no TXT records
- [x] no variable is used as a bare full record value — note: this template has no variables
- [x] no bare variable is used as the full `host` label — note: no variables
- [x] no variable is used in the `host` field to create a subdomain — note: no variables
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — note: the single CNAME is the service itself; removing it means disconnecting the service, so it is not independently user-modifiable

## Online Editor test results

**Editor test link(s):**
[Test blogdat.ai/custom-domain example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB%2BjgWoC%2F91S0W7aMBT9FctPm0jABJpCpEkrbSdNEwitVJqEUGTs2%2BCRxJntQAPi32cTUmCVtvc9Wfa959x7js8eG8iKlBrA0R4XSm4EB%2FWV4wgvU5lwatpUYO%2BtMqGZ7cSjumYLGtRGMDgiWKmNzHwuMyryc%2B0Cg%2BoW9NayAaWFzHHU9bCty2eV2taVMYWOOp3zCh2R0QR08xK73jiIU5GsTLvIE0vFQTMlCnOkw1MpcqNRJUuFHAjpcllPRUai0%2F5oK8wKUXQ%2FuRs%2Fog8Pkyck87RCHZQoqBBLZck%2Ftp2SKmcWw9Y4eqGpBg%2BvpDbf4VcpFFjpRpVQd03L5TeoHmp9f5iogEnFNY7me2yqwplynIxrOnv97Kw%2Bbj6TJ7RuX3EYYw3qhYQcFgcP72QO8Zl2YV1oJsMrtR8LbSazM7%2BjsrdEybKIRYMpqKKZdgFo0PMr%2BKLBz2sCN1kkuVQQa3tSUypoPMjK1IiYbun5ibOYFkVa2UW1rVqa9%2FrzOiOn%2Faxa%2Bg%2F5Ho45cysLl7ygB7zPbkKfhUPm90nI%2FOEQuP9CevS237%2FtD4LgIsXv8%2F23GF97B1pDbgR1Ob1Lt7TS%2BHBYeNbH%2F0%2BV%2FXhNN8Bj6loDEoQ%2BGfjdcNbtRv0w6g3bg2GPBN0WIREhTghoU8vc24xcpgOPWyMl1utJp9qV0x%2Fmkdw8G27hZfGFzChpqZ%2BT2Wy0e7qfjD%2Fhw28xfP1jmAQAAA%3D%3D)

Note: `hostRequired` is `true`, so per the stated exception the apex test is not required; the test above applies the template with host `blog`.