### PR TITLE
Add KapsuleHost templates (kapsulehost.com): hosting and email

### DIFF
--- a/kapsulehost.com.email.json
+++ b/kapsulehost.com.email.json
@@ -42,61 +42,6 @@
             "host": "autoconfig",
             "pointsTo": "autoconfig.kapsulehost.com",
             "ttl": 3600
-        },
-        {
-            "type": "SRV",
-            "name": "@",
-            "service": "_imaps",
-            "protocol": "_tcp",
-            "target": "mail.kapsulehost.com",
-            "priority": 0,
-            "weight": 1,
-            "port": 993,
-            "ttl": 3600
-        },
-        {
-            "type": "SRV",
-            "name": "@",
-            "service": "_submissions",
-            "protocol": "_tcp",
-            "target": "mail.kapsulehost.com",
-            "priority": 0,
-            "weight": 1,
-            "port": 465,
-            "ttl": 3600
-        },
-        {
-            "type": "SRV",
-            "name": "@",
-            "service": "_autodiscover",
-            "protocol": "_tcp",
-            "target": "autodiscover.kapsulehost.com",
-            "priority": 0,
-            "weight": 0,
-            "port": 443,
-            "ttl": 3600
-        },
-        {
-            "type": "SRV",
-            "name": "@",
-            "service": "_caldavs",
-            "protocol": "_tcp",
-            "target": "mail.kapsulehost.com",
-            "priority": 0,
-            "weight": 1,
-            "port": 443,
-            "ttl": 3600
-        },
-        {
-            "type": "SRV",
-            "name": "@",
-            "service": "_carddavs",
-            "protocol": "_tcp",
-            "target": "mail.kapsulehost.com",
-            "priority": 0,
-            "weight": 1,
-            "port": 443,
-            "ttl": 3600
         }
     ]
 }

--- a/kapsulehost.com.email.json
+++ b/kapsulehost.com.email.json
@@ -1,0 +1,102 @@
+{
+    "providerId": "kapsulehost.com",
+    "providerName": "KapsuleHost",
+    "serviceId": "email",
+    "serviceName": "KapsuleHost email",
+    "version": 1,
+    "logoUrl": "https://kapsulehost.com/logo.png",
+    "description": "Delivers your domain mail to KapsuleHost, with SPF, DMARC and mail client auto-setup.",
+    "syncPubKeyDomain": "kapsulehost.com",
+    "syncRedirectDomain": "kapsulehost.com,kpanel.kapsulehost.com",
+    "syncBlock": false,
+    "records": [
+        {
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mail.kapsulehost.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:_spf.kapsulehost.com"
+        },
+        {
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=none; rua=mailto:dmarc-reports@kapsulehost.com; fo=1",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
+            "essential": "OnApply"
+        },
+        {
+            "type": "CNAME",
+            "host": "autodiscover",
+            "pointsTo": "autodiscover.kapsulehost.com",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "autoconfig",
+            "pointsTo": "autoconfig.kapsulehost.com",
+            "ttl": 3600
+        },
+        {
+            "type": "SRV",
+            "name": "@",
+            "service": "_imaps",
+            "protocol": "_tcp",
+            "target": "mail.kapsulehost.com",
+            "priority": 0,
+            "weight": 1,
+            "port": 993,
+            "ttl": 3600
+        },
+        {
+            "type": "SRV",
+            "name": "@",
+            "service": "_submissions",
+            "protocol": "_tcp",
+            "target": "mail.kapsulehost.com",
+            "priority": 0,
+            "weight": 1,
+            "port": 465,
+            "ttl": 3600
+        },
+        {
+            "type": "SRV",
+            "name": "@",
+            "service": "_autodiscover",
+            "protocol": "_tcp",
+            "target": "autodiscover.kapsulehost.com",
+            "priority": 0,
+            "weight": 0,
+            "port": 443,
+            "ttl": 3600
+        },
+        {
+            "type": "SRV",
+            "name": "@",
+            "service": "_caldavs",
+            "protocol": "_tcp",
+            "target": "mail.kapsulehost.com",
+            "priority": 0,
+            "weight": 1,
+            "port": 443,
+            "ttl": 3600
+        },
+        {
+            "type": "SRV",
+            "name": "@",
+            "service": "_carddavs",
+            "protocol": "_tcp",
+            "target": "mail.kapsulehost.com",
+            "priority": 0,
+            "weight": 1,
+            "port": 443,
+            "ttl": 3600
+        }
+    ]
+}

--- a/kapsulehost.com.hosting.json
+++ b/kapsulehost.com.hosting.json
@@ -1,0 +1,27 @@
+{
+    "providerId": "kapsulehost.com",
+    "providerName": "KapsuleHost",
+    "serviceId": "hosting",
+    "serviceName": "KapsuleHost website hosting",
+    "version": 1,
+    "logoUrl": "https://kapsulehost.com/logo.png",
+    "description": "Points your domain at your KapsuleHost website.",
+    "variableDescription": "%ip%: the IPv4 address of the KapsuleHost server the website is on",
+    "syncPubKeyDomain": "kapsulehost.com",
+    "syncRedirectDomain": "kapsulehost.com,kpanel.kapsulehost.com",
+    "syncBlock": false,
+    "records": [
+        {
+            "type": "A",
+            "host": "@",
+            "pointsTo": "%ip%",
+            "ttl": 3600
+        },
+        {
+            "type": "A",
+            "host": "www",
+            "pointsTo": "%ip%",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Two new templates for KapsuleHost (`kapsulehost.com`), a hosting and email provider.

- `kapsulehost.com.hosting.json` points a domain at a customer's hosting (apex + www).
- `kapsulehost.com.email.json` publishes the mail record set: MX, SPF via `SPFM`, DMARC, and the autodiscover / autoconfig CNAMEs.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`kapsulehost.com`, both templates)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set
- [x] no TXT record contains SPF content: SPF is published with the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`Prefix`)
- [x] no variable is used as a bare full record value, **except the two A records**, justified below
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

**Justification for the bare variable in the A records.** `kapsulehost.com.hosting.json` uses `%ip%` as the whole value of its two A records. An A record's RDATA is an IP address and nothing else, so there is no fixed part to constrain it with; any non-bare form would be invalid. The variable is confined to the record value and never appears in a `host` label.

## Online Editor test results

- [Test kapsulehost.com/hosting example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMSgjWoC%2F%2B1TYW%2FaMBD9K5GlfloICckyFmnSmJjWDmnrprarWqHoiA%2Bw6sSW7ZBSxH%2BfHWBAR7WP06R94ri8d7737m5FDJaSg0GSrYhUYsEoqgtKMvIAUtcc50KboBAl8X99%2FgKlhZPRBnBuAfajRrVgBbZUx2HVbJ%2F9neE1ONHMoLfHLlBpJiqSRT7hYiauFXe1jJE663aftdN1iEC2RIq6UEyalkwuBauM9paiVh4VJbDKA7P5e%2BL9wD0MisGE4%2FCozhmTZ5ln5uhdXC4SDyhVqLUnpm3usJQTiapN71QxC6yc%2FmVVXNaTES6HbSsnfXWg70iZwsK8BPMfJFTIg9PsD1wUDySbAtfoE1tHKKpJdr8iZimd8wMLdBwbvneTbD26EluZNmOMNTtOw3DtnyI1TfMH2njtkydRYb5%2FfWxHs5ODj2D3DLc9b6vaaKZELXO2w0tQUGq3izvm%2FRF1vOPeExcz6aJeGAdhEEVx8Ia4NtisEgpzbX%2FB1MpKMaq2vpQ1NyyHBvYpWuQgJV%2Farq2tru6xZ9VmcZ1nFAzY8PCxA%2F0%2ByWnh%2BmbuAOgUkzBJ%2B50JpGnHBkVn0kuhg3E6fQs9TPpRfHBQL9zb6ZPae2fXESvDwJ3JgDew1GT9bHzb%2Fjfj%2B0cUjH27Cf%2FH8NfHYO9LwwJpDqZtt5d2wn6n9%2FoqSrIwzpJ%2BkEZhnEavwjALQ6cBtdmIW9krPLw%2F0n0a3fFv06%2B3k5Fi%2FC4Znt%2Bm4WxYfp4vysHjzY%2FmY1pFs0%2FnN%2Fr6HVn%2FBG6eNauWBgAA)
- [Test kapsulehost.com/hosting example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMWgjWoC%2F%2B1TYYvaQBD9K2HhPl2MifGiBgq9IlxP22KtV3qIhDE76mKSXXY3Wiv%2B9%2B5GrXr16NcW%2Bkln8t7svDczW6IxFxloJPGWCMlXjKJ8pCQmSxCqzHDBlfZSnhP31%2BdPkBs46e8B7w3AfFQoVyzFimo5rJifsr8znDVOFdPonLArlIrxgsSBSzI%2B508ys7W0Fiqu11%2B0U7cIT1REiiqVTOiKTAacFVo5G15Kh%2FIcWOGA3odX3vfswyAZTDPsXtS5YeImdvQCncfBqukApRKVcvisyp2XsiJRVumjKmaAhdW%2FKdJBOe3jplu1ctVXCxoiZRJT%2FRrMXQooMPOus99lPF2SeAaZQpeYOlxSReLxluiNsM7fG6DlmL9v7SQrj0b8INNktDZmh5Hv79xrpPV6%2FQfaZOeSH7zA5PT6xIzmKAe%2Fg9kzPPR8qKoWXJhoLnkpEnbkCJCQK7uPR%2Fb4gj458sf7AiZmwkYNP%2FR8LwhCr0VsO2xecImJMr%2BgS2kkaVkaf%2FIy0yyBNZxSNE1AiGxjujf22tqX3hX7BT40TEGDic7fO7PCJQlNbfvM3sJ01qAAQVpLIbirNcMoqrWnAdbalLYiP4R2y5%2Bd3dYrp3f9ui5tNNuJhWZgr%2BY%2BW8NGkd2LaR5kmGl6%2F56UiWu24%2F9Y%2FrqxmPtTsEKagK5abkQ1v11r3I2CZuyHcbPjhe1OK4xufT%2F2fasDld4L3JorPb9PMo96s9FD71v3dtXLdTgdzEbzj%2BXXReO50%2F88%2FBDQp%2BGgePjS4%2FL5Ddn9BKm%2Fj5O%2BBgAA)
- [Test kapsulehost.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMagjWoC%2F%2B1WXW%2FaMBT9K5FfFyCktKKpkMrafVQTLTA6VapQZGwHrBo7sh1aWrHfvms%2BA6TdXqr1gack9rnH91zfe5QXZNk4FdgyFL2gVKsJp0xfURShB5yaTLCRMrZM1Bj56%2B1rPAY4%2BrEAfAcAbBqmJ5yweSgbYy42a%2Ft4b4WYMG24kiiq%2BkioobrVApAja1MTVSo7KVQcopzKIQRSZojmqZ0Ho0smuKPypirTHlXALj13hGeVlzvX9x65HXk%2F219977LV7F54WNIFkAjOpPVwZlXJMJulZSdgKkk7G%2Fxg08s5Z2FZHKjLKNeM2Ndg%2FkOKJRPl4ujPQpEHFCVYGOYj4FGaGhTdvyA7TV3pWneAdEHwfu5uQnFpTU%2FBp0u%2BXHRXXGlup1DZwEfWQlmPToJg5q85oQitbVaTJl1ggZMRl0RklEUxrO2x50h6d70NR0zHWBN3Odhi%2BJ405jWunnlpQyrJzjyd4YZL2Kpoji1pliptzfnOEWdeohpVlEscXp%2FshZKJ4MS2sCUjLoctRV0Sbc0S%2FoQKIcu9TTIAY8bAVXPsWu1GNtNUTPOaLq6brS8bVa4jKDdEQYNtlz6%2FU3AFRUUv4CaQMR%2FuMy%2FW3%2BTtz3z0DIWNNy3Th%2BqvepA9YZhttgxbHglvQ62yNOYrfIo1Hhs3%2F6vI%2B63Q%2Fir2HiF3Ih9KpVls4IltpkGW1Rn07TgTlsf4EW%2BWKImxKy8kCCIcxU5Py4U1nG%2Ba5pV%2BzjXCdmvHlLjUufMdXKOnNKS4lBAclGpBNSnhJExK9SAkdcJO65SQnI%2B9YnNFTrYpXr55muIRTw2a7Q3EvqxJAyap6r01V95vLMRKKij94OLed9r%2Fp%2FK1JxQM7lL8jiksS%2FCvhvDhLrZA3dqWctr%2BbkkfRFnfB2M7WM3Bag5Wc7Cad7Ya%2BD0yeMJojB0sDMKTUlAvhce9ai0KjqLjoFw9DcPT8FMQREHgFDBjF0pf4G8q%2Fx%2BF2jVD%2BE0X287NdaVzNfl1ezJ47okrelftTMedwTdypNsDWTm5rTfQ7A%2B5ofgNvQ0AAA%3D%3D)
- [Test kapsulehost.com/email example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMagjWoC%2F%2B1WXU%2FbMBT9K5Ffl5akX6xBlShlE2wrFNYhJIQiYzuthxtbtlPaVd1v33U%2FaEoD28OkMYmnNs65x%2FccXx9lhiwbKYEtQ9EMKS3HnDJ9SlGE7rEymWBDaWyZyBHyH1%2Bf4RHA0ecl4AQA8NIwPeaELUrZCHOxWdvFe2vEmGnDZYqi0EdCDuQ3LQA5tFaZaG%2FvSQt7DlFW6QAKKTNEc2UXxeiYCe6ovKnMtEclsKee28Kz0svt63sP3A69r72PvnfcbV92PJzSJZAIzlLr4czKkmE2U2UnYJqSXnb3mU2PF5yFtjjQJaNcM2Kfg%2Fn3CqdMlIurj4Qk9yhKsDDMR8AjNTUoupkhO1XOuu41IF0R%2FD90JyF5ak1fwqNrvlx0VlxqbqfgbOAja8HWaiMI5v4jJ5jQ3WY1KrkEFtgZ8ZSIjLIohrUd9hxJ%2F7q%2F4YjpCGviDgdbDM%2Fj1sLj8MBTrVSm7MDTGW65hq2MFtiSZkpqaw6fbHHgJbIVolzj8HdiOzJNBCe2iy0Z8nTQldQ10dMs4RNUCFm92zQDMGYMHDXHbtTO07ZSYprX1Dlrdz9sVLmJoNwQCQO2bX3%2BTcERFJlewE2gYz7YZV6uv8h7O%2FfRDzA23ozMLbi%2FnkE2wXC32apstaUZSgVPAy0zFfN1jcIaj4zLgHX1zVb57br%2BZkngduaDVGoWG%2FjFNtMgz%2BoM5neUCctj%2FIA3S5TE2NkMjYIYR%2FNkttNlRKyaW83PM6Odm4ntKY8pcQq4i6Cw2qzV6zgo4UY9KdWSRrN0RxusFLyvJFV6F5JKUstF2jOJVxRq2z7mZ6ktHvDUoPnO%2FShUN27B3Qq9l26a9xMLsVYMgv8DjcsMKD%2BV%2BjeD4F9b8BgZBfd65cJWMmx78aeh8SqPukDmKqZ2Rf4%2Bv16RxFsfUvAtk94y6S2T3jLptWQSfHQZPGY0xg5aCSoN2LhUqffDWhRUo3pQbjYbzTB8FwRREDgVzNil2hl8n%2BW%2FzFBv0p6cTk%2FE8GKU9Y%2F2yXlCr%2Ft3V92g0xP1TnWf7H%2B6%2F9L5Tq9qFy00%2FwVcyS2xFw4AAA%3D%3D)

### A note on apex SRV, left here because it is useful to you and to the next provider

An earlier revision of `kapsulehost.com.email.json` also carried five RFC 6186 / RFC 6764 client-discovery SRV records at the zone apex (`_imaps._tcp`, `_submissions._tcp`, `_autodiscover._tcp`, `_caldavs._tcp`, `_carddavs._tcp`, all `"name": "@"`). **I removed them so this PR can pass, not because they were wrong**, and I would like to add them back when the editor allows it.

The Online Editor rejects **every** apex SRV before it will produce a test link:

```
Error! A problem has been occurred while submitting your data: Invalid data for SRV host: __tcp.@
```

This is not specific to my template. Measured against the live editor:

- `"name": "@"`, `"name": ""` and omitting `name` all fail identically.
- Spelling `service` without the leading underscore fails identically.
- **The README's own SRV example, verbatim, with valid ids, fails identically** (`__tls.@`). That control still runs on every regeneration of these templates, so the claim stays true rather than being a sentence somebody wrote once.
- The same records at a **subdomain** work fine, which is why the `host=shop` links above exist.

Note the error string: `__tcp.@` is `_` + *empty* + `_tcp` + `.@`, so the `service` field is reaching the validator empty.

`hostRequired: true` would satisfy the coverage check and is not a fix: the specification defines it as *"authored to work only when both domain and host are supplied"*, so it would make these records applicable only to a subdomain, and apex mail is the common case.

`"name": "@"` appears to be correct and is what 23 already-published templates in this repository use, including `microsoft.com.o365.json` and `godaddy.com.professional_mail.json`. **If the editor is fixed, I will open a follow-up PR restoring these five records.**
