### PR TITLE
Add anvilmail.io templates (verify, dmarc, spf, dkim)

### DIFF
--- a/anvilmail.io.dkim.json
+++ b/anvilmail.io.dkim.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "dkim",
+  "serviceName": "Managed DKIM",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Delegates one DKIM selector to Anvil Mail with a single CNAME, so key rotation and record upkeep happen without further DNS edits. Mail signing itself is unchanged.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%selector%._domainkey",
+      "pointsTo": "%dkimTarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/anvilmail.io.dmarc.json
+++ b/anvilmail.io.dmarc.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "dmarc",
+  "serviceName": "Managed DMARC",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Delegates your DMARC record to Anvil Mail with one CNAME, so your provider can manage policy and reporting for you without further DNS edits. Your existing mail flow is not changed.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "_dmarc",
+      "pointsTo": "%dmarcTarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/anvilmail.io.spf.json
+++ b/anvilmail.io.spf.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "spf",
+  "serviceName": "Hosted SPF",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Adds Anvil Mail's hosted SPF include to your SPF record so your sender list stays under the 10-lookup limit automatically. Your existing senders keep working.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "%host%",
+      "spfRules": "include:%spfInclude%"
+    }
+  ]
+}

--- a/anvilmail.io.verify.json
+++ b/anvilmail.io.verify.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "anvilmail.io",
+  "providerName": "Anvil Mail",
+  "serviceId": "verify",
+  "serviceName": "Domain Ownership Verification",
+  "version": 1,
+  "logoUrl": "https://anvilmail.io/domainconnect/logo.png",
+  "description": "Proves you own this domain so Anvil Mail can monitor and protect its email. This adds one small TXT record; it does not change how your mail or website works.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.anvilmail.io",
+  "syncRedirectDomain": "anvilmail.io",
+  "warnPhishing": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_titan-verify.%host%",
+      "data": "%verifyToken%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Four synchronous-flow templates for Anvil Mail (providerId `anvilmail.io`, providerName "Anvil Mail"), a DMARC monitoring and managed-DNS platform. All four flows are signed (RS256).

The syncPubKeyDomain is `domainconnect.anvilmail.io` and the public key TXT records are live at `_dck1.domainconnect.anvilmail.io`:

```
"p=1,a=RS256,d=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2QqIpCxxL/IhRVjT+AD27JU3RKSDEXTEnRqk8ehU1ow7EDjczF/ak9IYvwi1n6TW/uqHDtnRRo1da3RweT07v5ABH6gh9XMG41VHkR4N9e9/H0ZTNsnrVMV0RSFn1UF5en7sgtrDVJXQoAxBhW"
"p=2,a=RS256,d=yenq0NJN4U/KjmkgVobadg3Q3OaUm4PoxrWn9CoCC574nPDnodQDfj9mEFKrFnAfnD7ltW02g6zgtXMLC8CHXnlJvLq9wQJf6tRRLAnwm2/+PWk7kUKda82PzSFU3pmxKZvmYlPe3GVKm8LjJge/AG3pSdGiAONdECJtff2cuYMN1QyLg68Ruadffcyrh6"
"p=3,a=RS256,d=TdQIJwIDAQAB"
```

Logo (512x512 PNG, hotlink-stable): https://anvilmail.io/domainconnect/logo.png

Templates:
- `anvilmail.io.verify.json` — TXT ownership verification
- `anvilmail.io.dmarc.json` — CNAME `_dmarc` delegation for hosted DMARC
- `anvilmail.io.spf.json` — SPFM include
- `anvilmail.io.dkim.json` — CNAME DKIM selector delegation

🤖 Generated with [Claude Code](https://claude.com/claude-code)