### PR TITLE
Add WISP - Web Gateway

### DIFF
--- a/wisp.gg.webgateway.json
+++ b/wisp.gg.webgateway.json
@@ -1,0 +1,22 @@
+{
+    "providerId": "wisp.gg",
+    "providerName": "Wisp",
+    "serviceId": "webgateway",
+    "serviceName": "Web Gateway",
+    "version": 1,
+    "hostRequired": true,
+    "logoUrl": "https://cdn.wisp.gg/assets/connect/square.svg",
+    "description": "Serves a website for your game server through the Wisp web gateway, with automatic HTTPS.",
+    "variableDescription": "target is the hostname of the web gateway assigned by the Wisp panel managing the game server (for example gateway.physgun.com). Wisp is a multi-tenant, white-label platform, so the gateway hostname differs per hosting company and cannot be fixed in the template; apply requests are signed (syncPubKeyDomain).",
+    "syncBlock": false,
+    "syncPubKeyDomain": "dc.wisp.gg",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%target%",
+            "ttl": 3600,
+            "essential": "Always"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for [Wisp](https://wisp.gg), a multi-tenant game-server panel platform. Customers point a hostname on their own domain at the web gateway operated by their hosting company's panel (reverse proxy with automatic on-demand HTTPS). The template creates a single CNAME.

Two deliberate choices worth calling out:

- **Bare `%target%` in `pointsTo`:** Wisp is white-label and multi-tenant — every hosting company's panel has its own gateway hostname (e.g. `gateway.physgun.com`), and node-local gateways have per-node hostnames, so the target cannot be fixed or suffixed in the template. Misuse is mitigated by mandatory request signing: `syncPubKeyDomain` is set and our panels always sign apply URLs.
- **`hostRequired: true`:** the gateway only serves hostnames below the zone apex (an apex CNAME would be invalid), so apex application is excluded at the protocol level.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`dc-template-linter -loglevel info -tolerate warn wisp.gg.webgateway.json` passes with no findings.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `dc.wisp.gg`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — not used; the panel polls DNS instead of round-tripping
- [x] no TXT record contains SPF content — no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — no TXT records
- [x] no variable is used as a bare full record value unless necessary — `pointsTo: %target%` is bare by necessity; justification in the description above
- [x] no bare variable is used as the full `host` label — host is `@`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set appropriately — `Always` on the single CNAME; the record *is* the service, removing it disables it

## Online Editor test results

**Editor test link(s):**
[Test wisp.gg/webgateway viction.dev/connect](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA3ejWoC%2F91U7WrbMBR9FSEodDR2nO%2FEY7B%2BbGsZ67o1ZbASgizf2KK25EpyUifk3XcVJ026di%2BwX0ZH8rnn3HukFbWQFxmzQMMVLbSaixj0VUxDuhCm8JOENp7ha5bjMfoLNxA1oOeCQ30WogQ5Fqzab%2BxOQ0S%2BPO%2FNQRuhJA1bDZoqY3%2FCYyk0IIfVJTRophJ1pzP8L7W2MGGzyWPpb6U0mTFgTZMrKYHbpnksmQbfzJ3IGAzXorAbdnqLGsAQRlCZERbITGlSqVKTBGURJxE0salWZZLiF4hz5U6TrZEGWQibElZalTMrOLkcj29ufeeBacGiDC5eVLRMJ2CJMBs25026Smq2WR8QE3QhEgkxiap95YJJyEjOJEuETDb4odJjpx%2BeGM4KdkR%2BkVYmKaXPVf7Or2mE85yXmRWeBcmkRRsp%2BvcyFiG%2FmzQy5Q1i1LZGrelZbyxmM5wRKbCoA50Y5Ed5KFzGhDMplSURdlQ8oQchNzy7FL0nrCiyimicKxiLajR6qO0em0rymzL6CtUF9lTId66bDjzLFH%2Bg4YxlBmrk8Bg2N%2Bb%2BPo4auNKxoeH9itqqcCE7vz799onWkcLlRxdaJaQ1Y4XLo3o2R4hai9nq9IOgQQHDJK1gLmynGTbB0PVk3aBLJWG6rzHBaO1kYKzdtP0Y5vti2zQikGCaiqnY%2FVYwzXLj7tWO4P4Fw2RHcf%2FMgVCt1YFvjJk6gdhNpWHquspsqWF3dzZjn7IF20Mxn27mgX4M7iLr657J%2Bp7ubcTMMgTeKv%2BigdOYO3PCPQCDXjfu8kHfG446I6%2FbawdexAaB1%2BnyVrvVZu1R0D14Sf56YP75lLxq8VtDW08a2O7%2F0hjmwbA5xFPmTreDdt8Lhl67N24Nw3YvbA38VjDoDAYnQRAGgXOBl662ucKkHGaEzpffdfqjKfuf%2B6OrcdlUxe%2Fl0%2FXZiN%2BNLjsn6e3yYRmdd2zrvBp%2BoOs%2FZjphIxkGAAA%3D)