### PR TITLE
Add groundlio.com.connect.json (Groundlio domain connect template)

### DIFF
--- a/groundlio.com.connect.json
+++ b/groundlio.com.connect.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "groundlio.com",
+  "providerName": "Groundlio",
+  "serviceId": "connect",
+  "serviceName": "Connect your domain to Groundlio",
+  "version": 1,
+  "logoUrl": "https://groundlio.com/favicon.ico",
+  "description": "Points your domain and www at your Groundlio website (Render-hosted, auto-SSL).",
+  "variableDescription": "No variables - the target records are fixed.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "groundlio.com",
+  "syncRedirectDomain": "groundlio.com",
+  "shared": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "216.24.57.1",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "groundlio.onrender.com",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Domain Connect template for Groundlio (groundlio.com), a website builder for local service-area businesses. It lets a customer who already owns a domain at a supporting registrar point it at their Groundlio site with one click instead of entering DNS records by hand. The template is fixed-target with no variables: the apex (`A`) and `www` (`CNAME`) point at our hosting origin.

Supersedes #1568, which stalled because its Online Editor link encoded an earlier revision of the template (before `syncRedirectDomain` was added), so the automated template-coverage check failed. The link below was generated from the exact file in this PR. Please close #1568 in favour of this one.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — we use `redirect_uri` in our apply flow
- [x] no TXT record contains SPF content (`"v=spf1 ...`) — N/A, this template has no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A, no TXT records
- [x] no variable is used as a bare full record value — N/A, this template has zero variables; both records are fixed
- [x] no bare variable is used as the full `host` label — N/A, no variables
- [x] no variable is used in the `host` field to create a subdomain — N/A, no variables
- [x] `%host%` does not appear explicitly in any `host` attribute — N/A, no variables
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — N/A here: both records are the site's actual hosting target (apex + www), not independently user-editable content like a DMARC policy

## Online Editor test results

Check template and Test apply both pass with 0 errors, resolving to:

```
example.com.       A      600   216.24.57.1
www.example.com.   CNAME  600   groundlio.onrender.com
```

**Editor test link(s):** [Test groundlio.com/connect example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHNig2oC%2F%2B1T72%2FaMBD9Vyx%2F2tQkTSiEEmnSaDut1TbUtd00rULRYR9gLbEj24FSxP8%2BGwIUiWpf%2B2Ff8sN37927d74ltVhWBVik2ZJWWs0ER33DaUYnWtWSF0JFTJU02AUHULpk%2BnkbdiGDeiYYrmFMSYnM7k%2Bb%2FMvNOVmoWhOuShCSWEVe0sxQG6EkzZKAFmqifujCAafWViY7PT3QczoGx61k5B4OydEwLSq7RtNbJaQ1B5VAcjKfzwk0AnZlyRxHRlgk7%2B5Quu7CqTIWeUCgtiq8v%2F%2F6PvLKQAsYFXh1UGegyDZgSEjsFIkFPUFLNDKluSGgkYzFE3JPYhaSXRSK%2FaHZGAqDm5PbevQFF1drmUdc9yl3yIVjtK8nTV0hvqNtqtPscUntovLu912W78x9fvSzXDv0oNxvK0mjVjvqdKPEBax1lqdxvAp20MtB%2F9unPdy5eEiwF6OkXnvYqNpxDVcBfVYS872woZvZtht8AncFsUE1ZdyXJ65ysc2vQENp%2FDXdIh8PoMMt9pFSX1FMpNKYG%2FcGW2vXitW1c6esCytymMP%2BiLMcqqpYOIHGRR3FoXNyc4W9cxwsvOpaQHPOvELhN2EMI8ZHvBuO09Z52I577RDSXjeETpymeDZCFsOLvTq6dMc3a%2B8RGoPSCvCL0i%2FmsDB0dWR2TQOb2TUt%2FHNub6SbYeCm%2F38eb2cebtEMzJDn4NNacSsN4%2FMw6T4kveyskyWdKE7SpHt2EsdZHPsG0NhNk0u3ly83kt60n6tfultMet9LvBn8rC%2FY707CBDuZXpez814%2FMdftoryaPMQf6Oov%2FMIdaq4GAAA%3D)· [Test groundlio.com/connect example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE5vg2oC%2F%2B1TW2%2FaMBT%2BK5afNo2kIVAokSaN0XaqtqKut10qhJz4AFaDHdkOgSH%2B%2B45DgEai2msf9pL4XL5zzncua2phnqXMAo3WNNNqITjoK04jOtUqlzwVyk%2FUnDb2xiGbozP9sjOjyYBeiARKWKKkhMQetJX%2FYKsnK5VrwtWcCUmsIi%2FDLEAboSSNmg2aqql60CkCZ9ZmJjo5qdVzMmEYW0kfP4jkYBItMlui6Y0S0ppaJiY5KYqCsKqAfVpSQGyEBfLuFiSy82bKWOANwnKrvLu7b%2B99VxnTgsUpnNfyDBXZGQzxiJ0BsUxPwRINidLcEKaBTMQSuAtiVjL5nKrkmUYTlhrYam7y%2BCuszssyj3TdudwCFxjRvu40w0R8H7bKTqOnNbWrzHW%2Fj16OGT4%2FuVmWHbpXKIbNjh%2B2%2FdOu30SDtdjyThBsGnvoYNi%2FvjjAsYv1AIdilNRlD6uq9rFGmwb9oySMD4WNcGY7NrBkuIJQoao0Jo9RcLGzsdhBMqbZ3LhN3YGfaujRDv5U4lFk7u0eTq6eicSN3Pk5hV3un%2FPlXllOcith%2FWIqlYaxwT%2BzucbGWJ1jr%2Bd5asWYFeyg4smYZVm6QroGrRiiPge5PYgtQ84se3UKDTrmiaMrysuKu2EviHteO%2B61vHYYMO8MIPbCMOzxyWRy2ubdF3d69IiPX2qt52AMSCuYu71%2BWrCVoZsj61CxwHXwa0z%2BuQ5vh9SogUv1fzZvczbuZtkC%2BJg5zzAIO15w5jW792EQtYIo6PjtIOx1zz4EKASOAxi75bnGe315qfS5N%2Fh9c3kxfPx1etUyD5PB0oQ%2F7GOrO%2Fh5DVP9ddi6%2B94UlzLrFx%2Fp5i960mefFAcAAA%3D%3D)

`syncPubKeyDomain` (groundlio.com) signing is live end-to-end: the public key is published at `_dcpubkeyv1.groundlio.com` and server-signed apply links verify against it.
