### PR TITLE
add PressyPress, PressyPress WordPress Hosting

### DIFF
--- a/pressypress.com.wordpress.json
+++ b/pressypress.com.wordpress.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "pressypress.com",
+  "providerName": "PressyPress",
+  "serviceId": "wordpress",
+  "serviceName": "PressyPress WordPress Hosting",
+  "version": 1,
+  "syncPubKeyDomain": "domainconnect.pressypress.com",
+  "logoUrl": "https://pressypress.com/domain-connect-logo.png",
+  "syncRedirectDomain": "pressypress.com,www.pressypress.com",
+  "description": "Points a domain at a customer's PressyPress-hosted WordPress site. Both records target the site's own permanent hostname rather than a server address, so the domain keeps working if the site is ever moved to another server or another hosting provider.",
+  "variableDescription": "target is the site's permanent hostname on pressypress.com's own DNS (for example mysite.pressy.site). It is per-site and never changes for the life of the site; PressyPress repoints it internally when a site moves. The value is signed into the apply request.",
+  "records": [
+    {
+      "type": "APEXCNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%target%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds PressyPress (pressypress.com) managed WordPress hosting provider. The template points the apex and www at the customer site's own permanent hostname on our DNS (eg mysite.pressy.site) rather than a server address, so the customer never has to touch DNS again when a site moves. Justification: The bare `%target%` in `pointsTo`: the target is a per-site hostname, so no fixed prefix or suffix is possible. The template sets `syncPubKeyDomain` and every apply request is signed by our server with the target covered by the signature, so the value can never be set by a third party.

## Type of change

Please mark options that are relevant.

- [X] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [X] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [X] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [X] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [X] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [X] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [X] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [X] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [X] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [X] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [X] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [X] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [X] `%host%` does not appear explicitly in any `host` attribute
- [X] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test pressypress.com/wordpress example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABM6jWoC%2F%2B1Wa0%2FbMBT9K5YltE1LQvqk7TRpZVQbQ6COMW0Tqio3ubQeiR1sp6VD%2Fe%2B7dtIXUJD2DWlfKvv6nvs4x77NHTWQZgkzQDt3NFNyymNQxzHt4Aa0nrvfIJIp9VbHZyxFd9p3Du4XDzWoKY%2FAQWdSxdm2%2FSGG%2FECvYvVZasPFGL2noDSXgnYqiJyLqJ%2BPTmB%2BJFPG0Uhjt4ikEBCZ4GGFiRzL7ypBz4kxme7s79%2Fz2S8i%2BGUI3wKCzKW26c4h5grtq4T34N5sNnskbQw6UjwzrnLal1wYTRgpchFmcB3l2sgU1CtNNjjwJ9g5xBtUaG4gIIfSTAgWgmZNDFNjMMRMwJ1iBDkTJAOVMgHCEBtDIL1EMfRR6MgwKbHE447FsQ3sES1diLKoa4BMExTqGokn%2FGoVnnBNwAJTOcXKjCRMSBe3DCjVyjIpdCPLixFYBZnibJTA0RYnZQ8Ye6ONR1qQ2Ng2vWW7R2ffyOsrzA23DC8skHTuqCq8A7t%2BE5BjlwLj%2Bq4VJmIiXDMRcjIGTWwEW0HCrzDZuut3m6og81mhIcd4woASLEnmZDYBR6wNbdnRAblA%2FJQluaNN87FAyhBRUM2yDFEKbnLQxnJTKko7l3fUzDP7ILr93s%2BPZ93THh5bFtD0wT41l%2F9C4nav4G4Prcbg1a6F4cJb4e9h8X4%2Bjx4sPPpHChiu6xl45dtCSMlwebfLwLgaK5lnQ770z5hiqbZjY4m83IIOlthLatdFHXa3pVypnwNgWcigVDC0TDKTK%2BzQqBw8muaJ4UM2Y2tTHA0dwdiFxlOM%2FDiropg8ltWYGYbLXQWsKfLoMI5sa9yOs2hUabZrUcsf1SLw6wfVtj%2BqNlt%2BrV2NGpVWuwbN5sZ43DE9dw3INcG4x8fAmZ1f3WTG5pouHpG6bKiQ%2BiW2NPDw%2FvwX64WIhW9XM%2FwrGDLrVg2rTT9s%2BdXGRdjs1BudWjs4qFRqYettGHbC0DaB067o9M6tdfFpsapnuPnJsfy7cE7LGfEEQzumlJtNdi4t7JS182DnlC0V2cAHW8w%2FI9KTGgf%2FHHWAlwclSvDjA6m2tG2LuCYN%2FTbnI7350r%2But%2FunF78zcX7YPVC9ryo7qdTPDie9q9qv2%2FwwjuqNanf0qfeeLv4C%2BgptgPEJAAA%3D)

[Test pressypress.com/wordpress example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACJCjWoC%2F%2B1WbW%2FTMBD%2BK5YlBIgkS7st64qQGHSwgagK2zRgqio3ubWGxM5sp6FU%2Fe%2BcnfRt6zTEt0l8qezzPc%2FdPWdfOqMGsjxlBmh7RnMlJzwBdZrQNm5A66n7DWKZUW953GUZutOec3C%2FeKhBTXgMDlpKleSb9rsYcole1epEasPFCL0noDSXgrYbiJyKuFcMP8K0IzPG0UgTt4ilEBCb4G6GqRzJC5Wi59iYXLd3dm757FQMfk3hW0CQu9A23BdIuEL7MuAtuFeW5ZawCehY8dy4zGlPcmE0YaSKRZjBdVxoIzNQTzVZ08AfY%2BWQrEmhuYGAvJFmTDARNGtimBqBIWYM7hQZZClIDipjAoQhlkOgvEQx9FHoyDAoscLjjiWJJfaIlo6iTuonQK4JNuonCk%2F49ZKecE3AAjM5wcyMJExIx1sTSrW0jKu%2BkcXFCGwHmeJsmEJnQ5O6BuReK2NLCRIL25S3LrfTPSPPrjE2%2FGJ4YYFkUydV5R3Y9fOAnLoQyOu7UphIiHDFxKjJCDSxDDaDlF9jsFXVL9e7gsrnVQ858gkDSrA0nZJyDE5YS23V0QE5R%2FyEpYWTTfORQMkQUUnN8hxRCm4K0MZqU3eUtq9m1Exz%2ByCOesdf33aPPh3jsVUBTa%2FtU3PxzyVun1TaPUGrMXi1d8Nw7i3xt7B4Px9G9%2Bce%2FS0FDFb59L36bSGkVri%2B2zWxHsscdyMli3zAF5icKZZpOzoW6KsNeH%2BBv6oIcF%2FlYy13O0htZiiiVDCwYjJTKCzSqAI8mhWp4QNWspUpiQdOYyxE4ymSbhdWVMPHCpsww3C5JfZKII8OktgWxe0wGx7CXhQlid%2BIhkN%2F7yBq%2BcNhM%2FGb0e5%2B1DpoQXjYWBuO98zO%2B8bjprxow%2BfAmZ1gR2nJpprOtzS7rscOoxr4CMvqe3iD%2Fvfr8fQLH69m%2BE0YMOvaDJuRH7b85v55eNBuhu2wGexFB2Gr9SLETWgLwbFXFTpza139x1jmNCi5GVeRZ8vvhnNaDIntAv39pLJTam7nrh0P987duj1rbMFGG%2B5v1sO9Dv6FtY%2BXCFuV4j8RlNtKt9nMlXDotz4paSc%2FeddrspPv%2B2fvLie7x8PeYaP40P384jxq3HS6F739yZvO%2B6j7Q3x7Red%2FAD2DuA3%2BCQAA)
