### PR TITLE
Create xbuildnow.com.web.json

### DIFF
--- a/xbuildnow.com.web.json
+++ b/xbuildnow.com.web.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "xbuildnow.com",
+  "providerName": "xbuild",
+  "serviceId": "web",
+  "serviceName": "Web Service",
+  "version": 1,
+  "logoUrl": "https://xbuildnow.com/favicon.ico",
+  "description": "Connect your custom domain to xbuild platform",
+  "syncPubKeyDomain": "xbuildnow.com",
+  "syncRedirectDomain": "xbuildnow.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "185.158.133.1",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "185.158.133.1",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Description

New Domain Connect template for xbuildnow.com web service.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

## How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern <providerId>.<serviceId>.json
- [x] resource URL provided with logoUrl is actually served by a webserver

## Checklist of common problems

- [x] syncPubKeyDomain is set — this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] warnPhishing is not set alongside syncPubKeyDomain — the two must not appear together
- [x] syncRedirectDomain is set whenever the template uses redirect_uri in the synchronous flow
- [x] no TXT record contains SPF content ( "v=spf1 ..." ) — use the SPFM record type instead
- [x] txtConflictMatchingMode is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. @ TXT "%foo%" ) unless necessary — prefer @ TXT "service-foo=%foo%" ; if bare, justify in the PR description
- [x] no bare variable is used as the full host label — the non-variable parts are fixed to limit misuse (e.g. %dkimkey%._domainkey , not %dkimhost% ); if bare, justify in the PR description
- [x] no variable is used in the host field to create a subdomain — use the host parameter or multiInstance instead
- [x] %host% does not appear explicitly in any host attribute
- [x] essential is set to OnApply on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

Editor test link(s):

* [Test xbuildnow.com/web example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO%2FzhGoC%2F%2B1T246bMBD9FeTXAoFcCEGq1NX2pV212u5F1SqKkMFD1grY1DZh2Sj%2F3nFINps2rfpWVeoL2DNzxmfOzGyIgaouqQGSbEit5JozUB8YSchT1vCSCdn6uayI%2B%2BL8TCt4caNdg1rzHHaYFrKjZR%2F4FTLntregbw1KcylIErqklEt5r0qMeTSm1slgcPLmoKAIksLHDyIZ6Fzx2uzQ5FIKAblxOtkoJ2%2B0kZXDZEW5cIx0%2BjyOLayQyrLXncivm%2BwKuve7qDMF2pAbYFxh3l8GoVMqpkky3xDT1bbACzQ%2FSm3w%2BM7qJLkw%2Bk7iNYwnfjiJ%2FXA08kN0GYPFjqIg2Lrn0G3b%2Fil%2BsXXJsxSQHvksUKIDa3ii2FXYc96nx9NSyaZO%2BSG%2BpopW2nb%2BgJyfQBcH7JwQ%2ByJfCqkg1finplFI36gGXFI1peEpbenRxPKU1nXZIUGNXkxxKpjoh8MKxqihvyvWJSnLLUluRyyajqdhEIGXQQjeOC4KLxtNQ6%2BIoZjQfDbLgujVtJ4d5Z9H9igRaA3CcGrH8qJsaafJ9od27bn37foH2C9cbPZ%2F%2Bf%2Ba%2FLhGmq6BpdSGDYNh5AWxF87ugiAJ4iSc%2BNE4HMbjN%2FYeWPagTV%2FYBrfu9b6RT%2Br6csWi2cPNg6liWWUfo1iVU3OfCbHKn9VYrvRVNIy%2BDb68JdvvL3GQlN8FAAA%3D)
* [Test xbuildnow.com/web example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACr3hGoC%2F%2B1TbY%2FSQBD%2BK81%2Bvba0QEtpYiLx1JwkRE%2BM5ghplu4Aa9rdurulB4T%2F7iwvx6Fo%2FKiJX7rdmXlm55l5ZksMlFVBDZB0SyolV5yBumMkJY%2BzmhdMyMbPZUncJ%2BeIlvDkRrsGteI57DENzM6WY%2BBnmDkfDxb0rUBpLgVJQ5cUciE%2FqQJjlsZUOm21Lt5szSmCpPDxg0gGOle8Mns0eSWFgNw4a1krJ6%2B1kaXDZEm5cIx0DnkcS2wula1er0X%2Bvp4NYX27j7pC0IbcA%2BMK8%2F4yCJ1SMU3SyZaYdWUJDtC8lNrg70vbJ8mF0WOJ1zCJ%2FDBK%2FLDT8UN0GYNkO3EQ7Nxr6KZp%2FhQ%2F3blkIwVk53qm2KJT1fBIcapwrPmY3gAeLlkoWVcZP2Eqqmip7fRP6MkFfHrCTw4J7Mt8IaSCTONJTa2QhlE1uKSsC8Mz2tCzieUZrapijYVq9GKay8aJg0iOtTFq6O94uyRjua2VW7XNO3OIkk7g9SGIvW7U63tJFFNv3mVxNwx7UU7ZM%2BFeVfXP6r3sFmgNwnBqVTooGrrWZPfD9I4UcHr%2Bv0Vj6qIA%2Fo%2FjrxkHrpqmK2AZtaHtoB17QeKF%2FXEQpO12GrT9JIyjfnSD9yCwDDDbgdwWt%2FL5PpJF%2FDD4Ou4tb0I21Gw0Evqu2Qzvvy31ZvhWD14%2FCBrevvsygzcfXpDddzhxTowHBgAA)