### PR TITLE
add Metorik, Engage email authentication

### DIFF
--- a/metorik.com.engage-email.json
+++ b/metorik.com.engage-email.json
@@ -4,7 +4,7 @@
     "serviceId": "engage-email",
     "serviceName": "Engage email authentication",
     "version": 1,
-    "logoUrl": "https://app.metorik.com/img/mtk-version-notification-logo.svg",
+    "logoUrl": "https://metorik.com/img/brand/logo-icon.png",
     "description": "Adds DKIM and custom return-path records so Metorik Engage can send authenticated email from this domain.",
     "variableDescription": "%dkimSelector%: the Postmark DKIM selector; %dkimValue%: the Postmark DKIM public key; %returnPathTarget%: the Postmark return-path CNAME target",
     "syncBlock": false,

--- a/metorik.com.engage-email.json
+++ b/metorik.com.engage-email.json
@@ -1,0 +1,29 @@
+{
+    "providerId": "metorik.com",
+    "providerName": "Metorik",
+    "serviceId": "engage-email",
+    "serviceName": "Engage email authentication",
+    "version": 1,
+    "logoUrl": "https://app.metorik.com/img/mtk-version-notification-logo.svg",
+    "description": "Adds DKIM and custom return-path records so Metorik Engage can send authenticated email from this domain.",
+    "variableDescription": "%dkimSelector%: the Postmark DKIM selector; %dkimValue%: the Postmark DKIM public key; %returnPathTarget%: the Postmark return-path CNAME target",
+    "syncBlock": false,
+    "syncPubKeyDomain": "metorik.com",
+    "records": [
+        {
+            "groupId": "dkim",
+            "type": "TXT",
+            "host": "%dkimSelector%._domainkey",
+            "data": "%dkimValue%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All"
+        },
+        {
+            "groupId": "return-path",
+            "type": "CNAME",
+            "host": "pm-bounces",
+            "pointsTo": "%returnPathTarget%",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for Metorik Engage email authentication. The template creates the Postmark DKIM TXT record and custom return-path CNAME for apex domains and sending subdomains.

The DKIM value is intentionally supplied as the complete TXT record value because Postmark prescribes the full authentication value and it cannot be safely prefixed with Metorik-specific text.

The template uses Metorik's official square brand icon hosted on the public Metorik website.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

No records are independently user-editable: both records are managed Engage email-authentication records and must remain aligned with Postmark.

## Online Editor test results

**Editor test link(s):**

- [Test metorik.com/engage-email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALvJjmoC%2F%2B1UTXPTMBD9Kx7NcCJO7CQNqTs5lCaFUgKl%2BQCm08kokuKIyJKR5NDQyX9nZTvEaQsHTgzDybJ29fTe7tPeI8uSVGDLUHSPUq3WnDJ9QVGEEmaV5qs6UQmq%2FQy9wwmkomERhIBhes0Jy48wGeOY%2BSzBXOxD5ZFBHvTyoIczu2TScoItVxJy10wbt4rCGhIqVhMt4MzS2tREjUaFS4MncWOusaQNl%2BdzomQ9lTFgUGaI5mmOGKFTSo3Xv7wYepDrkcxYlXia2UxLP8V2CWuiNOQY5ZVyvJIjwdIzDE5VaDJaUl9owLFLbjyqYEPWHXusOZ4L1j9g8IyueDJighFAfxbBIeZdKWMTrFcFM1MGT7w8d4pFxp5MTLO54MRbsQ2kFiKuQMMY65jZhyeqIs%2FenQ4Hns3zXEs2krwUiqxQtMDCsGLnKptfsk0%2Fl%2FOo82WZUHRzj2KtsjRvtaMLQbtJXW%2FHn8bwswQCj2TXZ0WZgLprEbZ4l1KodSAWet3qBAEs7%2ByZkgvQaofYkiWX8VBRd8WpEGhbq1KoyNwzyfXuuaSJP1eZJMw4DysurRkrR%2BBRDas8trfbGvquJJvtxd8C%2BV2B2B2GR8PKApVXwSrnNuN5%2Fq5CVZaAkWKNE%2BMe2w7t5gDudod3g9w6R%2Fw1WrXSOVLu310kL7DbXvecicITb9XTBp94ae%2FD5E3%2FejB9dR0s34xWdjieHF1Nzs9Hk%2FB6OhX088ep6jmYh2VyaGlSTyw267qEf1cpHkul2czAF0M6XGl1BtZKMmH5DH%2FD%2By1KZjhNxQYKayAKcOCqAxPJYloUSp40zx%2BqOfDZjBLXA%2B58FLbbZN46PvZp90XHb3e7HR%2FT5sIPF0eLTrPFSPdFszIBnxiOv5mBe3MwY9wowSI38ze8MWjrDP3AuKX%2BA%2BOWwg8K%2F1fKua3BO%2Fnf0X%2BpozAEDF4zOsMurRk0O37Q9ZudcRhGYRAdhfVOKzwOgudBEAWBE8GMLeTdw2yoTgV096k9UKPji4%2FvW0Gn%2BfptezQc8FdfXh7hvkkbG5GdnwVT%2B5W%2B15Me2v4AI8oDapwIAAA%3D)
- [Test metorik.com/engage-email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMTJjmoC%2F%2B1UUW%2FaSBD%2BK5alPhWDIUB7jnhIGnpqKqJcAqS9CKH1ejBbr3f3dtekNOK%2F36xtiklyfehTVR2yhL0z8%2Fn7Zj7Po28hV5xY8KNHX2m5YQnoD4kf%2BTlYqVnWpjL3W99DVyTHVH9SBTFgQG8YhbIEREpSCCAnjB9Cdcm4DHpl0COFXYOwjBLLpMDcDWjj7qJuy%2BcylTPNsWZtrTJRp9Pg0mF52ok1EUnH5QWMStFWIkWMBAzVTJWIkX%2BWJMa7%2BPhh4mGuRwtjZe5psIUWgSJ2jfdUaswx0qvleDVHSoRnAKsaNCGpqa804tg1M14i8UC0HXuiGYk5XBwxeJVkLL8FDhTRX0VYBN61NDYnOquYmTp46pW5c8ILeDFRFTFn1Mtgi6mViGvUMCU6Bfu0oiny3dXZZOzZMs%2BNZCvoOZc086MV4Qaqk%2Bsi%2Fgjbi1LOs8nXbfKj%2B0c%2F1bJQ5agdXQzarXKznX6a4sMaCTyT3V5WbULqbkTEkn1KpdaBWJz1yTAM8farfSfFCrXaCbF0zUQ6kYl7xRnn%2Fq7VpNCQeWBS6j1wUXkQy0JQMM7DkglrptIReNbDJo%2FdYtfyv0kBy4P4BZLfNwi%2BEvxooG5Q%2Fara9CW%2FJStr9l1qMkUcRTTJjfvg9oj3R5CLPeZ9BbqoUf8bsdnxEq308T5SNtodb0bOTN1TLxtpQ049NfprdnlxM57%2FeROuL28zO5nOBtez9%2B9vZ92b%2BZwnn%2B%2FmcuRgnrbLoam8nVtiNm2Bz65jLBVSw9LgP8F0fKXVBVosL7hlS%2FJADkcJXRKl%2BBYbbDCKcOiuIzOJamtUShomatd9rp30k5KOTLdMqBsGc6Z6m4SrGLqroBvHNOgT0gviEN4EQ%2FwNYDCEYX%2FVWIcvbMofLMRjp4AxbrcQXrr7gWyNv3MOf%2BLkuhEHJz%2FpwNEYflldixZ%2BQf%2FP%2BPeeMS4KQzaQLIlL7YW9YRC%2BDXrDabcb4RWG7V5%2FMBz2X4chPjghYGwl8RH3R3Nz%2BOG0y1N1PlD%2FjE%2FElze9b%2Bfk6vLc%2FnGSPEgT3nUG483fq9us3%2F%2BSjfzdvw6GKRDICAAA)
