### PR TITLE
Add posthastemail.dev.dkim template

### DIFF
--- a/posthastemail.dev.dkim.json
+++ b/posthastemail.dev.dkim.json
@@ -6,6 +6,7 @@
   "version": 1,
   "syncPubKeyDomain": "posthastemail.dev",
   "syncRedirectDomain": "app.posthastemail.dev",
+  "logoUrl": "https://posthastemail.dev/icon",
   "description": "Publishes the DKIM public key that lets Posthaste sign mail for this domain.",
   "records": [
     {

--- a/posthastemail.dev.dkim.json
+++ b/posthastemail.dev.dkim.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "posthastemail.dev",
+  "providerName": "Posthaste",
+  "serviceId": "dkim",
+  "serviceName": "DKIM Signing",
+  "version": 1,
+  "syncPubKeyDomain": "posthastemail.dev",
+  "syncRedirectDomain": "app.posthastemail.dev",
+  "description": "Publishes the DKIM public key that lets Posthaste sign mail for this domain.",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "%selector%._domainkey",
+      "ttl": 3600,
+      "data": "v=DKIM1; k=rsa; p=%dkim%",
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `posthastemail.dev.dkim.json` — a new template for Posthaste, a
transactional email service.

The template publishes the DKIM public key for a customer's sending domain.
That single TXT record is the one thing required before Posthaste will sign and
send mail for a domain, so this is the whole of the onboarding DNS change.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`logoUrl` is `https://posthastemail.dev/icon` — a 96x96 PNG served over HTTPS.
Confirmed with the linter's own `-logos` check, which fetches it.

Also validated with the official linter, which exits 0:

```
dc-template-linter -loglevel error -tolerate info -logos posthastemail.dev.dkim.json
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove

Notes on two of these:

**Bare variables.** The record value is `v=DKIM1; k=rsa; p=%dkim%`, so the
variable is constrained to the key material rather than the whole record, and
the host is `%selector%._domainkey` — the selector varies, the `._domainkey`
suffix is fixed, exactly as the guideline's own DKIM example suggests.

**`essential`.** Not set, because this record is not one an end user can
modify or remove without breaking the service: removing it stops Posthaste
being able to sign their mail at all. `txtConflictMatchingMode: "All"` is set
so re-applying replaces the record at that label rather than accumulating
duplicates, which matters because a selector is rotated periodically.

The signing key is published and live — `_dcpubkeyv1.posthastemail.dev` serves
both key versions today, so `syncPubKeyDomain` verification works now rather
than being aspirational.

## Online Editor test results

**Editor test link(s):**

- Apex (`example.com`, no host) → `s1._domainkey.example.com. TXT "v=DKIM1; k=rsa; p=…"`
  https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABwUhGoC%2F%2B1TTXPaMBD9Kx7NcCofMtAYnOHgJDTDEEjSEhImw3iEvdgqtqVIgoQy%2FPeuSAlJmpx67U3afat9%2B%2FZpQwzkMmMGiL8hUokVj0H1YuITKbRJmcY841k1hhUpvwCGLMcCcrWHYEqDWvEIdqXxgueH0B%2FwWb83cH7wpOBFgskVKM1FQXwXgesiulrO%2BrA%2BE9it%2BKS7hX2HmCuIzAuQSVn9CJyJRNyoDBGpMVL7tdpfqBqPkECZxKAjxaXZ0SFIJOM6Be2YFJwda2lDkbOANcaYcTIw2nkZ3tE4lGMfdeZCIYJrJ97Rq%2BLjSFaoWBP%2FfkPMWlolRncjTKRYj5eShgznEapUDZ%2BrsA2mjUHujSNKkR8zDJGrjiXjHjuLjtLs2JGdkhW6ZMFP5lQUcyRpBsxEKUo8ELHtFWQZ2U63ZfJLFBAeyEzx2b2E8MTQA1CNRH7ghadEiaUM%2BR4vmWK5tj7ZV96%2FKZ3ua%2B%2BJPe%2Fnsnft2sjOFngb9HonvZ%2FB8CRZPKQLft5%2BpCfBdfdbEFyeBtetwOZPkz6eu0Eed%2B%2BCwdVFt9%2BdXA4vJsTOgnoLBaHVnZmlwjmNWkKZ5MvM8JA9skMojkJ0SLbG0TVmsf37PRTP9tTuW%2F0%2FFf2f2L%2FZaxhHVk1uv4znNeZenUUVGrlepdlk9UqbNo8q9Ctr0xmdg9tqvvqAn%2F7QD77hYaGgNRSGs2xnjEe21mS7nZZxuf9FeSeKNTBbQRwyC6vTOnZtVdzWiLZ8t%2BG7R9W257pt7wulPqV2BNDmWZ4NOvS1N4nQk2H3%2FDqX7LI%2Fv5HeTNDa5HZ20b%2Fh47wxHt2OIaHUFGM16JDtbz9HQC6TBQAA

- Subdomain (`example.com`, host `mail`) → `s1._domainkey.mail.example.com. TXT "v=DKIM1; k=rsa; p=…"`
  https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFMUhGoC%2F%2B1TTXPaMBD9Kx7NcAoYGScBnOFgCO0QIB9NMs3HMB5hKbaKbSmSgBCG%2F94VhJC04dRrb9LuW%2B3bt09LZFguM2IYCpZIKjHjlKkeRQGSQpuUaMgTnrmUzVD5HXBOcihAl1sIpDRTMx6zdSmd8HwXegOf9ntD55onBS8SSM6Y0lwUKPAAuCjiy%2Bm4zxanAroVe7pb2A9GuWKxeQcSKd2vwJlIxK3KAJEaI3VQrf6FqvIYCJQRZTpWXJo1HQREMq5Tph2TMmfNWtpQ7EzYAmLEOBkz2nkf3tEwlGMfdZ6EAgTXDl3Tc%2BFxICsU1Sh4XCKzkFaJm7sbSKRQD5eSZhnMI1TJjTZV0AbSxgB3%2Fxhj4EcMAeSsZcl4J86kpTQ5cWSrZIUuWfCL6YjiCUiaITFxChIPBbW9wixDq9GqjF5FwaIdmRE8u5WQvRDwAHNjke942XngligxlRHf1kiiSK6tV7bVj5%2FKR9v6x80DI%2BuCzXw2pj0bWdsDbsNer937FZ63k8lzOuHfm3PcDq%2B638LwohNeNUKb7yR9OHfDnHbvwuHloNvv3l%2BcD%2B6RnQl0F4pFVn9ipgrmNWrKyiifZoZHZE52IRpH4JRsARJoyEL7P%2FdRbGyqvQ97cN9U2LuBfxrh05IjGltZuf0%2FTcywN8aNymHdH1cOG01cIXW%2FVql5tE5ozPxjn374jXu%2F6xd%2F8vN2mdasMJxka6fMyUKj1WpUhk3%2FV2efOtbSZMZoRCy0hmvHFeDiNW5wI%2FAOA89z695R0%2FcOMA4wtmMwbTYSLcGzH92KdO718eD1Nhxft48abYOp33k5u06q5Dn5eSY7ycFd%2FvAwbZ8O5i20%2Bg0Oux9hrQUAAA%3D%3D
