### PR TITLE
add zenith hosting domain connect

### DIFF
--- a/zenith.hosting.app.json
+++ b/zenith.hosting.app.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "zenith.hosting",
+  "providerName": "Zenith Hosting",
+  "serviceId": "app",
+  "serviceName": "Custom domain for your app",
+  "description": "Points a custom domain at a Zenith-hosted app by adding one CNAME to the deployment's canonical zenith.hosting host.",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "zenith.hosting",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "zenith",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300
+    }
+  ]
+}

--- a/zenith.hosting.app.json
+++ b/zenith.hosting.app.json
@@ -4,6 +4,7 @@
   "serviceId": "app",
   "serviceName": "Custom domain for your app",
   "description": "Points a custom domain at a Zenith-hosted app by adding one CNAME to the deployment's canonical zenith.hosting host.",
+  "logoUrl": "https://zenith.hosting/assets/wordmark.svg",
   "version": 1,
   "syncBlock": false,
   "syncPubKeyDomain": "zenith.hosting",


### PR DESCRIPTION
# Description

adds template for zenith.hosting. Zenith Hosting runs open-source apps as managed SaaS. On our platform, customers map a custom domain onto their hosted app. the provided template simply writes the single CNAME that points a customer's subdomain/domain to a Zenith app.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

for %target%, the CNAME target is the customer's specific deployment's zenith hostname (e.g. foo.bar.zenith.hosting), which is different per deployment, so no fixed prefix is possible. 
## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test zenith.hosting/app example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALaAhmoC%2F91T7U7bMBR9FcsS2o81aVIK7SJNGmPTmDYQm0BMoCq6tW9TjyQOtlMIVd9910lL6WAvsF%2BJ78e59xwfL7nDosrBIU%2BWvDJ6oSSar5In%2FBFL5ebhXFunyoz3nrJnUFA1v27z7OQpb9EslMC2GapqG1k3HNfW6YJJXYAq2Uwb1ujasK5UohVGVU7pkkrPtSqdZcDETg84CnVzA78XSt%2FNpg0DKWkJpktkx2dHp5%2BZ08zNkUmsct0UWLo3lgkodakE5GyXG%2FPfkJbIdaYvTU4LzJ2rbNLv7xb2wVp0tn%2BvjSzA3IZ24Ykv0Nh275goN6X4mGtxy5MZ5Ba7yHk9%2FYbNp5bFa9L6v594VyuDpJ4zNfUZFDTG8uRmyV1TtQp6alSeGV1Xzy5pjUDnD%2F6eWvEuNB33HJgM3R5FnSNe%2B1G0mqx6%2FJGESrcDJqT%2FZjd8ADIEhkIXW9jujtqxqWpbNpOptQIDhfX%2B2YDc7KBMNjA3Lc5kDbQL0i3qY1Mw4Uzr8C%2BR%2FNoqK7XB1NIXXG1wI1VR506lcA%2FbkBQpDcsbYmkpS8AvZSw7X64NCA7o8I%2FpW%2F16PJXCk1Ve%2F3c4GB3IqQzig2gQDEcyDqajGILD4XgMcjgSQhw%2BezqvP6yXD2dHdiTTlU6B9%2BVRfg%2BN5avVpEe39p9RIhtYWKBMwVcOosFhEI2DQXQRDZNBnMRReDAcxfH4bRQlUeQJoHUdySW547kv%2BMksyvoPj7m6zq%2Fi%2BveJ%2BV6dXvanP6L4%2FE7fXc1EbE%2Fd0Zf9h1%2FZe776A47cKCMHBQAA)