### PR TITLE
add Sentry, Managed ingest

### DIFF
--- a/dsntry.com.managed-ingest.json
+++ b/dsntry.com.managed-ingest.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "dsntry.com",
+  "providerName": "Sentry",
+  "serviceId": "managed-ingest",
+  "serviceName": "Managed ingest",
+  "version": 1,
+  "description": "Routes Sentry SDK telemetry through a managed custom ingest domain.",
+  "variableDescription": "%target% is the Sentry-managed CNAME target for this ingest domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "dsntry.com",
+  "syncRedirectDomain": "sentry.io,getsentry.net",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the signed CNAME template for Sentry managed ingest domains. The target is supplied by Sentry in the signed synchronous apply request.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

No `logoUrl` is included in the template.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.

- [x] `syncPubKeyDomain` is set - this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain` - the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) - use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary - prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label - the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain - use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

`%target%` is intentionally the full CNAME value. It is supplied by Sentry in a signed request so the configured managed-ingest target can vary by environment. The CNAME is required for the service, so it is not independently editable and does not use `essential`.

## Online Editor test results

**Editor test link(s):** [Test dsntry.com/managed-ingest example.com/errors](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL%2F0g2oC%2F91TYW%2FaMBD9K5GlfmrCQgqFRpq0rkxTV5VNlE2qKhQd9gFWkzi1HboU8d93JgnQVuoP2Kfo7t69u3t%2B2TCLWZGCRRZvWKHVWgrU14LFTJjc6qrDVcb8fWUMGSHZHboa5Q3qteS4a8gghyWKQOZLNPZQbHpu67K3L69RG6lyFnd9JtBwLQu7i9lElRaNV0%2Fx7kY3nsUUM3SRXWlVLlceeM08j5fGqqzh9YTKQOYdxw9awjzF0SvuEwt6ifbEk4a4sBkStGRX48vbb16N8RZKE4aA77hNlfOvqeKPLF5AarDO%2FCrnN1iNdqi3Crr6BIXUyO0eYXbDO1L5NK4JcnTirJSxE3wqCU%2FaWl3SCGpVWhgWP2yYrQon6m7dBk7hF%2FdUSubWTNXRrZS1NmXx2XkYbmdbn72oHJMD3YweoF0J%2FwIZAputG17UWmlD8ZLELxLZdhWgITPOOm3%2FwyuCWcvw0FJQpl7K5WpZO0c6ueXkMlcaE0NfsKXG9vysTK1M4BkOKcETKIq0olsMVYnzvTR5bb%2F9CQIsUPx%2B9pFIPksEd2dJZ%2BwLHnGxIGcP%2BoNh0OvORQBwxoP5cBH1B92zRURv5H%2Fw93z4l7yVGI0zggRahV2mz1AZtt3OfJL7f72NPGFgjSIBB47C6DwIh0F3OA37cf8ijgadi955NOyehmEchu4WYq9P3ZBfjp3CqtPff%2FRV7%2BXejsIfa%2FUzekz1p0JX9%2FPrydPwO4%2FwZrq6XI3G3d5ntv0HoAEOLf8EAAA%3D)