### PR TITLE
Add Araute email sending templates (Resend and SES record sets)

### DIFF
--- a/araute.com.email-sending-resend.json
+++ b/araute.com.email-sending-resend.json
@@ -1,8 +1,8 @@
 {
   "providerId": "araute.com",
   "providerName": "Araute",
-  "serviceId": "email-sending",
-  "serviceName": "Araute Email Sending",
+  "serviceId": "email-sending-resend",
+  "serviceName": "Araute Email Sending (Resend)",
   "version": 1,
   "logoUrl": "https://www.araute.com/favicon.svg",
   "description": "Autoriza a Araute a enviar e-mails em nome do seu domínio, com SPF, DKIM e DMARC.",

--- a/araute.com.email-sending-ses.json
+++ b/araute.com.email-sending-ses.json
@@ -1,0 +1,55 @@
+{
+  "providerId": "araute.com",
+  "providerName": "Araute",
+  "serviceId": "email-sending-ses",
+  "serviceName": "Araute Email Sending (SES)",
+  "version": 1,
+  "logoUrl": "https://www.araute.com/favicon.svg",
+  "description": "Autoriza a Araute a enviar e-mails em nome do seu domínio, com SPF, DKIM e DMARC.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "araute.com",
+  "syncRedirectDomain": "app.araute.com",
+  "variableDescription": "%dkimToken1%, %dkimToken2%, %dkimToken3%: os três tokens DKIM emitidos para este domínio; %signingZone%: a zona de assinatura, que varia por região; %spfTarget%: host de retorno da região de envio",
+  "records": [
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "%spfTarget%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkimToken1%._domainkey",
+      "pointsTo": "%dkimToken1%.%signingZone%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkimToken2%._domainkey",
+      "pointsTo": "%dkimToken2%.%signingZone%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkimToken3%._domainkey",
+      "pointsTo": "%dkimToken3%.%signingZone%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/araute.com.email-sending.json
+++ b/araute.com.email-sending.json
@@ -1,0 +1,44 @@
+{
+  "providerId": "araute.com",
+  "providerName": "Araute",
+  "serviceId": "email-sending",
+  "serviceName": "Araute Email Sending",
+  "version": 1,
+  "logoUrl": "https://www.araute.com/favicon.svg",
+  "description": "Autoriza a Araute a enviar e-mails em nome do seu domínio, com SPF, DKIM e DMARC.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "araute.com",
+  "syncRedirectDomain": "app.araute.com",
+  "variableDescription": "%dkimSelector%: seletor da chave DKIM emitida para este domínio; %dkimValue%: chave pública DKIM; %spfTarget%: host de retorno da região de envio",
+  "records": [
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "%spfTarget%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "%dkimValue%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two Domain Connect templates for **Araute** (https://araute.com), a Brazilian payments
platform. Both authorise Araute to send transactional e-mail on behalf of a merchant's own domain,
so invoices and receipts reach the merchant's customers from the merchant's address instead of ours.

There are two because the record set is decided by the sending backend, and the two backends
authenticate differently:

| | `araute.com.email-sending-resend` | `araute.com.email-sending-ses` |
|---|---|---|
| DKIM | one TXT at `%dkimSelector%._domainkey` | three CNAMEs, one per token |
| Return path | MX at `send` + SPFM | MX at `send` + SPFM |
| DMARC | TXT at `_dmarc`, `essential: OnApply` | same |

The SES variant follows Amazon's Easy DKIM, where SES holds the signing key and publishes three
CNAME tokens. Its target is not a fixed host: AWS documents that "the hosted zone portion varies by
AWS Region and cell", which is why `%signingZone%` is a variable rather than a literal
`dkim.amazonses.com`.

Merchants commonly send from a subdomain (`mail.example.com`) to keep the root domain's reputation
separate, so both templates are exercised at the apex and with `host` set.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (confirmed 200 `image/svg+xml` at https://www.araute.com/favicon.svg)

Both files also pass the official linter with exit 0:

```
dc-template-linter -loglevel error -tolerate info -logos araute.com.email-sending-resend.json
dc-template-linter -loglevel error -tolerate info -logos araute.com.email-sending-ses.json
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`araute.com`) on both — public key published as TXT at `_dcpubkeyv1.araute.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.araute.com`) on both — the synchronous flow uses `redirect_uri`
- [x] no TXT record contains SPF content — the SPF line uses `SPFM` in both
- [x] `txtConflictMatchingMode` is set on every TXT record (`All` on DKIM, `Prefix` + `v=DMARC1` on DMARC)
- [x] no variable is used as a bare full record value **except the DKIM key in the non-SES template**, justified below
- [x] no bare variable is used as the full `host` label — DKIM hosts are `%dkimSelector%._domainkey` and `%dkimTokenN%._domainkey`, with the RFC 6376 label fixed
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter carries the sending subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on both DMARC records

**Justification for the bare variables.**

In `araute.com.email-sending-resend`, the DKIM record's `data` is `%dkimValue%` with no fixed prefix. A DKIM
TXT value is entirely key material minted by the sending provider, and its exact shape is the
provider's to choose: it may arrive as `p=…` alone or as `v=DKIM1; k=rsa; p=…`. Fixing any prefix
would break the moment that shape changes and would produce a record that does not validate. The
record is pinned to a `._domainkey` host, so it can only ever write a DKIM record.

In `araute.com.email-sending-ses`, each CNAME's `pointsTo` is `%dkimTokenN%.%signingZone%`. Neither
half can be fixed: the token is minted per identity, and AWS documents the zone as varying by Region
and cell, retrievable only from the `SigningHostedZone` field of the API response.

## Online Editor test results

**Editor test link(s):**

`araute.com.email-sending-resend`

- Apex (`lojadomarcos.com.br`, no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHQciWoC%2F%2B1WbW%2FiRhD%2BK6uVTmp12DEQXuKIDwbuolyOC6%2B9U9IILfYA29hed3cNIRH97Z01EMOFSqn6pZHyyet5eWZn5pmxn6iGKAmZBuo%2B0USKBQ9AXgbUpUyyVIPti4gWnjXfWISW1Mt0KFcgF9yHzAEixkNLQRzweGZJMKfc5MCTfDK2ZLCxJb%2F0M%2BNf0XoBUnERU7dYoKGYiZEM0WuudaLck5Plcmnn9zqZMkQWsa0WM3QNQPmSJzpzp16qheSPjDCyjckIxAvOJAHLRFcEIhKLCEggiIIUH9HvqeNAEHNRIIhPBt3PBdK%2BuuwQIO2O12%2FZJp9V7DdD4d9Td8pCBRtJN51cwaotEDn%2BuXhG34eAS%2FB1bpEk9oHVgknOJiG0D9L4ENzzaAAhugr5wcWLhoAnEjDiz9kCtteLuOYoShCRgNJwkMw5yVB%2BY2EKCLHxS4x6igG5zzIQtFLJdMjkDDRazYXSJAAiTbhYmIASZjwDLQujMdUUeHFMS8hAUff2iepVYrrc%2BYFyg4DnLQ0SwWOthsLklMfJqMWxUXqFLXcKVGvsd7nqOOvCMxq2ofMCDzH6aQgYlvLYD9MAXBaxRxErUNuKHsMa%2FhjmUIfFtcdB1px7WBk2Mc12JpvK7SPi8UG3RDzF8ukO0%2F4cedwRQUbxMKT%2FFHEcREz6OfyikfGqeE6SRixiOH9tkK6EKX%2BgR022uhwdzUBh3TRnZpquYy9JwhVd360LFCsG47yFd3i1HUVD8QczL9IXWUnticwzwdNMijQZ852fIV%2BkzB7ZIdwehbjbYdxSc34mgxFMAYIJ8%2B8tFenEVswCprRVtA9bay651znjuF03W03WMCNOGp3Li2nHcy5agz8vBpeTcrv3qen1Rp53evHNa7eavHfVnPXa7d7yun2jKqz%2BVX297jh%2B4MkpNQXis1hIGCt8Mp1KhNUyxamP0lDzMVuyXBT4Y2Yqi%2FVUqMUL%2FDQS8WYJbim85cDrcj7gxeHMjAPfVJ2bJVyrlsvlOptYTnVatU7PnKJVL1cqVql%2BVqueVkrlWsXf2%2BcvN%2F0rNnrOgH1WeeGSrRRdv6D%2B0aQXDex7kRwdXfIXwxE6SPhtpLhxP7pH%2FiMR32Ax%2FuWq%2B38k9bwa13cF3Gnv4%2Fs%2Bvu%2Fj%2BybH1%2FxZ4H9uMGbGruSUqpZTt0qloVN2K45bLNn1Sr10Vv%2FoOK7jmGTwv3mT6xN%2B9fe%2F9%2FSSj24%2BR4%2Flj98fuqtKOOnOv4xaVye1waRSW%2FSX329OHxPtNIejrt%2Bg678B93xh41QNAAA%3D
- Subdomain (`lojadomarcos.com.br`, host `mail`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIgciWoC%2F%2B1WW08rNxD%2BK5alI7VqdlkSLmERDwtLEYUcyIX2qBRFjj0JLrtrY3sTclD62zveBJIAp0LqS0%2FF03o9M9%2Fcvhn5kTrIdcYc0PiRaqPGUoA5FTSmzLDSQchVTmvPks8sR02aVDK8t2DGkkNlADmTWWChELIYBQb8aamyZkmOvS7pznXJD51K%2BUfUHoOxUhU03qzRTI3UlcnQ6tY5beONjclkEi7j2hgyRFZFaMcjNBVguZHaVeY0KZ0y8isjjCx8MgLFWDJDIPDeLYGcFCoHIhSxUOIn%2F6OMIhCFVDWC%2BKR7%2BXONpGenLQIkbSWdo9DnMy34Yab4HY2HLLMwv7ksB2cwTRUiFy%2BL5%2BUdENIAd0sNrcM1rTEzkg0ySNfS%2BCTuZN6FDE2V%2BRRjoBngiQhG%2BC0bwyK8XDqJVxoRCVgHa8nskwrlV5aVgBBzO%2B3FQ3QoOatAUMvqYY%2BZETjUulXWEQHEeHeF8g4NjGQF2lBe4qupMHBMSxlhaXz9SN1U%2By63vuC9R8DzggZaycLZnvI5Lf1U1JLYKDfFlkc16hz2u7ETRbPaMxq2ofUKDzE6ZQbolsqCZ6WAmOXsqyos2EVF38LqfektodaLG%2FZF1Zw7mHo2MceeVOaVW0XE44M7UsUQy%2BdazPFb5HFLiYriWUa%2F5bEvcmb4En58UPFqc5%2Fog0IVsP9eJ5cGhvKBvqmykC3RUQ0s1s1J5qfpoki0zqZ0djOrUawY9JctvMHQniiaqT%2BZ%2FzFcVSUNB2aZiR8h%2FBsZVeq%2BfLL1BMyt3yVPKNdvwtw84VzPgW6qhs5J4S%2BHAGLA%2BF1gc6dDywJg1gWb4XqLfbArHfSGi7WzkFSN89f6oHV6Mmwl0clR9%2F6kezpopO3jw6R9lSRbJ5%2BT9OhQts8OR%2B00bU8u0t%2FtNmue2%2FOLVsRFYobUF0qOCmWgb%2FHLXGkQ1pkSpz8vMyf7bMKWV4L3ma8w1tWiFAN4MRrFfBn6UMNFIReEeF%2FiayRZH6C%2B4L780m%2FkQVTn9SZvBo0658FWM4oCtiV2gl2x2RzUGzDYY4OV5f567b9jva%2FTYZVmSTZhU0tnr2bh29mPD5AFm%2BTNgSZ%2FsSxbz%2Fz7yXUOsbJhXiT%2BL%2Fn5nVZlvg1fceAfV%2BJ%2FJ7vnNTq7qeHu%2BxjxjxH%2FGPH%2F7Yj7Fwq%2Bm0Wfed16VN8JomZQr%2FeiRrwdxY16uN2Itut7P0VRHEU%2BIXyHz%2FN9xNfD6ruB8s5vD53zpm4d67QdJY1dfXo%2FEfpqQ9ynh7ncvbpt%2F7K3d3G5cdc8oLO%2FAW8yQw2kDQAA

`araute.com.email-sending-ses`

- Apex (`lojadomarcos.com.br`, no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO4aiWoC%2F%2B1XbU%2FjRhD%2BK6uVkFpdEhwnJMGIDynQirsLhyDXXo%2BiaPGOk23sXbO7NgSU%2FvabNQmOIbpw6pe7FilS9mXmmbdnZuV7aiFJY2aBBvc01SoXHPQxpwFlmmUWGqFKaO3x5oQlKEn7xR2eG9C5CKFQgISJuG5AciHH%2BG%2FK%2B4oaOXKC5PxBkPx0fnT%2BM4rmoI1QkgbNGo3VWH3UMapMrE1NsL19c3PTKD3ajhjCKtkw%2BRhVOZhQi9QW6rSfWaXFHSOMLAwyAjIXTBOoO9OGQEKkSoBwRQxk%2BJf8lXkecClUjSA%2BOT%2F9tUYO3x0PCJDDQf%2FsoOGCmcnwl1iFUxpELDbwcHKaXb2D2aFCZPk0be7%2BDLjQENpSIk0bFamcacGuYjishLHFpyIZqinI5laNlDu%2FsmttBUQZYnURAMOVOzUL3xNhBcfrFO0RMBYqoe6RLSPGEovwWUlAIEbulGSEY8aMEZLZTLMauc6AFC6SVGmiYSwKhFahn0ZDpsdgUXuijHW6GjD%2FUhHOVoXdjauCwoAxHUpzQ4OLe2pnqaPG4BOeOwRcOwo5zikhrRkql4vSTkFGgQW2M6SKV6PWIk9aHc%2Bb1x7RsHyDZ3iIcZbFSMuAChnGGYeAJQwjRqouKrEO6%2BCkPzgqwVbL0hjxoqhTmD3xd1WokuRvNeK%2FxIj%2FL420XmKk9TIjw0%2FD0sSIJ0yHrkOZZbjP94tmau6RdF8iyN4qCC5v7YGSUSxCO2A2nKCpgeIO9VRDJG7pWpHFXYmOYmCw6FYwN0I%2ByH6axjM6v5zXKJYbRiX%2FLtG1ZV%2FG6m%2FmNjpUBR8aV7qMBFdjrbJ0JJZ6rqcS48bmEuFiLcTlEuOCuvUjk91BBMCvWDitm8SmDcPq2MG23mxUeemcfOSTU4NoJ7%2B%2ByzTP4yt9PbHXUR7O1OwuWawLO2WpnIoD%2BAqs72SSfCzbPLrNc3vb1nFkkp3sOpeT5a6i0XIaaXf2NUfuqEs5OqI0jJxDbqKgO1ZnODyTLLZixG5YecTDEXO1wgoZvEUTTyaEfHhIFh29YNXLslhhWnWEjHjo6iiKV8z3dqDVhjr0es16u9lhddbd7dWjXqfb4btN1tvtrTyIz5%2FKTU9iSahVkvbjGzYzdP6sk9ZGnO8jjZpk7Rgj%2F7A4rkb7fca3HEeLCDeRujqiFonYqLSG9z9eajY15trUbFT6T6Rm0wRam5qNSj9maioD4xuf3u8gosd3en5Zwwf2dfK%2FTv7Xyf86%2BV8n%2F%2F9p8rsvF5YDHzEn53t%2Bp%2B716r4%2F9FpBG39%2Bo7frd73WG88LPM9FAsY%2BBHqP3xqrXxn0TX6Q387G8fizTdrbJ2%2BF9Vv%2Bb3%2F8fpa%2FP4JpdzLpnO9007fvj7M%2F9%2Bn8C6NnLpcLEwAA
- Subdomain (`lojadomarcos.com.br`, host `mail`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABsbiWoC%2F%2B1XW2%2FbNhT%2BKwSBABtmKbJsJ66CPDiXbl3gJkjcom0WGLRI2awlUiYpJXbg%2FfYdynZk5eYMe2kHP4mXc75z%2B3gOdI8NS9KYGIaDe5wqmXPK1AeKA0wUyQxzQ5ng2sPNR5KAJO4Ud3Cumcp5yAoFlhAeO5oJysUQvrq8r6ihUyuIrhaC6Jer06tfQTRnSnMpcFCv4VgO5ScVg8rImFQHu7u3t7du6dFuRABWClfnQ1ClTIeKp6ZQx53MSMVnBBG0NEgQEzknCjHHmtaIJUjIhCEqkWYZfJK%2FMs9jVHBZQ4CPri7e19DJ2YcuYuik27k8dm0wUxEexTIc4yAisWaLk4tscMamJxKQxeO02ftLRrlioSkl0tStSOVEcTKI2UkljB065klPjpmo79RQufMru8ZOgKRGRhUBEFjZU730PeGGU7hOwR5i2rBKqAdoR%2FOhgCJ8k4IBEEEzKQiikDGtuSAmU6SGJhlDhYsolQopNuQFQqPQT6MeUUNmQHsktbG6ikH%2BhUSUrAvbG1sFCQFDOqSiGgfX99hMU0uN7hc4twiwthSynJNcGN2TNhelnYKMHApspkAVr4aNAZ409jxvXntAg%2FJ1n%2BABxmUWAy0DzEUYZ5QFJCEQMVB1WYnnsI4%2FdrqnJdh6Wdw%2BLYo6ZtNH%2Fq4LVZL8b434bzHi%2F0cjjbcYabzNSO9LrzTRpwlRoX2hxBDY54fFY6ofoPRQAMjBOggs78yxFFHMQ9MlJhyBqa6kFvVCsYjf4WdFlnclOogxDUU3nNgWci46aRpP8fxmXsNQbtYv%2BXcDrq3eZSy%2FE7tRoSz44A5UGYntG7AbKpmlfb7Ste8q0bZ1rlCun4W5WeFcL4BuCjYuGG0PI8bogIRjRycmdTVx4CUbp%2B5W%2BWmdfeCVVWNRK5%2FMMkXzeKAmIzOJ8nAqp7NkuS7slCWzKhbgFVi%2FcDEfiiaN7vLc3DVVHOmklU1yMVrtKhoNq5HuT19zZIZt6sERqVjfOmQ7C7hjVAZNNMliw%2FvklpRHNOwTWzOolIZbMPGoU4jFQLEv212WZkmxt6WyQrtqP%2BnT0BaU25FG37UbTY9Sp92gdafpRS2n%2Fa4ROeGg1arXWYuQwf7adHw6NzfNxyq71lnbiW%2FJVOP5k6f1cuj5IZCqjp5tbuhvEsfVsH%2FcQFeNahnqJpqvNa9HGdmo%2Bcxz%2BDlztOnNvpyjjZr%2Fmxxt6lIv52ij5s%2Bbo0pTWczrJ23l1aH9g4T2MOXnNzUYzdt5sZ0X23mxnRfbebGdF5vmhf1LIjmjfWJlfc%2Ffc7y24%2Fs9rxE0m4G%2F77bbrWar%2BZvnBZ5no2HaLIK9h%2F%2Ba9T8aXP%2B%2B6%2B%2Fps6P3g8%2FfvrbHf%2Fjd4exo8OfwPB9F6nyW3g2PR93fLz8nE%2B8Qz%2F8BS1Bken8TAAA%3D
