### PR TITLE
Add host.impossibuild.ai custom-domain template

### DIFF
--- a/host.impossibuild.ai.custom-domain.json
+++ b/host.impossibuild.ai.custom-domain.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "host.impossibuild.ai",
+  "providerName": "hostimpossibuild",
+  "serviceId": "custom-domain",
+  "serviceName": "Custom domain",
+  "version": 1,
+  "description": "Connects a domain the user owns to their app or published site: one CNAME to the platform edge and one ownership-proof TXT record.",
+  "variableDescription": "verify is the hex ownership token the dashboard or CLI shows when the user adds the domain.",
+  "syncPubKeyDomain": "host.impossibuild.ai",
+  "syncRedirectDomain": "host.impossibuild.ai",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "host.impossibuild.ai",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_hostimpossibuild-verify",
+      "data": "hostimpossibuild-verify=%verify%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "hostimpossibuild-verify="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for hostimpossibuild (host.impossibuild.ai) custom domains.

The template connects a domain the user owns to their app or published static site on the platform: one CNAME to the platform edge (`host.impossibuild.ai`) and one ownership-proof TXT record:

`hostimpossibuild-verify=%verify%`

The template is intended for the synchronous flow and uses signed requests via `syncPubKeyDomain`. `hostRequired` is set: the service connects subdomains only, so the apex case does not apply. No `logoUrl` is included.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template

## Online Editor test results

**Editor test link(s):**

[Test host.impossibuild.ai/custom-domain example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHN3jGoC%2F%2B1UW2%2FTMBT%2BK5YlnmiqJG3SNhISYxsSjCEY46apqk7sk8UiiYPtNC3T%2Fjt2k64du%2FDACw97Suzznct3zudzRQ2WdQEGaXJFayWXgqN6w2lCc6nNUJS11FqkjSj4EAQd3GDeQ4k9ah9kERrVUjDcBGGNNrL0uCxBVDtb73y4sZIb6xKVFrKiSTCgHDVTojabMz2UVYXMaAI9mpgcSWPDEdlWmhjpLoQiUNdEKlI3aSF0jpxoYTAhskJy%2BP7g9LhHEsc5k6okyC%2BRQMU3EBvLlpCL2rM0ZUbOv50ThUwqPnTlgRKQFnh0qzRbtMjWROhN3BxXuyg22Q%2FsSuWg81SC4q66w3dviM5lq0mb4x4V4LyL0nF0OfW6Yh%2Ba9ATXR12XHhyMQ54hF7Ze8zesuz7Dn40F2ykZ1eCAdjw1TS6uqFnXm%2Fm4jvVwe3zpxi9FZfS5fDi2MQVNRrHvXw9uAtk%2B7sIs%2FtSM17XQIjgYuEdUPeDFs%2B77bD%2BL%2FV0ZK4%2BsEMycgmG5qC5PJXdpPyjMxIreC%2BltDyej1%2FPrAf1lZbHYtWZua9z2Fldgnw4OmSx35Nq2tYdLJZt6IbYuNSgotXthW%2BeLW97zrfvFxn8%2B6EXlLmZZyCYQ4DQd81EWg88iDPkkncE4C9gU43TEfZhkYwzYLI35CPxsgmMWpFMeQZhRx0JcVlLhQtsvmEbhduZlUxixgBZ2V5wt7Bsq1pa0tlZbwl09VN3z7bjuzewxNQzogjPXAuH2As9mIxz5gRf7IXjjWTD1IJ7GHox5lI6DmEd%2BvLdsHltIj62bW0NBrbEyAmxB9KBoYa3p9R2N9tQe0ujwDuf7pPPPM%2Fv%2F%2BzYfWGE%2FKeNJGXeVYdeXhiXyBThk6Iex50%2B9cHwexEkUJUE09IMoHE2f%2B37i%2B44RatP17cruqv0tRY%2FL9t2XyaeT6KAI8eTt8dfpD%2F767PPSF3X86Wf58SsbvQq%2Bm1VdHtuF%2FRviqeduzggAAA%3D%3D)

[Test host.impossibuild.ai/custom-domain example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJt3jGoC%2F%2B1U247TMBD9FcsSTzRVmqZptxISq2UlECwsSx%2BQVlU1sSeNIYmD7fTCav%2BdcZNuu%2ByFB154QKqUenzmcmaO54Y7LOsCHPLpDa%2BNXimJ5p3kU55r6%2FqqrLW1Km1UIfugeO8O8xFK7FDHIEJYNCslcBdENNbpMpC6BFUd7jrns90tu7tdobFKV3w66HGJVhhVu92Zn%2BmqQuEsgw7NXI6soXBMryvLnPYGZRjUNdOG1U1aKJujZFY5nDJdITv7eHpx3iGZ55xpUzKUS2RQyR2EYlEJuaoDoqkzNvs6YwaFNrLvywOjIC3wzb3SqGiVbZmyu7g5bg5RKNl3bEuVYPNUg5G%2BurMP75jN9dqydY5HVEDKNkrL0ee020pcNul73L5pu%2FTkYDzyCqWiet2fsN58hT8aAtOUnGmwx1uelk%2Bvb7jb1rv5%2BI51cDq%2B9uPXqnJ2pp%2BO7VzBp8MkDG97d4Goj4cwi981E7QtJIQEB4%2BIqgO8etF%2BXxxnob8bR%2FLICiXcBTiRq2p5oaVPe2kwUxv%2BKKS7ezoZv53f9vhPksXi0Jo51bjvLW6Ang72hS4P5Eh%2FdFga3dQLtXepwUBp%2FQvbO1%2Ff857v3a93%2FvNeJypviGEiBtkYI3mSJjAUIY6yiYxgnMbiBAdZIocQphMciSg7kWOI0wFORJKRVY7SCLlnoZaVNriw9AXXGNzPvGwKpxawhoNJigXVUGyJtKVbKuGhHqr2%2BbZcj2b2nBp6fCGFb4HyewESwHgIcTDGGIJ4PA4DGGAUJIMwSiYnOI4m4mjZPLeQnls394aC1mLlFFBB%2FLRYw9by2wca7ag9pdH%2BA86PSeevZ%2Fbv923eI2H%2FV8Z%2FZTxUBq0vCyuUC%2FDIiNIH4SSI4tkgmY5G9OtP4jAaDl6G4TQMPSO0ru3bDe2q4y3FP119K138dvjp%2FWeE7Vv95efqfBmXP1az8%2B%2BNnEk72pxW20jb5JQW9i%2FaYKUjzggAAA%3D%3D)
