### PR TITLE
add Photon, Email sending and receiving

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @invisicat

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @invisicat

--- a/photon.codes.email-sending.json
+++ b/photon.codes.email-sending.json
@@ -1,0 +1,58 @@
+{
+  "providerId": "photon.codes",
+  "providerName": "Photon",
+  "serviceId": "email-sending",
+  "logoUrl": "https://assets.photon.codes/defaults/domain-connect/photon-icon-primary-v1.svg",
+  "serviceName": "Email sending and receiving",
+  "version": 1,
+  "description": "Configures an exact domain or subdomain to send and receive email through Photon.",
+  "variableDescription": "%dkim1%, %dkim2%, and %dkim3% are Amazon SES Easy DKIM tokens issued for the connected domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.photon.codes",
+  "syncRedirectDomain": "app.photon.codes,app.staging.photon.codes",
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "dkim",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com.",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "dkim",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com.",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "groupId": "dkim",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com.",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "groupId": "mail-from",
+      "host": "bounce",
+      "pointsTo": "feedback-smtp.us-west-2.amazonses.com.",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "groupId": "mail-from",
+      "host": "bounce",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "type": "MX",
+      "groupId": "inbound",
+      "host": "@",
+      "pointsTo": "inbound-smtp.us-west-2.amazonaws.com.",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Photon `email-sending` Domain Connect template for configuring an exact domain or subdomain to send and receive email through Photon.


## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test photon.codes/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP8DhGoC%2F%2B1WbW%2FbNhD%2BKwSBfKpk66W1YwEFmiYulhUpgiQrsgWBQYlnm7MkaiTlRAuy376jJMdW684p0A9L4U%2Fikcd77jnyHuqBGsiKlBmg0QMtlFwKDuqU04gWc2lk3kskB02dp7VPLENfel6v4rwGtRQJ1FsgYyJ1NeRc5DNcS%2BVM%2FqZSXJkbU%2Bio32dag9G9zdh9DlNWpgYHEvfnbiLzHBLTb5xcgbZbKJExVblLv6eXszVsm83YApMWmLCcEwUJiGWTxhKUFphs5DsUARMlClPb9FjmUzErFWjcROCeJYY0WRCpiC7j1jCyDr4RGUhNlpi5kuVsTpp69CwaU4LFKZx0kA74QmT%2BgUPqQYADG6s2wgPCFJCjjP0tc3I5viRjpity8vH0DIEXkGsitC6BkykmZeZA2grhTJOfhdVVnrxPZbKg0ZSlGpqZ8zL%2BCNVJ7YVZNO7t9t4XJ2z9L4ALJGiedrCi6Pg5dkIbNsPSfhkAN0rFNY1uHqipCnswx5%2BOzsa4NMMqFfUdsYxxYi61WZelN2kyW0Blr5oUudFXcmPdfnqsrpAGjYiZ5WwM3q1w4HmPzvchBjsQgx%2BOGO5ADL8H8ey6A1d33VTJDcxYlnkCXZwpAI9ZsnB1Zopeqd070MYNvobEZpNKmAobxtuewOX5h7Nnp6CL6UWZ4g2JKN69tOQQdSDpt5mJ3Ebh66DvupTa9e2M2N1ORrePDkVPmKyv7q3TdonVs3uG4gh1kk8prBKciNp%2FddibFViljbEKplimrbiuot50wt6u4t5QO64j745ad4V181dWYK1gZYXWCqmlJ2a5VDDR%2BGUGlY5GRpWoDhlKrpiwO7ae4skEuzutsBoaVzHG142cN4Lrd28zZ4bVszvusEMnPLHFEPZ0g6EfD%2BMBuKNRHLivR6ORO4IgcOOEJwP2xh%2ByMNh4eba9Sv%2F1%2BqzPC%2FDVyY1g9iU6Su9YpenjlgZuuQVbuQU%2FBbdwK7fwZXKrxaIl9qQ2LaVni90Gx65K%2FB8ZX11ffZvy8i0qrU%2B2aiz5h6Xpii2SfQEn%2Bm7N7Lky%2FwLO8tbBF2Yvq3tZ3cvqXlb3svrDZBV%2FfDVbAp8w6xZ4wcD1Dl3%2F8MobRt7rKPR7nn94GA5feV7keZYUkm3q8IB%2FyZv%2Fx%2FTYG1Tiz99%2Fubj%2B9fSzf6%2F47OgP2V%2BI4V%2BhFwTwZgwM7k3%2FIv8g39LHfwE5fLuBQxEAAA%3D%3D)
[Test photon.codes/email-sending example.com/agents](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPUGhGoC%2F%2B1WbW%2FbNhD%2BKwSBfKoly5Ln2AIKLMvL5rUO0sYdUgSGQUtnmbAkCiTlVA2y376jZNly4s0psA%2FL4E%2BS7o733HM8PtQj1ZBkMdNA%2FUeaSbHiIchhSH2aLYQWqR2IEBRtbXzXLMFYelN60a5ArngA5RJIGI8tBWnI0wh9sYjEFxmjZ6F1pvx2mykFWtnN3O0Q5iyPNb4IXJ9agUhTCHS7CrI4fluZ5AmThbXq2GoVbWHX1VwaYLIGJiwNiYQA%2BKoqYwVScSzW77QoAgaSZ7r8pucinfMol6BwEYFvLNCkqoIISVQ%2BW39oUSZvZAZSkiV6IUUeLUjVD9ugMcnZLIaLHaSTcMmTzkmLlC8uvphc5Yd3QpgEcpaw7yIlt5e35JKpglx8GI4QeAmpIlypHEIyx6L0Asi6Q2ip6jOwqkiDX2IRLKk%2FZ7GCynKTzz5AcVFGYRVV%2BHq5%2FWyHTfxnCDkS1JsVLMt24lrGoDSLsLXPE%2BBCIUNF%2FftHqovMbMz59dnoEl0RdikrZ8QwRsNCKL1tiz2tKltCYUZN8FSrsWj4zcNmZYcUKERMDGetcba8nuM8tX4M0T2A6P7riN4BRO9HEEd3O3DlqZtL0cCciTwNYBdnDhDOWLC0VKIzO1fWAyhtuS8h8bAJyXWBB8bZX8DtzdXo1SWobP45j3FCfIqzF%2Bch%2BDuQ9O%2BZ8dRkCbdJf96ltPbvZ8QeDjKaPLUoRsJ0O7qT1vqUGD37xlAcoSxyUwKLAOHrMqe8XFVvebMPdfGYMWOSJcpIbJ37fif5pM5%2BX6efrPMfzl2ekDqsU1vc2uLWFq%2B2eNTQ5lEqJEwVPplGBaS%2BljmqRoJSzKfsgW1NYTDFUx8X2CWFXszz8oCnlRCXNTQm3d50K2SabQIOjHqLTsPAdIubIXAG%2FZnbm4HV6Tqe1e12ehbrs4EVeqc%2Fdbtdt9%2F3eo0Lat%2Fl9U%2BX1PNtBbyiUs2ZubbO4gdWKPq057Q3CLuHCLv%2FM8LeIcLeWyZcatCabSViLzi%2BWkobhHc16L9Lf3w3Psh%2F9R5FvUP2yjn5k8VxTR2Zv5m9fk7ytZfLm9njSQtvt6N0H6X7KN1H6T5K95uSbvyJV2wF4ZSZYNdxe5bTtzr9sXPqd059Z2B3sbxT953j%2BI5jqCHlqhuP%2BLff%2FM%2BncQR%2FDOH6Uxb8PmQXd%2B3fgsHo%2FGO3Py4GV9%2B%2Ffl06%2FeXwy9WvcLUcvqdPfwFTkDybIxIAAA%3D%3D)