### PR TITLE
webp image changed to svg as requested by cloudflare

### DIFF
--- a/azbrand.ca.web.json
+++ b/azbrand.ca.web.json
@@ -4,7 +4,7 @@
   "serviceId": "web",
   "serviceName": "AZBrand website hosting",
   "version": 1,
-  "logoUrl": "https://azbrand.ca/logo2.webp",
+  "logoUrl": "https://azbrand.ca/logo2.svg",
   "description": "Connect your custom domain to your AZBrand website.",
   "syncPubKeyDomain": "azbrand.ca",
   "syncRedirectDomain": "azbrand.ca",


### PR DESCRIPTION
# Description

Updated service logo image format from `.webp` to `.svg` in `azbrand.ca.web.json`.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test azbrand.ca/web example.com/azbrand.ca](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAHmjGoC%2F%2B1T70%2FbMBD9VyJLfFrShqZpIdKkQWGM8UODdWyAqsi1r8XDiTPbKZSq%2F%2FvOKSUtdN83aZ8s%2B%2B6e37t3NyMWskJSCySZkUKrieCgjzlJCH0aaprzBqPEf4mc0wwzyd7NvothwICeCAZVxQMM65f1TA9jRljw7pSxIh9j3gS0ESonybZPpBqrb1pi%2Fp21hUmazfr3pgu2GghQYBUHw7QobFVJeirPgVlvqkrtsdJYlXlcZVTknlWL11cEGo7hNGdfyuEJTA%2Bq3NdiXfwSuNAIvTljQrWgQwkHa2zso02tuoc88XpSlXwkqYYlLSc8x554qFuMBKOuyKvSn7%2Fcl4rdk2REpQGfuPxL%2BFUiC%2Byt1SW%2BISGluSHJ7YyMtSqLqu3MwSKGnRau473zvbNDsgDA6wfnnhK5NX2FV%2BBjaKxpsRb7HoXh3F8FXWVZY%2Fd%2F9GvklI2ChbhgKc4ZRC3F4NZLM7ZW%2FvBdj9C0kRTMnlHL7nAWzhSvJkVKMh%2FMffKkckhrqQPEXJoAjxSnFRpMZTWPNTWVglQsKwuqaWbcbC8xbtdABkuU21WYgV976ULE0RLjXGlIDZ7UlhqWpmSltCKlD7R%2B4iylRSGnqMJgFCHQsFf25Iv9WCP%2F3Ls%2Fe%2BSTlDOnRjiP4uFu1A53eMC3IQzacQeCIdsJg07Y4rQd8dZue7iyu2%2B3%2Bu3ybmopGAO5FVRWJj3QqSFzNyxrM%2FEsZ8NMNDZJ%2FCs1DXwcmf9O%2FQtO4YYaOgGeUlfQCludINwJWnE%2FDJN2J4m7jW4URXH0Du9h6DSAsQtFM9zl1S0m8cVpfnzxPepKm30sj%2Bi4PJreXB3F571Pl6fj3avD5uev1z%2Fv4173%2Bg2Z%2Fwb1wCr4MgcAAA%3D%3D)