### PR TITLE
Add qlara.ai template

### DIFF
--- a/qlara.ai.email-composer-ses.json
+++ b/qlara.ai.email-composer-ses.json
@@ -1,0 +1,64 @@
+{
+    "providerId": "qlara.ai",
+    "serviceId": "email-composer-ses",
+    "providerName": "Qlara",
+    "serviceName": "Authenticated email sending",
+    "version": 1,
+    "description": "Publishes the DNS records that let this domain send authenticated email: DKIM signing, a custom MAIL FROM subdomain with its SPF authorisation, and a DMARC policy.",
+    "variableDescription": "%dkim1%, %dkim2%, %dkim3%: DKIM tokens issued by Amazon SES for this domain; %mailFromPrefix%: subdomain used as the MAIL FROM; %awsRegion%: SES region; %dmarcValue%: the DMARC policy to publish",
+    "syncPubKeyDomain": "qlara.ai",
+    "syncRedirectDomain": "qlara.ai",
+    "sharedProviderName": true,
+    "sharedServiceName": true,
+    "shared": true,
+    "multiInstance": true,
+    "hostRequired": false,
+    "records": [
+        {
+            "groupId": "dkim",
+            "type": "CNAME",
+            "host": "%dkim1%._domainkey",
+            "pointsTo": "%dkim1%.dkim.amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "dkim",
+            "type": "CNAME",
+            "host": "%dkim2%._domainkey",
+            "pointsTo": "%dkim2%.dkim.amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "dkim",
+            "type": "CNAME",
+            "host": "%dkim3%._domainkey",
+            "pointsTo": "%dkim3%.dkim.amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "mailfrom",
+            "type": "MX",
+            "host": "%mailFromPrefix%",
+            "pointsTo": "feedback-smtp.%awsRegion%.amazonses.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "mailfrom",
+            "type": "SPFM",
+            "host": "%mailFromPrefix%",
+            "spfRules": "include:amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "dmarc",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "%dmarcValue%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
+            "essential": "OnApply",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for Qlara, an email sending platform built on Amazon SES. Applying it publishes everything a domain needs to send authenticated email: the three SES DKIM CNAMEs, the MX and SPF of the custom MAIL FROM subdomain, and a DMARC policy.

The template is shared across the platform's tenants through `sharedProviderName` and `sharedServiceName`, so a single template and a single signing key serve every brand rather than one submission per tenant.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — not applicable, no `logoUrl` is set

Also validated with `dc-template-linter` (exit 0, no findings).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — the public key is published at `_dcpubkeyv1.qlara.ai`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — the MAIL FROM authorisation uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — the DMARC record uses `Prefix` with `v=DMARC1`
- [ ] no variable is used as a bare full record value — **justified below**
- [ ] no bare variable is used as the full `host` label — **justified below**
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — the DMARC record

## Justification for the two bare variables

**`%dmarcValue%` as the full value of the `_dmarc` TXT record.** A DMARC policy has no fixed prefix that could be kept literal while leaving only the variable part: the whole record content *is* the policy, and prefixing it would produce an invalid DMARC record. The risk this rule guards against is mitigated twice over: every request is signed, since `syncPubKeyDomain` is set, so tampered or third-party links are rejected; and the record carries `txtConflictMatchingMode: Prefix` on `v=DMARC1`, so an existing policy is surfaced as a conflict instead of being joined by a second record.

**`%mailFromPrefix%` as the `host` of the MAIL FROM records.** Amazon SES lets each sending domain define its own custom MAIL FROM subdomain, and that value is chosen by the service provider when the identity is created — it is never supplied by, nor echoed from, the end user. It is a single label with no dots, so it cannot reach an unrelated part of the zone, and the signature binds it to the specific domain being configured. Making it literal would prevent serving domains whose MAIL FROM was provisioned with a different prefix.

## Online Editor test results

**Editor test link(s):**

- Apex: [Test qlara.ai/email-composer-ses example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJZrjGoC%2F%2B1XX2%2FiOBD%2FKpalPi2ghFBKs%2BoDKq2u6tLtQnevd1WFnMQBQ2IH2wHSivvsNw4EQovKVbqH3bs%2BYXv%2Bz%2FxmhjxjTeMkIppi9xknUsxYQOVVgF08jYgkNcJwBSsqZ8yn%2BTONCYuqvogTAc9VRRUwFII3JAZF%2BJsR3cqtX9upHlGumQ%2FWApTrQYrygPEh8M6oVExw7NoVHFDlS5bo%2FI5vUy9iakQVAnnUuekjSX0hA3MnGkVUw4EpFAhQyXOViLy25aLO9VUXKTbkYLGCCPJTpUWMuu2rL%2Biy9xVoqbdWMmd6hJhWqH97mSsTkiliHAJBox91uu3eOUpExPysZvwnkhEvop0d34%2BCCYvtowrKD%2FXi4BytvdFiQrlCTKkU%2FPQy1I7Jk%2BCof9FHoZDlwD6jIxPGpRTxraQhW4COrcOpAnmyStEmIBAhc9WjQ3AGuI1SmV%2BAEMRE%2Bj9IlFKg5IktBQR%2BoWSVdlPGjPtQhGuadXJjL8AB1B4NGBRF76WPiKTB7Q5CtExpQemXQVImFLc4jTS74koT7m9YRkLpHp2mLGcMSaTgcY0L7D4846EUaZIj1iQc%2FNBZYlB4ftPuXuCVgm2BaoNVHic0M3AWjGt1J0p081MjeXEA8jXAv1GpI%2Bw6TctaVt5nsH7AYP3fNugcMOi8z6ABYihFyWj3vmTxBU537YWUBh7xJ1UV66RWAugr44lk0HY6g5lgvcMVaNnum86oJOylEQwuFzPuR2lA3X%2BaaNM0W0t393dbQ4OCGBBN8rxuO8yILPS54CF0l%2B4S7Y9gBnVFYLSsHNvPsqa5eHaW96cNbFQpM9oIeIi%2F8naSRNmOx4%2FLCoZg6GDbDo%2FgVdGadEFg4tN1oGvn4ZRHOWAFfwINHCuzFQrJhx3Rx0L2AZtz3ibmMlUnQX3BR%2BGYTp0Jj%2F1sPI5FNvamT9lk6DcK5rphXjTiWTPxpI6e%2FPqcT0fqeByE2cmEOkSkQ1YwO4bZOx3PHTmdcD1rLUb%2B03EsooSkqpkF4ZCyumHeLbaRMi%2BGssFZHkhanVOlq3ZuYFMnQyoS%2FRklZxyyiE06YWcISQdmdxCdSrozmgZkTrZPgT8gpiSQfQVUUAnD6EVn8tVCPJSq3ZZdw%2Bqg0Nt9XAGc%2BqaqzODZ8nyfevVm1W5Qv9pohk719CRsVEPbdlrEbrWsU6%2B03t%2F9v2CLrjJo29GcZAovTW%2Ftz8whXOzNzEGh%2F0JmDjXB3swcFPolM5OvnHVa8i7fxLu7YjbN%2FlaEu7vmp4x3tW32Bjw7g51mo73bDP1FougXKOdOeC%2BX6aup%2FJPFU%2Bzh5fKxAtvzY%2BR%2FjPyPkf8x8j9G%2Fv9i5MNHhCIzGgyI4atb4IrVqtYbd3bTtRqu06rZDce2jz9ZlmtZJhAA5yrMZ%2Fi6KH9X4G4a%2Ff6HGI75b9%2F70fTyWOkfV8z7cpO05n%2BeX7D70ym99KafJtf29zO8%2FBtn8pEswBMAAA%3D%3D)
- Subdomain: [Test qlara.ai/email-composer-ses example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL1rjGoC%2F%2B1XW2%2FiOBT%2BK5alPi1hAwFKM%2BoD6mWn26HD0u5utVWFnMQBQ2IH2wHSivntcxxICb2xlfZhZsUTic%2F9nO%2F4I49Y0ziJiKbYfcSJFDMWUHkRYBdPIyJJlTBcwYrKGfNpfkxjwiLLF3Ei4NhSVIFCYXhFYnCE%2FzCmG7v1aSfVI8o18yFagHI%2FSFEeMD4E3RmVigmO3VoFB1T5kiU6f8e91IuYGlGFwB6dXl0jSX0hA%2FNONIqohgemUCDAJc9dIvIylotOLy%2B6SLEhh4gVRJCfKi1i1O1cfEHn%2Fa8gS721kznTI8S0Qte989yZkEwRkxAYGv%2FotNvpn6BERMzPqiZ%2FIhnxInq6lftBMGFx7aCC8od68eAcrLPRYkK5QkypFPL0MtSJyYPg6PrsGoVClgv7hA5MGedSxD1JQ7YAH5uEUwX2ZNWip4LAhMxVnw4hGdA2TmX%2BAoIgJtL%2Fi0QpBUne2FJBkBdKVm03Y8y4D0O4pNlpHuwZOEDapwGDoehX5SMiadDbQoiWKS0k12WQlAXFW5xGml1wpQn3n1RGQuk%2BnaYsVwxJpOBwjQvs3j3ioRRpkiPWNBzy0FliUHhy1eme4ZWDzYCqg1UfJzQzcBaMa3UjSnLzUyX5cADyVcC%2Fcakj7Dot215WPhawviNg%2Fb8O6OwI6HwsoAFiKEUpaPe2FPEZTrfjhZQGHvEnlop1Ui0B9EXwRDJYO53BnWB%2FIBVY2e67yagk7KcRXFwuZtyP0oC6%2F7bRZmk2kW5ubzaBBoUwIJrkfd1smDFZ6BPBQ9gu3SXaH8Ed1BWB8bJK7HWVtczFs%2BN8P2ugRpUyVxuBDPFX3kmSKNvK%2BH5ZwVAMHWzW4R6yKlaTLgjc%2BHRd6Dp5TufmHs8rHbDCJoEljpVhhsL6bsv8vrC%2FWzkwYcy6mIOpOgzqCz4Kx3TqTHjsZ%2BNxLLKxN33IJkO%2FUSjXjfKiEc9aiSd19ODX53w6Us1xEGaHE%2BoQkQ5ZoewYZe9oPHfkdML1rL0Y%2BQ%2FNWEQJSVUrC8IhZXWjvD10Y2VOjOQJb3kxqTWnSlu1PMDTvIyoaPgnlBxz6CY2bQXuEJIODIcQnUq6dUUNyJxsjgJ%2FQMxoYAoKpOASLqVnG8pXxLirVaXVra4HtcbYTsv3l7oCoPXNeJkBt3NEHb8Wti2vRtpWwz6yLS9sBBZp0Fbo%2B47jNZslrv%2Fwn4RtqJVR3InmJFN4aZbt9RbtAsjbLdpp%2BX9p0a61eLtFOy1%2F2hblrLTuj3H2rPBtKnq6DN4rdZuTftjCV8z0duWzYyDBGnqV%2FtA3EkU%2FyYC36lwx8ItKn93jP2BhBYsvl%2FcV4N09UeyJYk8Ue6LYE8WeKN4kCvhgUWRGgwExunW73rLstlVv3NRart10a4dVu33YarZ%2FsW3Xtk0xANlVqY%2FwJVP%2BhsHj3y8nlFw0aXN%2Bdv5P72hKYo%2Ffjo8%2B%2F3Zy%2B%2Fm21aW9y0ntb%2FLrnzftY7z8DtRyc0A0FAAA)
