### PR TITLE
Add files via upload

### DIFF
--- a/bouncy.ai.apex.json
+++ b/bouncy.ai.apex.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "bouncy.ai",
+  "providerName": "Bouncy",
+  "serviceId": "apex",
+  "serviceName": "Bouncy Custom Domain",
+  "version": 1,
+  "logoUrl": "https://bouncy.ai/icon-192.png",
+  "description": "Connects your root domain to your Bouncy deeplinks and website.",
+  "variableDescription": "ip is the A record Vercel assigned to this Bouncy project; wwwtarget is the CNAME target for the www subdomain.",
+  "syncBlock": false,
+  "sharedProviderName": false,
+  "syncPubKeyDomain": "dc.bouncy.ai",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%wwwtarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/bouncy.ai.sub.json
+++ b/bouncy.ai.sub.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "bouncy.ai",
+  "providerName": "Bouncy",
+  "serviceId": "sub",
+  "serviceName": "Bouncy Custom Domain (subdomain)",
+  "version": 1,
+  "logoUrl": "https://bouncy.ai/icon-192.png",
+  "description": "Connects a subdomain to your Bouncy deeplinks and website.",
+  "variableDescription": "target is the CNAME target Vercel assigned to this Bouncy project.",
+  "syncBlock": false,
+  "sharedProviderName": false,
+  "syncPubKeyDomain": "dc.bouncy.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two new templates for Bouncy (bouncy.ai), a link-in-bio / deeplink platform. Customer domains are hosted on Vercel infrastructure; each customer domain gets its own project and Vercel assigns per-project record values, so the record data uses variables:

- `bouncy.ai.apex.json` (serviceId `apex`): A record at `@` (`%ip%`) plus a `www` CNAME (`%wwwtarget%`) for root domains.
- `bouncy.ai.sub.json` (serviceId `sub`, `hostRequired: true`): a single CNAME (`%target%`) for subdomain setups.

All apply requests are generated server-side by bouncy.ai and signed (`syncPubKeyDomain: dc.bouncy.ai`, key published at `_dck1.dc.bouncy.ai`), so third parties cannot substitute arbitrary record values.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checklist:
- Bare variable record values (`%ip%`, `%wwwtarget%`, `%target%`) are necessary here: the A and CNAME targets are per-project assignments returned by Vercel's domain configuration API and cannot carry a fixed prefix. Requests are signed (`syncPubKeyDomain`), which prevents third parties from substituting values.
- The templates contain no TXT records, so the SPF and `txtConflictMatchingMode` rules do not apply. No `redirect_uri`-dependent records, so `syncRedirectDomain` is not needed. All records are the essential routing records of the service, so `essential: OnApply` is not applicable.
- No variables appear in any `host` field (hosts are fixed `@` and `www`).

## Online Editor test results

**Editor test link(s):**

[Test bouncy.ai/apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIaki2oC%2F%2B1T30%2FbMBD%2BVyxLPNGkTmlLm2nSCmwDpiGY2CZAVeXE19aQ2JnttJSq%2F%2FvO6e%2BNhz3ysDfn7ru7774vN6cO8iLjDmg8p4XREynAXAga00SXKp2FXNLaJnHFcwTSkyqFcQtmIlOo8LyA521oD0lOS%2Bt0Ts50zqVC0ASMlVrROKrRTI%2F0d5MheOxcYeN6fTO5LlOtgqjbCAs1wjIBNjWycFUpPdVKQeosmenSEKO1I6IaQJxexlbTBUCRSfVkCVeCTCGx0kHoaXAjeZLB2V5fWRBpiRsD6REDqTaC%2FACTQka4tXKkQPgBboyg1QCU5xGZvCPT6dRxMwK37nB61fv6kaxiQ22qIKKILZMlWc%2FDzlR6kun0icZDnlnAyJgbENd7sq9TCL4uky8wW8kZU5GGu26NtXXf4FcpscWmbLmJpfHDnLpZ4c3prbD4%2FOBN1lI5e6vx80AWBxhxDm05ajO2qG2Kqo22hbjLH6UbDfY79Bc1%2BqIVDLZE%2BujoegV45vgfQpjqfNscXyOjy2Ig1%2FiCG55b%2F6%2BuKx%2F2Svvr2gfq37Lwr0bUDqMWC6Mw8sENQZ9rNoetLk8ifsyGCTAeTiqrA6FswLCuaorU0XdtYOD95640qIQzJcqal5mTAz7l25BIB7woshluajGLU%2FYlV8vT8JIL7jg%2BdwnuaFajA5H6XaW%2Fr1aHdaNOxIP0SHSCZrMTBZwnwwBENBy2ocXSbnfnVP%2B64VdudSszWAvKSe7PsJdN%2BczSxSumr6gvTV%2BR%2FxcF39BS%2FRr%2BR%2F8NeUOG4ElaPgEx4B7WYI12wDpBo3nLorjViqNO2G63G6x7yFjMmKcO1i13neNl7t4kjSYsT36qXp5%2FStq3NxfNu9b93fnL58vHG%2B7syf34un55nubH7PDpPV38Bt6nTUj%2BBgAA)
[Test bouncy.ai/apex example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKKki2oC%2F%2B1TyW7bMBD9FYJATrEUSV5iqyhQJy6KtoiRpolRIDAMShzbjGWSISk7juF%2F70he1ebQYw69cZY3M%2B8NZ00dzHXGHNB4TbVRC8HBfOU0ponKZbrymaC1Q6DP5phIr8oQ%2Bi2YhUihzGcaXo6uSia5zq1Tc9JTcyYkJi3AWKEkjcMazdREPZgMk6fOaRtfXBw6X4hUSS%2FsRL6WE4RxsKkR2pVQeq2khNRZslK5IUYpR3jZgDi19e26cwCdCTmzhElOlpBY4cAvxmBGsCSDXqWu0ERY4qZAusRAqgwnAzApZIRZKyYSeNHATTFp1wDlecJJPpDlcumYmYDbV7jud28%2Bk51vrEzpxCxi82Q7bDGHXcn0KlPpjMZjlllAz5QZ4LcV2fchTL7Nk%2B%2Bw2skZU576p9uaKuvu4DkXWOIA2zKxNH5cU7fSxXK6u1x8fiqWrIR09l6heSb0GXqcw7XUW0GwqR1AJaMjELn8AT1oUK0w3NToq5IwOg4yxI3uKcALw38Ifqrmx%2BJ2qjRaE6NyPRJ7jGaGzW3xX%2Ffoxwp8uMc%2FbgugLXRhRWHLD5uBH%2Fph4TwMWsQajXGzw5KQXQbjBALmL8qVe1xaL0BcWRgp4P6VgVHxD5jLDSriTI7yzvPMiRFbsqOLpyOmdbZCxhaj2KUqvdyeyI4kZ46hdTrjiXw1OuJpQVkUpxY0240oAubVeSv1GlE79VjYBK%2FNw6jTrjci3klOrvavc37jbKuKg7UgnWDFVXazJVtZunnjD%2BwYoJB%2BlcW%2FqPnO2A1r%2BLf%2BL%2BgdLwhP1rIF8BErUqMganlB24sa90EYN5txo%2BV32gH2Pw%2BCOAiK8cG6Ld81Xu7pzdL6T%2FXl5im7b9%2F0wvT18m726%2BFZXNbPZ73zH%2F3F4Ntg4rr9p%2F5A9oOPdPMbXQwQjiYHAAA%3D)
[Test bouncy.ai/sub example.com/links](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG2ii2oC%2F91TYW%2FaMBD9K5alSptGqJMGCpEmraXTVE1F1dZ13SqEHPsA08TObAeaIf77LkAKrF%2F2ed%2Fsu3fP757vVtRDXmTcA01WtLBmoSTYa0kTmppSi6rNFW29JIY8RyC93KQw7sAulIAN3pXpPnIEJIPSeZOTK5NzpckbRMrN8S0WLMA6ZTRNwhbNzNR8sxkWzrwvXHJ6%2BiLiVAmjg7AftQs9xTIJTlhV%2BE0pHRitQXhHOHkhJ96QypSW7ERIgCJT%2BglBWpIlpE55aNcKuFU8zeDqiNJzOwVPlCN%2BBmQwvLj5SHaxe7ACMsKdU1MNsn7IzxC4ewjNmqOYmtpVWlxmRjzRZMIzBxiZcQvy9sjPJoXg2zL9DNXWKBQhRfvwG2bG%2BS%2Fwq1RIQRNvS6yyIIyVjiaPK%2BqronZ9I3YHx%2BuH%2BgON0t7dGbyebLs4waj36PVZl7H1aN2iv42G8Z5uhCY3OuCZ45RAW5h8z7sxE69Ta8pirJqiglueu3qcmvLHo%2FpRQ%2FC4Y8DAVlIdiuNJp8%2FTkJ%2BzSQqMtxcbswOpXcDC7pYBxaLzxsK4%2FgHuSwuNHXmZeTXmS74PSTHmRZFV2JvDLL7y2iq9ndemJck9x%2Bu%2FiDlwsUXHUtSNq3ofQskhYul5AL04DWImegHyyOC8H0%2BE7ESi35EHq%2FVq517v1l%2B%2Bg3OgveL1vlxkS145ul6PWvgH%2F3N%2FOC2OL0COeY2NWNQNWC%2BI4jsWJnE3icJ2D6WH4TvGEsZq%2BeD8tt8Vzs3hxNAbP5kOzp6HvYfousN%2BfOrI71893HWG93HxkImfl%2Fa6N5n73nw%2BfU%2FXfwAS978iLAUAAA%3D%3D)
