### PR TITLE
Add Easy Street CRM email sending template (theeasystreetcrm.com.sending)

### DIFF
--- a/theeasystreetcrm.com.sending.json
+++ b/theeasystreetcrm.com.sending.json
@@ -1,0 +1,41 @@
+{
+	"providerId": "theeasystreetcrm.com",
+	"providerName": "Easy Street CRM",
+	"serviceId": "sending",
+	"serviceName": "Email sending",
+	"version": 1,
+	"syncPubKeyDomain": "theeasystreetcrm.com",
+	"syncRedirectDomain": "theeasystreetcrm.com",
+	"description": "Verify a domain for newsletter sending from Easy Street CRM. Adds DKIM, SPF and Return-Path records on a subdomain — nothing existing is replaced.",
+	"records": [
+		{
+			"groupId": "outbound",
+			"type": "MX",
+			"host": "%spfDomain%",
+			"pointsTo": "feedback-smtp.%region%.amazonses.com",
+			"ttl": 3600,
+			"priority": 10
+		},
+		{
+			"groupId": "outbound",
+			"type": "SPFM",
+			"host": "%spfDomain%",
+			"ttl": 3600,
+			"spfRules": "include:amazonses.com"
+		},
+		{
+			"groupId": "dkim",
+			"type": "TXT",
+			"host": "resend._domainkey",
+			"ttl": 3600,
+			"data": "p=%domainKey%"
+		},
+		{
+			"groupId": "click-tracking",
+			"type": "CNAME",
+			"host": "%clickTrackingSubdomain%",
+			"pointsTo": "%clickTrackingCnameTarget%.resend-dns.com",
+			"ttl": 3600
+		}
+	]
+}

--- a/theeasystreetcrm.com.sending.json
+++ b/theeasystreetcrm.com.sending.json
@@ -28,7 +28,8 @@
 			"type": "TXT",
 			"host": "resend._domainkey",
 			"ttl": 3600,
-			"data": "p=%domainKey%"
+			"data": "p=%domainKey%",
+			"txtConflictMatchingMode": "All"
 		},
 		{
 			"groupId": "click-tracking",

--- a/theeasystreetcrm.com.sending.json
+++ b/theeasystreetcrm.com.sending.json
@@ -6,6 +6,7 @@
 	"version": 1,
 	"syncPubKeyDomain": "theeasystreetcrm.com",
 	"syncRedirectDomain": "theeasystreetcrm.com",
+	"logoUrl": "https://app.theeasystreetcrm.com/icon.png",
 	"description": "Verify a domain for newsletter sending from Easy Street CRM. Adds DKIM, SPF and Return-Path records on a subdomain — nothing existing is replaced.",
 	"records": [
 		{


### PR DESCRIPTION
# Description

New template for [Easy Street CRM](https://theeasystreetcrm.com), a CRM for real estate agents whose customers verify their own newsletter sending domains. Records mirror the field shapes of the existing `resend.com.mail.json` (same underlying email infrastructure): MX + SPFM on a `%spfDomain%` subdomain (Return-Path), DKIM TXT at `resend._domainkey`, and an optional `click-tracking` CNAME group. Additive only — nothing at the apex is modified.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://app.theeasystreetcrm.com/icon.png, 200 image/png)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published at `dck1.theeasystreetcrm.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — the `SPFM` record type is used
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (`All` on the DKIM TXT, so a re-apply replaces a stale key rather than stacking a second one)
- [x] no variable is used as a bare full record value — the DKIM value is prefixed (`p=%domainKey%`)
- [x] no bare variable is used as the full `host` label — **justification for `%spfDomain%` (MX/SPFM) and `%clickTrackingSubdomain%` (CNAME):** these labels are issued per-domain by the sending infrastructure and arrive only through signed apply links (`syncPubKeyDomain` is mandatory here) — the end user never types them, and in practice they are the fixed labels `send` and `links`. This mirrors the accepted `resend.com.mail.json` (v6), which uses the same variable hosts for the same records.
- [x] no variable is used in the `host` field to create a subdomain — same justification as above: the subdomain labels are fixed by the mail infrastructure, not user-chosen, and only reachable via signed requests
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not applicable: all four records exist solely for this service; none is a shared record a user would maintain independently (DMARC is deliberately not part of this template)

## Online Editor test results

**Editor test link(s):**

- Apex test: [theeasystreetcrm.com.sending — example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABdyj2oC%2F%2B1WXW%2FiOBT9K5ElnoZACJQWpD6EjyK2m24pzGxnuxUy8QWsJnHGdmhpxf72uU747DDdkfZlK%2FUJyz6%2Bvufce254IRqiJKQaSPOFJFIsOAPZZ6RJ9ByAqqXSEkAHMioFIiLFLeaKRniHdBFiDTOM1b7xEaBALngAWQwFMePxbLe7uRVRHlq70wVIxUVMmhVELuPgOp1cwrIjEBb%2FPBWDvAHGJQT637ChmInPMkTAXOtENctlmiSlY%2BAyD0RcSrK8GKhA8kRnuZEvIPl0aVGLZY9ZUyGtGB5VCFqD3NCxplJE1itdSpbHmLI6l32%2FaA2vLywaM%2BsGdCpj%2B5rquYUchESEiDG%2BSifrJ%2F5OXadSs2Kh5yY0PHGlzYIrvIF1C4CVMM%2F1bdK8eyEzKdIkU1%2BkeiLSmCFALxOju3%2BL67lQGtcFlUxz1QqmrILHWo0EHkwB2IQGD7aKdFIqSJgh%2FUKJRvRZxArUWlGtUc1q3XFMT3AhuV5i%2FZxV8e0UkLz%2FsyT2QuL%2BTRoCUiI8DsKUQfMwgcN32AOPdm%2BMbke7JySYwpTGuaIPsDx8iFFNEZWcF3IA9l2WypNui3ga8kD7VAdGfV8wE9wLw1ePB4h6sLVEzfJ2XqfRvvL87h7XDDdaw4abGr9S%2FxDVjtEwIypnoAulnInN4h9KsLpfFQmKA%2BNdJ9wjt40p4Imiy2F9bZ0PrjIOY57h92u1lvMVMYyYUEkjZWbFJvbdQfD7TfQ7YtZZ%2FF%2BNvW0Fc8EwNZt595mdVNnoVW1XyJYZ1sqc%2BP3e1PecXnv4rTfsT6qdQbflDT57Xq135XXaLT64bM0G7ZPuredf%2F9697H5t%2FdH52u94A69lgh2vi4kcYsOoHyB7RdmCMCssAZ%2FFQsJY4S9Fb2MTaJlCkURpqPmYPtLdFgvGOIHCJVZM4SkGQu%2Fu2zTOR2UmxLZND725leRXzVkkYxaY6nHTt2f1%2BrTmVBr2tNqgds11XXvCGlW7dgqnJ%2BAwdurW9yb%2BW1%2BF40N%2F12igcFdzGmYGeqRLRVbGRAeGPcp4cY59UbGODgHrH4pmPGD7DvgdG0jbKfSfevkdKLGZiWstcoNt%2BedWemPQ%2Fb9o3Rdxyn7Y9sO2H7Z9V7Y1fzboAtiYGpjruHXbObPd%2BsitNp1Gs1IpnTWqzonzyXGajmOIgNI51xf8yu9%2F34lzVXF%2FC7vRSQJnyUVPiXJaYadDdtFSn%2F6kz6xTnv31VKPu8613TlbfAVO7HOtwDQAA)
- Subdomain test: [theeasystreetcrm.com.sending — example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAENyj2oC%2F%2B1W2W7rNhD9FUGAn67lyFsSG8iDvDQxUqVx7BRZahi0SNmMKVKXpJy4gfvtHUrymqUX6EtvkSfL5JnlzMwZ6dXWJIoZ0sRuvtqxFAuKiexhu2nrGSFILZWWhOhARqVARHZxg7lCEdjYXYBYgxRjtW98ACgiFzQgqQ9FOKZ8uj1dW0WIMmt7uyBSUcHtZhmQSx5cJ5NLsuwIgPGPUzHIG4KpJIH%2BJywTU3ErGQBmWseqeXSE4rj0HviIBoKX4jQvTFQgaazT3OzfiaTh0kIWToNZoZAWJ8%2BKEa2JXNOxQiki66AuJcvDWFmdy55ftAbXv1iIY%2BuG6ERy5xrpmQUchASE4OBfJZM8xB9JxS3XLC70zLgmL1Rp80AVWEDfAoJLkGdubTcfX%2B2pFEmcVl8keiISjgGgl7Gpu38HzzOhNDwXVBxmVSuYtgrKtRoKuAgJwRMUzB0V6bhUkGQK9AslFKE%2FBVdE5RXVGqpZPXZdMxNUSKqX0D93Vfw8BSDvf5TEjks4v0kYAUo25QFLMGnuJ7AfB89ptI0xvBtuQ0hiGlMaZxWdk%2BV%2BIIw0AlR8VsgAMHdpKi%2B6LXjIaKB9pANTfV9g49xj7CB4AKi5oyXULBvnPI32led3d7imuGEOG6x7fFD9fVSbg2CGSE6JLpQyJg7mb1qwGq2KNhSHjLeTMAJua1GQFwQqJ7lZno%2FRIPxLeYxparPbr7ykB%2BTAa4wkipTZF2v%2Fj3sBRusIj1mIUR7jR%2F1vRsIYGMbmMJtCc5IoBzSrnbK9YQg9Mzd%2B7zz0Pfe8Pfh%2BPuhNqp1%2Bt%2BX1bz2vdn7lddot2r9sTfvtevfO869%2F7V5271u%2Fde57Ha%2FvtYyz9%2FtjPDMYHPUGstOcDQiyglbQKReSjBX8ItA4DIOWCSnaUcI0HaNntD3CwRg2EVtC5xTcgiPQ8K5cebYy0yHOW5bP7L5QN3X5UaUW7TEOTBupGWI0wfV6A4fO6Sk%2BcWqNCnEaJ6enTgWdoEm5VgtPyrWd9f%2FZK%2BL9N8D%2B1BEFN5oilirqGS2VvTKq2lPwx9QXZzAlZevd1WD9hRjbp%2F2TEH2zqg5Yx2f%2FasR%2FkpKs12ZelFRWB4XIpPbJQvzv8RsVYSN%2FSftL2l%2FS%2Ft9J23y0oAXBY2SgFbdy7LiQwvGwUm26jWa9XmpU3Vql%2Fs11m65ryBClM76v8LWw%2B51ga%2BY%2FPA2D0O2VJ25VMca%2Bf0MPD3fzGRZddHH%2FdLu4uL04flLs%2Fsxe%2FQ3JmkN1wA0AAA%3D%3D)
