### PR TITLE
Add posthastemail.dev.dkim template

### DIFF
--- a/posthastemail.dev.dkim.json
+++ b/posthastemail.dev.dkim.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "posthastemail.dev",
+  "providerName": "Posthaste",
+  "serviceId": "dkim",
+  "serviceName": "Posthaste sending domain",
+  "version": 1,
+  "logoUrl": "https://posthastemail.dev/brand/postmark.png",
+  "description": "Publishes the DKIM key that lets Posthaste sign email as your domain.",
+  "variableDescription": "%selector%: the DKIM selector Posthaste generated for this domain (for example s1); %dkim%: the full DKIM TXT record value, beginning v=DKIM1; k=rsa; p=",
+  "syncPubKeyDomain": "posthastemail.dev",
+  "syncBlock": false,
+  "sharedProviderName": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "%selector%._domainkey",
+      "data": "%dkim%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for **Posthaste** (https://posthastemail.dev), a transactional email API.

Customers who send through Posthaste must publish a DKIM key on their sending domain so we can DKIM-sign their outbound mail. Today that means copy-pasting a long TXT record into their DNS provider by hand, which is the most common place onboarding fails. This template lets a supporting DNS provider apply that record in one click.

The template publishes a single TXT record at `%selector%._domainkey` containing the DKIM public key (`%dkim%`). Nothing else is touched — no MX, no SPF, no apex records — so it cannot disturb a domain's existing mail setup.

It is signed: `syncPubKeyDomain` is set to `posthastemail.dev`, and the RSA public keys are already live in DNS at `_dcpubkeyv1.posthastemail.dev` (two keys published, `p=1` and `p=2`, both `a=RS256`), so providers that enforce signature verification can verify it today.

**Note on the bare variable in `data` (Quality Guideline #6).** The record value is `"%dkim%"`, a bare variable rather than a fixed prefix plus variable. This is the documented exception: a DKIM record's value is prescribed by RFC 6376 and is a self-contained tag-value string (`v=DKIM1; k=rsa; p=...`). The `p=` payload is a per-domain RSA key, and the surrounding tags vary legitimately (`k=`, `h=`, `t=`, and key length all differ between domains), so there is no stable prefix that could be fixed in the template without breaking valid keys. The `host` field is *not* bare — the selector is scoped by the fixed `._domainkey` suffix exactly as Guideline #7 prescribes. This matches the shape of the already-merged `goentri.com.dkim-helper.json`.

`txtConflictMatchingMode` is set to `All` so re-applying the template replaces a previous Posthaste DKIM record for the same selector instead of stacking duplicates.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Additionally verified locally before opening this PR:

- `check-jsonschema --schemafile template.schema posthastemail.dev.dkim.json` → passes, 0 errors
- `dc-template-linter -loglevel info posthastemail.dev.dkim.json` → no findings at all
- `dc-template-linter -tolerate warn posthastemail.dev.dkim.json` → exit 0 (the CI gate)
- `logoUrl` → HTTP 200, `image/png`, 144x144
- `_dcpubkeyv1.posthastemail.dev` TXT → 2 records, `p=1,a=RS256,d=...` and `p=2,a=RS256,d=...`

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the points above:

- **`syncRedirectDomain`** — not set, and not applicable: this template does not use `redirect_uri`. The sync flow is initiated from the Posthaste dashboard and the user returns to it directly. Happy to add it if you would prefer it present anyway.
- **Bare variable in `data`** — justified in the Description section above (RFC 6376 prescribes the full record value; no stable prefix exists).
- **`essential`** — not set, deliberately. The DKIM record must keep matching the key Posthaste holds; if a user edits or deletes it, signing breaks and we want that to surface as a template conflict rather than be silently tolerated. There is no DMARC-style policy record here that a user would reasonably want to tune by hand.

## Online Editor test results

**Editor test link(s):**

- Apex (no host): [Test posthastemail.dev/dkim example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANfbgmoC%2F%2B1U627iOBR%2BlchSpVmVi0NJoFT9AWShwEBJgbZDVSEnMYmJSVLbCYWKd1%2Bby0Jnug8wmv3nc%2Ft8zncuH0DgZUKRwKD2ARIWZ8TDrOOBGkhiLgLEpR0RWvBwBnL%2FOgzQUgaA4dFFmjhmGXHxLtQLyfKk%2BtlZ4zjySORrXiyhI%2BmYYcZJHIGangM09uMJozIgECLhtWLxl0SKDkORt9MvEQsLSeRLEA9zl5FE7IDAMHUo4QHmmgiwZvU6fS3EaykgoVEsuHaWDvEjbQeuIa6t45QdMiuo1BAjyKHY%2BoR%2BwTHFrojZRe2Ef9SdQfs4wkyS62lzqRcB4Qdo7ZtS4HckyZcZ6H%2FdaBeKtQPePKV0Dzp%2BHmsMuzHztAzRFOc0B%2FskihR%2F2a1y0W%2B08JZxdKMlt4r0deTK4nt4be3p%2FbqTyq1BYzcEtTmiHEtNgBj2hp86fDDtE%2BCg9vIBxDpR3ZR5SZRAIn%2BiozDb1ye5Vi1BAinzrjIpCyH7egWhfL2LZhzNKXFFHwk3kOX0Y08B1ykF29dtDmziCM9OP79KuGNBB94Kbrw8JSFfPovTZEaO%2FgliaMnVYB8jXz6Fvh5jX4B6H4tQMteVZjfHUvqV6H6nPe%2FXYbs5emuPOs6VZf%2FdqNuTer3cHtStZoPYvYZvN9%2FavTS81y1c2QTThXl5B9%2FEYhw%2Bvq%2FGzSTr4TJuTmFr%2BMYIdJ1Sdzp%2F7hYt%2F8eoZWaTZLXstqurR3vaW%2BC2u7DuvxsTytOUtyK3uXlq2JWH3mAywnxpP%2FRH7fDR0YtXi0seTs2JeLo0UnhN7wZ8YQrb0Lk%2BGrJmI8SeM5jDcQLbTr9rrR%2FK%2BHoMy9PpqmPV7XoDKOblPsQMz9ReIJEy2RXB5OSBZUoFmaEVOqk8d4aShK5lo7i0SrJ%2BHpFov%2F1c%2F3I0%2FiBmz8d%2F5rlqLIk6llVoVEqohPLVebmaL8NrU76QkZ%2BXTcc0TK9imObZ6f3P2%2FzFAT5tBuby6AqC6G7DVmjNwXb7mpNb8n%2B%2Ffp9%2BqSOFMuzNkHIrwZKZh9W8XhnrsAZhzTAK13oVlq8uoZJVBZiLfec%2B5F6fbzTwv%2F8YF7vs4Skc%2BoP7Tc80KnF297xy457V4q2W3dpERdyN3GByC7b%2FANxZHI8oCAAA)
- Subdomain (host=`mail`): [Test posthastemail.dev/dkim example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA%2FcgmoC%2F%2B1UaW%2FiSBD9K1ZLkXYVDpszEOUD4IQAA4EAmRkihNp2%2BcDtI91tEyfiv283xwBz%2FIDV7jd3Hc9V71XVJ%2BIQxARzQM1PFNMo9SygPQs1URwx7mIm%2FNgjBQtSlPsRMMKBSEDjY4hwMaCpZ8Iu1fK94GT6OVhhEFpe6ChWJKBDEZgCZV4UoqaWQyRyojklIsHlPGbNYvGXQooGxaG1sweY%2BoU4dASIBcykXsx3QGicGMRjLjCFu6Dog95Q8SETD8wVApwpZ%2BV4TqjswBXMlCxK6KGygiwNUw8bBPQL9CsGBEwe0avmCf9oO4N2IAQqyLUUW9i567EDtPKXNMA7FuSLCrS%2Fb5UrydoBz04I2YPOvs0UCmZELSXFJIGcYoDjhaHkL72TIdqt4t9Rhm%2BV%2BE6SnoWmaH4Amb6n9%2FdKyrA2iUwfNW1MGAiLiylY4wuFD659AQw1Xz8Rz2KppqhLoLgC%2BYKOwmrfn%2BBaSoI5lu5dZ%2BLNudC1rKri6513otAmnsmHmJuuaGcYWRK4RQjaLrc59BGFsDr9eSngjg0deCuYUXAqQjYnXg6NknjlHXNiTHHA5HAfs18v0pfH%2FNc9wFKO7b4ZaWOatOzmWbx%2BJXzY69rDltrtTN%2B6055R1if37dZk3mpVuqOW3ml7k0HbmXTeuoPEf9J0qH%2B4i3Xt%2BlF94%2BuZ%2F%2FK%2BmXXidAAV6CzUh%2FEb9VTTKPUX9rd%2BUXe%2BTx9q6TzeBP3uzeZlshisoWuu9acv1TlhScIeQrPz8bU9qT8PRvMpsGDyPJx2%2FRdDK5bX18xf1Ob863U1URvkccTWNT6pakybjmmn7YNljGx1FqtdY9jXs%2BcKNGZqZbHY9PTWpNVGUgGxFxGFldwPzBMq1OFUTCAKEsK9Fd7gk8kyVziOSSYEY8IryPp5VML9FWDa2YgUDpod5uQ%2FRO%2F5LqwsU86nJy9nrWZXtDLgPDSwmq%2FUS0a%2BYeBaHldMtaJZWLtR7bM7%2FMdD%2FZtrfLkmwMQV5h4mu5Xb4Iyh7XaZEyvzv3D%2FQuHk2cIpWCssQ0tqqZZXb%2FJafaapTVVrVrXCTalaqlevVfFWZRfA%2BF69T7Hp5zuOoPcUNXwvawTkPnW0uTUsu7PsXsPjiH%2BH8Ufy%2BFR979v3z5p5h7b%2FALtNUfZCCAAA)

Both tests use `selector=s1` and a sample RSA DKIM value. The apex test produces `s1._domainkey.example.com. TXT 300 "v=DKIM1; k=rsa; p=..."`; the subdomain test produces `s1._domainkey.mail.example.com.` with no label doubling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
