### PR TITLE
Add peloran.com.email template

### DIFF
--- a/peloran.com.email.json
+++ b/peloran.com.email.json
@@ -1,0 +1,42 @@
+{
+  "providerId": "peloran.com",
+  "providerName": "Peloran",
+  "serviceId": "email",
+  "serviceName": "Email",
+  "version": 1,
+  "syncPubKeyDomain": "peloran.com",
+  "syncRedirectDomain": "app.peloran.com",
+  "description": "Configure DKIM, SPF, MX, and optional click-tracking CNAME for transactional email.",
+  "logoUrl": "https://www.peloran.com/peloran-logo3b.svg",
+  "records": [
+    {
+      "groupId": "outbound",
+      "type": "MX",
+      "host": "%spfDomain%",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "ttl": 3600,
+      "priority": 10
+    },
+    {
+      "groupId": "outbound",
+      "type": "SPFM",
+      "host": "%spfDomain%",
+      "ttl": 3600,
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "ttl": 3600,
+      "data": "p=%domainKey%"
+    },
+    {
+      "groupId": "click-tracking",
+      "type": "CNAME",
+      "host": "%clickTrackingSubdomain%",
+      "pointsTo": "%clickTrackingCnameTarget%.resend-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Domain Connect template for **Peloran** (`providerId: peloran.com`, `serviceId: email`).

Peloran (https://www.peloran.com) is a marketing and email automation platform for e-commerce merchants. Merchants connect their own sending domain so transactional and journey email (bulk campaigns, automations) can be verified with SPF, DKIM, MX, and optional click-tracking CNAME. Record values are provisioned per merchant through Resend and passed as signed template variables. Apply URLs use RS256 signing; the public key is published at `_dcpubkeyv1.peloran.com` (`key=_dcpubkeyv1`).

This template follows the same record shape as the merged `resend.com.mail.json` (SES outbound + Resend DKIM + click-tracking CNAME).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://www.peloran.com/peloran-logo3b.svg → 200)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — `peloran.com`; public key TXT at `_dcpubkeyv1.peloran.com` (key id `_dcpubkeyv1`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `app.peloran.com` (synchronous flow uses `redirect_uri`)
- [x] no TXT record contains SPF content — uses `SPFM` with `include:amazonses.com`
- [x] `txtConflictMatchingMode` — not required: DKIM lives on fixed selector `resend._domainkey`; SPFM/MX use dedicated send subdomain `%spfDomain%` (no shared apex TXT conflict)
- [x] no variable is used as a bare full record value without justification — **see justification below** (`p=%domainKey%` carries provider-issued DKIM public key)
- [x] no bare variable is used as the full `host` label — **see justification below** (`%spfDomain%` and `%clickTrackingSubdomain%` are provider-issued labels on dedicated subdomains, same pattern as `resend.com.mail.json`)
- [x] no variable is used in the `host` field to create a subdomain — `%spfDomain%` / `%clickTrackingSubdomain%` are record labels on subdomains already scoped by the `host` parameter, not subdomain-creation variables
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — all records are required for email sending; none are user-tunable optional extras (same as `resend.com.mail.json`)

**Justifications (per-merchant provider-issued records):**

Resend issues each merchant their exact DKIM public key (`domainKey`), send subdomain (`spfDomain`), SES region, and click-tracking CNAME target. Values are passed only inside RS256-signed apply URLs (`syncPubKeyDomain: peloran.com`), so they cannot be repurposed by third parties. This matches the established `resend.com.mail.json` template already in this repository.

# Online Editor test results

**Editor test link(s):**

- Apex (`example.com`, host empty, all groups): [Test peloran.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPLCjWoC%2F%2B1WXW%2FiOBT9K5ElnoakIXwMROoD5aPDILql0A6zVYWc2GQ8DXZqO1CmYn%2F7XIfPbNnRPo06Up%2Bw7GPfc8%2B954YXpOk8ibGmyH9BiRQLRqjsEeSjhMZCYu6EYo6K%2B6MrPAcout4cwoGicsFCml2hc8ziw94W29nuLqhUTHDklwCx4uF1GvTpqi3gmL%2BKZwA3lDBJQ72H4CRx8jBCVShZorN3UUvwGYtSSa12vzcoWqPrbtEaTIoW5sQSGQrHVhiz8NHWEoePjEdW66o56FgzIS3Y4gqHW1iWjAMxYhGJWxnD%2B9%2B0TpR%2FdrZcLo95nG3XtkGWA0ctIrgGzIUkCvn3LyiSIk0yiUSqA5FyAgC9Sow8gwmsvwmlYV1QyWyTbcFoLhjXaizgYEYpCYCwreY6cQqSRkCy4OA5%2FiG4omorh9ZAs1xzXVMwJiTTK5DbXRd%2FTQF0GvwXiaMnYf8mjSmkhBgP45RQP08gH4c8svkhxngyPoSQVFFOnCnJwjzSVT4QwRqbjjgvbADQJoV%2FPZ4v4iFMVs2jXDLceAsbpQE5pW4e1eLQt2MsI6oLzoapTfgridcP6yKC5On0UOkH4L5rVvqMwVl0e23LB1ZZDlO2wydY4rky7tvdvM9dfdjdvUdmva%2BN2TDUzOamHcxOqmyKlbZLaE8FxDMng97lbNB0L1ujp8tRLyi3h52L5vC22axcXjXbrQs27F9Ew9bHRfCEv7crszsv6PEf1w3tzhofvE8uaTzXk%2BEoIwZPdoXsEKaFHFOl%2F%2BLxquSVK9Xax3rDbV602p2uIXBafMMmhqqrV5Aj5fcgyAR0ZhEXkk4V%2FGINBke%2BliktonkaazbFS3zYIuEU5kS8grIoOIWHwIDHXuObsZSJt%2B%2B1vMH2Mv5fhxXRlISmiMw0ZyWoVTw8m9m0VA%2FsCnGJ3Wh4ZTusVt16Gbu1slc7mqknxu2pqXpoIaqAvGbYzKRmvMQrhdbGHjmrnUxzcQ4NVLJO2tf6B8dxPsW3mtSp%2BbEfGr%2B909%2BqZLtZuBVt47m9UBt3%2FWLAvYFcHoowIt%2Ft%2B27fd%2Fv%2BkfY1f1jwgpIpNjDP9Wq2W7e96rhU872GX647tWrDK7kfXNd3XcMeirRJ8AW%2B%2Bsffe6ST8c3i7u%2Bg79bOeunt83ASdr9%2B%2Beqt%2BmrxWTefeHdy81mld5Nh%2FRytfwKElPDW2QwAAA%3D%3D)
- Subdomain (`example.com`, host=`mail`, all groups): [Test peloran.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAbDjWoC%2F%2B1WXW%2FiOBT9K5ElnkpogJSPSH3gqwzq0C0DXXVUIeTEJuM2sVPbgWYq9rfvTQgfaZnRPK2qVZ8S2ce%2B59x7z5VfkaZhFGBNkfOKIilWjFA5IshBEQ2ExLziiRCV91s3OAQout1uwoaicsU8mh2hIWbBYS3HDvLVFZWKCY6cKiAS7t3G7jVN%2BgK2%2Bbt4KeAbJUxST%2B8hOIoqRRihypMs0tm9qCf4kvmxpEb%2FejQuG9Pbq7Ixvi8bmBNDZCgcGF7AvCdTS%2Bw9Me4bvZvOeGAshTRgiSvs5bBMTAViBMIXdzKA%2B39oHSnn%2FHy9Xh%2FzOM%2F%2FzRRZdytq5cMxYC4kUch5eEW%2BFHGUpUjE2hUxJwDQSZSmZ3wP%2Fz%2BE0vBfUtFyq7aU5lwwrtVMwMaSUuICYVOFOqqUJPWBZKmCQ%2FxTcEVVng6tgWa9YVlpwZiQTCeQbmtT%2Fj0FyNP4VySOroT1b3FAQRJi3AtiQp0igWIc8sTCQ4zZ%2FewQQlJFOaksSBbmiSbFQARrnHbEZWkLgDYpvbm8WMRDmKyaR1oy3CyHTWOXnMpuEdXj0LczLH2qS5UtU5PwdynezDdlBOLp4lDpOXDfNSt9weAsmh%2FL%2BeRWyHQs2O5MhCUOVerA3emHwvH57vzD9oJ5Vov%2BHptSTBe3bZGuxMqkWGmzivaUIInpzng0XI471rA3fR5OR269Pxl0O5O7Tsce3nT6vS6bXHf9Sa%2B5cp%2FxY99e%2Fl1zR%2FznbVtby%2FZZ7YtF2i%2BtaDLNyMGVV0IOCNNCzqjSf%2FEgqdbq9kWj2WpbnW6vP7hKCZwuQsomgOqrd5CjCuxBoATyzXwuJF0o%2BGINRkeOljEtozAONFvgNT4sEW8B8yJIoDwKduEiMOKx5%2Fh2PGWdmNclb7yi2%2Fa5%2FFO7ldGCeGk1WdqpdWI3mx61TQvbbdOu2VWz5bmuucT1Zr1BcbVOydGAPTF7T43YYj9RBSo0w%2BmQ6gRrnCi0Sf1S8N6v9a4uoZ2qxklTG%2F%2FgIChq%2Fcjq3k2WN1Kjy%2F%2FcAB85d7txmWcvc9qbjG3d95tB%2BEFEzcswSj8t%2FmnxT4v%2Fby2ePnzwipIFTqE1q9YwrZZZu5hVG06t7Vy0Ks1Gu1G3zyzLsaxUAVRsK%2FIVXg%2FH7wbk1b5Pr6OX5nA9tEM8%2Bfr17uIxSb74jers6jGKwpdVK%2BT6zHvuepdo8y%2FHvhF%2BKQ0AAA%3D%3D)
