### PR TITLE
Add SendHQ email sending template

### DIFF
--- a/sendhq.cc.email-sending.json
+++ b/sendhq.cc.email-sending.json
@@ -1,0 +1,35 @@
+{
+  "providerId": "sendhq.cc",
+  "providerName": "SendHQ",
+  "serviceId": "email-sending",
+  "serviceName": "SendHQ Email Sending",
+  "version": 1,
+  "logoUrl": "https://sendhq.cc/logo.png",
+  "description": "Configures the three Amazon SES Easy DKIM CNAME records required to verify and authenticate a SendHQ sending identity.",
+  "variableDescription": "dkim1, dkim2, and dkim3 are Amazon SES Easy DKIM tokens constrained to fixed _domainkey hosts and dkim.amazonses.com targets.",
+  "syncPubKeyDomain": "sendhq.cc",
+  "syncRedirectDomain": "sendhq.cc",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Adds a signed synchronous template for SendHQ email-sending identities. It applies only three constrained Amazon SES Easy DKIM CNAMEs. The service signs the complete query using syncPubKeyDomain sendhq.cc and returns only to sendhq.cc.\n\nPublic template: https://sendhq.cc/domain-connect/sendhq.cc.email-sending.json\nService implementation: https://github.com/barotdhrumil21/sendhq\n\nThe signing-key TXT publication is pending before this draft is marked ready.