### PR TITLE
Add Vonza custom domain template (vonza.com.custom-domain)

### DIFF
--- a/vonza.com.custom-domain.json
+++ b/vonza.com.custom-domain.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://vonza.com/images/logo.png",
   "description": "Connect your domain to your Vonza website or landing page, including SSL certificate validation.",
-  "variableDescription": "ip: the Vonza load balancer IP assigned to this customer's platform. acmhost: host name of the AWS ACM SSL-validation CNAME, unique per domain. acmtarget: value of the AWS ACM SSL-validation CNAME, unique per domain.",
+  "variableDescription": "ip: the Vonza load balancer IP assigned to this customer's platform. acmhost: label of the AWS ACM SSL-validation CNAME, without its leading underscore, unique per domain. acmtarget: value of the AWS ACM SSL-validation CNAME, without the fixed .acm-validations.aws suffix, unique per domain.",
   "syncPubKeyDomain": "vonza.com",
   "syncRedirectDomain": "vonza.com",
   "syncBlock": false,
@@ -29,8 +29,8 @@
     {
       "groupId": "ssl",
       "type": "CNAME",
-      "host": "%acmhost%",
-      "pointsTo": "%acmtarget%",
+      "host": "_%acmhost%",
+      "pointsTo": "%acmtarget%.acm-validations.aws",
       "ttl": 600
     }
   ]

--- a/vonza.com.custom-domain.json
+++ b/vonza.com.custom-domain.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "vonza.com",
+  "providerName": "Vonza",
+  "serviceId": "custom-domain",
+  "serviceName": "Vonza Custom Domain",
+  "version": 1,
+  "logoUrl": "https://vonza.com/images/logo.png",
+  "description": "Connect your domain to your Vonza website or landing page, including SSL certificate validation.",
+  "variableDescription": "ip: the Vonza load balancer IP assigned to this customer's platform. acmhost: host name of the AWS ACM SSL-validation CNAME, unique per domain. acmtarget: value of the AWS ACM SSL-validation CNAME, unique per domain.",
+  "syncPubKeyDomain": "vonza.com",
+  "syncRedirectDomain": "vonza.com",
+  "syncBlock": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "hosting",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 600
+    },
+    {
+      "groupId": "hosting",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 600
+    },
+    {
+      "groupId": "ssl",
+      "type": "CNAME",
+      "host": "%acmhost%",
+      "pointsTo": "%acmtarget%",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for [Vonza](https://vonza.com) — an all-in-one creator platform (courses, communities, websites, funnels). Customers connect their own domains to Vonza-hosted websites and landing pages. The template creates the apex A record pointing at the customer's assigned Vonza load balancer, a www CNAME, and the per-domain AWS ACM certificate-validation CNAME used to issue the customer's SSL certificate.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published at `_dcpubkeyv1.vonza.com` (RS256, live)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set
- [x] no TXT record contains SPF content (template has no TXT records)
- [x] `txtConflictMatchingMode` — n/a, template has no TXT records
- [x] no variable is used as a bare full record value in a TXT record (variables appear only in `pointsTo` of A/CNAME, required since the load balancer IP and ACM target are per-customer)
- [x] no bare variable is used as the full `host` label — the ACM validation record is now pinned on both sides: the host carries the fixed `_` prefix (`_%acmhost%`) and the target carries the fixed `.acm-validations.aws` suffix (`%acmtarget%.acm-validations.aws`), so the variables can only ever produce an AWS ACM DNS-validation record. Same pattern as the merged `clarflow.com.funnels.json`, `weweb.io.hosting.json` and `swivu.site.json` templates.
- [x] no variable is used in the `host` field to create a subdomain — `%acmhost%` creates a validation record, not a delegated subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — not set; all three records are required for the service to function, none are user-modifiable extras

## Online Editor test results

**Editor test link(s):**

[Test vonza.com/custom-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHBNkGoC%2F%2B1U227bOBD9FYKAsQ%2BVZVmWfBGwQL1JuyjaZrNN9oYgEEYiZbORRIWk7NpB%2Fn2Hki9yN2nRty7QN5Izc2bmzOE8UMOLKgfDafRAKyVXgnH1htGIrmS5BTeVBXUOhgso0JH%2BaU34rLlaiZQ37mmtjSz6TBYgyqOtG0HOGh9yvvdZcaWFLGk0dGguF%2FIPlaPv0phKR4PBoYCBKGDB9cC6uFW5wEjGdapEZZpoeibLkqeGbGStSFsBMbK9tpnXPNHCcCIVyaFkolyQCjEdIso0r5v71dU7knJlRCZS5IOsIBcMbAbXlgpKQJLz85PEooqIWfJdklwCIwlgAsQhby4JaC0WJWe2GLMUmrQkcfWTJpb0TKrCJZAWS6lNhJUlPCcyayDnf12R%2Bdl7W1b%2FWAo5u5i%2Ff%2BWQtTBLWRsijCY5h6aBusQJ6VQqbKsuxX3NScX3fDRpDKgFx0SIh8ZvSmQ9M%2FEJe3ERqOOoXVhrousMrU%2FltVLYlOllnbzlm93kT8VlzR84EwpH%2BKzDL7lM72iUQa65Qy1fH%2Fh9jTHs8IjxUjFNo5sHulCyrhpdWlfRaMZsKivFOW3j8fjSSluK0uhrideeqHrWz6AKx5736HwRpyHoiLVer0%2FRXj4LpXX%2BLEzc28mh91lth%2FH1nhpAN9fto0O3suTxkZBb%2FDF7ZvknwB%2FPd9zu0uKpqS8WjX%2BnW1sshlegoNB2SeyBbk6QbvdQN9SeG7AngUTzPAld3x37ru%2BH9nHXs7WMshkMEz8NWMjH2QSmySz12JD72QiCJEx37i0XNiDuWidsymeZ1yCMWMDDbAzuxzvGtlujt1gmcoNfEv9IbL8mmFrhEIyqUT9FnRsRwxqOTyyNoaryDVKp0YrpUFsdHZXtdrOjxmEAHruNHWfi0Jilljxh558NwR%2FCbNIPxyn0g2wy6s8Cf9gfekEWTtjI44nXWbr%2F2cZfWrvHeXKteWkE2JU6z9ew0fTR6vAz3e1aaOW7a%2BJUIv%2BfJuKviufQ4reo5isf7rvh5dbBj%2F5DoD8E%2Bt0KFHe3hhVnMVg33%2FPHfW%2Fa9yfXwyAKwsgLXH86nEyDF54XebYKw7VpCXnAzd3d2fTeK6dZ%2FXd4NX1dBC%2BWby%2BS38PVeZ28ulz9M767Nvq3tXr9azgafAx%2Bpo%2F%2FAqyqVMDpCgAA)

[Test vonza.com/custom-domain example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMlNkGoC%2F%2B1UbW%2FbNhD%2BKwQBox9qK7L8LmBAPTdYi65tELsb1sAQaPJks5FEmaTs2kH%2B%2B46SHNtZ0qLfVqDfSN7dc3fPPbw7aiHNE2aBhnc012ojBei3goZ0o7I987hKafPB8IGl6Ej%2FciZ8NqA3kkPpzgtjVdoSKmUyO9pOI8ik9CGvDz4b0EaqjIbtJk3UUn3SCfqurM1NeHHxUMCFTNkSzIVz8fJsiZECDNcyt2U0nagsA27JThWaVBUQq6prlXkLCyMtEKVJwjIhsyXJEbNJZMaTorxPp38SDtrKWHLkg2xYIgVzGTxXKtOSLRJ4fZZY5iGxK6iTJIoJsmCYAHHI2yvCjJHLDIQrxq6kIRVJoF8Y4kiPlU49wni6UsaGWNkCEqLiEnL895SMJ%2B9dWa1jKWTyYfz%2Bskm20q5UYYm0hiTAygaKDCdkuNLYVpHJdQEkhwMfZRrL9BIwEeKh8YcSOc9YfsVePAQ6cTQe2xpiihitT%2BV1Uthl%2FKpYvINdPflzcTnzNQipcYTPOvyeKH5Lw5glBprU8XUN6wJjxMMjxistDA1v7uhSqyIvdelcZakZu8udFMe0isfjKydtJTNrZgqvDZk3nJ9FFfZ9%2F775TZySoCPWdrs9R3v1LJQxybMwUaOWQ%2BNRbQ%2Fjazw1gNNc8%2Fsm3asMoiMhc%2FwxB2bhK8MfDzW3dVqzUjneyhojWcacdOwKRoicaZYatygOYDdnaPMD3E2FN68BnwST5fOg5wVeP%2FCCoOce696dpROPWHsR8K7oQT8esOFixH3RhiDusO6ix2v3ihMXEJ1aB2IIo9gvETqiC724z7wvt0Ls99bssVTkCL8m%2FpXIfVFmC43DsLpAHaVFYmXEtuz4JHjE8jzZIaUGrZgONXaip6zacjWLOBeGt9PejuNp0khwx6F0UujFWG6w8Ft9FvBWtxMPWyMQ0GJxtx%2FEgxGP%2B8OT%2FfufxfytDXw%2BWjAGMiuZ27DjZMt2ht47WT6SYd0Jqtk778bdvHPt%2FFwtRd9T1KOGf0RP3%2FmS%2FyuC5k1cB7%2Fk%2B0u%2BP6l8ce8btgERMeca%2BEG%2F5Q9bwWDW7obdftjpeJ1Otz0cvfT90PddG2BsRcodbv3TfU%2Bv0j82s3dDfz02g%2BmXbDL6%2FFFO8rHq%2FPNxBrPpy8vL6zfr9u3nN2vzG73%2FF9O3RiItCwAA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

