### PR TITLE
Update logo URL from .webp to .svg format

### DIFF
--- a/azbrand.ca.web.json
+++ b/azbrand.ca.web.json
@@ -4,7 +4,7 @@
   "serviceId": "web",
   "serviceName": "AZBrand website hosting",
   "version": 1,
-  "logoUrl": "https://azbrand.ca/logo2.webp",
+  "logoUrl": "https://azbrand.ca/logo2.svg",
   "description": "Connect your custom domain to your AZBrand website.",
   "syncPubKeyDomain": "azbrand.ca",
   "syncRedirectDomain": "azbrand.ca",


### PR DESCRIPTION
# Description

Updated service logo image format from `.webp` to `.svg` in `azbrand.ca.web.json`.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test azbrand.ca/web example.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGDnjGoC%2F%2B1T207jMBD9lcgSTyRtCL0RaaWlsGgvKkKoq90FVZFrT1uDEwfb6YWq%2F77jtCEtsO887JNlz8zxOXNm1sRCmktqgcRrkms1Fxz0N05iQp%2FHmma8wSjxXyLXNMVMcn7XdzEMGNBzwaCsWMC4fjnM9DBmhAVvpowV2RTz5qCNUBmJT3wi1VT91BLzZ9bmJm4269%2BbLhg1zNwVcTBMi9yWheRCZRkw661UoT1WGKtSj6uUisyzavv66v%2BGI7jK2E0x%2BgGryzL3tVYXvwUuNEK%2FnzGnWtCxhMsDNnZpE6seIYu9C6kKPpFUQ0XL6c6wJR7KFhPBqCvyyvTdl32p2COJJ1Qa8InLv4WnAllga60u8A0JKc0Nie%2FXZKpVkZddZw4WMewqdw2%2FuD4ffCFbALx%2BduYpkVkzVHgFPoXGgRZrse2nYbjx90H3WdbYw9%2FDGjlhk2ArLqjEOYOopRm8emnG0d4fvusRmjaRgtkBtWyGozBQvBwUKclmtPHJs8ogqaWOELMyAZYUhxUaTKU1Dwt4%2BFvuiahqcqppatxQV9X3B%2BWjqv5%2BCzDya%2F%2Bqx6C8BXMqCyCOmphmSkNi8KS20FAZkxbSioQuanpM5wJR7KFhPBqCvyyvTdl32p2COJJ1Qa8InLv4WnAllga60u8A0JKc0Nie%2FXZKpVkZddZw4WMewqdw2%2FuD4ffCFbALx%2BduYpkVkzVHgFPoXGgRZrse2nYbjx90H3WdbYw9%2FDGjlhk2ArLqjEOYOopRm8emnG0d4fvusRmjaRgtkBtWyGozBQvBwUKclmtPHJs8ogqaWOELMyAZYUhxUaTKU1Dwt4%2BFvuiahqcqppatxQV9X3B%2BWjqv5%2BCzDya%2F%2Bqx6C8BXMqCyCOmphmSkNi8KS20FAZkxbSioQuanpM5wJR7KFhPBqCvyyvTdl32p2COJJ1Qa8InLv4WnAllga60u8A0JKc0Nie%2FXZKpVkZddZw4WMewqdw2%2FuD4ffCFbALx%2BduYpkVkzVHgFPoXGgRZrse2nYbjx90H3WdbYw9%2FDGjlhk2ArLqjEOYOopRm8emnG0d4fvusRmjaRgtkBtWyGozBQvBwUKclmtPHJs8ogqaWOELMyAZYUhxUaTKU1Dwt4%2BFvuiahqcqppatxQV9X3B%2BWjqv5%2BCzDya%2F%2Bqx6C8BXMqCyCOmphmSkNi8KS20FAZkxbSioQuaP3EWULzXK5QicEoQqJpryzKtiuyE7Dr3L8d8knCmVMknEOnLGwDjTrBSSdqB612dBZQYBCw3rhDW%2BNo0mt19xb37Uq%2F3dzDhoIxkFlBZWnOgq4M2bghOZiFnYR3ZqFxKOtNPz%2BWrpGPQ%2FPfoY%2FsEG6ooXPgCXWpUYgEwl4QtYdhGLejuNVrdE87Z53uMd7D0LFHtK22Ne7u%2FtaSh36%2FMKun6fEN617N7nqLJn8ctH5Epnn1K%2FsuHr5yvXyaLU%Turb%2FfyOYvKoFslCUHAAA%3D)