### PR TITLE
add Kissaki, Kissaki Domain Ownership Verification

### DIFF
--- a/kissaki.io.domain-verify.json
+++ b/kissaki.io.domain-verify.json
@@ -1,0 +1,23 @@
+{
+    "providerId": "kissaki.io",
+    "providerName": "Kissaki",
+    "serviceId": "domain-verify",
+    "serviceName": "Kissaki Domain Ownership Verification",
+    "version": 1,
+    "description": "Publishes the TXT record that proves ownership of this domain to Kissaki, authorizing Kissaki to run owner-authorized security scans against it.",
+    "syncPubKeyDomain": "kissaki.io",
+    "syncRedirectDomain": "kissaki.io",
+    "syncBlock": false,
+    "variableDescription": "token: the per-(workspace,domain) ownership challenge issued by Kissaki; the record published is kissaki-verify=<token>.",
+    "records": [
+        {
+            "groupId": "ownership",
+            "type": "TXT",
+            "host": "@",
+            "ttl": 3600,
+            "data": "kissaki-verify=%token%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "kissaki-verify="
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **Kissaki** (`kissaki.io`), service `domain-verify`. Kissaki is a security‑scanning platform; before it will run any owner‑authorized scan against a domain it requires proof of ownership via a DNS TXT record of the form `kissaki-verify=<token>`, where `<token>` is a per‑(workspace, domain) challenge issued by Kissaki. This template lets a customer publish that record with one click instead of pasting it by hand.

The template uses the synchronous, signed flow (`syncBlock: false`, `syncPubKeyDomain: kissaki.io`) and is intended to work with Cloudflare (sync‑only, signature‑verified) as well as any other Domain Connect DNS provider.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`kissaki.io.domain-verify.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver — **N/A: no `logoUrl` in the template.** The service logo (SVG) is supplied to Cloudflare out‑of‑band per their [onboarding instructions](https://developers.cloudflare.com/dns/reference/domain-connect/).

Also validated locally with the official linter:

```
dc-template-linter -loglevel error -tolerate info -logos kissaki.io.domain-verify.json   # exit 0, no findings
dc-template-linter -cloudflare -loglevel info kissaki.io.domain-verify.json               # exit 0 (only informational "not supported by Cloudflare" notes)
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`kissaki.io`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`kissaki.io`) — the synchronous apply URL carries a signed `redirect_uri` under `app.kissaki.io`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set (`Prefix`, prefix `kissaki-verify=`) so re‑apply replaces the prior verification record
- [x] no bare variable as a full record value — the record is `kissaki-verify=%token%` (fixed prefix, single variable)
- [x] no bare variable as the full `host` label — `host` is `@`
- [x] no variable in `host` to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set where the end user may need to modify the record — **N/A:** this is a single, fully service‑managed ownership‑verification record; there is nothing for the user to edit independently.

## Online Editor test results

Generated with the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) ("Check template" passed, then "Test apply template"):

**Editor test link(s):**

- [Test kissaki.io/domain-verify example.com/ (apex)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFseimoC%2F%2BVUf2%2FaMBD9KpalSpsKLD8aoNkPrQypWitWNrXT2gohY1%2FAIsSZ7UAp4rvvnECBtds%2BwP6K43t3fu%2Fe2StqYZanzAKNVzTXai4F6M%2BCxnQqjWFT2ZCK1p4iX9gMkfSyimHAgJ5LDmWGUDMms%2FoctEyWu9hhDumWKHK1yECbiczJd4eXnFmpMszCdONWsV%2BjAgzXMi8jMe0Xo1SaCRhiJ0Cuf1wTDVxpgb%2FMEkcRQ%2BqprkowIA2paBGryIZCjbDCTpSWjzIbbzddXBdZlV%2FfAkAQA7zQ0i6J4SwzhI2xmLFE2oaTuMw40rqEZSXr9765%2BDcQEonaPyM6qeJTGicsNYANYFqyUQrdA%2FFWTSGLS%2BU5Eny1UHpqcsahVul7vaecT1iaQjYGgicVqGG03Mp8W1bY9C3fNFQgjmxYbex7%2F6488IMTWaENje9XdKxVkZduPx2HCLvMncVoCf5MlLH489Ht25TGYdPz0Epm2U779pSj8pQjB32wn1SWpJLbHrN8gtb0lHBV%2BxoS%2BfAyZBN7VpeuB%2BsafVQZDHfsB7XNiCIeHhjOPTS4mu0o46rUN5Qlfk8ipuZMs5lx12Rb5P6gymBb5p66dVnoWZFSrttl%2FijgoTiBKGmy1qjNT4UHfhKwcHTCI9Gkjr8cZ0rD0OCX2UJjM6wucEJmRWrlkC3YbkvwIcvzdIlyDUbxCDTrwJasuobOlpe9%2BCelAz%2BHgrteSDcKozDxgihs1yMRtOonkfDrp4nfrp%2F6fjvAzCCMvL1H5Pnz8rdXZOcNGAOZlQw50LN0wZaGrteDGvr6v2jFCTJsDmLIHCzwgmbda9eD4DoIYt%2BLw6jRaje9dnTsebHnaFgwturACudpf5Lobb9XFOet6CJRZ52rpNPpCn6Tnt%2B9uegWi6%2F%2B%2FHguej%2FD4u6mf4vX6RctoxMSKQYAAA%3D%3D) → produces `example.com. 3600 IN TXT "kissaki-verify=<token>"`
- [Test kissaki.io/domain-verify example.com/www (subdomain)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJAeimoC%2F%2BVUbW%2FTMBD%2BK5YlJBBNSdKXdeFFwAYI9ipUAdJUVRf70lpN42A7a7tp%2F51z0q4tG%2FAD%2BNTa99zd89xz8S13OC9zcMiTW14afa0kms%2BSJ3ymrIWZaivNW%2FeRc5gTkp80MQpYNNdKYJ0h9RxUEVyjUdlqG9vPYcc1il0sCjR2qkr2zeOVAKd0QVmUbv2%2FJGpxiVYYVdaRhF9Waa7sFC1zU2TDH0NmUGgj6QiOeYoU0vd1dUYBZVlDiznN1hRaDCo31UbdqGKyufRxUxVNfrABoGQWRWWUWzEroLAMJlTMOqZc20tcFYJoneCqkfX73Hz8K0pFRN2fEe9zLWY8ySC3SAMAoyDN8XhPvNMzLJJaeUkEny60mdkSBLYafc92lIsp5DkWE2TUqSIN6Woj82VdYT23cj1QSTi2ZrW27%2FWruuEbL7JBW55c3fKJ0VVZu33fjhBuVXqLyRI6TLV1dHjr713Ok04%2FDMlKcLDVvunypO7yxEOX7kgXWa6EOwMnpmTNmZa%2B6qXBTC0fh6xjD%2Bryu9Fdi9%2FoAsdb9qPWekUJj0ugvce20PMt5cViQYda4ljVKTsqKbsEA3Prv5RNnau9QqNNpau61Ghd60GdWrS%2FhSiNRUd2sZf14SAdiEMZYpTF0Em7oif73KtQk0IbHFv6BVcZGokzFe3JvMqdGsMCtldSjKEs8xWJthSlFmTZnjlF8zE2Sh%2F35J%2Bk9nwdS%2BEHovxKZHFfYm8gg0EciaA7OIiCQdTpB2kvlZE8BJmFcucxefjM%2FO012fMIrcXCKSAa%2FF2%2BgJXld3ejFln8XwmmXbJwjXIMHhmHcT8IB0EcD%2BM4iaIkHrQHnS4Reh6GSRh6HWhdM4Rb2qzdneJ55%2FDTx58QzY%2B%2BT5cXZ%2FpFPE%2FTgw%2F2%2BEAtT0%2BHXy7zi8n5OZ6YTNDn9Qsy7tHFOQYAAA%3D%3D) → produces `www.example.com. 3600 IN TXT "kissaki-verify=<token>"`
