### PR TITLE
Add SiftServe templates (siftserve.com: sift-pilot, sift-www)

### DIFF
--- a/siftserve.com.sift-pilot.json
+++ b/siftserve.com.sift-pilot.json
@@ -15,7 +15,7 @@
     {
       "type": "CNAME",
       "groupId": "service",
-      "host": "%host%",
+      "host": "@",
       "pointsTo": "sift-proxy.siftserve.com",
       "ttl": 3600,
       "essential": "Always"
@@ -23,26 +23,29 @@
     {
       "type": "TXT",
       "groupId": "verify",
-      "host": "_cf-custom-hostname.%host%",
+      "host": "_cf-custom-hostname",
       "data": "%cfpre%",
       "ttl": 300,
-      "txtConflictMatchingMode": "None"
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
     },
     {
       "type": "TXT",
       "groupId": "verify",
-      "host": "_acme-challenge.%host%",
+      "host": "_acme-challenge",
       "data": "%acme1%",
       "ttl": 300,
-      "txtConflictMatchingMode": "None"
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
     },
     {
       "type": "TXT",
       "groupId": "verify",
-      "host": "_acme-challenge.%host%",
+      "host": "_acme-challenge",
       "data": "%acme2%",
       "ttl": 300,
-      "txtConflictMatchingMode": "None"
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
     }
   ]
 }

--- a/siftserve.com.sift-pilot.json
+++ b/siftserve.com.sift-pilot.json
@@ -1,0 +1,48 @@
+{
+  "providerId": "siftserve.com",
+  "providerName": "SiftServe",
+  "serviceId": "sift-pilot",
+  "serviceName": "SiftServe pilot hostname",
+  "version": 1,
+  "logoUrl": "https://siftserve.com/logo.svg",
+  "description": "Connects a pilot hostname (e.g. sift-test subdomain) to SiftServe so AI agents and bots are served your Sift pages while your production site stays untouched.",
+  "variableDescription": "cfpre is the Cloudflare custom-hostname pre-validation token; acme1/acme2 are the certificate validation tokens. All three are generated per-connection by SiftServe.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "siftserve.com",
+  "syncRedirectDomain": "siftserve.com,app.siftserve.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "service",
+      "host": "%host%",
+      "pointsTo": "sift-proxy.siftserve.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_cf-custom-hostname.%host%",
+      "data": "%cfpre%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_acme-challenge.%host%",
+      "data": "%acme1%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_acme-challenge.%host%",
+      "data": "%acme2%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "None"
+    }
+  ]
+}

--- a/siftserve.com.sift-www.json
+++ b/siftserve.com.sift-www.json
@@ -15,7 +15,7 @@
     {
       "type": "CNAME",
       "groupId": "service",
-      "host": "%host%",
+      "host": "@",
       "pointsTo": "sift-proxy.siftserve.com",
       "ttl": 3600,
       "essential": "Always"
@@ -23,26 +23,29 @@
     {
       "type": "TXT",
       "groupId": "verify",
-      "host": "_cf-custom-hostname.%host%",
+      "host": "_cf-custom-hostname",
       "data": "%cfpre%",
       "ttl": 300,
-      "txtConflictMatchingMode": "None"
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
     },
     {
       "type": "TXT",
       "groupId": "verify",
-      "host": "_acme-challenge.%host%",
+      "host": "_acme-challenge",
       "data": "%acme1%",
       "ttl": 300,
-      "txtConflictMatchingMode": "None"
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
     },
     {
       "type": "TXT",
       "groupId": "verify",
-      "host": "_acme-challenge.%host%",
+      "host": "_acme-challenge",
       "data": "%acme2%",
       "ttl": 300,
-      "txtConflictMatchingMode": "None"
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
     }
   ]
 }

--- a/siftserve.com.sift-www.json
+++ b/siftserve.com.sift-www.json
@@ -1,0 +1,48 @@
+{
+  "providerId": "siftserve.com",
+  "providerName": "SiftServe",
+  "serviceId": "sift-www",
+  "serviceName": "SiftServe for your site",
+  "version": 1,
+  "logoUrl": "https://siftserve.com/logo.svg",
+  "description": "Serves your site through SiftServe: A Web Infra layer for AI agents, AI agents receive your agent-readable pages, people are passed straight through to your site unchanged.",
+  "variableDescription": "cfpre is the Cloudflare custom-hostname pre-validation token; acme1/acme2 are the certificate validation tokens. All three are generated per-connection by SiftServe.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "siftserve.com",
+  "syncRedirectDomain": "siftserve.com,app.siftserve.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "service",
+      "host": "%host%",
+      "pointsTo": "sift-proxy.siftserve.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_cf-custom-hostname.%host%",
+      "data": "%cfpre%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_acme-challenge.%host%",
+      "data": "%acme1%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_acme-challenge.%host%",
+      "data": "%acme2%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "None"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for **SiftServe** (providerId `siftserve.com`) — https://siftserve.com, web infrastructure that serves agent-readable pages to AI agents while passing people straight through to the customer's site.

- `siftserve.com.sift-pilot.json` — connects a test hostname (e.g. `sift-test`) so a customer can trial SiftServe without touching their production site.
- `siftserve.com.sift-www.json` — production wiring for the customer's canonical subdomain (usually `www`).

Both share the same record mechanics: `CNAME @ -> sift-proxy.siftserve.com` under the `host` parameter, plus three TXT validation records (`_cf-custom-hostname` pre-validation, 2x `_acme-challenge` certificate validation). The TXT variables (`%cfpre%`, `%acme1%`, `%acme2%`) are per-connection validation tokens generated by our backend when it builds the (signed) apply URL. `hostRequired: true` on both — these never target the apex.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `siftserve.com`; the public key is live at `_dcpubkeyv1.siftserve.com` (TXT, 2 parts): `dig +short TXT _dcpubkeyv1.siftserve.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `siftserve.com,app.siftserve.com`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — explicitly `None` on all three: the two `_acme-challenge` records must coexist at the same label by design (dual certificate validation tokens)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — **justification for bare values**: `%cfpre%`/`%acme1%`/`%acme2%` are Cloudflare custom-hostname and ACME DCV validation tokens; the validating party requires the TXT content to be the exact token, so a fixed prefix would break validation. The records live under fixed, purpose-specific labels (`_cf-custom-hostname`, `_acme-challenge`), which limits misuse.
- [x] no bare variable is used as the full `host` label — hosts are `@`, `_cf-custom-hostname`, and `_acme-challenge`; no variables in any `host`
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used instead (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — the three validation TXTs are `OnApply` (removable after certificate issuance); the CNAME is `Always` (removing it disconnects the service)

## Online Editor test results

**Editor test link(s):**

[Test siftserve.com/sift-pilot nextonservices.com/sift-test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOUYgmoC%2F%2B1XC2%2FbNhD%2BKwKBAhtqybIsP4cBc9KiTZt4WeJ0WVPDoEjKZiOTKkk5UYL89x3lZxxli4sNCLYAhi3zHt8d77sTeYsMm6YJNgx1b1Gq5IxTpg4o6iLNY6OZmjGPyCmqrIR9PAVldAriUysGkVXjhK3M3JQn0qwF2yZOIXcmUhthRRU0Y0pzKVC3VkGJHMszlYDBxJhUd6vVe6FUrdzTszGYUaaJ4qkpTNG%2BFIIRox28BeD8wLyx5xShGaaNo7OIyinm4kfHSGcdl5ZO78DBYyasF0GdSNoHBRIrp04uM1XoOyloaedqwhM2X4X9oRmxoQCQAQuDc%2B1kwsiMTBj1bJZYcRwl7M29sEmcAgDXjpkwZz%2BRGY0TC0kybeTUXSUBWu4MJ5ziAsTISyZ%2BcjCZslrVfgdFoNYJYcrwmBMoq7NtoT2nlySgphgrDCBZpkCTOilTLpnvoVWP8vXO2Oh1LsheIskl6sY40Wy%2BcpxFH1n%2BptjNEtZYlRNGuQKn5UoVnKbetplN%2BoR9y8AOSGVUBmjgQiqqUffiFpk8tYza7%2FeO3oL6WMksndNvzriFC1j4xVJXcijoQK7oqeR1%2FgDTGOBcven7FcS0BgpwbEnYS66gkOiuskIdnA%2FuYQJ5eZyvIUckdreKZ7mKDQbhq6Lcr1Z4Fs5cG%2BBunHBijrAhEy7GR5JaqL4U1nYznl9FL02TfKeALD1cMsFJwsR4M5iCPc8pmOCfCGZ4V0E3IB%2BtKTMEmCX9BLs2UiyYojcYt%2BSHnRHLHEa8sN8g1iIh8JhihafaTs6l74sy58Ol94sN98OF%2F8d8FzSxQhzG7RoJmNuJ6i03pI2G2479wG2yGu3USQtHNd8aFKW0Bueqnv7WmR1OB8HVx6%2Ftz1GfNM7y9%2FQtbr2LT2r6kwz5XlN88C%2BPlnaBtTu%2BaZrfvwXn5FM7P7ysn0w%2FdOj7qNGPezV2Nm7JUx7O9v2vg%2Fb1H8juMB8LqdhIwy82mQ123qfTLDF8hK%2FweomSEbalgYJokALawx4W85fEZgEWxHhaz44osZXglnOYElonNebSFo3ckEShG2HWcVthg4XtuEX9RmPjlVb6vnv0pVbClLJ58aAlFgmWTAevJOknlX2zVZ5L%2FqsufHQD7g%2BAsuR3ofB%2FdQ92acfnvQfDCozfl4Z%2FafiXhv%2BfNDwcKzSG%2B9IIW4PAD5qu33ZrzUHgd%2F0OfLxmGAbN8LUP%2FwtWg7v5NtwWz3r5MFpFN5qHAevLa1ShtDgnPbV9FqekHQm3OCPtWKLvO3CWHwjv7P3Hnp1K7z%2Fbo9R7iOjdH55%2FN2m%2Fa5j9JewG6pcnVesLQjt309Mj2IEA%2F24gO3DKBjKEEQP8SOA%2BDf1VEKdb3imgt3k4R%2B%2BOD3Rd3fiRjGufSSNo7x1PRCaqLDv0FbvBiX96Is7TevX1wc%2Fo7k%2BiDa%2FiGhIAAA%3D%3D)

[Test siftserve.com/sift-www nextonservices.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEIZgmoC%2F%2B1XW1PjNhT%2BKx7N7NPGwXYcx0mnMw2Xgd0NgQ3hvkxGlmRH4FhGUhIMw3%2Bv5NwhdOO22247vICjc9f5viPpCUgySGMoCWg8gZSzEcWEf8KgAQQNpSB8RMqIDUBpLmzDgVIGJ0p8osVKpNUoInMzczweL5ZfGhgh40bGhtwQVGrzEeGCsgQ07BKIWcROeaz0%2B1KmorG1tZLHlpaXxShSZpgIxGkqc1OQuxYLv4bsczaM%2BsY8bsNoGuckMD4lIYdGDDPC81SanwwYkUSK0uLT4AQRqnLN%2FeVrJicQwyAmRqp%2BK%2BWUsFT9glyvCEGwISSHNOrLeWzJlhIaJqgPk4jgsq4Zcqqd7a4UgcJUeaNCOSDGTsyGOIy1fzQUkg3MPhMyUbtpKC1zBGOKoTZUYe5I8osB0YDYW%2Fqvk2elnSDCJQ0pUh02XlqIstGMY50smZShyiRcaWJVGzcRSxKCcvUgW2yjzl5kCdqOGboDjRDGgkxWjofBF5LtsgGkyRoAaZUOwVRtrVyvVIJpWn5ppovukPuhslP4knyooikXjGMBGtdPQGaphtdOu3m4p9QjtfPpBIkT%2BE1dqIXfNIoZVe3tshlSFaofslcxpVQIrHiWVQJEdTaRFGpINuMxzAR4Ls2jdi%2B6KzEVlGmYLUL2UGi%2BaJ5GLpRQCT%2Fk7f4wj6fDyQe5w5IwpkgeQon6NIkOGdah2izRtsv5HCXNNI2zQglpeJgKiHFMFBaXksnR8zMl4%2Fwdydw8l8CjkvcWkLlRYWbwS8iDZMkUKWIJcUo2GWJ59j2aWy5BalqK8pVCDgdCj8%2BZ1%2Bt1bm9mfq9zxzdTz295zaGhhbjuBLXQhaaNPN90iVUxgyqumz50Qs9Crk1qNW2Qt08b7I%2BqSefev5SH9sM5clvpl9rtFXZOwu16fw9W2Cn1Bm2L71bHX2d2jrbr3jnj46B29njh8vagvnP%2FuRpdYv8gbNnkBHrDI1q57VjZYQ3tAb2rNEoYJz2h%2FkM51MlOuDkYxpL24BguljDqQd0O1QShpCraa94mk1NisulTGGzG0B5GevepRpgdBgHyMTZDTJDp%2BhXX9OsuMn0PQuTAer3mWktn2dqD7o3TbAUV66bCK%2BBPS1ozA8orZW7U4mUq%2FNsVz9n1ZsmrxF4ttwhA%2Fz9VF6HXz1n1TUmNznfivhP3nbj%2FMeKqY17AEcE9qFUdy%2FFMyzdtr%2BtYDdtquE7ZrXq%2BZ320rIalE5FEyEn5T%2Fm3mH305ln1UhozqddnT5lcaXpvAdANfRs5xKwHlZrp4mrV9EPLMT1i43oF1WBg60DTWwu44JX0a33UGnSd8Zdb%2Fypoo%2BppdoD3YG0%2F7NjijLl020s%2BW3eHYH5nAcePnjy%2Fdy7QmZ%2B17iqdwec6Pgiq7bBpk9Ooxk6oO9qxbrv%2BwyXY8NKX76yuFPzhBe1Zv0H0XWbtG2QKq7mv8uuI5dVR%2BL25WWREbRZ2Keq3jbr1DYBN%2BfMnMigAgB%2BbSAFM6UQ0El4QQ1PxLVpseGLMaFFs4s5oUWxiFX0L%2FQVCKC%2F%2FLBW%2BF3Cl85v0pgD2CsUu0OgflUIB1EyA%2F6zPpJggqQ6WfGI21jFBaS2%2FEcHV5QU9a1n9e9I6b5Ejf9tvnzudo8evUUyP3OZ%2BrWvdZcPH4%2Bg4%2BhU8%2Fw7idONdoBQAAA%3D%3D)
