### PR TITLE
add PerformaShop, Apontar dominio da loja

### DIFF
--- a/performashop.com.apontar-loja.json
+++ b/performashop.com.apontar-loja.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "performashop.com",
+  "providerName": "PerformaShop",
+  "serviceId": "apontar-loja",
+  "serviceName": "Apontar domínio da loja",
+  "version": 1,
+  "syncPubKeyDomain": "performashop.com",
+  "logoUrl": "https://performashop.com/logo-oauth.png",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "fallback.performashop.com",
+      "ttl": 3600,
+      "essential": "Always"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for PerformaShop (Brazilian e-commerce platform), service `apontar-loja` (Portuguese for "point store"). Sets a single CNAME record pointing the merchant's chosen host at our fallback origin (`fallback.performashop.com`), which routes to the merchant's store based on Host header.

## Type of change

- [X] New template

# How Has This Been Tested?

- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [X] resource URL provided with `logoUrl` is actually served by a webserver (confirmed 200 at https://performashop.com/logo-oauth.png)

# Checklist of common problems

- [X] `syncPubKeyDomain` is set (`performashop.com`) — public key is published at `_dcpubkeyv1.performashop.com` TXT
- [X] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [ ] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A, this template does not use `redirect_uri`
- [X] no TXT record contains SPF content — this template has no TXT records at all
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A, no TXT records in this template
- [X] no variable is used as a bare full record value
- [X] no bare variable is used as the full `host` label — the single record uses the fixed placeholder `@`, relative to the applied domain/host
- [X] no variable is used in the `host` field to create a subdomain
- [X] `%host%` does not appear explicitly in any `host` attribute
- [X] `essential` is set to `Always` on the CNAME record — it is the sole record of the service; removing it disconnects the merchant's domain from the platform, so it should not be independently modifiable while the template stays applied

**Note on `hostRequired`:** set to `true`. Our CNAME record uses `host: "@"` (relative placeholder), which per the JSON schema (`DomainConnectTemplateWithHostRequired`) requires `hostRequired: true`. This also correctly reflects reality: a bare CNAME cannot legally exist at a zone's true apex (RFC conflict with NS/SOA), so this template intentionally only supports pointing a subdomain (e.g. `loja.merchant.com`) at the platform, not the literal zone apex. Apex domains are supported through a separate manual/DNS-provider-agnostic flow in our own product outside of Domain Connect.

## Online Editor test results

**Editor test link(s):**

[Test performashop.com/apontar-loja minhaloja.com.br/loja](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD6thmoC%2F91S0W7aMBT9FeTXEnACTSDSpKGunaaNqmrZw8ZQdBNfiLvEdm2HliH%2BffYIo1vZtOc9Rc459%2Fjc47MlFmtVgUWSbonScs0Z6neMpEShXkpdgyml6hWyJt2f%2BDXUjk9uWsadYzjUoF7zAn8Mg5LCgg4qeQ9HqJ2b7MEOk%2FWXhlJkgssOg05LXqM2XAqShm5wI4qbJn%2BPmzeyBi5O%2B6rkSn7UlQNLa5VJ%2B%2F3fSX1PCSQ0tuwpsXIzpTT2Fh8artEZtrrBLtFYSM0MSedbYjfKe724nkwvW7o7vvYpSC6smUl3XEJV5VB87Z0wZa0zNIgp7RI0BoXl4B1OqkfYGLJb7LrkmxSYHS9ddAk7bFlzUYIPxKv1cn200Ka00rJRGT8MKtBQG%2F%2BIB4n5S43FQWS%2BV%2FEe%2BEpIjZlxX7CNxkMWdVNZnsEjHH%2BxIgOlqo2zbBzqZF7mJPZP3JpkYOHfY8pY4RfgvkB4DggJJMF4FJ8Hw2hAgxziYTBORsMcGA0ToM8a%2BafG%2FqWTv8Z56ol2i66L9n%2Ff0ZXCwBpZBp4a0SgO6CiI6Iwm6SBMQ9pL4kESDs8oTan3Y9HY%2FdJb15%2FnzSHT%2BMJ%2BGpyN3n6%2BDJcVfZpeRffjD086v1vTgvbL5OEqCvlyVM8mr8juO%2BlX5%2Bt9BAAA)

This confirms `domain=minhaloja.com.br&host=loja` applies correctly, producing:

| Name | Type | TTL | Data |
|---|---|---|---|
| `loja.minhaloja.com.br.` | CNAME | 3600 | `fallback.performashop.com` |

Per the PR template exception, an apex-domain test was not conducted since `hostRequired=true` on this template (see note above on why apex is intentionally out of scope).

Also validated locally with the official [dc-template-linter](https://github.com/Domain-Connect/dc-template-linter) (`-loglevel error -tolerate info -logos`), exit code 0, no warnings/errors.
