### PR TITLE
Add StreamAgent hosting templates (streamagent.io)

### DIFF
--- a/streamagent.io.hosting-apex.json
+++ b/streamagent.io.hosting-apex.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "streamagent.io",
+  "providerName": "StreamAgent",
+  "version": 1,
+  "syncPubKeyDomain": "streamagent.io",
+  "syncRedirectDomain": "app.streamagent.io",
+  "syncBlock": false,
+  "serviceId": "hosting-apex",
+  "serviceName": "StreamAgent custom domain",
+  "logoUrl": "https://app.streamagent.io/icon.svg",
+  "description": "Points the customer's apex domain at their StreamAgent workspace, so their video pages, landing pages, and routes serve from their own domain.",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "76.76.21.21",
+      "ttl": 600
+    }
+  ]
+}

--- a/streamagent.io.hosting-subdomain.json
+++ b/streamagent.io.hosting-subdomain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "streamagent.io",
+  "providerName": "StreamAgent",
+  "version": 1,
+  "syncPubKeyDomain": "streamagent.io",
+  "syncRedirectDomain": "app.streamagent.io",
+  "syncBlock": false,
+  "serviceId": "hosting-subdomain",
+  "serviceName": "StreamAgent custom domain",
+  "logoUrl": "https://app.streamagent.io/icon.svg",
+  "description": "Points a subdomain of the customer's domain (for example www or watch) at their StreamAgent workspace, so their video pages, landing pages, and routes serve from their own domain. The host is supplied by the caller.",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for **StreamAgent** (streamagent.io), an interactive video lead-generation platform. Customers connect their own domains to serve their video pages, landing pages, and routes:

- `streamagent.io.hosting-subdomain.json` — CNAME for `www.`/`watch.`-style hosts (`hostRequired: true`; the connecting host is passed via the `host` parameter).
- `streamagent.io.hosting-apex.json` — A record for bare apex domains.

Both templates are signed (`syncPubKeyDomain: streamagent.io`, key published at `_dck1.streamagent.io`) and validated with `dc-template-linter` (clean, `-loglevel error -tolerate info`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes: the templates carry no variables and no TXT records, so the TXT/SPF, variable, and `essential` rules are satisfied vacuously.

## Online Editor test results

**Editor test link(s):**

- [Test streamagent.io/hosting-subdomain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD4ug2oC%2F91TXW%2FTMBT9K5ZfANFkWdOvRUKiQIUAMca%2BXqYqcu2b1qpjZ7bT0FX971y3aTe0SfDMU3Rzz%2FU95%2Fh4Qz2UlWIeaLahlTUrKcB%2BETSjzltgJZuD9rE0tHPsnrMS0fRq1x%2BHPjZXYJ00mmanHerWml%2FUs2%2Bw%2FmRKJvVLhwXMJQhpgfsjilVV%2FCLygzJ8SbOCKQf4B%2BxKctixXBjnpZ5Hrp6J%2FTHH%2FnOehNfOm5IckcrMzY1V4RzvK5ednDyncCK50bFbzREvwHErK79TSi%2BM1N4RRo7LiSmIX0C7B%2Bwr1%2B4irwtjCfxiaDaQpmkIlg3zfPGGMB9mpCVPmTbGLl3FOHSIM20%2FuG9IhcRchyimBQo%2FlFgRa2oPjgT5QAqLQvdzptEtjZhcI7vgGZEIrKtKSRBktt6zZkqBjVFnQFzCfY3XgyZ7W6PreFPGCkezuw316ypY%2B%2FF8%2FH3SwrF8H0Ky8%2BTaYMk1XkCMweCgIqFdzE2JCO%2FR73SQJNvptkMfjIb88egpenxIQ%2BtWO9buQOuwmKPUKpeHkYpZVrqQ4MPw3R%2FT08P43W4%2B7JVzbSzkDr%2FM1xYOKstaeZmzhj3%2BEjzHVKg10nTYxVOeO6D3WduzE8yzf9DfobnggbQMQR52eymbpaOolwwHUU%2FMetFsmJ5F7KzgvN8tEkhHTx7hy0%2F0by%2FjDxPBORyULMR%2FrBq2dnS7nXbQ0P9ZH2bBsRWInAVkN%2BkOomQUnQ6vT%2FtZv5ulSTzsp4NR722SZEkS9IDze8UbzM3TxNBxKSbuZvJjcX%2B1vLVpsewXCpUsbu%2FLSf%2Fha48VD5NqOfgpPzfv6PY3%2Bj0WE2wFAAA%3D)
- [Test streamagent.io/hosting-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMEug2oC%2F91Ta2vbMBT9K0Zf9mG2a6dOnBgGaxl7UDJKHzBWgrmVbl2ttqVKctIk5L%2F3Ks%2BWdvsBA4Etnfs45%2BhqyRw2ugaHrFgybdRUCjQ%2FBCuYdQahgQpbF0vFwj36ExqKZpdr%2FMTjBE7RWKlaVqQhs%2FOWn3e3Zzj%2FohqQ7XvFfMwFCmmQu30UaB2%2FG3laK%2F7AijuoLdIJmqnkuGZ5r6yTbRWBxie2h95SDHhnnWoCsekVslpV6trUvoRz2hZHR2%2B7H0mu2thOK4oXaLmR2q1FsnMlW2cDd4%2Fbwmg%2B2MCT2HYIwHlUmuAliZkyD1YDxzCwaot7T1WgqacNgxpaQXJ2W9oFRnUObeCVYXBnSMMmT83aba%2BY6HkfLvCxI0PF3igyVxlhWXGzZG6uvSUn21j6%2FezvdK3jStE2H8S0eiktApwjawZJspqsQrZQLZaHYhNyY3dl%2BAQ0Pxhz1Rwq019FtHUpd%2FEaDDTWz9gu8%2BZV6mSXe8OY7yirVhksLX3BdYaYO9ORoqarnSxhBocjwUu6uXpOBC2hVOK12nYzC16tAAd%2FVRqyUnDPUPq5gtEwzweYRIIPB1GG%2FVE0OhZZxO96Oea9PmbH8OJNvP9i%2FjGoB6fQWkqQ4EfxpJ7B3LLVahKSa%2F%2BDDrpYC1MUJfiwXtIbRMkwSvOrtF%2F0syJL4ywbDdP0Y5IUSeJloHUbfUuag5cTwBbXalrp2e%2Fb%2FGveNK67hF%2BL5nh8NhbZfNT8sePxtz72qsfvp%2BNPbPUMUGgA39sEAAA%3D)
- [Test streamagent.io/hosting-apex example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACsyg2oC%2F91T7WrbMBR9FaM%2F%2B1HbdbLEaQyDZQxKKaxZm0K2EowsXbuitqVJsp005N17lc%2BWdnuAgcCWzv045%2BhqTSxUqqQWSLImSstWcNBXnCTEWA20ogXUNhSS%2BEf0B60wmtxt8YnDEWxBGyFrkvR8YlY1mzbZNay%2By4qK%2BqNiLuYWuNDA7DGKKhV%2BGPmtlOyJJDktDeAJ6FYw2LJ8lMaKugiogiU5Qu8peqwxVlYe3%2FXySSkLea9LV8JaZZLz8%2FfdzwWTdWjaAuM5GKaFsluRZCpFbY1nH2FfGPQn4zkS%2Bw4etQ4V2ntNopP6ySjKwPeM3OPOU%2Bkp7Gl8r6Q1RzmHLe48LRsLxnPKwMs1atjlya7e9wqRnvPhFv40aCg%2FGoXmSs0NSR7WxK6Us2Syj8Xfr%2B5OtzpmErejOMTV7%2BFCwFq0Jo6izWLjk2dZQ3oqtkA3DlcGS4rzAyGT1aly13W4KZC5SsUhRVFNK%2BPG7JD88CZ7cUh%2F2Oa7vqKopYbU4JfaRiN%2FqxvUVTWlFSnt6OmIsxTvr1whTYMoVnmrud5NxI4Zp5b%2BVbFPUs4cTeHma0DH8SiPRkHORnEwuMiyYJzFEAxGbJD14ryfU%2F7qbXz8cv4xsG8cA2MwR1A3lZOyoytDNpuFj%2B79N2Lwlg1tgafURfajfhxEF0FvNOvFSTROesNwGMcX8fAsipIockrA2J3ENU7E61kghfhZzJdTNrmZNZe%2FZ2ef1fL%2Bsni%2BG8%2FFFWtn3fWvyTzLWp3fsC9k8wKTwz7j6wQAAA%3D%3D)
