### PR TITLE
Add enrolliq.app website template

### DIFF
--- a/enrolliq.app.website.json
+++ b/enrolliq.app.website.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "enrolliq.app",
+  "providerName": "EnrollIQ",
+  "serviceId": "website",
+  "serviceName": "EnrollIQ Website",
+  "version": 1,
+  "description": "Connects your domain to your EnrollIQ website.",
+  "variableDescription": "project is the Cloudflare Pages project that serves the EnrollIQ website",
+  "syncBlock": false,
+  "syncPubKeyDomain": "enrolliq.app",
+  "syncRedirectDomain": "enrolliq.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%project%.pages.dev",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for EnrollIQ (enrolliq.app), a website platform for small businesses. The template connects a customer's domain to their EnrollIQ-managed website (served via Cloudflare Pages) with a single CNAME. `hostRequired` is set: the template is applied at a host (typically `www`); apex handling is done through provider-specific guidance in our product.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver — N/A: no `logoUrl` in this template

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — N/A: no TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — the CNAME `pointsTo` is scoped as `%project%.pages.dev` with a fixed suffix
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — N/A: the single CNAME is owned by the template

The signing public key is published and resolvable at `_dck1.enrolliq.app` (TXT, chunked `p=N,a=RS256,d=...` per spec); our sync-flow links carry `sig` and `key`.

## Online Editor test results

**Editor test link(s):**
[Test enrolliq.app/website exampledomain.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHyIhWoC%2F%2BVT227bMAz9FUNAnxYHiuvGsYEB6%2B2hLdZ1RYENCAJDsZham2y5kmzHDfLvo%2BIm6SXDPmBPBsnjQ55DakUsFJVkFkiyIpVWjeCgrzhJCJRaSSmehqyqyGBXu2UFYsnlpnr1HSsGdCMy2PzUwtwIJNtl38G9HztAA9oIVZJkNCAcTKZFZTcxOVdlCZk1Xqdq7XFVMFF6VvXhjuml1dBRMS3YXMLFGxqc%2BBfSeMJ4NgfvXKqaLyTT4N2xRzDetm5zZj03LvTA9x2cmK7MzqTKfpNkwaSBPnNXz2%2Bgu9jM99Ewh7gHLjT2%2BBsmV8bew1ONIHTP6hqZEa80NySZrojtKufe%2Be3p18sXOIZf3DqUKK15UBgevQg5GlZO15BDgwBrJUmOx5SuZ%2BsBeVYlpHvmGVq%2BG2nJ8AKgj4eZKvaN2rbF4FGrukrF9seKaVYYdy5biukBjtmWZLphmQ2263AZdNmvNC4rV0r6zPq8LjI%2FyLKYzieB3xwTN7N4LJWG1OCX2VrD1qCillakrGX7FM9SNFR2KNFgFXt8NK%2FsL7HXxJllGPxzkMOWDkjKM%2BeAcDc%2FjxdxRPnYH4%2BB%2BmEYHvtxxMCni5MwCOJRTCf81QM69LgOP6E3WwBjoLSC4QjkVLasM2S9ng1wI%2F%2BJVDwhwxrgKXPIgAZjn078UfwwokkYJDQcRuEkik4%2BUZpQ6jSAsb34FV7T6zsimotLfvvtIr%2FOzA1rfzYhGJ3DjSq6yWQ5Xl9e51EUFPRBm89k%2FQewXmOaJQUAAA%3D%3D)
