### PR TITLE
Add template: mailnail.com / mailbox (MX, SPF merge, DKIM, DMARC)

### DIFF
--- a/mailnail.com.mailbox.json
+++ b/mailnail.com.mailbox.json
@@ -1,0 +1,51 @@
+{
+  "providerId": "mailnail.com",
+  "providerName": "MailNail",
+  "serviceId": "mailbox",
+  "serviceName": "Mailbox",
+  "version": 1,
+  "logoUrl": "https://app.mailnail.com/logo.svg",
+  "description": "Receive email at your domain with MailNail (MX, SPF, DKIM).",
+  "variableDescription": "dkimpk = the domain's DKIM public key; dmarc = the DMARC policy record value",
+  "syncBlock": false,
+  "syncPubKeyDomain": "mailnail.com",
+  "syncRedirectDomain": "app.mailnail.com",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.mailnail.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx2.mailnail.com",
+      "priority": 20,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.mailnail.com"
+    },
+    {
+      "type": "TXT",
+      "host": "mn._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimpk%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DKIM1"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarc%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for MailNail (mailnail.com), a custom-domain email hosting service. The template applies the records needed to receive mail at the user's domain: MX ×2, SPF merge (`SPFM`), a DKIM public key TXT at `mn._domainkey`, and a DMARC policy TXT at `_dmarc`. Synchronous flow only, signed requests (`syncPubKeyDomain: mailnail.com`, public key served at `_dcsig1.mailnail.com`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Justification for the bare `%dmarc%` value** (`_dmarc TXT "%dmarc%"`): a DMARC record's value must be the complete policy string. When the domain has no DMARC we pass our default (`v=DMARC1; p=none; rua=...`); when the domain already has a policy we pass the existing value back unchanged, so applying the template never weakens a stricter policy. A fixed prefix inside the value would make both cases impossible. The record is constrained by `txtConflictMatchingMode: Prefix` with `txtConflictMatchingPrefix: "v=DMARC1"` and marked `essential: OnApply`, and every apply request is signed, so the value cannot be tampered with in transit.

## Online Editor test results

**Editor test link(s):**

Apex (Domain=example.com, Host empty):
[Test mailnail.com/mailbox example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIxvg2oC%2F%2B1WbW%2FaSBD%2BK6uVoruqQGxDEuIIKYakFco5pYQ75S6KrMVeYIvtdXfXBjeiv72zNq8JkXJSq%2BZDkCzW87Yz88w88gNWNEpCoii2H3AieMYCKroBtnFEWBjDU%2FN5hCtr3TWJwBa7oLmGBzSSioz5dO005PONdMu8lGdUSMZjbJsVHPIx%2F1uEoJ8olUj78JAkSW374kNtUpPZGDwDKn3BElV44z71KcsootocEYVyngoUcHiN0YypCVqliP50byvopvehgi6uuu67ms6CCEaGIb3YiRlMWZRMUQupCV2G%2BkMWTihJhyHz0ZTmZyiIiPCXVheu0%2B%2BghIMyR4L6XAQoI2FKdQvy2G%2BH3J9ie0RCSUtJLx1e0fyiiP60zdqiTwMGodTa5nFXwK68SmL77gGrPCl6fAvyCZcKzucaMc5iJQdcXzI3a0%2FwZFwwlQMQRgUrBSjUjw1jUXlZPOv5eNYz8QABdzeiTEb9NKRQBWaxH6YBtT2Q7YbeijC4HWwCRHHNKzECUPR4EEVAnLU0XuYZmraEJGcoaR2UsB7grbTgOFcdHo8AN%2BUS5U9YPHZ5oG%2FpCTpielT3mCx162uezc4rhmST1kHx%2FtNz0NNnghmVksaKEb1Ln2InScIcL%2B4XFfyNx9TbDMs9JLSaKjonsPp0id8ybziNBU8Tj63sEyJIJDU9rDzvdlzvV753WJ%2FLZus3t9ttd7841%2B3x9Otkyj6ezoy28%2Fnyg%2BN86jifm47Wd8ZXcL50jP%2Bm9WVQQNN1Bpf9rvPXiIvB5c2Ax2HuwK9dxC%2F6CuFX1WuIY6jyDImUtPToKG4XVuc7c6S7wcYxF9ST8E9UKqDTSqSwl1EaKuaRGdmIAt8juo3QPAlauPHRpsUls51vMN6zZVtg7y6cF%2Fi6pUyTpjk8OW2cjKxqvVmvVxsGDaqnRw1SPTatJrWa5NT0%2FS0G3sfO%2Bzl4g%2Bn2fDjhjOQSLx6v%2Br6CrBcVZL26gspdfFpR1gJ%2BMdGzbIO%2BkzBclQlVvu7CXkyBv2AVd0bhFffoMRH%2FX9p4LXWuWX1xXwFafiOjNzJ6I6M3MvrtZASfZJJkNPCItrMM67hqNKvmycAy7LppG83aiXlkNYz3hmEbhq6ASlWW%2FwBfZNvfYnge9ZpxMBuZ7SPqzxq9WxJ97TdYJ2y8%2F1fFQ6f9D%2BffZjT6ctNt4cUPAwhH6rwOAAA%3D)

Subdomain (Domain=example.com, Host=mail):
[Test mailnail.com/mailbox example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABp3g2oC%2F%2B1WC2vbSBD%2BK8tCuB6xHUmuE0fBUNlxD19OeTguDQlBrKW1vbWsVXdXipXg%2B%2B03K%2FkdG1roQQoxCEnz2plvZj7rBSs6iUOiKLZfcCx4ygIqOgG28YSwMIKr4vMJLi11l2QCttgFzSVcoJFUpMynS6c%2Bn66ka%2BaFPKVCMh5h2yzhkA%2F5FxGCfqRULO2jIxLHlfWDj7RJRaZD8Ayo9AWLVe6Nu9SnLKWIanNEFMp4IlDA4TVCT0yN0CJF9MG9K6Hb688ldH7Rcf%2Bs6CyIYKQf0vONmMGYTeIxaiA1ovNQf8jcCcVJP2Q%2BGtPsDAUTIvy51bnrdFso5qDMkKA%2BFwFKSZhQDUEW%2Bc2Q%2B2NsD0goaSG5TvoXNDvPo7%2BGWVt0acAglFrabKMCdsVREtsPL1hlcY7xHchHXCp4%2FqQ7xlmkZI%2FrQ6Zm5VU%2FGRdMZdAIo4SVgi5Ujw1jVvqxeNb%2BeNaeeNABdzOijAfdJKRQBWaRHyYBtT2QbYZei9C7660CTKKKV%2FQImqLHgygC4rSh%2B2WeoXFDSHKG4sZB0dYDvJYWPE5Vi0cD6JtyifJHLBq6PNCnXAs6YHpUd5jMdctj9mbn5UOySusgf%2F%2FlOejpM8GMSkkjxYjepavIieMww7PHWQk%2F84h6q2F5hIQWU0WnBFafzvu3QLXY6aHgSeyxhU9MBJlITREL74cN98eF%2F0MRQB%2BTg64lbqfT7HxzLpvD8ffRmP11%2BmQ0nZv2Z8e5ajk3dUfrW8MLeG47xv24Og8MXXWdXrvbcf4ZcNFr3%2FZ4FGYO%2FJp5%2FBxfCL9AQbc6gmrPkEhIQ6ehuJ1bfdqYJ40KG0ZcUE%2FCnahEAOJKJLCfkyRUzCNPZCUKfI9oOAFECVo4cWvjooLh5sDN271j4db6vrl7XuBrZJnmzzqtBeSU0PJpzTgtf6xVj8t9atHycf3E6A9qdRNua2S8i6h30%2FFme9fHxQmfSCbxbHvz99Rl%2FVBd1pusq9jQnYWlDSAeE%2B2lIfQvCcNFtVDsb1DfOj9WtqvdJsn%2FYUk3RuONg1XQ9WuUfopZ3lLByz%2BB2WMJGPyds945652z3jnrd%2BEs%2BMCTJKWBR7StZVjHZaNeNk96lmkbVduyKmbV%2FHhSPTQM2zB0FVSqAoIX%2BL5b%2F7LD6b3vO%2B2j6d%2FOPa19u%2B0%2F174PD28OL7ou6fcC0Rq7X75ml8%2Fy6qrdwLP%2FAISE07YSDwAA)
