### PR TITLE
Create attribi.com.first-party-tracking.json

### DIFF
--- a/attribi.com.first-party-tracking.json
+++ b/attribi.com.first-party-tracking.json
@@ -1,0 +1,13 @@
+{
+  "providerId": "attribi.com",
+  "providerName": "Attribi",
+  "serviceId": "first-party-tracking",
+  "serviceName": "Attribi first-party tracking",
+  "version": 1,
+  "description": "Adds a first-party tracking subdomain (track) so analytics load from your own domain and survive ad-blockers and Safari ITP.",
+  "syncPubKeyDomain": "attribi.com",
+  "syncRedirectDomain": "attribi.com",
+  "records": [
+    { "type": "CNAME", "host": "track", "pointsTo": "%cname%", "ttl": 1800 }
+  ]
+}

--- a/attribi.com.first-party-tracking.json
+++ b/attribi.com.first-party-tracking.json
@@ -4,6 +4,7 @@
   "serviceId": "first-party-tracking",
   "serviceName": "Attribi first-party tracking",
   "version": 1,
+  "logoUrl": "https://attribi.com/apple-icon.png",
   "description": "Adds a first-party tracking subdomain (track) so analytics load from your own domain and survive ad-blockers and Safari ITP.",
   "syncPubKeyDomain": "attribi.com",
   "syncRedirectDomain": "attribi.com",


### PR DESCRIPTION
# Description

Adds a new template `attribi.com.first-party-tracking.json` for **Attribi** (https://attribi.com), a multi-touch attribution / web-analytics service.

The template provisions a single first-party tracking subdomain: a `CNAME` at `track` pointing to the customer-specific target Attribi assigns them (`%cname%`). This lets the customer's analytics load from their own domain, so tracking survives ad-blockers and Safari/Chrome third-party-cookie restrictions.

Synchronous flow only, digitally signed — `syncPubKeyDomain = attribi.com` (public key published at `_dcpubkeyv1.attribi.com`).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`attribi.com.first-party-tracking.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://attribi.com/apple-icon.png returns 200.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `attribi.com` (public key published at `_dcpubkeyv1.attribi.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `attribi.com` (the synchronous flow uses `redirect_uri`)
- [x] no TXT record contains SPF content — this template has **no TXT records** (a single CNAME)
- [x] `txtConflictMatchingMode` — N/A, no TXT records in this template
- [x] no variable used as a bare full record value — the only variable is the CNAME `pointsTo: "%cname%"`. **Justification:** a CNAME target is inherently a full hostname with no fixed prefix to attach; `%cname%` is the customer-specific target Attribi provisions. This is standard for first-party CNAME templates and is covered by the template signature.
- [x] no bare variable used as the full `host` label — `host` is the fixed string `track`
- [x] no variable used in the `host` field to create a subdomain — `host` is the fixed `track`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` set to `OnApply` — **not set (default).** The single CNAME is the service's core record, not a user-tunable policy record like DMARC, so it is intentionally left at the default — consistent with other first-party-CNAME templates in this repo. Happy to add `essential: "OnApply"` if maintainers prefer.

## Online Editor test results

**Editor test link(s):**
- Apex (host empty):[Test attribi.com/first-party-tracking attribi.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC%2BbhWoC%2F91TYWvbMBD9K0JQ2FicymmdpIZ9CGs2urCSbVlXKMGcJSUVtSUjyQluyH%2FfyWmblGawz%2Fsk6e493b2n04Z6WVYFeEnTDa2sWSkh7ZWgKQXvrcpVl5uSdl5S11AilI52SUw4aVeKy5ayUNb5qALrm8hb4A9KL%2FeQ11RyACYH4JW0ThlN07hDC7M0v2yBpHvvK5eenh40dQpVVchIcaO7VUsV0nGrKt%2FS6UgIR%2BBoGeLqXJgSlCbv2th74gwBDUXjFXekMCDIwpqSNKa2xKw1eYKDFkhGOStJQER5YfgDNtzGf8ICrCJXs2k3iG40n9b5RDaXLfWNowHwQwplJfd%2FgWDKWOFoerehvqmCe5%2BuR9%2FGmLo3zuOx7T48j1Hau5nB0AnXaPQJBr1H6%2BIhY9v5tkMfjZbZ%2FsY5%2BnW86tPVuFtaU1eZesajiVC6MCjPzLtX1Pkz946GfdtHOLSbLj4sl0UktNuBsSW11MbKzOEKvrYI9raWHVrWhVcZrGEfEjwL792gAodZvPatJ7t6L54I8IDHo9UPzOnQTPAgSoURHgDv9RO%2BiM7koBedJ7GMhv3hIMoTJpLFQPCkxw%2B%2Bw5Gf8g8fYu%2BwdE5qryDM%2BKhYQ%2BPodjvvoNv%2FsTycDQcrKTIIsB7r9SM2jOKLWdxLWZwmcfeMXTB29oGxlLEgRjq%2Fk7vBqTmcF6rqr6vZ7WN%2BW4mqGOjJlzGUE%2BfUuH85Xv7OB9Mb%2B13dnH%2B%2BmrCPdPsH0azbPu8EAAA%3D)
- Subdomain (host = www): [Test attribi.com/first-party-tracking attribi.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAESbhWoC%2F91T72vbMBD9V4SgsLE4sZ3fhn0IWTvarVnpsrERgjlLcqLVlowkJ7gh%2F%2FvOTrOmNIN93if77t473Xs67agTeZGBEzTa0cLojeTCXHMaUXDOyES2mc5p609pBjlC6eRQxIIVZiOZaCipNNZ5BRhXec4Ae5Bq9Qx5SSUnYHIC3ghjpVY0Clo00yv9zWRIWjtX2KjTORmqA0WRCU8yrdpFQ%2BXCMiML19DphHNL4OwxxJYJ1zlIRd40ubfEagIKsspJZkmmgZPU6JxUujREbxV5goPiSEY5G0GAe0mm2QMO3OS%2FQgpGkuv5XbsWXSl2VyafRPWhob5ytAbcCy6NYO4vECxpwy2NFjvqqqJ2bzqb3F5iaa2tw7CZvr4eLZWzc42pC6bQ6AtMOofWBSPf3y%2F3LfqolYifOy7Rr%2FOnPrXebrcYrIwui1geKegj5LbelSN58YK9PNIXDR%2FDZpo6bn7aeL1MZB5X9oDHweRKaSNii19wpUGwM6Vo0bzMnIxhC88pzuL61ivUYbGKbV87czjv4Ez7IIKDA0ydneDEphaNOau1yXqZRR%2FCbjhOvG5%2FwLzeaJh4SToceCFL%2B0Ha6w67I3byMM68mX94Gi%2B8FtYK5STUCz%2FJtlBZut8vW%2Bj7%2F68SN8XCRvAYamTohwPPH3nBeB6EkR9GQdgOwh6m3%2Fl%2B5Pu1HmHdQfEOd%2Bh0e%2Bjd%2FZcb973%2FufPz43Tqhzer9eOP8e1wNlynm%2FurYjxWv5KrS9Zj5eo93f8Gp%2BuD0QMFAAA%3D)