### PR TITLE
Add arythmatic.cloud lms-custom-domain template

### DIFF
--- a/arythmatic.cloud.lms-custom-domain.json
+++ b/arythmatic.cloud.lms-custom-domain.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "arythmatic.cloud",
+  "providerName": "Arythmatic LMS",
+  "serviceId": "lms-custom-domain",
+  "serviceName": "Arythmatic LMS — custom domain",
+  "version": 1,
+  "description": "Point a subdomain at your Arythmatic LMS portal. Adds a CNAME to the Arythmatic edge and a TXT record proving you control the domain.",
+  "variableDescription": "verifycode: a one-time, per-domain verification token issued by Arythmatic (not a secret) — it only proves the request came from the LMS tenant that asked to connect this domain.",
+  "syncRedirectDomain": "lms-manage.arythmatic.cloud",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "domains.lms.arythmatic.cloud",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_arythmatic-verify",
+      "data": "arythmatic-tenant-verify=%verifycode%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Service Provider template: **Arythmatic LMS — custom domain** (`arythmatic.cloud` / `lms-custom-domain`). It connects a customer's subdomain to their Arythmatic LMS portal by adding exactly two records: a `CNAME` to the Arythmatic edge (`domains.lms.arythmatic.cloud`) and a `TXT` ownership-verification record (`_arythmatic-verify … arythmatic-tenant-verify=%verifycode%`). Automates the same two records a customer would otherwise copy/paste by hand.

## Type of change
- [x] New template

# How Has This Been Tested?
- [x] Template functionality checked using the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) (see link below)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`arythmatic.cloud.lms-custom-domain.json`)
- [x] No `logoUrl` provided (optional), so the served-resource check is N/A

# Checklist of common problems
- [ ] **`syncPubKeyDomain` is set** — **not set; justification:** this template touches only two low-risk records — a `CNAME` on the requested subdomain and a single ownership-verification `TXT`. It cannot alter `MX`/`NS`/nameservers or any zone-wide/email-affecting record, so it carries none of the hijack risk signing primarily guards against. `syncRedirectDomain` (below) is set to bound the synchronous redirect, and the Service Provider independently validates the `redirect_uri` server-side before ever building the apply URL. A signed variant (`syncPubKeyDomain` + `_dcpubkeyv1` publication + RS256 request signing) is a planned follow-up; requesting guidance on whether unsigned is acceptable for a two-record CNAME+TXT template of this shape.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — neither is set
- [x] `syncRedirectDomain` is set (`lms-manage.arythmatic.cloud`) — the synchronous flow uses `redirect_uri`
- [x] no TXT record contains SPF content — the TXT is `arythmatic-tenant-verify=%verifycode%`
- [x] `txtConflictMatchingMode` is set on the TXT record (`"All"`) — the verify TXT must be unique per label
- [x] no bare-variable full TXT value — value is prefixed: `arythmatic-tenant-verify=%verifycode%`
- [x] no bare variable as a full `host` label — hosts are fixed (`@`, `_arythmatic-verify`)
- [x] no variable used in `host` to create a subdomain — uses the `host` parameter (`hostRequired: true`), not a host variable
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential`/`OnApply` — N/A; neither record is user-modifiable without breaking the connection

## Online Editor test results

`hostRequired: true`, so per the guidelines only a subdomain (host-set) test is required; apex test not applicable.

**Editor test link(s):** [Test arythmatic.cloud/lms-custom-domain — acme.com / learn](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOIngmoC%2F%2B1UbWvbMBD%2BK0JQ2KgdbCd1iqGw0oxSWPbShjHoQlClS6LVllxJTuuF%2FPed7Lz1je3r2D4ZSffcPfc851tSB0WZMwc0W9LS6IUUYC4EzSgztZsXzEne4bmuBA227x9ZgfH0dBtBPgyv8N2CWUgODTwvbMgr63QRCl0wqXbvL8LJ9yqJ4h5pMWSLWYCxUiuaxQEVYLmRpWvO9LOWyhFGbHXTRhPmSK0rQ55kLrVxLO%2BQUyEsxp99PB2%2BJ04TN4f9UBAzIEwJDBl9GxEDXBtBmp7VzCcmXCtndN4A25Idz5AZyW5yGDxih7zltOZaQIYJtYLQyQICUoJZC0KaEMmZRyCfW1BEWluBIDf1PrE3Sjd9Ajfg3m6Ekg6z5nVDEGzDycBdBdYRjgKTqUEZ%2Fa2XwIFiKJabo0TM3mIJ7B%2FbUcD9rbR7%2Fdha8UsQEgVwg9aG1s6CKTaDzguDMdfWXWJxxKD3zlQQ0FY%2FS7PrJXV16R1vlF%2BH4%2FGdHylvoh1pPLYMbAdLvVTDuZxm3ShaBdt8aNMu22SHCVvx8U0wxx7NctgqsY44OdjZdOBrPLgzraa55G7IHJ%2Bj8UN88sOa5%2FscxquA%2FkRTJ7sux8G6A1%2BPF9Dhutixy4EZP84zo6tyIjeIkhlWWP%2FvbbDXO%2FB4g75ew8fB3lj5a4dux0mXejpyprSBicUvc5WBjQ9FlTs5YfdsdyX4hJVlXiN7i6%2BY6blHqv1JN7zXQv6hRwGdCO67kn4V9OPecQoxD1na74c96PZDBt0kjPlRL50m3X7C97fLa9vnd9vlidJgLSgnWd64d89qS1fPZmfd5fPZ6Txp%2FNUJ2ljwFzQ%2FDnDk%2Fjv9LziNm8KyBYgJ87FJlKRhdBzG6SiJs7ibRWkn6Udp0j2MoiyKfEvYXCvAEnfJ%2FhahvJ8cDvR0XqqjL1%2BPejb6IQ5lmlwNzj%2FdJfP7xdw8LI7vzOLifHhCV78ATyb1iFIIAAA%3D)
