### PR TITLE
Add Vambe email template (vambe.ai / email)

### DIFF
--- a/vambe.ai.email.json
+++ b/vambe.ai.email.json
@@ -14,7 +14,8 @@
       "groupId": "outbound",
       "type": "TXT",
       "host": "_vambe-verify",
-      "data": "%verifyToken%",
+      "data": "vmb-verify-%verifyToken%",
+      "txtConflictMatchingMode": "All",
       "ttl": 3600
     },
     {
@@ -27,14 +28,14 @@
     {
       "groupId": "outbound",
       "type": "CNAME",
-      "host": "%dkim1Host%",
+      "host": "%dkim1Selector%._domainkey",
       "pointsTo": "%dkim1Target%",
       "ttl": 3600
     },
     {
       "groupId": "outbound",
       "type": "CNAME",
-      "host": "%dkim2Host%",
+      "host": "%dkim2Selector%._domainkey",
       "pointsTo": "%dkim2Target%",
       "ttl": 3600
     }

--- a/vambe.ai.email.json
+++ b/vambe.ai.email.json
@@ -1,0 +1,42 @@
+{
+  "providerId": "vambe.ai",
+  "providerName": "Vambe",
+  "serviceId": "email",
+  "serviceName": "Vambe Email Channel",
+  "version": 1,
+  "syncPubKeyDomain": "domainconnect.vambe.ai",
+  "syncRedirectDomain": "vambeai.com,vambe.ai",
+  "syncBlock": false,
+  "description": "Verify domain ownership and enable email sending through Vambe.",
+  "logoUrl": "https://app.vambeai.com/logos/vambe-logo.svg",
+  "records": [
+    {
+      "groupId": "outbound",
+      "type": "TXT",
+      "host": "_vambe-verify",
+      "data": "%verifyToken%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "outbound",
+      "type": "CNAME",
+      "host": "%spfHost%",
+      "pointsTo": "%spfTarget%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "outbound",
+      "type": "CNAME",
+      "host": "%dkim1Host%",
+      "pointsTo": "%dkim1Target%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "outbound",
+      "type": "CNAME",
+      "host": "%dkim2Host%",
+      "pointsTo": "%dkim2Target%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Vambe** ([vambe.ai](https://vambe.ai)) — an AI-powered customer communication platform (WhatsApp, Instagram, email and more) used by businesses across Latin America.

The template connects a customer's domain for outbound email through Vambe: one TXT record for domain ownership verification and three CNAME records for email authentication (SPF return-path and two DKIM selectors, provisioned per-domain via Twilio SendGrid, hence the host/target variables).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Justifications:**

- `%spfHost%` is a bare host variable (a SendGrid-generated return-path subdomain such as `em1234`). Its value is generated by Twilio SendGrid's domain authentication and passed by Vambe's backend in a signed request — it is never user-supplied. The record is a CNAME pointing to a SendGrid target, mirroring the already-published `sendgrid.com.domain-auth` template, which uses the same variable host shape for the same reason.
- DKIM hosts fix the non-variable part (`%dkim1Selector%._domainkey` / `%dkim2Selector%._domainkey`); selectors are also SendGrid-generated (`s1`/`s2`).
- `essential: OnApply` is not used: all four records are required for the service to function and none are user-managed records like DMARC.

## Online Editor test results

**Editor test link(s):**

[Test vambe.ai/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMhAj2oC%2F%2B1WXU%2FbMBT9K5ElnmhCkoY2jbQHxj6oGOyrQ5sQipz4JrVI7Mh2yzrEf991WtpQIVZNkyYknuIen5x7r%2B89Tm%2BJgbqpqAGS3JJGyTlnoMaMJGRO6ww8yklvjZ%2FTGnnkwu4grEHNeQ4tG2rKqw3WZTpv7Z5zPKVCgOXMQWkuBUkC5C9E%2FmmWncLijUQagoS1i1wiOzdeJw3L%2FQKMK8TX7Hafci%2BXdW%2BL%2B7qS%2BTVJClpp6BEGOle8MW1kcgGKFwtnGcuRNwJzmvLGoYI5IGhWgdOW5GgQjIvSMVMlZ%2BXUaUvyMEIlS%2FlNVag1NabRycEBbRqvk86BZeiDFnHt2tPzEl%2FE9KVimiSXt6RE0aY9QDkzmZwJhgSzaOzhTb5P8MdUaoM%2F0qXMvE0bYUYNtdXX2Qpz95bPibwGsWdVfppjKYqK5%2BaMmnyKRZxJZoWPKtsFYzD3%2FsD373pP53F8fnT2dpPJnm6KE1zaGI3kwuiJXMETqkpoN%2F5anF3zOvgKFbZYqj0vXTboGhZb0VreP4oX7hgvfCze1V2P%2FJIC0k1br3qrGba%2B%2BEnRX2DnYRMVV22OKW%2F5mzTxzYYqWmvrxnuNywciV%2Fcql8SuW51tjc4k2K1h0c9HNAjdKIvBjYqQuiM2CFw%2FP4SYDrN%2BEUb2tVVj24h1EPbvwWXZFp5Z9HAw9G4qXHnWG6XizBO4bavuNs%2FydbCGNyI68Nan7O2gGD5QDNdwRzHcVRGbxUshFaQan9TMFA6FUTO8H%2BpZZXhKb%2BgGYnmKnq4W2FuNuxgKLfvAnWJ5z%2F3ZnTv1oDNXPZKy3E4Bt3MchwWLIsbcOI4O3WgUjNyMZZkLQTbo9yEYZaOic09v39%2BPXdSbUQSNZ2Q4rdqr4YYuNLmzNtpyzKrU1WSsa3zquJ9DPTiND0y%2FKmvnIX0WNYaP1xg%2Bvxqveni9vrjwxYUvLvyfLrR%2FDOgcWEotLfTDgevHbjiYBKOkHydR7AXDYBAP9n0%2F8X2bOmizLPgWv8Hdry%2Bp98ejL9F%2B0%2FCj8cnHDM5%2F1P6Hz6cwLk%2BH76N3w5Nsf%2FE%2BrE19Mn5F7n4DUas3S7IMAAA%3D)

[Test vambe.ai/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGVBj2oC%2F%2B1WUW%2BbMBD%2BK8hSnxYoOEAbpD202aZNU6tpy7puVYQc7BCvYCPbJM2q%2FPedIU1IVlXRtIdV6hPm8%2Fm7O999B%2FfIsLIqiGEouUeVknNOmfpAUYLmpJwwj3DU2%2BCXpAQ7dGV3ANZMzXnGGmtWEl5ssa6l89buOcMZEYJZmzlTmkuBkgDslyL7VE8%2BsuUbCWYAItosMgnWmfE6YVjbz4xyBfjGutkn3Mtk2duzPS9kdouSKSk06yHKdKZ4ZRrP6IopPl06rS9HLgTENOOVQwR1mCCTgjlNSo5mgnKRO2amZJ3PnCYlDzwUMpdfVQFcM2MqnRwfk6ryOuEcWwt93CCuXXt6nsNBCF8qqlFyc49yIK2aC5S1mchaUDAwy8pe3uh6BC8zqQ28pC3NvAkbYEoMsdmXkzXmHrXPkbxl4siy3JmhFNOCZ%2BaCmGwGSVxIaonPClsFYyD2fuz7q97TcQwvzy7ebiM50tX0PSytj0pyYfRIruERUTlrNv6anN7yMvjCCiixVEde2hboli33vDV2%2F8gfPtAffszfeNVDv6Rg6bas4966h60u7gjoi9l%2B2Hpda6WJM%2BXNmW2ocLoiipTaKvKB52aHaPzAdNNSjddc%2BzydjrBbJ9N%2BNiABdsPJKXPDKSbugMaB62cROyUnk%2F4Uh%2FbYusCN1zLA%2FQewTd%2FCtUWj%2BMRbFLDyrEZyxaknYNtm3y2itdfBBt6S6MDb3LZ3ACPeYcQbuMOID2WEovFcSMVSDU9iagXNYVQNc6KsC8NTsiBbiGYpaLtYQo017IIrkO6OSkU773ZU6q3L%2FKdUDypEp8l6KKWZbQdumzqaRNmJH4RuSHEMFCF2CWGnLnDhKJ7GPsZZZ2jvD%2FPHpvZuXzINl2U4KZpZsSBLjVZWV3sSWufctshesk9d%2FnNJDPpzOw728ju4d59NsviJZPHzTHbcg1H8otQXpb4o9X9Xqv3BIHNGU2JNsQ%2B%2B%2FVMXx6NgkIRBgiMPh4MojF%2F5fuL7NnymTZv0PXzLu19xRObke%2Fj558%2Fz4Fvhn32oo%2Brdqzpe%2FIpmLBgM3yx%2BDKPry%2FxOfvp48RqtfgNeBUmCAg0AAA%3D%3D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
