### PR TITLE
Add rudys.ai website template

### DIFF
--- a/rudys.ai.website.json
+++ b/rudys.ai.website.json
@@ -1,0 +1,26 @@
+{
+    "providerId": "rudys.ai",
+    "providerName": "Rudys.AI",
+    "serviceId": "website",
+    "serviceName": "Website",
+    "version": 1,
+    "logoUrl": "https://app.rudys.ai/logo.png",
+    "description": "Connects your domain to the website built and hosted with Rudys.AI",
+    "variableDescription": "%ip%: website load balancer IPv4 address; %target%: hostname the www record points at",
+    "syncPubKeyDomain": "rudys.ai",
+    "syncRedirectDomain": "app.rudys.ai",
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip%",
+            "ttl": 300
+        },
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "%target%",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **Rudys.AI** (rudys.ai / website): connects a customer's domain to the website built and hosted with Rudys.AI. Two records: `A @ -> %ip%` (website load balancer) and `CNAME www -> %target%` (the site's stable hostname). Synchronous flow only, signed (`syncPubKeyDomain: rudys.ai`, public key published at `_dcpubkeyv1.rudys.ai`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — template has no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — n/a, no TXT records
- [x] no variable is used as a bare full record value unless necessary — the two variables are the A record target IP (`%ip%`) and the CNAME target hostname (`%target%`); as address/hostname targets these are inherently full values (the common pattern for website templates), and every apply URL is signed via `syncPubKeyDomain`, so values cannot be tampered with in transit
- [x] no bare variable is used as the full `host` label — hosts are fixed `@` and `www`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — n/a, both records are the service itself

## Online Editor test results

**Editor test link(s):**

[Test rudys.ai/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH5hhGoC%2F%2B1T227bMAz9FUFAn5Y4ju1c6mHAsmYF0q6XdS2KrQgC2eISoY4lSLI9N8i%2Fj8o9RbHnPuxJBMlDHh6KC2phrjJmgcYLqrQsBQc94jSmuuC18ZigjZ3%2Fms0xj96tIoMRRgzoUqSwAlSQGIGFdt5N%2BuPOX4I2QuY0bjdoJqfyQWcYn1mrTNxqMaW8bdOWC3sqnyKKg0m1UHaFpGcyzyG1htSy0ITLORM5sZLYGZANA5IUIrOE5ZzMpLHASSXsjBzQLpkWLMlgeFT6RKiTeFckk4yThGUsT0GT0W0ZEca5BmM%2BkhPL9BQsZrsGOc657l9VREMqNSdKihxJMuvkqPP0tkguoR6u6B6L66J3wAUC7S5%2BqAXmrIsaGj8tqK2VU3WAbtcczc9uRat%2B93IzBnqsRXFD3182dpiz68HV1z0O6b5CbsY6RI%2BXDfoic5jsOYxxJ1ui8Ifh%2FwEvlfN9YbSmWhZqIrb5imk2N%2B6PbZFPR9DxFvtEnS2Us3odL%2FC6vtdxrjW1A1yzkvrZKJbCVimlqGMrprnUMDH4MltoHNzqAhp0XmRWTFjF9i6eThCV1TicwShWPxY4X%2F9gJzBnlqG557TXqEEnPHWzCXcGUdrvdaDfbwaddrcZ%2BV1ongb9sAltP0ySpBuGSefgpl7f2tsXtRcW%2Fx%2FkVjB3OYOsYrWhyzdWvGG%2BXvGG%2B7%2BEe0%2FTjBv4Zf4v4h0sAu%2FOsBL4hLm0wA%2B6Tb%2FfbPfv22EchXHQ9XpR0O9EH3w%2F9n3HHYxdD7nASzy8Qfr75uH%2Bcf7rx7fzYcu%2BnJfhxfCyfi4uRles%2FnJTBdHDaXoJnSL6%2Bf0TXf4F%2Bbuf%2BJkGAAA%3D)

[Test rudys.ai/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC1ihGoC%2F%2B1T32%2FaMBD%2BVyxLfRqEBGgaMk0aa1eNbqs61KlbK4RMfIC1xHZtB5oi%2Fved%2BU1V7bkPe0p8d9%2Fdd9%2FdLaiDQufMAU0XVBs1ExxMj9OUmpJXNmCC1nb2a1ZgHO2vPN0eeiyYmchgBZjDyApMtLNuwu929hkYK5SkaVSjuZqonyZH%2F9Q5bdNGg2kdbIs2vDvQcoIoDjYzQrsVkp4rKSFzllSqNISrgglJnCJuCmTDgIxKkTvCJCdTZR1wMhduSg5oz5gRbJTDxVHqE6FP0l2SXDFORixnMgNDejezNmGcG7D2PTlxzEzAYbQvILHPdf35nBjIlOFEKyGRJHNejkpmN%2BXoK1QXK7rH4npvH7hAoNv5D7XAmHVSS9OHBXWV9qp20eyL4%2B9HP6JVvVu1aQMtzqG4rTBc1naY8%2Bvu9897HNJ9gdy0dYgeLGv0WUkY7jkMcCZbovDEcH8gyFSxT2ynSuNrYlSph2KL0cywwvo926IfjuCDLf5hnQDfQvvX2WnQDOIwOPWmNcUDbH2uzB%2BrWQZbxTRikbWYSGVgaPHLXGlQAGdKqNGizJ0Ysjnbm3g2RFReYZMWvZj9WGi53uRNX5w5hq89rb1cNTrkmW9R%2BIuAVsaTkCf1doeP6%2B1sfFbvZDyrRzHESQx8NO4kB%2Bf18uxeP65jjXEdQTrB%2FCF18zmrLF2%2BMvFNAzjx4LiJf4n41toa1HCN%2Fg%2FmDQ4G79KyGfAh86HNsBnXw6QeJbdRK23HaTMK2lEcnZ2%2BC8M0DD1%2FsG7d6AIv9fBG6S99f9V%2F%2BnHf%2BSTur5oNJ7%2B0xq3oTieX579n%2FV5ffbt6Hl0%2BFuVj%2BwNd%2FgUNaZjiwQYAAA%3D%3D)
