### PR TITLE
add Agent Tolls, 2 templates

### DIFF
--- a/agent-toll.com.gate-apex.json
+++ b/agent-toll.com.gate-apex.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "agent-toll.com",
+  "providerName": "Agent Tolls",
+  "serviceId": "gate-apex",
+  "serviceName": "Agent Tolls gate (apex)",
+  "version": 1,
+  "logoUrl": "https://agent-toll.com/assets/brand/logo-128.png",
+  "description": "Connects an apex domain to the Agent Tolls gate: publishes the domain-ownership proof and routes the domain's traffic through edge.agent-toll.com (flattened at the apex), so AI agents pay a per-page toll while human visitors browse unaffected.",
+  "variableDescription": "txtvalue = the account-bound ownership token shown in the Agent Tolls dashboard (the part after 'agent-tolls-site-verification=')",
+  "syncBlock": false,
+  "shared": false,
+  "hostRequired": false,
+  "syncRedirectDomain": "app.agent-toll.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_agent-tolls",
+      "data": "agent-tolls-site-verification=%txtvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "agent-tolls-site-verification=",
+      "essential": "OnApply"
+    },
+    {
+      "type": "APEXCNAME",
+      "host": "@",
+      "pointsTo": "edge.agent-toll.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/agent-toll.com.gate.json
+++ b/agent-toll.com.gate.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "agent-toll.com",
+  "providerName": "Agent Tolls",
+  "serviceId": "gate",
+  "serviceName": "Agent Tolls gate (subdomain)",
+  "version": 1,
+  "logoUrl": "https://agent-toll.com/assets/brand/logo-128.png",
+  "description": "Connects a subdomain to the Agent Tolls gate: publishes the domain-ownership proof and routes the subdomain's traffic through edge.agent-toll.com, so AI agents pay a per-page toll while human visitors browse unaffected.",
+  "variableDescription": "txtvalue = the account-bound ownership token shown in the Agent Tolls dashboard (the part after 'agent-tolls-site-verification=')",
+  "syncBlock": false,
+  "shared": false,
+  "hostRequired": true,
+  "syncRedirectDomain": "app.agent-toll.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_agent-tolls",
+      "data": "agent-tolls-site-verification=%txtvalue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "agent-tolls-site-verification=",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "edge.agent-toll.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for **Agent Tolls** (agent-toll.com), a toll gate for websites: AI agents pay a small per-page toll over x402, human visitors browse unaffected. Connecting a domain needs two records — an account-bound ownership-proof TXT and a CNAME routing traffic through `edge.agent-toll.com`.

Two services because a CNAME cannot live at a zone apex (the schema's own `hostRequired` rule):

- `agent-toll.com.gate.json` — subdomains: plain CNAME + TXT, `hostRequired: true`
- `agent-toll.com.gate-apex.json` — apex domains: APEXCNAME + TXT

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (200, image/png)

# Checklist of common problems

- [ ] `syncPubKeyDomain` is set — **justification below**
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (mode `Prefix` with prefix `agent-tolls-site-verification=`)
- [x] no variable is used as a bare full record value — the TXT data fixes the `agent-tolls-site-verification=` prefix, `%txtvalue%` carries only the token
- [x] no bare variable is used as the full `host` label — both hosts are fixed (`_agent-tolls`, `@`)
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the TXT proof record (verification is re-checked over DNS by our claim step; an owner may retire the record later without breaking routing)

**On `syncPubKeyDomain`:** not set in this revision. Apply URLs are generated server-side by our edge worker exclusively for authenticated dashboard sessions; the only variable, `txtvalue`, is an account-bound HMAC token that is useless to any other account and is independently re-verified over DNS by our claim step before a domain is connected. We are setting up a signing key and are happy to add `syncPubKeyDomain` (URL signing) in this PR if maintainers prefer it land signed from day one.

## Online Editor test results

**Editor test link(s):**

- [Test agent-toll.com/gate-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABd3iGoC%2F%2B1UbWsbORD%2BK0JQknJee%2F0aZyFQ95UGkuulLpSEYGZXs7sia0knaf1yIf%2F9RnYc26lLoF8Kx32xrZlnNPM8ejz33OPUVOCRJ%2FfcWD2TAu1nwRMOBSofeV1VzUxPeeMpewlTQvNRyLMx5R0lHdqZzHBVWdB1ERhcbOM%2F1rCAYscB9ppwM7ROasWTdoNXutDfbEX40nvjklZrf5YWOIfetVILSrQCOmp3hk2jCrpIoMusNH51GX%2BnlcLMOwaKhVZM6ClIxbxmvkT2fJ6EmTqtpCvRrfJrdKTnisYrpWGkgc7pMsGsrv0e6ogOFvJcZhSkbFEyFAU292dnxzmp7VGhYOBX5SsJGsxpNvrMVmjHDCwZMIM2MhRhoZrNS1khK%2BspcZlJJ722jqVWzx2yWlFnIoqiGcQEKyGt8P2eFn7hZ1DVyM7WbbNM1zRZSp%2BCbSl6fYeKuZIiLCj1TCYBrkw1WMGOQ8qA9Qxyj5YdbZm6iMbDiB5Vkh4QBjg7Cs%2Fslip7W%2Bnsjic5VA4pUoJF8XQstfNX%2BHctd4Oh6goFxTL%2FfiV28KcxzR88SghthePJzT33SxM8N%2F4%2B5ut76TDZmTGYBTzsWf3Q4K82wr2iCu%2FJl91BHDeCnmSvvJKZvwCflVIVF1qEll8s5jK4%2FwDkMfdSUypGcrnyEsIf4U81MqZa8ofGE6%2FRlw%2Ff312OLj5s2b0J%2F1ItyUBjTccD9ttl8HD70OD%2FaIWTrWq3pMlGYFwArQZ8LHtsQb8KMreZyA2eHABTF9bHpvJmr%2FR2U3vDw%2B%2BNmOEctzvdXn9wMjyFNBOYPz%2FzMKEslLY4cfQNvrZU6G1NppjWlZcTmMM2JLIJBJmIkKMstXhuA7XeQ79igxeH3TPHRGRBEhn2YT%2FO0sGwnUaYDkXUg34WnfbiTpRBNz7ppKftbru3s18Pb9%2BfLdjtuxz0y08M86jDmy35F8zy2xmNqjksHRG6bZDr%2Fn%2FX%2F9670nJwMEMxgQDrxJ1BFA%2BjTnvcHiRxL%2BmeNk8G9DjxH3GcxHEggc6vWd7TntjdEHzRHsJ1%2F1N33utfX86ns5O7y%2FOp%2BfS1%2BKjNvLUYX48WeC7fXt2d%2F3XGH%2F4F4NB5QQYJAAA%3D)
- [Test agent-toll.com/gate example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPZ2iGoC%2F%2B1Ua2%2FbNhT9KwSBIh1q2bLsOJ6AAHPTbWi3pFvqbM0Cw7gSryyiMsmQlB03yH%2Ffpd9ODWTfBgz7YoP3wXvO4dF95B6npgKPPH3kxuqZFGjfC55ymKDykddV1cz1lDe22SuYUjUfhDwbUt5R0qGdyRyXnZNw3Tb0bTkLBey1qzOhpyDVd1Q8Q%2BukVjxtN3ilJ%2FrGVtRUem9c2modYmmBc%2BhdK7OgRCtUR%2B2k3zRqQhcJdLmVxi8v4xdaKcy9Y8C245jXzJfIniNKmamzSroS3TK%2Fqo70XBG2UhpGAuiC0Uxmde3XVdtrT%2BhsoShkTnEqmJQMxQSbh9gbzGk2eM%2BWUccMLAiaQRsZirBQxealrJCV9RQUm0knvbaOZVbPHbJa0QQihKIZRAMrIavw3QFn%2F%2BBnUNXIzpcAIc91TQgy%2BhVsx8brL6iYKynCgijPFBHgykyDFex1SBmwnkHh0bKTHSMXETyM6PEk8YYA4PwkPKdbqPxtpfMvPC2gckiREiyK7bHUzl%2FjfS2XQW9rXDVdo6BQ7t8tNQ02NKb5jRWpQlvheHr3yP3CBH8NPw%2F56lo6jPcgBk%2BAhwNHH8P9aqPbK%2BrwnuzX6cVxI8hJLioqmftL8Hkp1eRSizDyN4uFfOBHS9a5l4ZSM5KZlZcQ%2FP5RDYypFvypseV1cTW4%2FHHH7IfwIWpJ3hlqOh5x2D76p9FTg3%2FVCsc7xUakx0ZcfAD6%2BnHdth6R0RdFpwl52IzlpocMAFMXtsSm%2B%2B6gfbTpv1tdMGpsjRhicTvpdE97Z%2F3vIcsFFs%2FPPCCVE6Utjh39g68tbowxrSsvxzCHXUjkYwhSETFHWRrx3ApqtXf2rdBcU%2FtHfngR8YFLxiIP2siw%2Fwpo9xNxGkdxp5tH3SQ5jaCLWVRkRXGW9Lqn2Gnv7dPj2%2FbIQj18n6O%2BOWKctQ6H1F%2Fwzb%2FNZ1DNYeGIzqhB3vv%2FZf%2BLL0sLwsEMxRhCaRInvSjuR0l72O6lcTeNe82430l67TdxnMZx4IDOr0g%2B0q7Y3xIcB%2BJ%2BUC8%2Btd58%2FOv%2Bj%2FLnq9vi7NPt%2Fdxcvf319vNPN79c3Hz98%2FqDhLPfz%2FnT3y68lNb1CAAA)
