### PR TITLE
Create karmaflow.ai.emailsending.json

### DIFF
--- a/karmaflow.ai.emailsending.json
+++ b/karmaflow.ai.emailsending.json
@@ -1,0 +1,46 @@
+{
+  "providerId": "karmaflow.ai",
+  "providerName": "Karmaflow",
+  "serviceId": "emailsending",
+  "serviceName": "Karmaflow Email Sending",
+  "version": 1,
+  "logoUrl": "https://karmaflow.ai/images/kflogo-blk.png",
+  "description": "Authenticates a sending domain for Karmaflow email: SPF, DKIM, an optional DMARC starter policy, and the open/click tracking host.",
+  "variableDescription": "spfinclude: the SPF include target for the sending platform. dkimselector/dkimkey: the DKIM selector and public key issued per sending domain. trackinghost/trackingtarget: the open/click tracking CNAME. dmarcpolicy/dmarcrua: a starter DMARC policy, only applied when the zone has none.",
+  "syncPubKeyDomain": "karmaflow.ai",
+  "syncRedirectDomain": "omni.karmaflow.ai,omni-dev.karmaflow.ai",
+  "records": [
+    {
+      "type": "SPFM",
+      "groupId": "sending",
+      "host": "@",
+      "spfRules": "include:%spfinclude%"
+    },
+    {
+      "type": "TXT",
+      "groupId": "sending",
+      "host": "%dkimselector%._domainkey",
+      "data": "k=rsa; p=%dkimkey%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "CNAME",
+      "groupId": "tracking",
+      "host": "%trackinghost%",
+      "pointsTo": "%trackingtarget%",
+      "ttl": 300,
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "groupId": "dmarc",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=%dmarcpolicy%; rua=mailto:%dmarcrua%",
+      "ttl": 300,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Karmaflow is a CRM and marketing platform. This template authenticates a
customer's email sending domain in one click: SPF, DKIM, the open/click tracking
host, and an optional starter DMARC policy.

Records are grouped so the caller applies only what a given zone needs:

- `sending` — SPF (SPFM) and DKIM. Always applied.
- `tracking` — the open/click CNAME. Omitted when the customer's zone already
  uses the label for something else.
- `dmarc` — a `p=none` starter policy, applied **only** when the zone has no
  DMARC record at all. We check for an existing policy before every apply and
  drop this group if one is found, so an existing `p=reject` is never downgraded.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**On the one unticked box — the bare `host` variable.** Every record fixes its
non-variable parts (`%dkimselector%._domainkey`, `_dmarc`, `@`) except the
tracking CNAME, which uses a bare `%trackinghost%`.

That one is the documented exception: the tracking label has no fixed suffix to
anchor it to. It defaults to `email`, but the label is not ours to dictate —
customers frequently already use `email.<domain>` for legacy webmail or another
vendor, and in that case we move the record to a free label (`mg`, `mail`,
`track`, `link`, `click`) and reconfigure our sending platform to match. A fixed
prefix would make those collisions unresolvable. The value is drawn from our own
platform configuration for that domain, not from user input, and the record is
`essential: OnApply` so a customer can remove tracking without breaking the rest
of the template.

`spfRules`, the DKIM value and the DMARC value all carry fixed prefixes
(`include:`, `k=rsa; p=`, `v=DMARC1; p=`), so no variable expands into a whole
record value.

## Online Editor test results

**Editor test link(s):**

[Test karmaflow.ai/emailsending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB99iGoC%2F%2B1WXU%2FjOhD9K5alPm2bph9AyQqJ0AJCbLl8dBESQpWbOK3VJM7aTksXcX%2F7nUmaJmWhex954Il0Zjw%2BM%2BfMmBdqeJSEzHDqvNBEyYXwubrwqUPnTEUsCOXSYoLWN74rFkEsvSy84NJcLYTHs1M8YiLUPPZFPC1dbw%2BRUwwjd5u4BVdayJg6rToN5VT%2BVCHEz4xJtNNsVqE0RcSmXDfnAcY1JuHcSrIUPteeEonJ0lA3NTMeG%2BFBaZowsoZEfAk3xySQipRoMtAOubs%2Bq5PB5cWwTlhMZJaKhWQwdG%2F7RBumDFckkaHwVhjhE7gCwnjc9MA2J0Yxb46XzKQ2FlbFlGCTkA%2B2oOkkELEXpj53sgxwLVkbCFwy5SaDh64CNTIEtsgi%2FlxEmofcM1I18cecr%2FI0CJwUrgxekk4AF4EIIrROOViggO1OWBvUCLpZ%2FMhxOB9W2L9yh6eAJmLKyzvSzL5Vyhzs9rpZeeuKlsk4XBGWJKEAKEugJ0v%2FW8aczJgmMXxg1%2FQq9q7TySVfDTKIf2oRI265LxTUuomRUSysamAdLQ2fL6w3x%2BGYVL6mzuMLNasElQkcDMEzVTJNMh2XEsa%2BgOEY702C2zTkcJIWDNZKNmv0tb5JOHoY7c5XqzJZs8Y5HcAVSpkZhlUfKc2%2Bk%2BSotia6Bj5jYDI6tg1fz6Yv4wB6a4bMeDNIP5Q%2BXu6GYRVLRtYWmoLHCpyqDPCeRIrY6JGs%2BnJVbKPgWuOcMZzXf2IX2F3t6kOmkvLacfF7XfLiKJNMK6%2B6VFftOwFpHeGcGunUCq39HcquNl0rHojn90PWvhIRfX16rVMU67jUzxMAL%2FTHnxlsUm55MirrK2ofiyy%2BIoMKBXkPIFfCFIs0buIi6%2BNW2qci7yPF7yzz37OWCsVYbOE0jS2ppuisqhDdc6ULM2oRLMOL82Do2uf9u1%2FndxeTzuDm9MS9%2Bem63fMrd9A%2FETeXJ9MbPFSVUAYd76o6cv28h6JkGr24CTZmoBlt2XdD8UQqo4%2B3ugK8iGksFR9r%2BMtMqqBSo1Jep1EaGjFmS1aafG%2BMO2gFNGrwQu7HN2qN89fquCpLaGKr2NJOBT35l8GwrVW4b6MMx76HFAqUe7fF2UFvjzWCoNdudCdBt3HY7nUbHrMPO0Ev6HjepPK4vvfw7nhdS5FVpe%2BGS7bS9PWPKVzXBRTvXjf%2Fk%2FHq6H3Cmoutt646F%2BOm2KoAP1MhmxX6EXu7NibOzdai%2FHhoPmfNT3VYqV%2Fj%2BDWOX%2BP4KcYR%2F3tgC%2B6PGca17fZ%2Bw%2B412q1Rax%2BwOu2O1T3Y2%2B%2Ftf7Ntx7axCq5N3okXeJWr7zH1z86ik9%2Bqt7wbRT86v8xw0Tw77B3o22%2FL%2B4fljz3%2FXoUzfxU83LtH9PU%2F2r40kpkOAAA%3D)

[Test karmaflow.ai/emailsending example.com/mg](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI2BiGoC%2F%2B1WbU%2FjOBD%2BK1akfro2TUvpQlZIG%2Bgux3bL8dLVcUKochOn%2BPLinO0Uuoj77TfjNI3LAnsf%2BcAn0pnx%2BJl5nhnz4GiWFSnVzPEfnEKKJY%2BYPIkc30mozGicijuXcqe98Z3SDGKdce0Fl2JyyUNmTrGM8lSxPOL5onE9PUQ%2BYxi53MQtmVRc5I7fazupWIjvMoX4W60L5Xe7NpQuz%2BiCqW4SY1xnniZuYVJETIWSF9qkcYJS37Jc8xBKU4SSNSQSCbg5J7GQpEFjQPvk8uxLm4zGJ5M2oTkRJhVNyWgSXBwRpanUTJJCpDxcYURE4AoIY3k3BFtCtKRhgpfcCqVdrIpKTucpG21BU0XM8zAtI%2BabDHAtWRsIXLJg2sBDV40aGQJb5pIo4ZliKQu1kF38kbBVlQaBk9pl4BXlHHARiCBcqZKBBQrY7oS7QY2gu%2FWPCof%2FYoVHp8HkM6DJqAyrjnTNtyypj91eN6tqXd0ykacrQosi5QDlDugx6X%2BInJFbqkgOH9g1tcrDs3I%2BZquRgfizFjHigkVcQq2bGJHl3LUD22jpRGzpPjkOx4SMlONfPzh6VaAygYMJeBZSlIXRcSNh7AsYPuG9RXxRpgxOOjWDrYbNlvPY3iScXk1fz9eymWy5s4oO4AqlTDXFqg%2Bkoh9JcdBaE90Cn9YwGTueB1%2F3%2BkjkMfRWT6gObyH9RER4eZCmNhZD1haamkcLji0DvKcQPNdqKmxfpYptFEwpnDOK8%2FpHHgC7q9f6YFTSXDurf69LXh4YyfSqqht1tT4SkNYBzqkWfqvW2q%2BhvNamM8lifv98yNrXIHIebx7bDop11ujnBoDX%2BmP3FDYpc0ORNfVli7r6GTcnLCFYJFRdgGwFlTRTuIvrvNdbiW%2FqzNeY%2Bmad%2B9d5G5Wao9DGRZm7QpocthLRnUhVm1GPYJmcHMeTwDs%2Buvzn%2BPJkvjM6%2F3wYnH8PgsHxaTA6OuTn48PFOR6yZWTA4122o9LQcygattGL22BjBqrRZr47khVCavVpqy%2FADV%2FkQrKZgr9UlxIq1bJkbScrU81n9I42piic4R5aAZUKvJD7%2Boli8%2BrFMvxttAld7NWr2rfgk38pTNxaikMPtTiLQmSRo%2BaHvfk%2Bi%2FZox%2BtH%2Fc5gEO129rw91onnu7vxzjCM94eR9cI%2B9%2Fq%2B8sTaSrMnIEjv6Eo5jz8N47o0YNnaOq5d6Wbx%2FE%2Fe7SF8k4XXG3Bdukm0VbGtxbdVzWanvsRjtULdbaU2WxTnaGt5vjxEb7XwmzYs2vcBfR%2FQ9wF9owOK%2F2HQJYtmFCP7Xn%2FY8fY6%2Fd60N%2FQH%2B37vg9vf7e94u795nu95WAdTuurFA7zc9pvt6F4Sij8ng9X9eHT39970S3o17ibf%2FvqW7J%2BGg%2BmPSXH1Nf1Q5ue%2FiwPn8T%2FmrRxnwQ4AAA%3D%3D)