### PR TITLE
Add instantpixapp.com/gallery template

### DIFF
--- a/instantpixapp.com.gallery.json
+++ b/instantpixapp.com.gallery.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "instantpixapp.com",
+  "providerName": "InstantPix",
+  "serviceId": "gallery",
+  "serviceName": "InstantPix Client Gallery",
+  "version": 1,
+  "logoUrl": "https://www.instantpixapp.com/app-icon.svg",
+  "description": "Serves your InstantPix client photo galleries from a sub-domain of your own domain",
+  "variableDescription": "`studio` is the InstantPix studio label the gallery sub-domain is pointed at (the photographer's account slug); the CNAME therefore resolves to the InstantPix gallery ingress. `token` is the single-use ownership-verification code InstantPix issues for this domain — it is published as `instantpix-verify=<token>`, and InstantPix reads that record back and compares it byte-for-byte before it will issue a TLS certificate for the host.",
+  "syncPubKeyDomain": "domainconnect.instantpixapp.com",
+  "syncRedirectDomain": "www.instantpixapp.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%studio%.instantpixapp.com",
+      "ttl": 600
+    },
+    {
+      "type": "TXT",
+      "host": "_instantpix-verify",
+      "data": "instantpix-verify=%token%",
+      "ttl": 600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a sub-domain template for **InstantPix** (https://www.instantpixapp.com), an India-first event photo marketplace.

Photographers deliver client galleries from a sub-domain of their own domain. Today that means asking each of them to hand-create two DNS records at their registrar, which is where they get stuck — the most common support case we see is a record published at the wrong name or with one wrong character.

Applied with e.g. `domain=photographerdomain.com` and `host=gallery`, the template writes:

| host | type | value |
|---|---|---|
| `gallery.photographerdomain.com` | CNAME | `<studio>.instantpixapp.com` |
| `_instantpix-verify.gallery.photographerdomain.com` | TXT | `instantpix-verify=<one-time token>` |

The CNAME points the gallery sub-domain at our ingress. The TXT carries a single-use ownership token we issue for that specific domain, behind a fixed service prefix; our provisioning worker reads it back and refuses to request a TLS certificate for the host until it matches exactly.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — `instantpixapp.com.gallery.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://www.instantpixapp.com/app-icon.svg` returns HTTP 200 (`image/svg+xml`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `domainconnect.instantpixapp.com`; key published as TXT at `_dck1.domainconnect.instantpixapp.com` (RS256, `p=1`/`p=2` chunks)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `www.instantpixapp.com`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the TXT record — `All`, since only one ownership token may exist at `_instantpix-verify` for a given host
- [x] no variable is used as a bare full record value — the token is written as `instantpix-verify=%token%`, not as a bare `%token%`
- [x] no bare variable is used as the full `host` label — the TXT label is the fixed string `_instantpix-verify`
- [x] no variable is used in the `host` field to create a subdomain — the template is `hostRequired: true` and scoped through the protocol's own `host` apply parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` where applicable — **not applicable here.** Neither record is one an end user would modify or remove without breaking the service: removing the CNAME takes the gallery offline, and removing the TXT withdraws the ownership proof our certificate issuance depends on.

## Notes on the two variables

- `%studio%` — the photographer's account label, forming the CNAME target `<studio>.instantpixapp.com`. Used only as part of a fixed suffix, never as a whole value or a host label.
- `%token%` — a single-use ownership code we mint per domain, written as the record *value* `instantpix-verify=%token%`.

## Online Editor test results

**Editor test link(s):**

[Test instantpixapp.com/gallery example.com/gallery](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAxZiWoC%2F%2B1UbY%2FjNBD%2BK5alFSCabppNX%2BEQR%2FfEHtweq7sigZZV6ziTxFrXDrbTbm7V%2F8446Std4CsSSJGS2DPPzDPPzDxTB8tSMgd08kxLo1ciBfM2pRMqlHVMuVI8sbLscr2knb3Be7ZEB%2Fq2NbkTT3hnwawEh8Y3Z1KCqQ%2BnZw5kKgUoR77fW67AWKEVnfQ6VOpc%2F2wkehTOlXZyebler7tnGV3iOxBcq65d5QiRguVGlK6BoR8xNFhS68qQo8C8DVwW2mnSJirQLDN6SRixVRKkesmEIjprffVakfbIZ8mMYImE65NQC%2BuqVOgFEZa4Ao7DtTdEsgRkc7etzXEk9Cq1UA5Swhz53Fs16eWGlQWYzyxhnOsKs7ayyr%2F4qsGZvn99%2B8Z%2FGci0AWLAaukJI60%2F5bALKVSOVrZLFk4%2Fgtqna%2FFCQlBZ8GRRh0KUAeohMsGZp0i4Tk8QhbWVL5o2CIAoWyK%2FVVHYi4lwDaUqkcIWnpQli4N4LXL96usmiW8WHcJUegxugKU%2BMayFAa5NShLGHxsrFL1kyMGHSGoHAWYQ%2BA%2BStFXA87WQsk0Q9Zy9%2B0g4GNdSgW3GQAptXdf3Z634XZX8CPV1K%2FGEtlywqxRw131pDLzTB0gFZuf2bi92KBr7SB%2Fg9wqtcTScqaBDW1qWTu6fqatLPxqNnFtz%2FP3WT5vvCTvT%2BHvRttHFixGcw0kZhOGms0eb%2FTI7YM3Pau9nhTl2MuU7WS4aWS6OcPHryU21yqTg7pY5XmC%2F3GJHoP9rKenmYdOhn7SC%2BYHXQ2dbR7SBJ4Y7Bo7qcbIicqOrci52bqgvW1q%2FjnYA9ycIDzuI%2Bz0GHrX18YdSLEGKvHBR7C8aNv6c9ZKIX6Ux9LNBOOyNovEVi5M%2BH6RDGGXjkHoWIlfYRXOLb%2BYqAzvBlpV0Ys7W7HCU8jlKIGskbfEWQ5yLqdq1d%2BC6rfpRjn%2BraIfOU%2B5LIfxWDft83I%2BzNOj3s1EQX42jYMTDXsAHWQ9phGk8To6W9F9u8Zc39ZkuuClwUQomG5nXrLZ0c9ZiW4bnLdY9I33eav8oyb%2B5Eg8d7Nb%2FJf9PSe4XDVtBOmfeOgqjQRCOgiiahaMJPnHcHQ6HvUH0ZRhOwoYLWNfW4hm3y%2FFeofGdurmS6vq7aa1%2BuJ0mYpReCXXz65qHN8yNCj7N2U%2Fc8Kp%2BfEU3fwC2eYo2qQkAAA%3D%3D)

Sub-domain test (`domain=example.com`, `host=gallery`, `studio=limelight24`, `token=a1b2c3d4e5f60718293a4b5c6d7e8f90`) produces:

```
gallery.example.com.                     CNAME  600  limelight24.instantpixapp.com
_instantpix-verify.gallery.example.com.  TXT    600  "instantpix-verify=a1b2c3d4e5f60718293a4b5c6d7e8f90"
```

No apex test: the template is `hostRequired: true`.

---

Shape follows existing templates for comparable services (`coda.io/subdomain`, `smugmug.com/custom-subdomain`). Happy to adjust anything that does not match house conventions.
