### PR TITLE
add Hintoric, custom domain and CAA templates

### DIFF
--- a/hintoric.com.caa.json
+++ b/hintoric.com.caa.json
@@ -1,0 +1,20 @@
+{
+    "providerId": "hintoric.com",
+    "providerName": "Hintoric",
+    "serviceId": "caa",
+    "serviceName": "Authorize SSL issuance (CAA)",
+    "version": 1,
+    "logoUrl": "https://cdn.hintoric.com/assets/logo/dc/black.svg",
+    "description": "Authorizes Amazon to issue the SSL certificate for a subdomain used with Hintoric",
+    "syncPubKeyDomain": "hintoric.com",
+    "syncRedirectDomain": "hintoric.com",
+    "records": [
+        {
+            "type": "CAA",
+            "host": "@",
+            "data": "0 issue \"amazon.com\"",
+            "ttl": 3600,
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/hintoric.com.customdomain.json
+++ b/hintoric.com.customdomain.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "hintoric.com",
+    "providerName": "Hintoric",
+    "serviceId": "customdomain",
+    "serviceName": "Custom domain",
+    "version": 1,
+    "logoUrl": "https://cdn.hintoric.com/assets/logo/dc/black.svg",
+    "description": "Enables a subdomain to work with Hintoric",
+    "variableDescription": "`slug` identifies the organisation at Hintoric and is supplied by Hintoric, not by the user.",
+    "syncPubKeyDomain": "hintoric.com",
+    "syncRedirectDomain": "hintoric.com",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "%slug%.hintoric-dns.com",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds two Domain Connect templates: `hintoric.com.caa.json` and `hintoric.com.customdomain.json`.

These configure a subdomain of a customer's own domain to serve that organisation's Hintoric page, which is otherwise reachable only on a Hintoric subdomain.

`customdomain` adds one CNAME to the organisation's hostname under `hintoric-dns.com`, which fronts a multi-tenant CloudFront distribution. The label comes from the `host` parameter.

`caa` is separate on purpose. Amazon issues the certificates, and a zone with CAA records that omit `amazon.com` blocks them with no visible error. Before we create the domain, we look up the CAA records. If they block Amazon, we offer the customer this template.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->


**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test hintoric.com/customdomain hintoric.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPHLjWoC%2F91Ua0%2FbMBT9K5ElPi1pHlBoI00aGhWbJipAwCZQFW5jN7VI7WA7bUOV%2F77r9D0e2r7uQ5Xa9%2Fj43nPv8YIYNilyMIzEC1IoOeWUqe%2BUxGTMhZGKp61UToi7ifVhgljybRXFiGZqylPWHEpLbeSEyglwsQ2tznxtgs4mOmVKcylIHLokl5m8Vbm915hCx76fUtHazcEHrZnRvkX6NPWHOaRPLT3NkIkynSpemIaN9AQMc6YdcHQ5XN7mGOnMpHpyZtyMnZ3kp6C4RZ%2FtMTzqvMweHaxXGD7iyGXGzJEqA8E1WJADZkPjgKAO13hbUeScUWdYbWKuI6SxG5agRD1aVpZKpJfl8AerzpZavFLbIq4Z5Yql5j3MWGpzzZ5LBKH0RpXMJYiXimoSPyyIqYpG9f7pRW8Fx%2BUX20uJTPpG4vLAVnqwEdqjQq%2FojcFuHAZBPahd8iIFS7bkA5T8g6xw1zD8uCRTsiwSvj5UgIKJtqO2Pv6wf36wJnhYMuDaJrhee7YFXrNjs%2BKZkIolGr9gSsXWKkzK3PAEZrDdomkC2J0Ki9AYRcLXConlmK5Sp2Bgtdpe%2B5FQLkloamvj1gnHnSgIjoB5EHVD7whG4HVHh6F3ErEUfyM2PAx3bPWW5T4w1r7KDJ2BgwrWPqf5DCpN6nrgouL%2FfZF2QGDKaAIWGgXRsRd0vKh9E57EQScOwlbUaR91u5%2BCIA4CWwiyLateNP%2BbadwUvJcBBtbPQ4NaTuKfg%2FhPVrA2qK1N7RC%2BadOd%2Fuw9f629Jvxl39C7tZU4x2cENWoyid%2BpFoG7TiL%2BvHd93m%2Fr6vbkqpxfZvn91fzuuQjCX9HLzxE%2FfzLt8Pbuon%2Ffyz6T%2BjdtP09aSQYAAA%3D%3D)

[Test hintoric.com/caa hintoric.com/test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHvMjWoC%2F91UUW%2FaMBD%2BK5GfNjWBAIWESJOGuk3rhraubHtYi6LDPsBrEme2QwWI%2F75zgAFrO22ve7Lj%2B3x33%2BfvsmYW8zIDiyxZs1KrhRSoLwVL2FwWVmnJG1zlzP8V%2BwA5YdnbXZQiBvVCcqwvcYDDyQ46qOycoCv0RqOhJ42poODoPbsYDJ4TeIHaSFWwpOWzTM3UF5256taWJmk2uSgax500wRi0pumQTcGbkwz4XcMsZpRJoOFalrbOdihrvEEOK1V4VtXV0bPzbS8ctZVTyYm%2BN1XaA89UE6FykIVXGRTevbRz75jqsuBX1eQ9Ll%2FVqIcyOcQ1CqmR26cwFFNaGJbcrJldlk4j0oICc2Usfbx0XMACbcNdx7cMag4uwy2juLWkUqcXhj5DUqSwEpxsH4tBWWZLthlvfEZ4TA%2FFxpT1iY52hS3S4rOZVlWZyv2lEjTkxvljf%2F3m9P54n%2BBmm8HVlrNCaUwNrWArTRytrtBneZVZmcI9HI4ET8E1Ta0ailKa33UptkbatfcP0qSCu76lsya0u90%2Bx%2FOAi0kUnEciDibQngadXiymcdSPsTU98vljM%2FDQ6afCPfoSm7FPKv5nlOjJDSxQpOCw7bDdC8I4aHc%2Ft6KkFSatfqMT9ru9zlkYJmHoGFC6Lct1va%2F9tO8lcJXpewFawiTDE7P9hVedTzdurpx%2FHpmrI7FPfiaNU2n%2F%2FAo0UhunV0aTTcTr%2BskpBYofO55dR%2B%2BWUTu%2FXA2jOL%2BDsljFo%2B%2F2%2FOr1p7MfZ6Phxbc3g6jbv676Xy9fsM1PIwVmaIwFAAA%3D)

[Test hintoric.com/caa hintoric.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAvNjWoC%2F91UXW%2FaMBT9K5GfNo2AE74jTRpaVVG2rt3aah8URTeOAatJHNkOjCL%2B%2B64DDFihWrW3PcXxPffec4%2BPvSSGp3kChpNgSXIlZyLm6iImAZmKzEglWJXJlFR%2Bxz5BiljS30QxormaCcbLJAaw29lAe4WZIvSROzc3Hx2hdQEZ486r973eawTPuNJCZiTwKiSRE3mnEtvdmFwHtRqLs%2Bo%2BkxpozY2uWWQtZrUoAfZQ1bMJVoq5Zkrkpqy2a6udXgqPMnOMLLtzx0zXXBhXRowFw%2FGdsVQOOLqIYpmCyJxC89iZCzN19kddZOy6iD7wxVmJeiqTRXzhsVCcmVMYjEkVaxIMl8QscqsRaoGBqdQGf97ZWcAALumG8T2BcgZb4Z5g3BhUqd6itEI4KpIZAVa2q6yX58mCrEarCkE8D3fNRlj1BKNNY1xNlCzyUGwTclCQauuNberwMHe0TR4SYnuKSSYVDzV%2BwRQKZzOq4BWSFokRIcxhtxWzECxZpKgxiiX%2B1CNbG%2BiFeoQxs4RF6cdWvdvueJE7ZhF1G2Pqu90IOi7tNr3GuNtuUNraM%2Fcx4z%2B1906to9KvRhWU7n%2BZBQ9Yw4zHIVicT%2F2WSzuu37z12oHnB416teU3On79DaUBpZY912Y94bJcl%2B7Z8nBtV%2FyfgRIQJfzAWidcaYtsnWldubI3yDrmyA3aqGxTDp6N6qGsz59AeXn2Gbv2HZCFcdeM%2FpL%2BSwj%2FC9eVPdcE3xs8pFKr4BnyCN6%2FnOTh%2FPo8Gcxbg5%2F%2BoqDtO6%2Fvfe2cFVO%2F2R5c1L9Pfmj9%2Barbv%2F3WvXxLVr8A%2Fz%2Fnhy8GAAA%3D)

