### PR TITLE
Add straby.app.whitelabel.json configuration file

### DIFF
--- a/straby.app.whitelabel.json
+++ b/straby.app.whitelabel.json
@@ -1,0 +1,15 @@
+{
+  "providerId": "straby.app",
+  "providerName": "Straby",
+  "serviceId": "whitelabel",
+  "serviceName": "Straby digital cards",
+  "version": 1,
+  "logoUrl": "https://straby.app/icon-192.png",
+  "description": "Points a domain or a subdomain at Straby, so digital business cards are served under the customer's own brand.",
+  "variableDescription": "%host%: the label the cards are served from, empty for the domain apex.",
+  "syncBlock": false,
+  "warnPhishing": true,
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "straby.app", "ttl": 3600 }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Straby (https://straby.app), a digital business card service.
Resellers on the white-label plan serve their customers' cards from their own
domain or subdomain; this template points that name at Straby with a single CNAME.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] Template contains a single CNAME record, applied to the host passed in the apply URL
- [x] No variables in `pointsTo` — the target is a fixed hostname (`straby.app`)
- [x] `warnPhishing` is set, as the template attaches a customer domain to a hosted service
