### PR TITLE
Add siteprompter.com.hosting template

### DIFF
--- a/siteprompter.com.hosting.json
+++ b/siteprompter.com.hosting.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "siteprompter.com",
+  "providerName": "SitePrompter",
+  "serviceId": "hosting",
+  "serviceName": "SitePrompter website",
+  "version": 1,
+  "logoUrl": "https://app.siteprompter.com/logo_dark.png",
+  "description": "Point this domain at the website you built with SitePrompter.",
+  "syncRedirectDomain": "app.siteprompter.com",
+  "syncPubKeyDomain": "siteprompter.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "198.245.53.67",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "custom.siteprompter.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for SitePrompter, a website builder for small businesses. It points
a customer's domain at the site they built with us: an `A` record on the apex and
a `CNAME` for `www`. Both values are fixed for every customer, so the template
declares no variables.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checklist:

- This template contains **no TXT records and no variables at all**, so the SPF,
  `txtConflictMatchingMode`, bare-variable and `%host%` rules are satisfied by
  construction rather than by choice.
- `essential` is not set on either record because neither is one the end user can
  usefully modify — changing the `A` or the `www` `CNAME` is exactly what breaks
  the service. They are the service.

## Online Editor test results

**Editor test link(s):**

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEbOg2oC%2F%2B1Ty67TMBD9lcjbm6RO0qQlEhLlsaBAVWjvqqoiJzatIYkt22nIrfrvjPsuFMTyLljFGZ85c%2BbMeIsMq2RJDEPpFkklNpwy9Z6iFGluGAQqaZjyC1Eh93w%2FIRXg0QwQ0yMCbjVTG16wffJaaMPr1SV6J8VpWW6LAGjDlOaiRmngolKsxKMqLYkxUqe9HpHS%2F1VNz8IyStR3X%2B7rUKYLxaXZ06Cp4LVxzJprh4qK8Noh9pedajqdaJy84aVxWm7WzrUu36ru6uILo1yxwrzdEwDpPR1H7LTJP7DujLyDAiahqEbpYotMJ60ZIwhbo%2BD4yrprNeu5gN%2FgxdAP%2B7EfR34ygCtjwI8owXjnnrPfTEaf3l0Y2ra95SgabUR1Kxg6uGFb7lz0JGqWXdQtwcpTG98E07JsqhxGeWzjWA1OKyUamfFTkiSKVNpu0Sl98Xv%2B8kSwQMjW5qtaKJZp%2BBLTKGjLqIa5qGpKwzPSkkuIFhmoLzuQquEWKG6NrA8LZo2kxJC%2FmeiijBZWKberikkS4pwwrz%2FEidcPgtAjJIk8QCY4j6KgGOCr3f%2FT27i%2F%2FRe7mNasNpzYxR6VLek02t2Z5rGNwzSPjfzDJJ9PS0sXtuH%2FaJ7laOD5abJhNCMWFuIw8fDQC4ZzHKVBnAZDfxAkYRw%2BYJxiK8MwbQ6dbuG1Xr9TlM%2F64Xw24SR%2BiscPj%2F2P43K%2BouNABlHx%2BUcePPBu9vX1HPOefol2PwFbcograAYAAA%3D%3D

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFrOg2oC%2F%2B1T247TMBT8lcivTdLcmraRkKh2EaoWVhUUBKqqyEnc1rtJbGynIVT9d47b9BIoiEeQeHJyPJ4zcy47pEjBc6wIinaIC7alGRHTDEVIUkUgUHBFhJ2yApnn%2B0dcAB69B8SsRcCtJGJLU3J4vGFS0XJ9id54YtQk0UkAtCVCUlaiyDVRztbsg8g1iVJcRv0%2B5tz%2BUU1fw%2BIMi2ebH%2FJkRKaCcnWgQTNGS2WoDZVGxgpMSwPrX3LKaTSsMpKK5sqoqdoY17psrbop03cko4Kk6v5AAKS3dLTYWZU8kOaMvIECJiYyiaLFDqmG62JMIKwLBZ8vdXW1Zjln8OuOR7YXDOyBb4dDuFIK6uGHjrM3z6%2FvHidvX10Y6rrucqSVVKzoCgYHHbbl3kTfWEnii7ollPJk44kRyfOqSKCVrY02myJwmGgtWMVjenrIscCF1JN0olj8zLE8kSyOLFoDXZdMkFjCiVUlwJ4SFTFRUeWKxrjGl1CWxuAib0CyhFug6Ra0PA5aKzDDCv%2BuniaKs1QLpnpqU%2ByOnSTwrTAgKyvAXmDhcOhbq%2FFolRIfAuPh1Rr8ak1uL0K3ckRKUiqK9ZxP8ho3Eu1vNLd1A821u47%2BoLt%2Fl7elCRPyv1X%2FRKtgRSXekizGGuo5Xmg5I8sdzR0%2FcgeRDx0KPW8w7jlO5DjaCLAd3e5gm6%2F3GMlPQ%2FeODvvzJLxXgwfMq%2BDjaPL6i6yeps%2Bf1%2BX8KxvWvTdlL5%2B%2BQPvvQIVIC5AGAAA%3D
