### PR TITLE
Add template: tinidy.io / proxy

### DIFF
--- a/tinidy.io.proxy.json
+++ b/tinidy.io.proxy.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "tinidy.io",
+  "providerName": "Tinidy",
+  "serviceId": "proxy",
+  "serviceName": "Tinidy Website Translation",
+  "version": 1,
+  "logoUrl": "https://tinidy.io/logo.svg",
+  "description": "Routes your website through Tinidy so your translated pages are served on your own domain.",
+  "variableDescription": "%ip%: IPv4 address of the Tinidy edge proxy that serves this domain. %target%: the per-project Tinidy routing label this domain is attached to; it is always completed by the fixed suffix .route.tinidy.io.",
+  "syncPubKeyDomain": "tinidy.io",
+  "syncRedirectDomain": "tinidy.io,www.tinidy.io",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%target%.route.tinidy.io",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Tinidy** (`tinidy.io`), a website translation service. The
service serves a customer's translated pages on the customer's own domain, so
connecting a domain requires exactly two records: an `A` on the apex pointing at
the Tinidy edge proxy, and a `CNAME` on `www` pointing at the per-project
routing label inside our own zone.

Synchronous (signed) flow, `syncPubKeyDomain` set. The public key is published
and resolvable from outside:

```
$ dig +short TXT _dcpubkeyv1.tinidy.io
"p=1,a=RS256,d=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A..."
"p=2,a=RS256,d=QNPNn5PR4B/TcoL7OfIk1VkTA5fGjvR/..."
```

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — the template has no TXT record at all
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — n/a, no TXT record
- [ ] no variable is used as a bare full record value — **see justification below**
- [x] no bare variable is used as the full `host` label — hosts are the literals `@` and `www`
- [x] no variable is used in the `host` field to create a subdomain — the protocol `host` parameter is used instead (second editor test below)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove

### Justification — bare `%ip%` in the A record

`{ "type": "A", "host": "@", "pointsTo": "%ip%" }` is the template's only bare
variable, and it is bare by necessity: the value is an **IPv4 address**, which
admits no fixed prefix or suffix the way a hostname does. There is no
`service-foo=%foo%` form available for an A record.

The risk the rule guards against — a variable resolving somewhere outside the
provider's control — does not apply to the other record: the `CNAME` value is
`%target%.route.tinidy.io`, scoped by a **fixed literal suffix**, so `%target%`
can only ever resolve inside our own zone.

This is also the only finding reported by `dc-template-linter -merge-or-fail`
(`DCTL1040`). The linter is otherwise **silent** on this template, including
with `-logos`:

```
$ dc-template-linter -logos tinidy.io.proxy.json
$ echo $?
0
```

## Online Editor test results

**Editor test link(s):**

- Apex (no host): [Test tinidy.io/proxy example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANk5iGoC%2F%2B1VS0%2FbQBD%2BK6uVOGEbO3ZC4qpSEeFAaQHR9IFQZK29E2crx2vtrhNMxH%2FvrPMGVPXWHnrKZF7ffPNYL6mBWVUwAzRe0krJueCgLjmNqRGl4I0nJHW2hms2Q0c6ak2o16DmIoPWH30e93QHruQ7pFoYICPFSo1wQpboOgelrRQHDi1kLr%2BqAkOmxlQ6PjnZFnBibZ6e5xjCQWdKVG2CmN7J2oAmjawVWawhzFTJOp%2BSNbKWK7NZIwMnFcsxiCkgtlZUyHLlIxcl4XLGROnZ6pgSLC1geAB5JKqjmFzeziPCOFegNZETBIUNIPAcSNsM1DKzwtAoC71JTo4MUzkYTGQDK1AuBvyEzGySIAWkn5OCpVDsxxKUmDEsm2LdRr4jwrSqYsEaTTKJwwTLMW3a1BPxiH90PUGBeDYreNu%2BWpK6KbPbOr2CZtjmfzF4a74DLhTW9trBWSwW3r47uknFNY0fltQ0lV2AM1RPpTYofrCbJEVp9EiuO4kaY3DoYc%2F3HYrNhNIIZrfgpjyrqqKhz8421fn12eeLXToEf5Fw3dWXPP8AZPzs0CdZQrJjMMZl2zCGR2Yb62F%2Fd%2Fgo5YhUJWLjXzHFZtpe0iby4SB0vIl9oFYWlZU6fuj5XhCEXuBb7YqEtbA04zAJOmHU7VFbochLqSDR%2BMtMrbAnRtXg0FldGJGwBdupeJYwSw0JabRiusORlKvztCPhzDAUD%2Bo46FjCM8tJ2CsPu1Ha7%2FuRy6F76kaT09RNo8HADaHjZ4N%2BGLEw3HswXr0kb70Yu36%2BOZs3NmBd%2FWoD1vXvd%2Bv3G%2FC3%2BYwdXJb%2F4%2FhnxoFHpxl%2BBxJm2sZ3eq7fdzvBKAjiKIw7ged3%2B1E0OPb92G%2BHAdqsaC7xKvfvkeb9T%2FVNTzdX88BvmmF5fPEUVD%2BYvPt2f97NxZfTj5%2Fmw0gfB8X9e%2Fr8C6hw4Gl%2FBwAA)
- Subdomain (`host=shop`): [Test tinidy.io/proxy example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGN%2BiGoC%2F%2B1VW2%2FaMBT%2BK5alPg3SACnQTJOG2klD27rSMU1dhdAhPgSjEEe2Q0hR%2F%2FuOw72tpj32Ybxgn8t3zncuzppbXGQJWOThmmdaLaVA3Rc85FamUpSeVLy2V9zAggz5sFKR3KBeyggre7JZHclOTNkvnBhpkQ01pIbCSZWS6RK1caewUeOJitVPnZDLzNrMhOfn%2BwTOnc4zy5hcBJpIy6wCCPmdyi0aVqpcs2Ibws60yuMZ20Y2aqO228goWAYxOYFG5nIlgUo3NqpImVALkKnnsgMtYZLg9UnIM5mdhax%2FuwwYCKHRGKamFBR3AVHEyKpikBTsJoahszQ7cHZmQcdoCcg5Zqjr5DDHyO5AiALRj1kCE0yOfRmdwFqIZpS3Ve%2BZtJUoKaA0LFLUTHQcJ2UFPZUruph8SgfmOVT09nV1JE2ZRrf55AuW1xX%2Bs8Y79R0KqSm3lwa1oii8Y3MyU1oYHj6suS0zNwA9Es%2BUsXT86CZJydSaodpWkiTWUtNbbd%2BvcSomplaCm4LvaS%2FLkpI%2F1fZQVze9b58OcBT8GeC2qs95%2FkOQ0VONP6oUxwcGIxq2HWNcgSusR%2FU9xDczldEtpmjZWO58MtCwMG6bdt4PJ%2B6jnf%2FDBoDuMnO3pt%2FyfK%2FRaHkN30k3ZJwGJpHAaaPZCi7a3GUq41RpHBv6B5trqo3VOdb4Ik%2BsHEMBB5GIxuAoEjFDWoI7bU26WdMtFwEW6HaSyknxxiJy1KRb%2BItp1IWpL%2BrQ8Dv1IOgG9W4LsB60p36nFbQ7l92Lo7fjxaPy2uNxWtpXW%2FXKQGxJuGk8JXJcub9PxVsgNqrRAP1vz5ttDy2lAfpejMFWXWi263633mwMG%2B2wdREGHa9Jv8vuO98P%2FaozaOyG6pq29nhf%2BRUWy%2BLzYHU%2FexTzzsBP5D0MOoP7%2FPf8a5TNVz%2Fkcln2ode%2FCz7wpz%2BW0Y12pwcAAA%3D%3D)

Apex produces `example.com. A 203.0.113.10` and
`www.example.com. CNAME abcdef123456.route.tinidy.io`.
With `host=shop` the same template produces `shop.example.com. A` and
`www.shop.example.com. CNAME` — the subdomain comes from the protocol `host`
parameter, never from a variable inside `host`.

The IPv4 used in both tests is `203.0.113.10` (RFC 5737 documentation range),
not a production address.
