### PR TITLE
Add askotter.ai site and subdomain templates

### DIFF
--- a/askotter.ai.site.json
+++ b/askotter.ai.site.json
@@ -1,0 +1,41 @@
+{
+  "providerId": "askotter.ai",
+  "providerName": "AskOtter",
+  "serviceId": "site",
+  "serviceName": "AskOtter Website",
+  "version": 1,
+  "logoUrl": "https://app.askotter.ai/logosquare.png",
+  "description": "Connects a customer's primary domain to the website AskOtter hosts for them: the bare domain reaches AskOtter's redirect service and is sent to www, www serves the site, and two verification records prove ownership to AskOtter and to Azure before certificates are issued.",
+  "variableDescription": "apexip: IPv4 address of the AskOtter redirect service that forwards the bare domain to www. asuid: Azure App Service custom-domain verification ID for that redirect service. site: the label of the Azure Static Web Apps host serving this customer's site, without the fixed azurestaticapps.net suffix (e.g. 'wonderful-sea-09faea50f.7'). token: a single-use ownership token minted per site by AskOtter; the TXT value is always the literal prefix 'askotter-verify=' followed by that token.",
+  "syncPubKeyDomain": "askotter.ai",
+  "syncRedirectDomain": "app.askotter.ai",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%apexip%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "asuid",
+      "data": "%asuid%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%site%.azurestaticapps.net",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "askotter-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "askotter-verify="
+    }
+  ]
+}

--- a/askotter.ai.subdomain.json
+++ b/askotter.ai.subdomain.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "askotter.ai",
+  "providerName": "AskOtter",
+  "serviceId": "subdomain",
+  "serviceName": "AskOtter Website on a subdomain",
+  "version": 1,
+  "logoUrl": "https://app.askotter.ai/logosquare.png",
+  "description": "Points one subdomain at the website AskOtter hosts for the customer, and publishes the ownership-verification TXT record AskOtter checks before issuing an SSL certificate. Deliberately touches nothing at the bare domain, so a customer whose main website lives elsewhere keeps it.",
+  "variableDescription": "site: the label of the Azure Static Web Apps host serving this customer's site, without the fixed azurestaticapps.net suffix (e.g. 'wonderful-sea-09faea50f.7'). token: a single-use ownership token minted per site by AskOtter; the TXT value is always the literal prefix 'askotter-verify=' followed by that token.",
+  "syncPubKeyDomain": "askotter.ai",
+  "syncRedirectDomain": "app.askotter.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%site%.azurestaticapps.net",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_askotter",
+      "data": "askotter-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "askotter-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for AskOtter (https://askotter.ai), a marketing platform that builds and
hosts customer websites on Azure Static Web Apps. They replace the manual "copy these CNAME
and TXT records into your registrar" step our customers hit when connecting their own domain.

- `askotter.ai.site.json` — primary domain. The bare domain gets an A record to our redirect
  service (which forwards to www), www is a CNAME to the customer's Static Web App, and two
  TXT records prove ownership: one to us before we issue a certificate, one Azure requires to
  bind the custom domain.
- `askotter.ai.subdomain.json` — a single subdomain, applied with `host`. `hostRequired` is
  true and the template touches nothing at the apex.

**Why two templates rather than one with `groupId`s.** The synchronous flow does accept a
`groupId`, but it is optional — a provider that ignores it would apply every group, which for
a subdomain customer means overwriting the apex A record of the website they already run.
Two templates cannot fail that way.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `askotter.ai` on both. The key is live: `dig +short TXT _dcpubkeyv1.askotter.ai` returns the two-part RS256 key.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `app.askotter.ai`, the origin the customer returns to
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record — `Prefix` with `txtConflictMatchingPrefix: "askotter-verify="` on our ownership records, `All` on the Azure `asuid` record
- [x] no variable is used as a bare full record value — two deliberate exceptions, see note below
- [x] no bare variable is used as the full `host` label — every host is a literal (`@`, `www`, `asuid`, `_askotter`)
- [x] no variable is used in the `host` field to create a subdomain — the subdomain template uses the `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` where applicable — not applicable; all records are load-bearing and removing any one breaks the site or blocks certificate issuance

## Note on the two bare variables (`%apexip%` and `%asuid%`)

`askotter.ai.site.json` uses `%apexip%` as the full value of the apex A record and `%asuid%`
as the full value of the `asuid` TXT record. Both are values Azure prescribes and neither can
carry a service-specific prefix:

- `%apexip%` is the IPv4 address of the App Service that receives apex traffic and redirects
  it to www. An A record's value is an address; there is nothing to prefix.
- `%asuid%` is Azure's custom-domain verification ID. Azure reads the TXT value verbatim; a
  prefixed value fails verification and the customer's domain never binds.

They are variables rather than literals because App Service inbound IPs are not contractually
static. As variables, a changed IP is a configuration edit on our side; as literals it would be
a template version bump re-onboarded at every provider while every customer's apex is down.

Both are constrained by shape rather than prefix: `%apexip%` can only be written into an A
record, `%asuid%` only into the fixed `asuid` label.

## Why the apex is an A record rather than a CNAME

Domain Connect cannot place a CNAME at an apex, and providers reject `APEXCNAME`, so the bare
domain points at a redirect service that forwards to www, where the Static Web App is served.

## Online Editor test results

**Editor test link(s):**

`askotter.ai.site.json` — apex, no host (example.com):

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE69iGoC%2F%2B1X227jNhD9FYJAkBa1FMmWL1JRYB07QdPdbINu2l0gGxi0RNnE0qJKUnacIP%2FeISXLlziXYlsgD3lJJHGuZ%2BYMx3dY01nOiaY4usO5FHOWUHmW4AgT9U1oTaVLGG7URx%2FJDERxX3373RzCiaJyzmJqdRQDQ%2FWnHVn0mY4rgTmViokMR34DczERf0oOglOtcxUdHZE8dze8HxkJ9XdBJHXzbALqCVWxZLm2JvBAZBmNtUIExYXSYkbloUK5ZDMilygRM8IypAXSU4oWZQiojmkqFGimQprjWWSFxuBppScpiadU1QpgWdKESXCIqjQRyRLEFLxm2vhZLBYN88eeg6oxaZw2rKBeCATps5TFxCQA5mIhExOwmFMkFhlgM2W5sVRHaRXh%2FbaAyMYUwqUoplKXVsCHiZgpVdDENfASyciY0%2BEWTiSnNyyP0NnFPEAkSSRVConUxld7epCcnhJt8FkQE%2BQuPGW6LiKqYElUBdjPc%2FSpUi8r4lTiW4mfDSvcwcGuW9ciVpaDkzHldaDWwycNJmLTUMaZslUsVbMJiEExNjqhxH7B9FQU2hpJ2Q1NEDGmlLUEHafcjIKNIoVD9AN1Jy46XIgMWj4tuKMocbwwJZS0vdTtHv7oQurfaBZB0ylwyqlTqO3qwSmasUyDpxyAtW03XtZI%2F2wjufxyieaEF6Z6iPAFWZYYc5CWhENTUBPP4YoOjkVw%2BcshQMe5WIBxsGkhtB5N9dUyiy%2BK8Xu6HFrUH3DZCPxRAb4W2SYdiFWNiaOrO6yXuaUyfDZYw%2BM7MxQE5KcuBbwelN11AF%2B1BjK3Op5336gVIc%2B1qm0WQ2OiiVU171ua8HijgdcpZ7E%2BJzqeAsbnIrExcI43LA8%2B9s9P1rahG3cCM8AfuHuK%2FZJQ363D3C3BgQX8xWFf2ErivSLV2UMf%2BP76voFvRUZH62pcQ0irqtEbAuOburGYrYOGp4kURT5iK%2FmcSDJTZsSvNK%2B2VK9XulfYPJe1NG9Nz%2FX90PXcZtse2MrB99ZJt%2B%2BHg%2BDYGzbbp71%2BJ%2FC7J2Fr4B23h73Tpt8Pg0HnxGt1j3340DwNwr436IDW0D9u904DY8zeBWDrUZYZIQuykRJ6FKat2CfjZjcJaMdr97ABh00ymIYjBf%2BJhhrjSMuCNvCs4JqNCIyt%2BlMSj6D2fAlYKjgFq9udnZX31UbNN9PfqvMoiQ2aBgzc6YY0bdHA6aRp4AQ9kjhhp0Wcdhh3fD%2Fwe36vt3GD7rlc91yh61LClIaLhRFue99MCHz%2FoF2r0HeY9d1VeqU5rzhfZV1yvsr50W56bgS82qI%2BMYP2keJVpXTdgPHzxrI3lr2x7P9kmblNyZwmI6Itn5odx%2Bs5Tf%2By6UdeEPmB2251wqD7k%2BdFnmeChxKV2d7ZZ7sbrMIw1%2F9qT7irf0yUItVmsMPZai%2F4L6hQbgVPLAX1ToD31%2BWR3chuRGYbujebrbn%2FH2y2VSds6Lnbdd4zr56cEe6zpr5%2BN2RfMX6Ss8%2FH8O%2B4%2FFjCL0j1Bbwy2VwDR4EEHH6dQEeb7tygyEZvgtTm2ofj07%2Fa%2FL0fH81%2BvT2bTo6GH34LmsXSH8ybn%2FtL%2FoWzjH%2BYsMHFeQCL9T%2FkA5%2FZ%2BhAAAA%3D%3D

`askotter.ai.site.json` — with host (example.com, host=sub):

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALPFiGoC%2F%2B1XbU%2FrNhT%2BK5YlxCbakKTvmSbdUmBiE1wETJvGRZUbO61FGme201AQ%2F33HTpo2pffCdCeND3yB2D6vzzmPffqENZunMdEMB084lWLBKZNnFAeYqHuhNZMO4bhRHV2QOYjiobr%2FbA7hRDG54CGzOoqDoWprSxb9wSalwIJJxUWCA6%2BBYzEVv8sYBGdapyo4PCRp6mx4PzQS6u%2BMSOakyRTUKVOh5Km2JvBIJAkLtUIEhZnSYs7kvkKp5HMil4iKOeEJ0gLpGUN5EQKqYpoJBZqRkOZ4HlihCXha6UlGwhlTlQJYloxyCQ5RmSYiCUVcwTLRxk%2Be5w3zx56DqjFpnDasoM4FgvR5xENiEgBzoZDUBCwWDIk8AWxmPDWWqiitIqwfM4hswiBchkImdWEFfJiIuVIZo46Bl0hOJjE7ruFEUvbA0wCdXS7aiFAqmVJIRDa%2BytOL5PSMaINPTkyQ2%2FAU6TqIqIzToAxwmKboulQvKtIsxWuJnx2XuIODbbeORawoR0wmLK4CtR6uNZgITUMZZ8pWsVBNpiAGxdjohAL7nOuZyLQ1EvEHRhExppS1BB2nnISBjSyCQ%2FQDc6YO2s9FAi0fZXFTMdJ0BxFhpONGTm%2F%2FRwdSv2dJAE2nwGnMmpmqVw9O0ZwnGjylAKxtu8myQvonG8nNnzdoQeLMVA%2BROCfLAuMYpCWJoSmYiWd%2FRYemRXD58z5AF8ciB%2BNg00JoPZrqq2USXmaT39jy2KL%2BgstG4KoEfC1SJx2IlY2Jg9snrJeppTJsG6zh85O5FATkp24ELPeK7tqDXa2BzK2u6z43KkXIc61qm8XQmGhiVc26pgmfDxp4HcU81OdEhzPA%2BFxQG0Mc4w3Lo4vh%2BcnaNnTjVmAG%2BD1nR7HfEuqndZjbJdizgL857EtbSbxTpDx76QM%2F3z038KNI2HhdjTsIaVU19kDg%2BmZOKObroFU2gcVUiiwd85VKSiSZK3PLr5Rva9p3K%2FVbqw%2FLoqJmw3cdzxs4ruN37IGtH%2By3TnpDbzBqH7nHfue0P%2By2vd7JoDVyjzrH%2FVPfGw7ao%2B6J2%2BodebDhn7YHQ3fUBa1j76jTP20bY%2FZFAFtf5ZoRslAbKaHHg6gVemTi92ibdd1OHxuI%2BDSBO3Gs4D%2FRUGkcaJmxBp5nseZjApdXtUXDMXRAvAREFZyC1Xp%2FJ8WrVYBY1n4TgFq9xzQ0kBo4cMun%2FRYlbrMX%2Bm6z3WK0Oeh4XtPt%2BCzyI7fNCNt4SXc8sjue0lpJ4cKGN4aT2NLAXBb4%2BUXnlvHbIjm1LL67XO839dUtUCZv3qRa6l%2Ftrtcuhvdc4lqG21fHLqa8t7zuGnAzfbDvg30f7Ps%2F2GdeX7JgdEy0ZZnfbbr9pu%2Fd%2BF7QdgO35fh%2Bx3e7By4sXBM%2FlKpI%2BMl%2B23FiFYkZF1ajxVP1E6QQKSeJLSaXc8R%2FwYxiivjGEFHNEHh3ad48UZlp6tkMx2Z4eDEcr3vD2TDk1Gu%2F41p79R553dyX78bxC8avkvr1OP4d2b%2FBrrek%2FAbemazugMVAkhh%2B8EC7m9bdoNBG44LU5gyJ76%2BW1y12f8X%2FevQ871Hd%2BHL4mZ3FJ78cXOqLyUG3fe39SumI5gJm9X8A6tAhCk0RAAA%3D

`askotter.ai.subdomain.json` — with host (example.com, host=app):

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMm8iGoC%2F%2B1WbW%2FbNhD%2BKwSBwBtqK7Lj%2BG0YMCMZhqJJmzUuVjQNDEo6WYRpUREpO27g%2F947KrLsxFmDfRqGfYqpe3vueY7HPHALi0wJC3z0wLNcL2UE%2BduIj7gwc20t5J6QvLk1vRcLdOVjM%2F9ARrQYyJcyBBdjiiDSCyHT%2BvuTAPYXBEZaYDplgu36LyE3Uqd81G5ypWf6U64wLrE2M6PjY5Fl3g6iY%2FIwd4XIwcvSGYZHYMJcZtal4FdaptZgEahrMGGZTYCtHhFsISXaoG%2Bsc2cOC2P1AvImE2nEsiJQ0iRgnE2vUkSZyKyFaGUsQ0H12OTzhOUQ6jyqk4YJhHPDAsC8wKQxhUxnmJJdX1%2BwEHJbhoPHzkHJAHL8rdbM6iKkaqm2iQsoMQfYKCvbaDKjkboKJlshfGCuwaozJZeYApSBVQIYOAfIDJPWI5pFLkWg4HyPLwobuUpKBKCYjt1h%2FK3A8GuLbYakHBtnmIj4Yk5eBIgwzRZMwzDK1GQraRNdlNhjeQ8RE5TKuEyopfFSwBxFjEb2E3gzjzVWOsUBiwvVMiBa%2FjAWIE792Os3fvaQlzmkIxoZLKqgVZgdNUorW6DmWClDUhwNwXorxy8OCem0FKogPZhQK7EuZVXonQvFshwIT6MatFLl9a8NHA6l9AqTY06bkChUkfg06zS8KoJ3sD4vJ%2FnpzSGHjxBJHBBbu%2ByPM7oRqR%2FhrkA%2FvEk2L6DJy5kyfHTzwO06o3t09n58%2BfujOx5%2Fo6vpZn2i8XhEfR95B7hGP2vxQp30fH%2FT3KZDRupk0woRXSdhxU4rFRNHru%2Bj3Wz4896e6TRWMrSXwoY0t5c6ovRXjlB%2B0OXR9rwG39xumvwb3t1pTcAtQqrIg3uBOwu8UC9q8NgoHma5LrKprEIykYuFodVWBd%2FsRd9W4TcuHo9EIB1fHEZyciSQl7bTYXwStkXQ6Udd6PmnA07g5SzFWz81%2BFdY1KISdFEoK6diJepPUTjF0mqNvRq0YtbnYqflDi1bfFTmRYA%2FUr%2FJp1FIlEja2EE36gw6AK3T9slpq9s%2B8VvDjj9odU%2FCIXS6vXjY7u2s%2FwMvw0v7f08XMAZSKwWt9LG7eHzzbAwf25zW%2BXcbfjomh7j%2FV7Z528RR%2FF%2FU%2F5iotCvEEqKpIM%2BO3%2Bm1sHSnPem0R35n5Le9frfv%2B%2F4b3x%2F5PjWB8pVdP7jfbi1VcOri%2BLF6op1HuZD%2BZh9t1xE%2FTN6r1yatzA09OrSHDj469ch6O8m8fYX%2B0Si%2Famx%2BXPTrawbqK6cXZkPqK3yTUUKSY2c2ajHQaXeJ88Fdcnah3%2Bq7xRf%2FKr7%2B41KbcDz5NPxzfDF8c4H%2FOV0u3ynd%2F9AbGHzGvgMITEocXQsAAA%3D%3D

`askotter.ai.subdomain.json` sets `hostRequired: true`, so a single host test covers it.
`askotter.ai.site.json` is tested both with and without a host.
