### PR TITLE
Add EmyCommerce landing template (emycommerce.com/landing)

### DIFF
--- a/emycommerce.com.landing.json
+++ b/emycommerce.com.landing.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "emycommerce.com",
+  "providerName": "EmyCommerce",
+  "version": 1,
+  "syncPubKeyDomain": "emycommerce.com",
+  "syncRedirectDomain": "mi.emycommerce.com",
+  "syncBlock": false,
+  "serviceId": "landing",
+  "serviceName": "EmyCommerce Landing",
+  "logoUrl": "https://mi.emycommerce.com/favicon.svg",
+  "description": "Points a subdomain of the customer's domain to their EmyCommerce landing pages. The host (e.g. www) is supplied by the caller, so any subdomain is covered; the apex is not supported because it cannot hold a CNAME.",
+  "variableDescription": "token: opaque per-domain ownership-verification value that EmyCommerce checks in the TXT record at _emycommerce.<host>. Being an ownership nonce, the full TXT value is the variable by design.",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "connect.emycommerce.com",
+      "ttl": 600
+    },
+    {
+      "type": "TXT",
+      "host": "_emycommerce",
+      "data": "%token%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template `emycommerce.com.landing.json` for **EmyCommerce Landing**. It points a subdomain of the customer's domain (host supplied by the caller, e.g. `www`) to their EmyCommerce landing pages via a `CNAME → connect.emycommerce.com`, plus a `TXT` ownership-verification record at `_emycommerce.<host>`. The apex is intentionally not covered (a CNAME cannot live on the zone apex), so `hostRequired` is `true`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`emycommerce.com.landing.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://mi.emycommerce.com/favicon.svg` → HTTP 200, `image/svg+xml`)

Also validated with the official linter — no errors:
```
dc-template-linter -loglevel error -tolerate info -logos emycommerce.com.landing.json  → exit 0
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`emycommerce.com`); the signing public key is published at `_dck1.emycommerce.com`.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`.
- [x] `syncRedirectDomain` is set (`mi.emycommerce.com`) because the synchronous flow uses a `redirect_uri` back to the merchant panel.
- [x] no TXT record contains SPF content.
- [x] `txtConflictMatchingMode` — not set. **Justification:** the only TXT is the ownership nonce at the dedicated label `_emycommerce.<host>`; verification matches the exact token by iterating the label's TXT values, so stale duplicates never cause a false negative and no per-content uniqueness enforcement is needed.
- [ ] no variable is used as a bare full record value. **Not fulfilled — justified:** the TXT `data` is the bare `%token%`. The value is an opaque ownership nonce that EmyCommerce compares for an exact match server-side; prefixing it (`emycommerce-verification=%token%`) would break the existing verification and the nonce carries no meaning to prefix.
- [x] no bare variable is used as the full `host` label (hosts are the fixed labels `@` and `_emycommerce`).
- [x] no variable is used in the `host` field to create a subdomain (the caller-supplied `host` parameter is used; `hostRequired: true`).
- [x] `%host%` does not appear explicitly in any `host` attribute.
- [ ] `essential` is set to `OnApply` where relevant. **Not applicable:** both records constitute the service itself (removing either breaks the landing), so neither is a record the user may modify without breaking the template.

## Online Editor test results

**Editor test link(s):**
[Test emycommerce.com/landing example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAeriGoC%2F%2B1UbW%2FTMBD%2BK5YlBIgmS0vbbeFFbGUfgG3aRkDANFVX59KaJXZmO%2B3CtP%2FOOX1Zqw34ChLfYvvuuXueey433GFR5uCQxze8NHoqUzTvUh5zLGqhiwKNwJA%2BeGv1fAwFhfODoh4sAuhxisZKrXjcbnFbK3FSjT5g%2FVYXINWDaD7oDFNpULhVWCHDhyP3cy0ueZxBbpFu0EylwKbPHFQq1Zivbu%2B3xw5XMbke608mp%2FeJc6WNt7bul9zKgHC0Cu3Up6RohZGla9jxEy2VswyYrUZp0zbTGXMTZKKyThPIY8sWD077B2nYei%2BLflkJY7QhSyhzoq1jTzAch2w2mz1l0hJ6WeYSUzaq5%2BCQ52hazGoGql4rTrFCk%2FiYvmgCocRrf6m0a0C0cR4FBVQWmXSEpPzbROcpsRgc7x0dhH5%2BYCSMcny7wdbpS1Qx0yVcVchKNMGS80zRwCeyDKi2zKQAn8GmkFOcm4Db4CwmKC4t85JQi8mXhNHUtaEGHBuuq%2F%2FSS%2FE6ZPvoJYK1OkRICWw1AFmV5w3KvByx9bdLBl4ympkcK8%2FLA57hVUU%2BI7c4U5F95sUtj89vuKtL75ZGh0U4Hd94uzeTTjQdyQyKbPqAN50jL%2FWj6La1gqLG7oDW2XkvgQO6fdTo%2Bmg9%2F%2BK2xX9ohcO75i4ofrU%2F10B7uqy6ACez0GFsdFUO5TKlBAOF9eu8TD7fyL5Ypp83%2BXRsmmnC7nqdj7UO%2BlkHdkV7xH1%2FJKk2OPTSgqsMLvUsqtzJIczg7ioVQyAH10TH0iuh39dazRd1zmKhzJ%2BVbvFhKjw96be%2F3%2B2BgDYGGX0F3RSzYCSyKOjsRtHzqN8f9Xqw9uv6xZ%2Ft4f%2FJhspoLSonwf869vIZ1Jbf3hv6gtGGpTfo%2FU7hv5PiRYtM9X92%2F%2BbsaLktTDEdgo%2FsRJ1%2BEO0EnXbS3o27%2FbjdC6P2bre3%2FSyK4ijyLNC6Od0b2vf1Tef1wc7J%2B8%2FHttdNErmzvz8YZ6lLjpLZ6fazb1ffPw6i06%2Bd42xgDqNX%2FPYnBv82qlkIAAA%3D)

Result: `www.example.com CNAME → connect.emycommerce.com` and `_emycommerce.www.example.com TXT → "<token>"` — exactly the two records EmyCommerce verifies. `hostRequired: true`, so no apex test is required.
