### PR TITLE
add Melocalizai, Melocalizai Websites

### DIFF
--- a/melocalizai.com.website.json
+++ b/melocalizai.com.website.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "melocalizai.com",
+  "providerName": "Melocalizai",
+  "serviceId": "website",
+  "serviceName": "Melocalizai Websites",
+  "version": 1,
+  "logoUrl": "https://melocalizai.com/assets/domain-connect-logo.svg",
+  "description": "Connects the root domain and www hostname to a Melocalizai website while preserving unrelated DNS records.",
+  "variableDescription": "%IP% is the IPv4 address of the Melocalizai SaaS origin.",
+  "syncPubKeyDomain": "melocalizai.com",
+  "syncRedirectDomain": "melocalizai.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the `melocalizai.com/website` template used by the Melocalizai SaaS to connect a customer-owned apex domain and its `www` hostname to the selected website environment. The template changes only the web routing records; existing MX, TXT and other unrelated records are preserved.

The `%IP%` variable is necessarily used as the complete A-record value because the SaaS supplies its origin IPv4 address in each digitally signed Domain Connect request. The signature is verified using `syncPubKeyDomain`.

`essential` is intentionally omitted because the A and CNAME records are the core website-routing records and are not intended for independent modification while the connection is active.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.
- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Test melocalizai.com/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIv3jGoC%2F%2B1U227iMBD9FctSn0pCgIRLpJWKykpLq1ZsS7XdVggNsQFLSRzZhpQi%2Fn3HIRTY0u5rH%2FYpo8mc8TlzW1PDkywGw2m4ppmSS8G46jMa0oTHMoJYvIJwI5nQytvvW0gwnN7sA%2FCn5mopIl5Acz7RAlO%2Bed8jyK9tjMagJVdayJSGtQqN5Uw%2BqBiD58ZkOqxW%2F%2BJRBa250VUmExCpE8k05ZFxLM7VyxmmY1xHSmSmSEkvtwGamDknSkpDtkgCKSN5npO51CZFfsRIAuSQYimD5HMRc5IpXqhJZ2SRKm5rxkjv9p4oHknFtGuVgBIwiXnviMJZf3BGxJZBf7D0CTCGyTSR08J3%2BOY9wD2RSsxEahPqVRoNFpNrvuoVrE%2F2xQbdcSaQiPkkrORJw%2Bc1NavMNqSLbqsfzQvbYClSo4ey5IweY7AVDc%2FbVN4wl7fdm%2B97HJbwGHlxCBttKvRVpny8f3yEHdqR5C%2BA08dLgmVGtGZKLrKx2MVnoCDRdkJ3yOcj6GiHfabW7g%2BsVfM7btB0637gBm1qiYhZKhUfa%2FyCWSgUY9SCV2iyiI0YQw57F4vGkGXxCnlr%2FIv5jouWbgfaamVgAM3j5%2FYlqNAxiyx1YTcjaLT81nTadBqdSdvxg1rdmTTbEycAD8Bn01aHNw827YNFPL1r%2B%2FLhbPHUCLBr1I1zWGm6OdHBUsS2g6WM4458ORGjCs7D%2F1Z8iVbgpmlYcjYGG1b36k3Hazv1YOjVQ68W%2Bi231Wn4nn%2FueaHnWQlcm622dWEXGw0Zf7Hf3eksnHaD37Xxg6tR3Ap7Jzb2xNltfXfiyuoe4Nyjip6cm0%2B75P4r1yFHvIIbW%2BQY7zOWy0rHiEI4%2Bg%2FvEe0Mn5qX8PB43und9ZLX3zIY9vIfXda8WsDj9dU06V89zVXu8%2BbPb3TzB5sOZqC%2BBwAA)
- [Test melocalizai.com/website example.com/site](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANn5jGoC%2F%2B1VXW%2FaMBT9K5alPo2EQKBApElF7VqxqRUaVJtWIXQT34K1EEe2IaWI%2Fz47hI8U1lXqSx%2F2lPj6nptz7ldWVOMsjUEjDVY0lWLBGcoeowGdYSwiiPkzcDcSM1rZXd%2FBzLjT272DuVQoFzzCHJphqLgJubMeI8iPjY8yTguUiouEBrUKjcVE3MvYOE%2B1TlVQrb7gUQWlUKsqEzPgiROJJMFIOxbnqsXEhGOoIslTnYeklxsHRfQUiRRCkw2SQMJIlmVkKpRODD%2BiBQFySLGQQbIpj5GkEnM1yYTME4k2Z4xc3Q2IxEhIplyrBCSHMMarEoWzXv%2BM8A2DXn%2FRIMCYCaaIeMxth98cAAyIkHzCExtQLZOoPw%2B%2F4fIqZ32yLtbpOzJuiOhX3AqeNHhYUb1MbUG6xmz1m9cLW2DBE62GouBsLFqbUviet67sMJd33dsve5xJYRl5cQgbrSv0WSQ43n98ZCq0JYlPYLoPC4JFxKJ1JlLM0zHfYlKQMFO2S7fohxJ8tMU%2FbAKYc69vT7VGx22eu%2FVG0222qSXEJ4mQOFbmCXoujSgt51ihs3ms%2BRgy2JtYNIY0jZeGvzK3Jl45ecmmsQvKDDSYU%2FmL%2B2xU6JhFVgG3Q4Jt9LHpgxPV%2FdBpeJ2O0w7PfSeECB%2BbEbbACw%2BG7i8zeXrsypk0rYaJ5mCnqhtnsFR0faKghRZTULesx57ccqk%2BpKRRxTTK%2F%2Fp83PqYmVSwQDYG61r36ueO13bqzaFXD2q1wG%2B57Y7XbjU%2BeV7geVYGKr0Rucrf8%2FmHFJ%2Fsc7tsc6Od9aPC%2FmXP5JvFbpW1XYp2ro%2BWYpHrA5xbyurJTnq9Zv%2BKdcgx35tqHm4FvEPsiaX6Jukvm%2Brd%2Bt8U8KiVTSZsKjA2%2FzbTOLYJrNsuNebycJHTx9rsqXnNv16zG7%2Fqgz%2Fsskl23%2FpV7%2F9s%2FWbDxiCunt9Erfua732m6z%2Bl1HwT%2FwgAAA%3D%3D)