### PR TITLE
Update logo URL from .webp to .svg format

### DIFF
--- a/azbrand.ca.web.json
+++ b/azbrand.ca.web.json
@@ -4,7 +4,7 @@
   "serviceId": "web",
   "serviceName": "AZBrand website hosting",
   "version": 1,
-  "logoUrl": "https://azbrand.ca/logo2.webp",
+  "logoUrl": "https://azbrand.ca/logo2.svg",
   "description": "Connect your custom domain to your AZBrand website.",
   "syncPubKeyDomain": "azbrand.ca",
   "syncRedirectDomain": "azbrand.ca",


### PR DESCRIPTION
# Description

Updated service logo image format from `.webp` to `.svg` in `azbrand.ca.web.json`.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test azbrand.ca/web example.com/azbrand.ca](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPHojGoC%2F%2B1T72%2FaMBD9VyJL%2FbQEws%2BVSJNWoJOmrVVVsY21QpGxL%2BCSxJntUFLE%2F75zKA1p2fdN2ifLfnfP9%2B7dbYmBJIupARJsSabkWnBQnzkJCH2aK5ryBqPEfUGuaYKR5OJuaDEENKi1YFBmPMK8eqlHOohpYcBZSm1EusC4NSgtZEqClktiuZDfVIzxS2MyHTSb1e9NC7Ybem2TOGimRGbKRDKSaQrMOIXMlcNybWTicJlQkTpG7l9f%2Fd%2BwBRYpu8nnX6AYl7GvtVr8FrhQSH06Yk2VoPMYxrVqzMaERq4gDZxRLHMexVTBoSyrO8WWOChbRIJRm%2BSU4c9fDmPJViSIaKzBJTb%2BFn7lWAW21qgc37Agqbgmwf2WLJTMs7LrzNIihyky2%2FDR9cXVJdkT4PWjNU%2BK1OiJxCvwBTRqWozBtnd8f%2Bcekx5XWXFPppOKOWSRtxfnHcRZg6ihCJ69NOPs6A%2FX9ghNi2LBzBU1bImjcCV5OShxTHaznUueZAphJXWGnAcTYENxWKHBZFLVUVNTKgjFITOjiibajvaB475GMjuw3B%2FTzNzKSwsRW5ZYpFJBqPGkJldwMCXJYyNC%2BkirJ85CmmVxgSo0okiBhr2yJ92vR63459792SOXhJxZNcJ6NIBOp9%2Bh1POjQdvrDrrcm3ejc6%2FLu71eK%2FL7UW113y7129091VLQGlIjaFya9EgLTXZ2WGoz8SznxEw0Tkn8KzXNXByZ%2F079C07hhmq6Bh5Sm9D2233PP%2FfavYnvB71B0B40zvud%2FvvuO7z7vtUA2uwVbXGXj7eYNH%2BMHqZXyXRafF3CfHP5fazmRWvdUisxpcNP6mbY%2BRn1Nnfjh9UHsvsNq0slBTEHAAA%3D)