### PR TITLE
Add tradesite.ai website template

### DIFF
--- a/tradesite.ai.website.json
+++ b/tradesite.ai.website.json
@@ -1,0 +1,18 @@
+{
+    "providerId": "tradesite.ai",
+    "providerName": "TradeSite AI",
+    "serviceId": "website",
+    "serviceName": "TradeSite Website",
+    "version": 1,
+    "logoUrl": "https://tradesite.ai/tradesite-logo.svg",
+    "description": "Connects your domain to your TradeSite website",
+    "variableDescription": "verify is the domain ownership verification token shown in the TradeSite portal",
+    "syncPubKeyDomain": "domainconnect.tradesite.ai",
+    "syncRedirectDomain": "tradesite.ai",
+    "records": [
+        { "type": "A", "groupId": "apex", "host": "@", "pointsTo": "76.76.21.21", "ttl": 600 },
+        { "type": "CNAME", "groupId": "apex", "host": "www", "pointsTo": "cname.vercel-dns.com", "ttl": 600 },
+        { "type": "CNAME", "groupId": "subdomain", "host": "@", "pointsTo": "cname.vercel-dns.com", "ttl": 600 },
+        { "type": "TXT", "groupId": "verify", "host": "_vercel", "data": "vc-domain-verify=%verify%", "ttl": 600 }
+    ]
+}


### PR DESCRIPTION
Template for TradeSite AI (https://tradesite.ai), a done-for-you website service for trade contractors in the US. Our customers' sites are hosted on Vercel; this template writes the apex A + www CNAME (group `apex`), a single CNAME for subdomain installs (group `subdomain`), and an optional Vercel domain-ownership verification TXT (group `verify`, variable `%verify%`).

- providerId: `tradesite.ai`
- serviceId: `website`
- Signed requests only: `syncPubKeyDomain: domainconnect.tradesite.ai`, public key published at `_dck1.domainconnect.tradesite.ai`
- `syncRedirectDomain: tradesite.ai`
- Logo: https://tradesite.ai/tradesite-logo.svg

Contact: luuk@tradesite.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)