### PR TITLE
Add agentmail.to hosted-email template

### DIFF
--- a/agentmail.to.hosted-email.json
+++ b/agentmail.to.hosted-email.json
@@ -22,8 +22,8 @@
       "groupId": "a",
       "type": "MX",
       "host": "mail",
-      "pointsTo": "%mxtarget2%",
-      "priority": "%mxpriority2%",
+      "pointsTo": "%mxtargetmail%",
+      "priority": "%mxprioritymail%",
       "ttl": 3600
     },
     {

--- a/agentmail.to.hosted-email.json
+++ b/agentmail.to.hosted-email.json
@@ -4,11 +4,10 @@
   "serviceId": "hosted-email",
   "serviceName": "Hosted Email",
   "version": 1,
-  "logoUrl": "https://agentmail.to/favicon.ico",
+  "logoUrl": "https://www.agentmail.to/favicon.ico",
   "description": "Sets up the MX, SPF, DKIM, and DMARC records required to receive and send email for your domain through AgentMail hosted email.",
-  "syncBlock": false,
-  "sharedProviderName": false,
-  "warnPhishing": true,
+  "syncPubKeyDomain": "inboxtopia.com",
+  "syncRedirectDomain": "inboxtopia.com",
   "hostRequired": false,
   "records": [
     {
@@ -22,7 +21,7 @@
     {
       "groupId": "a",
       "type": "MX",
-      "host": "%mxhost2%",
+      "host": "mail",
       "pointsTo": "%mxtarget2%",
       "priority": "%mxpriority2%",
       "ttl": 3600
@@ -30,23 +29,25 @@
     {
       "groupId": "a",
       "type": "TXT",
-      "host": "%txt1host%",
-      "data": "%txt1%",
+      "host": "agentmail._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimp%",
       "ttl": 3600
     },
     {
       "groupId": "a",
-      "type": "TXT",
-      "host": "%txt2host%",
-      "data": "%txt2%",
-      "ttl": 3600
+      "type": "SPFM",
+      "host": "mail",
+      "spfRules": "include:amazonses.com"
     },
     {
       "groupId": "a",
       "type": "TXT",
-      "host": "%txt3host%",
-      "data": "%txt3%",
-      "ttl": 3600
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=reject; rua=mailto:dmarc@%domain%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
     }
   ]
 }

--- a/agentmail.to.hosted-email.json
+++ b/agentmail.to.hosted-email.json
@@ -1,0 +1,52 @@
+{
+  "providerId": "agentmail.to",
+  "providerName": "AgentMail",
+  "serviceId": "hosted-email",
+  "serviceName": "Hosted Email",
+  "version": 1,
+  "logoUrl": "https://agentmail.to/favicon.ico",
+  "description": "Sets up the MX, SPF, DKIM, and DMARC records required to receive and send email for your domain through AgentMail hosted email.",
+  "syncBlock": false,
+  "sharedProviderName": false,
+  "warnPhishing": true,
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "a",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mxtarget%",
+      "priority": "%mxpriority%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "a",
+      "type": "MX",
+      "host": "%mxhost2%",
+      "pointsTo": "%mxtarget2%",
+      "priority": "%mxpriority2%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "a",
+      "type": "TXT",
+      "host": "%txt1host%",
+      "data": "%txt1%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "a",
+      "type": "TXT",
+      "host": "%txt2host%",
+      "data": "%txt2%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "a",
+      "type": "TXT",
+      "host": "%txt3host%",
+      "data": "%txt3%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for AgentMail hosted email (providerId `agentmail.to`, serviceId `hosted-email`). It configures the records a domain needs to send and receive mail through AgentMail: root MX, an MX for the fixed `mail` subdomain, a DKIM TXT record (`agentmail._domainkey`), an SPF merge (SPFM) on `mail`, and a static DMARC record.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes:
- All record hosts are fixed strings (`@`, `mail`, `agentmail._domainkey`, `_dmarc`); only record values travel as variables. The DKIM value is constrained to the key payload (`"v=DKIM1; k=rsa; p=%dkimp%"`).
- MX targets/priorities are variables because AgentMail's inbound/outbound endpoints are region-dependent per account; the DKIM key is per-domain.
- The DMARC record is fully static (`rua=mailto:dmarc@%domain%` uses only the protocol-provided `%domain%`) and carries `txtConflictMatchingMode: Prefix` + `essential: OnApply`.

## Online Editor test results

**Editor test link(s):**
- [Test agentmail.to/hosted-email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAgCgmoC%2F%2B1WbW%2FaOhT%2BK5GlfirQhFJWUiE1pWxjFWtLuVfVqgqZ%2BAAuSZzaDi%2BruL%2F9HuelgMbuZfu0Sv0Cts%2F7eR4f54VoCOOAaiDuC4mlmHEGssOIS%2BgYIh1SHlS0IKVX2Vcaoi7xjLSLUhQpkDPuQ2o1EUoDK0O4JcqNPqdCq50LZyAVFxFxnRIJxFj8JQPjQetYuUdH8%2Fm8spnD0YiiKxFV8AeNGShf8linDsgdaGUlsaUnYHXvS9bdzceSdXnV6ZYsGjHrsuv1WpYEX0im8P854RIT0cKcAZ9BqqUAf9LMrZGQ1lIk0mIC9xH6lSIZT6zXsq2s0Ey9YipdRv5NMryC5WVqgknxaCgWWsScVnwR5jo9YBjb1z%2FXMp57eYrEHdFAQYnkuRP34YWMMZc4wwjV9TI2ve3e56a4Pjd4CR5p1Re4PQgXmsox6IMURy4k18vsvNgZidbY%2FuO6ba9Ke8TIMdwVxoh%2BHqqQ%2Fn%2B4%2Fn1%2FHW9NhUGGyRSWhgZUU5TOmgZs58yaNqWiZ1bcPGBTHsb7BUK2dH%2BoTMWjXhKASiHyg4SBS0P6XUQKVIrUfnkPWEilv5WpIaNjcpTwhEw4s2RCmyaqFm6qfX6QlbiVPS4XuiWiUcB9pKD2JzwadwUzEW8kjPiC7FTJZevIqAYKua45NfftOvLiOFiS1eOqRLA8GKy59ohpFzyFBcVJARskxUNcpS0Y8FQfu4AmMZU0VGagFMYPW9aPhfkDMevUwatxQSJzYK5GErGyCnVcSVQZqNJlp5LBQOeq8LYml7Fy7E0%2FKZp4OgJgQ%2BpPdzsrMN1yVphmDlM%2BmW2307noPHlfL8bT58mU355eeLftj5533fJuTz0jbY2vcN32NChtaGo6y8eRkDBQ%2BE91IhE1LRO82GESaD6gc7o%2BYv6AGkgQCIVSjImXfvMKRtk4PV%2Bzaq9ObZFp3TEHdwPmG7y4YXKNjfwaDKvlRq1RK9fqOM6HjeNG%2BaRWPWmcMGD1Y7bxIOx6LP7jRVgTZ5OEXjCnS0VW5k7tqDS3zYvdD8q3VW02M%2FJyf3XW%2FTojt5rzp7djG%2F1ZEyezY%2B2cydY%2FNAiK4rC2N1Dcb70P27P4D4Ly9TFZPZbw9XifW%2B9z631uvc%2BttzS38FNP0RmwATV6VbtaL9unZafed07dYwfzrTQ%2BVOt29dC2Xds2ZSA3sya84Hfe5hce6Ue%2B%2FNQ4fJq1P9yFo%2B53%2B7D95e9ExJ%2FkRbJ4VrzmLVqtTu%2F623LeJKt%2FAfMa9bKNDwAA)
- [Test agentmail.to/hosted-email example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIMBgmoC%2F%2B1WW3ObOBT%2BK4xm8rTggLNxKBnPlDjp1puhTdxs6ybj8cggsGJARBK%2BbMb72%2FeIS2wat3XfNjt5AaRzP9%2BnIx6RJEkWY0mQ84gyzuY0ILwfIAfhiKQywTRuSYb0J9kHnIAucpXUAymIBOFz6pPCasqEJIFBkoaoMnpfCLWLSjgnXFCWIsfSUcwi9hePlQcpM%2BEcHi4Wi9Z2DochBlcsbcEDjAMifE4zWThAn4gUWp5pcko0b6hrn67e6dr5Zd%2FTNZwG2rnnDnoaJz7jgYD3Q045JCKZ2iN0TgotQeBRZK6FjGsrlnMtYLBOwS9neTTVnsrWykJL9ZaqdJX6V%2FnkkqzOCxNIiqYTtpQso7jls6TSGZAAYvvy%2B1rK86BKETkhjgXRUZU7cu4eUQS5ZCVGoC5XmeqtN6xM4futwovRVIobBsuDZCkxj4g8KHCkjFO5KvfrlZJICe0%2F6pjmWt8jRoXhrjBK9P1QtfTn4W6GN5t4GyqMS0xmZKVogCUG6byrwLZOtVmXC3yqZd2DYEaTbL9AwBbvWWUiCwd5TEQBkR%2FnAXFwgv9mqSCiQGq%2FvMdBgrnfyFSR0VI5cnIPTDjVeI67KqpkTqH99qAssZE9fC5lj6VhTH2goPSnNI08FqiIV5yEdIl2qlSyTWRQIwK4LilW5%2B1j6mZZvELr0VpHUB4Zb7g2grRrnpIlhklBtkgKm2LKMlgVbRjTwgY6AWYZ5jgRaqjUDu4aHka1i7vSx6hy8uSgJpPaUEckTwNDJDJr5cIgWEjDapVw4IWoPW5Ipqwsc9tPgSrshoQEE%2BzPdjursW04q01LhwWv1NLr98%2F69%2B6Hs2j2MJ3Ra%2FvMvb5457ofe%2B617SppL7qE7wtXEiEVXVWHaZQyTsYC3ljmHNCTPIcDnuSxpGO8wJutwB9jBQ0AIkAKMeHwbx%2FFtByrFQgVwfZqVoNXm6ZZsBoHvoKNKlK3J0dHZmi3DRK%2BMY3fgzA0JifHHYP4nWPzxD%2FptKEn%2Bg%2FvjR9cDk0ObXPSjRd4JdBaHbEdBRfem1XvB%2BvLK7ucJVXdu2bgN314Pgh%2FnaaNLr2Evuzgw7wL89vSdk5u7R8cx3WVUOQLqbK8SZ7j%2FfPrpDm6%2F2PgPt0%2F65EOF87riHsdca8j7nXE%2FU9HHPxACjwnwRgr3bbZ7himbVidG8t22m%2Bc9lHrxD62bfs303RMlYxibNmIR%2Fh73P5vRH%2FY3vTB9HrWw0LMFl%2FO2dV93LuNPg%2BWbGi9H37Jj29vufkn65997aL1v8Nt7fvrDwAA)
