### PR TITLE
Add custom domain configuration for AboutMii

### DIFF
--- a/aboutmii.com.custom-domain.json
+++ b/aboutmii.com.custom-domain.json
@@ -1,4 +1,4 @@
-{
+{ 
   "providerId": "aboutmii.com",
   "providerName": "AboutMii",
   "serviceId": "custom-domain",

--- a/aboutmii.com.custom-domain.json
+++ b/aboutmii.com.custom-domain.json
@@ -12,13 +12,13 @@
     {
       "type": "A",
       "host": "@",
-      "pointsTo": "31.97.207.207",
+      "pointsTo": "%ip%",
       "ttl": 600
     },
     {
       "type": "CNAME",
       "host": "www",
-      "pointsTo": "aboutmii.com",
+      "pointsTo": "%cname%",
       "ttl": 600
     }
   ]

--- a/aboutmii.com.custom-domain.json
+++ b/aboutmii.com.custom-domain.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://aboutmii.com/favicon.ico",
   "description": "Point your domain to AboutMii (A on apex, CNAME on www).",
-  "syncPubKeyDomain": "aboutmii.com",
+  "syncPubKeyDomain": "aboutmii.com", 
   "syncRedirectDomain": "api.aboutmii.com,aboutmii.com,www.aboutmii.com",
   "records": [
     {

--- a/aboutmii.com.custom-domain.json
+++ b/aboutmii.com.custom-domain.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://aboutmii.com/favicon.ico",
   "description": "Point your domain to AboutMii (A on apex, CNAME on www).",
-  "syncPubKeyDomain": "aboutmii.com", 
+  "syncPubKeyDomain": "aboutmii.com",
   "syncRedirectDomain": "api.aboutmii.com,aboutmii.com,www.aboutmii.com",
   "records": [
     {

--- a/aboutmii.com.custom-domain.json
+++ b/aboutmii.com.custom-domain.json
@@ -12,13 +12,13 @@
     {
       "type": "A",
       "host": "@",
-      "pointsTo": "%ip%",
+      "pointsTo": "31.97.207.207",
       "ttl": 600
     },
     {
       "type": "CNAME",
       "host": "www",
-      "pointsTo": "%cname%",
+      "pointsTo": "aboutmii.com",
       "ttl": 600
     }
   ]

--- a/aboutmii.com.custom-domain.json
+++ b/aboutmii.com.custom-domain.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "aboutmii.com",
+  "providerName": "AboutMii",
+  "serviceId": "custom-domain",
+  "serviceName": "AboutMii Custom Domain",
+  "version": 1,
+  "logoUrl": "https://aboutmii.com/favicon.ico",
+  "description": "Point your domain to AboutMii (A on apex, CNAME on www).",
+  "syncPubKeyDomain": "aboutmii.com",
+  "syncRedirectDomain": "api.aboutmii.com,localhost,aboutmii.com,www.aboutmii.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%cname%",
+      "ttl": 600
+    }
+  ]
+}

--- a/aboutmii.com.custom-domain.json
+++ b/aboutmii.com.custom-domain.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://aboutmii.com/favicon.ico",
   "description": "Point your domain to AboutMii (A on apex, CNAME on www).",
   "syncPubKeyDomain": "aboutmii.com",
-  "syncRedirectDomain": "api.aboutmii.com,localhost,aboutmii.com,www.aboutmii.com",
+  "syncRedirectDomain": "api.aboutmii.com,aboutmii.com,www.aboutmii.com",
   "records": [
     {
       "type": "A",


### PR DESCRIPTION
This file contains configuration for the custom domain service, including provider details and DNS records.

# Description

<!-- short description of the template(s) and/or reason for update -->

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [ ] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [ ] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [ ] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)
- [ ] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [ ] `%host%` does not appear explicitly in any `host` attribute

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
[Test aboutmii.com/custom-domain aboutmii.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALkajWoC%2F%2B1TXW%2FaMBT9K5GlSpuaBCd8R5o01lVV1xZ1E9OEEIpMbKhXYlu2A2OI%2F77r8BGg3Z77sAfCte851%2Bce%2B66RZbmaE8tQskZKywWnTN9SlCAykYXNOQ8zmSP%2FkOuTHLCo57IPnEPGML3gGStJWWGszAMqc8JFlTsjeVclzPu8hy2YNlwKlEQ%2BmsuZ%2FK7nAH%2ByVpmkVjtWUpsSKChFCB8gUmYyzZUtyehRcmG9lSy0t1XgWekdDn3X86TwiGK%2FfO%2Bq33u4dsvlcvk%2BdEJXInssJndstRP1wgCH%2BMYo1yyzFUbx8BjnnyygeHhWBdhSU4OS0RrZlSpdge0naSyEH53RrgkzkLC84OoCdqwFN1oYb%2FwDp9Rf8eCgM2YmwPIT8njjo99SsLSSMAYD%2F9LtrjBEMy0LlfI9QRFNcuNey546OuWO9%2BQRcjFXLqpHYbcdxrj8ue1S30suaOQzITVLDfwTW2gAWV0wH%2BXF3PKULEm1RbOUKDVfQUsGslDu1NXtGaWrlFgC4amOyh0fpTRzTXH3ihsd1owiNgmibp0EDdxtB5MuzYI4ymgj7kxxNGkdjcRr4%2FKvoai8ZcYwYTlxr703X5KVQZtXbnnXx%2FaWd52cnfcWGxn78GD%2B38hbuhGYPEMWjKbEwWIctwLcCeLmADeSepQ062G70ahH%2BBLjBGPXBTN2298aZvN4KtGQTp4vb26Gd9n9gLQEEe3br20VS8Hb8Y%2Fhz%2FgLrX%2FqT%2B%2Fp9fPwA9r8AcyKcfdqBgAA)

[Test aboutmii.com/custom-domain /blogs](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPUajWoC%2F%2B1UTY%2FaMBD9K5GllVptErxJCBCpUhHlUK0W7W6pekAoMo4BS0ls2Q6URfz3jsNHIF31vIceQpiZ98bzxjPZI8MKmRPDULJHUokNz5j6nqEEkYWoTMG5T0WB3EtsQgrAoqGNPnEOEc3UhlNWk2iljSi8TBSEl02sRXJGNcz5doZtmNJclCh5cFEuVuKnygG%2BNkbqpNO5rqSzJJBQlD78ADFjmiouTU1Gz4KXxtmJSjnHChwjnMuhn4aOKB0i2W%2FXGU2GT2Nrbrfbz74tdFfS52rxyHanov5qgEW8sowrRk2Dkdy%2Fxrk3BiT3W1mALVSmUTLbI7OTdVfAvRbawN%2BvttFWhJ4KMO%2B4vAOPMdCNGOODe%2BHU9Tc8OKjFpCW0%2FIY8P7joTZQsbUqYQwPPSppkC7gBDeZKiUqm%2FIyURJFC2zE5c2YIzc%2Bs2YkGDi6tGT74g54f4Pqx7roiG7npiK2Kr0qhWKrhTUylAGRUxVxUVLnhKdmSxpXRlEiZ70CEhiiku%2B3j8YyLhIwYAuZtLU1PXJRm1CridnZxl%2BIwimKPBhHzIsIybxCE1IvDuL9cEBz1KblahPeW5F%2Br0Oou05qVhhM76MN8S3YaHd654JMgO0ktUa2jP6ymuQvT8%2F%2BWPvotwYZqsmFZSiw2wEHs4b4XdKc4SsIg6YZ%2BFA963fAe4wRjK4VpcxS5hx2%2B3l40iovleBq8jFRvsqHZePSr90Qm0Y817ryM6f0SPvZv%2Fe2rUo%2F0Czr8AUjfryqEBgAA)

