### PR TITLE
Add Domivy storefront template (domivy.app.storefront)

### DIFF
--- a/domivy.app.storefront.json
+++ b/domivy.app.storefront.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "domivy.app",
+  "providerName": "Domivy",
+  "serviceId": "storefront",
+  "serviceName": "Domivy storefront",
+  "version": 1,
+  "description": "Serves a Domivy booking storefront on a subdomain the operator controls",
+  "logoUrl": "https://domivy.app/icon.svg",
+  "syncPubKeyDomain": "domivy.app",
+  "syncRedirectDomain": "domivy.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "storefront",
+      "host": "@",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Domivy (domivy.app), a property management platform. It lets a property operator serve their hosted booking storefront on a subdomain they control. The template writes a single CNAME pointing the chosen subdomain at Vercel's ingress (cname.vercel-dns.com), where the storefront is served with an automatically issued certificate.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to domivy.app; apply requests will be signed, with the public key published at the key host under domivy.app
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — warnPhishing is not present
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to domivy.app
- [x] no TXT record contains SPF content — the template contains no TXT records at all
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — not applicable, no TXT records
- [x] no variable is used as a bare full record value — the single record has no variables; its data is the fixed host cname.vercel-dns.com
- [x] no bare variable is used as the full `host` label — the host is the literal `@`, resolved against the host parameter
- [x] no variable is used in the `host` field to create a subdomain — the subdomain comes from the `host` parameter (`hostRequired` is true)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — deliberately left at the default: the single CNAME is the entire service, and removing it disconnects the storefront, so it should not present as independently removable

## Online Editor test results

**Editor test link(s):**
[Test domivy.app/storefront theveyrai.com/book](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKY3jGoC%2F91TXY%2FaMBD8K5Ffm0AIuQMiVSotPQn17nrluIcKocixF3Cb2Knt5JQi%2FnvXfJSvVn3vU2Tv7OzOeLImFooypxZIsialVrXgoMecJISrQtRNi5Yl8X9XHmmBSDLa1vDegK4Fg22DsUrDQitpj4UzvHeGqEEboSRJOj7hYJgWpd2eyTP2gvGot2%2FLlPou5PKk3VMSy6bKcEkqpGdX4KkSNEWExxCgVW5wRq6W6kXnyLmytjRJu31U1RYIbJl66bZtJHuqsk%2FQjLaEl%2FJdfQJcaGD2z4iVMnYCPyqEoBdWV%2BATRCvNDUlma2Kb0hnx4XH48BHhS62q8to1x4J375zjSkhrpgqPTKKLLfSLQR5waVpMFYiwFoXdhuFmvvHJTyUhPQ6c%2B4Qf9kRzamg0Ffu%2B%2FRDn6mGTVGy7TpdBhpJqWhgXjAPX7IJsfmCb7ejme75LLlxQLCWeU4NfaisNB5OKKrcipa%2F0eMVZiqbmDeoxWEWyawPlLlh7EZxa%2Bm%2BjfJJy5uQIZ3x%2F0KGDbjYIGAsXQbxgvSDrDm6CRT%2Fu9rq9KOyH0Unyr%2F%2BJv2b%2F3GAwBqQV1KVwmL%2FSxpDNZu7jE%2F1%2FqvD9Da2Bp9RBozC6DcJ%2BEMXTTpRE3SSMWnE3iuPOmzBMwtCJAGN3MteYkdN0kPGE3r2vM%2FFl0rt%2FMDfjwbD3udIvjD1%2Fq5iYjGQxvnuKp%2Fd6%2FPUt2fwCxmU8sMkEAAA%3D)

The template has `hostRequired: true`, so per the instructions an apex test is not required. The linked test applies the template for domain theveyrai.com with host book and shows the single resulting record: book.theveyrai.com CNAME cname.vercel-dns.com, TTL 600.