### PR TITLE
Add Pixelize showcase site template

### DIFF
--- a/agence-pixelize.fr.site.json
+++ b/agence-pixelize.fr.site.json
@@ -8,7 +8,7 @@
   "description": "Points the domain to the static website built by Pixelize: an A record on the apex and a CNAME on www.",
   "variableDescription": "%siteip%: IPv4 address of the static hosting load balancer, applied to the apex; %sitehost%: hostname of the hosted site, target of the www CNAME",
   "syncPubKeyDomain": "agence-pixelize.fr",
-  "syncRedirectDomain": "pixelize-agency.onrender.com, agence-pixelize.fr",
+  "syncRedirectDomain": "pixelize-agency.onrender.com,agence-pixelize.fr",
   "records": [
     {
       "type": "A",

--- a/agence-pixelize.fr.site.json
+++ b/agence-pixelize.fr.site.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "agence-pixelize.fr",
+  "providerName": "Pixelize",
+  "serviceId": "site",
+  "serviceName": "Site vitrine Pixelize",
+  "version": 1,
+  "logoUrl": "https://pixelize-agency.onrender.com/pixelize-icon-v2-512.png",
+  "description": "Points the domain to the static website built by Pixelize: an A record on the apex and a CNAME on www.",
+  "variableDescription": "%siteip%: IPv4 address of the static hosting load balancer, applied to the apex; %sitehost%: hostname of the hosted site, target of the www CNAME",
+  "syncPubKeyDomain": "agence-pixelize.fr",
+  "syncRedirectDomain": "pixelize-agency.onrender.com, agence-pixelize.fr",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%siteip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%sitehost%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Pixelize, a French agency that builds and delivers static
showcase websites for craftspeople (landscapers, builders, artisans). The
template points a customer's domain at the static site we have deployed for
them: an `A` record on the apex and a `CNAME` on `www`.

Our customers are not technical. Today, connecting their domain requires them
to activate a DNS API programme at their registrar, order a €0 offer, create an
API key, copy two separate values and concatenate them. Domain Connect replaces
all of that with a single authorisation click, which is exactly why we are
adopting it.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Notes on the checklist items above:**

- *Bare variables as full record values (rule 6).* Both records use a bare
  variable, and this falls under the documented exception. `%siteip%` is an
  IPv4 address in an `A` record and `%sitehost%` is a hostname in a `CNAME`:
  neither record type can carry a service-specific prefix. Misuse is prevented
  cryptographically rather than lexically — `syncPubKeyDomain` is set, so only
  a request signed with our private key is applied.
- *No TXT records.* The template contains no TXT record, so rules 4 and 5 do
  not apply.
- *No `essential`.* Neither record is one the end user should change
  independently: altering the apex `A` or the `www` `CNAME` takes their website
  offline. Treating a manual change as a template conflict is the intended
  behaviour here.

## Online Editor test results

**Editor test link(s):**

- Apex (no `host`): [Test results](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKIHg2oC%2F%2B1UXW%2FaMBT9K5alPS1JEwiBZpo0um5TNbVFXbtOqxBy4gtYC3ZmG2iK%2BO%2B7DgToRPfchz3Zvr73%2BJz74RW1MCsLZoGmK1pqtRAc9AWnKWUTkDn4pXiEQjxBMNbU23lcsRlG0MH2Em8M6IXIoQ41wh6Ytr7f0EgWwmohgRwELkAboSRNI48WaqLudIHeU2tLk56cNM%2F7NZ0qUFKDRAJBrmb7S5Er6S9afidqBaWcICoHk2tR2hqZDpSQ1hA7BcLVjAlJrKpPxjIrcrKEzHEm2VwUlmTVjl9KmCR9oiFXmhMl6yBWwiPaOWHk41X%2F8pOzL5fLwIlhWrCsgPNnz79x4KJ8k5KLwSImjHMNxhA1PuQwVcYKOSGFYpxkrGCYfe3hY2UhgDeE3dvvSA3oAhDSLRJT3MC5M%2Fo7D49YpidgmyskuWHsilPJfDDPvkJ1XmfkpYo7vxvgAlNgd57%2Fqop3FGaTQUPThxW1Vekaoo9mRxa3H1xr1TW6VQf5Qqu12A3tJAzX3i6wkbANRlVHwuvsPAMYrj36pCSM9lyG2CiNJnh0kwC%2BBWP%2FIr99CHcTreblSDTBJdNsZtzoNDAPL%2BMMG6AH6vYbje7U7QStIAmDTmNu3LZQgQRbiHEVYC9Qp0JMpNIwMrgyO9eYE6vn4NHZvLBixJZsb%2BL5yHVQhaIN3iLq8wLIzXC6AnBmGW73bA6S59ERz51O4eY7GfNe2OW5H3e7kR%2FHUeKzPM78bshjFme9TtQ7PfgsXv5Ojnwa%2B1zjiIC0grnvoF8sWWXo%2BkgXbBVsumCr4VjiXqOaoYdd9L8gr6ggbgLZAviIObdW2Er8sOdH3duonYbdNE6CVtIJk%2BhtGKZh6DTgmG9ErnAyD2eShuHPi%2BLzCf8Snt3YKb9p%2F7q%2F%2FnF9dppNDW8zcf%2F7e%2Bvy8uy%2Bn90t39P1HzSFKMWLBwAA)
- Subdomain (`host=boutique`): [Test results](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKIHg2oC%2F%2B1UXW%2FaMBT9K5alPS1JQwKBZpo01G5TVw3RtZ1UVQg59oV6DXZmO9AU8d9nB1LSle55k%2FYUOL73%2BJz74TU2sChyYgCna1woueQM1BnDKSZzEBT8gj9Azh8hmCnsPUWMyMJm4PHu0J5oUEtOoU7V3LSgXeylBdGSG8UFoFbiEpTmUuC04%2BFczuW1ym30nTGFTo%2BOmuv9Wk4VSKFAWAEBlYv9IadS%2BMvI73WioBBzy8pAU8ULUzPjseTCaGTuADG5IFwgI%2Bt%2F2hDDKVpB5jSjrOS5QVn1pC9FRKAhUkClYkiKOokU8GBxhgg6GQ2%2FfnT4arUKnBmiOMlyOH12%2FRtHzos3KTobL7uIMKZAayRnbQ13Uhsu5iiXhKGM5MRWX3n2siLnwBrB7u53qCZ0CZbSfYQtcUPn%2Ftt4F%2BEhQ9QcTHNkRW4Vu%2BZUgo7L7Byq07oir3XcxX0Dxm0JzFPkn7riHaTZVlDj9HaNTVW4gRha2Im1Pz%2B40ap7dCVb9bKoMXYa4iQMN95TYmNhl2xdHUivq%2FOMYLLx8KMUMN1rmdhBaTzBg9sE8A1o85v43UWZLA3%2FWbqhnStZFlPekBREkYV2K9TQ3b7ON2kIb%2FeMFtt6dmi%2FF0RBEga9Bm7Cd5SBAJPzWRXY2cDOFZ8LqWCq7ZeYUtkaGVWChxdlbviUrMgeYnTqJqqyRdD21LI%2Bb4jYLmvLKiOGWGQvqlVTD08Zdba5W3ua0G7UTUIfMhr73YwyPxuEPZ%2F22aDT78TxYBC13pDXX5kDb8nLFtgNAmE4ca%2FFMF%2BRSuPNgSHZGXL7%2BdLUoYL%2BzfYmnp22%2Fw37hxrmNpgsgU2JC4%2FCKPHDgd%2FpX3XiNOyn3SQ4TuLecfI2DNMwdF7sc7E1u7ab3d5pPOuPzi7YxReS0ZNPP%2BbJ%2BWVcnn%2BOut%2FzYtQdmvjo8l7ezMrr8ub%2BPd78AisIIR3bBwAA)
