### PR TITLE
Add kovax.ai.email template

### DIFF
--- a/kovax.ai.email.json
+++ b/kovax.ai.email.json
@@ -1,0 +1,54 @@
+{
+  "providerId": "kovax.ai",
+  "providerName": "Kovax",
+  "serviceId": "email",
+  "serviceName": "Kovax Email",
+  "version": 1,
+  "description": "Adds the DNS records Kovax needs to send and receive email for your store.",
+  "syncPubKeyDomain": "kovax.ai",
+  "syncRedirectDomain": "app.kovax.ai",
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "mg",
+      "spfRules": "include:mailgun.org",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey.mg",
+      "data": "%dkimvalue%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "mg",
+      "pointsTo": "mxa.mailgun.org",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "mg",
+      "pointsTo": "mxb.mailgun.org",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "email.mg",
+      "pointsTo": "mailgun.org",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc.mg",
+      "data": "v=DMARC1; p=none;",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Kovax** (`kovax.ai`), a Shopify app that gives merchants a unified inbox across WhatsApp, Instagram, email and voice.

The `email` service configures a merchant's sending subdomain for Mailgun: SPF, DKIM, MX for inbound replies, the tracking CNAME, and a monitoring-only DMARC record.

All records sit under a fixed `mg` label, so the merchant's root domain and any existing company email are untouched.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [ ] resource URL provided with `logoUrl` is actually served by a webserver — *N/A, no `logoUrl` is set on this template*

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `kovax.ai`; the public key is published as two TXT parts at `_dcpubkeyv1.kovax.ai`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `app.kovax.ai`
- [x] no TXT record contains SPF content — SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — DKIM uses `All`; DMARC uses `Prefix` with `txtConflictMatchingPrefix: "v=DMARC1"`
- [ ] no variable is used as a bare full record value — **one exception, justified below**
- [x] no bare variable is used as the full `host` label — the DKIM host is `%dkimselector%._domainkey.mg`, so only the selector varies
- [x] no variable is used in the `host` field to create a subdomain — `mg` is a fixed label; subdomain application uses the protocol's `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — set on the DMARC record

## Justification for the bare variable (rule 6)

The DKIM record uses `"data": "%dkimvalue%"` with no fixed prefix.

This is the exception the rule allows, where *"the full record value is prescribed by an external standard and cannot carry a prefix"*. A DKIM record's content is defined by RFC 6376 and must begin with its own tag list (`k=rsa; p=<base64>`). Prefixing it with a service-specific string would produce a record that no receiving mail server would parse as DKIM, so signature verification would fail and the merchant's mail would be rejected.

The value is supplied by Mailgun per domain and written verbatim.

## Online Editor test results

**Editor test link(s):**

- Apex (`domain=kovax.ai`, `host=`): [Test kovax.ai/email kovax.ai/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFvQhmoC%2F%2B1WXW%2FaMBT9K5GlPg3SQPmueEgL3VAb1hakdUIoMrEDLkmc2U6AIvbbZ6ekCS3d1r2sm3hAxL7H1%2FfcjyOvgcB%2B6EGBQWsNQkZjgjDrIdACcxrDpQ4JKDzt96EvceBSWeQ2xywmDk7Q2IfEy%2FbySK27tcWYcUID0CoVAMLcYSQUyRqYCHFNzLDW6Q80hh3K5PrxcICxslGN4wBpUP6kHZMYa8mVmkuZtqIR07igDOsqhFXgXEeTS7zqUAkJdrko6y1GRHoRT3YYhnoOs40AtEZrIFahYjK4vrCkZUa5kCt%2FqjyF7m3kYQkDJHC8COGWimgaBTplCiCEB1onNcPYFJ78DO%2BGmZsjNCc%2Bx54MhbIj3UZJPHO80pMLEBQwRcXQi%2FCRcroU5zRwPeIICwpnRoKpRZFybXreK5dad89CDykJBB9StV5CfTfskBHKiFjJOhl%2F4m%2FyZn%2FnfdPqZi6TwuovHL8ttzbyIXN2Ehm3O5Z5e1461cJ2QAN8%2BtN0XjPskuV%2ByNaWuZQwzGWHCgJlXOBzYIaht9qJc7wpgAd5q51111iGtqdFtwzk15TRKLRJCg4hgz5Xk5oeG2XnxunBEVDf%2BdZKcIyn20kvJXttxqHKhtXrnfXuzf7ZdP5tNicfmwvjzLzpXgAVNJkGcrJsLv%2BhiJg8KViEC8CPPEFsuIDZFnJsqIhLjlxa5R2jZ9UJHoVhtyxykkranhnSvsPdni7IsjqKP1GaU0NGpYEqTnHi1uvFyonrFJvVBiyeOI5bbeJGzXErOfV6rmr75CtLfb6cpreAKw42L3pty0bm9rXh%2FXWK3yW9ZML31OqlWuSC3x30909l8q9RSXVyyyankymn1%2Fi8y7H5XYn%2ByzRSMd9sxgWpwgdFOyjaQdEOivZ%2FKJp8EnIYY2RDhSsb5VrRaBTLxrBktAyjVW3qRrlkGKUPhlqr2DEXj9TW8m2YfxWC%2B97X6LjW%2B1Tt3bidu%2BMvi27parAsi4f44cK9urQG9fAjQnUeGDdtsPkBWsbUYHsOAAA%3D)
- Subdomain (`domain=kovax.ai`, `host=shop`): [Test kovax.ai/email kovax.ai/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIHOhmoC%2F%2B1WW2%2FaMBT9K5GlPhWiQEsKqXgIUDZWQVnLQyWEIpM44Obi1HYCKWK%2FfXYg3Lupe2o1HhDyufl85%2FLFC8BREPmQI2AsQERJgh1EOw4wgEcSOFchBoWNvAcDYQfupUaIGaIJtlFmjQKI%2Fa1s11K5W%2BsSRBkmITBKBeAgZlMc8ewMTMdhCp8ipdV7UiiyCRXnlXOIkNQRhaHQUaD4CT3CCVKyKxWXUCUlMVUYJxSpMoU0tPvx%2BB6lLSJMwn0sUvuIHCyi8I0eRpG6Y7POABjDBeBpJJE89dtdoZkSxsUpmMhIkfsY%2B0iYARzafuwgQ2Y0iUOVUGnAuQ%2BMK13TloVNnMHzYBvmwvFwwJAvUiH0QrWcLB8PpWp2gQM5zK0S6MfoQgad8yYJXR%2FbvAu5PcXhpEscGdr0%2FXcu7T4fpB4RHHI2IPI8h%2Bp%2B2hHFhGKeij5p%2FxJv%2FOF4zZ7ZvduGzBqrHgX%2BWG0tJ4DU3itkUm91zcdm6VaJ6iEJ0e0fy9mnyMXz0yZr3TakMENMTCjHUOQFHkIzivx0L8%2FRsgDexK3WdrpGIrUTI7pGwKYkEqcJJXFk4dwhghQGTG5r7jrc%2Bo5y5%2BHKW16wM2KZLWW5OJupTFanDMqqdDudRufF7DUm3uvUw99qM61h%2FrxrA5k8noRiwywm%2FiGPqfDkNEYFEMQ%2Bxxacwa3IsS0oCyCwMqEVdwwPuhSuCCKYqGuYmx6JtSopJxZK%2BQX3B7wgemzLQmBJQLXxGFZ1Vy%2B6tcp18frGsYtQr8JiRa%2FoN7rmwlq5vENlhxR3isv2%2B7DbX9OfwZSB5dHwrWGJIu9v8wHKvxf80%2BLMdv%2B97h2TyQ6KfR74QpjGXxFTzqlrWDmnHoJ7D9inXa0Nrx8Rxwly%2FwR48k%2FBcjkqCP4%2B8%2BCZB888eObB%2F5kHxfOTwQQ5FpS2Za2sF7VqsawNtJpRuTK0ilqqla708qWmGZom80eMr%2BAtxDt09wUK9Nal9%2BOl32smD9VXr%2B3pnbf294f4%2FqZ5EzZnsT9ou424c92fmZM6WP4GpWtR%2BO8OAAA%3D)
