### PR TITLE
Add TitansHub (titanshub.app) domain-full-setup template

### DIFF
--- a/titanshub.app.domain-full-setup.json
+++ b/titanshub.app.domain-full-setup.json
@@ -17,14 +17,16 @@
       "type": "TXT",
       "host": "_cf-custom-hostname",
       "data": "%ownapex%",
-      "ttl": 600
+      "ttl": 600,
+      "txtConflictMatchingMode": "All"
     },
     {
       "groupId": "hosting",
       "type": "TXT",
       "host": "_cf-custom-hostname.www",
       "data": "%ownwww%",
-      "ttl": 600
+      "ttl": 600,
+      "txtConflictMatchingMode": "All"
     },
     {
       "groupId": "hosting",
@@ -52,7 +54,9 @@
       "type": "TXT",
       "host": "resend._domainkey",
       "data": "p=%dkimp%",
-      "ttl": 3600
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "p="
     },
     {
       "groupId": "email",

--- a/titanshub.app.domain-full-setup.json
+++ b/titanshub.app.domain-full-setup.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "titanshub.app",
+  "providerName": "TitansHub",
+  "serviceId": "domain-full-setup",
+  "serviceName": "TitansHub — Website & Email",
+  "version": 1,
+  "logoUrl": "https://titanshub.app/titanshub-logo-120.png",
+  "description": "Connects your domain to your TitansHub website (SSL issued automatically) and sets up email sending records.",
+  "variableDescription": "ownapex/ownwww: domain ownership proofs. ip1/ip2: edge IPs for the site. dkim: email signing key.",
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    { "groupId": "hosting", "type": "TXT", "host": "_cf-custom-hostname", "data": "%ownapex%", "ttl": 600 },
+    { "groupId": "hosting", "type": "TXT", "host": "_cf-custom-hostname.www", "data": "%ownwww%", "ttl": 600 },
+    { "groupId": "hosting", "type": "A", "pointsTo": "%ip1%", "host": "@", "ttl": 600 },
+    { "groupId": "hosting", "type": "A", "pointsTo": "%ip2%", "host": "@", "ttl": 600 },
+    { "groupId": "hosting", "type": "CNAME", "host": "www", "pointsTo": "edge.titanshub.app", "ttl": 600 },
+    { "groupId": "email", "type": "TXT", "host": "resend._domainkey", "data": "%dkim%", "ttl": 3600 },
+    { "groupId": "email", "type": "MX", "host": "send", "pointsTo": "feedback-smtp.us-east-1.amazonses.com", "priority": 10, "ttl": 3600 },
+    { "groupId": "email", "type": "TXT", "host": "send", "data": "v=spf1 include:amazonses.com ~all", "ttl": 3600 }
+  ]
+}

--- a/titanshub.app.domain-full-setup.json
+++ b/titanshub.app.domain-full-setup.json
@@ -2,21 +2,71 @@
   "providerId": "titanshub.app",
   "providerName": "TitansHub",
   "serviceId": "domain-full-setup",
-  "serviceName": "TitansHub — Website & Email",
-  "version": 1,
+  "serviceName": "TitansHub \u2014 Website & Email",
+  "version": 2,
   "logoUrl": "https://titanshub.app/titanshub-logo-120.png",
   "description": "Connects your domain to your TitansHub website (SSL issued automatically) and sets up email sending records.",
-  "variableDescription": "ownapex/ownwww: domain ownership proofs. ip1/ip2: edge IPs for the site. dkim: email signing key.",
+  "variableDescription": "ownapex/ownwww: domain ownership verification tokens. ip1/ip2: edge IPs for the site. dkimp: DKIM public key.",
+  "syncPubKeyDomain": "titanshub.app",
+  "syncRedirectDomain": "titanshub.app",
   "syncBlock": false,
   "shared": false,
   "records": [
-    { "groupId": "hosting", "type": "TXT", "host": "_cf-custom-hostname", "data": "%ownapex%", "ttl": 600 },
-    { "groupId": "hosting", "type": "TXT", "host": "_cf-custom-hostname.www", "data": "%ownwww%", "ttl": 600 },
-    { "groupId": "hosting", "type": "A", "pointsTo": "%ip1%", "host": "@", "ttl": 600 },
-    { "groupId": "hosting", "type": "A", "pointsTo": "%ip2%", "host": "@", "ttl": 600 },
-    { "groupId": "hosting", "type": "CNAME", "host": "www", "pointsTo": "edge.titanshub.app", "ttl": 600 },
-    { "groupId": "email", "type": "TXT", "host": "resend._domainkey", "data": "%dkim%", "ttl": 3600 },
-    { "groupId": "email", "type": "MX", "host": "send", "pointsTo": "feedback-smtp.us-east-1.amazonses.com", "priority": 10, "ttl": 3600 },
-    { "groupId": "email", "type": "TXT", "host": "send", "data": "v=spf1 include:amazonses.com ~all", "ttl": 3600 }
+    {
+      "groupId": "hosting",
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownapex%",
+      "ttl": 600
+    },
+    {
+      "groupId": "hosting",
+      "type": "TXT",
+      "host": "_cf-custom-hostname.www",
+      "data": "%ownwww%",
+      "ttl": 600
+    },
+    {
+      "groupId": "hosting",
+      "type": "A",
+      "pointsTo": "%ip1%",
+      "host": "@",
+      "ttl": 600
+    },
+    {
+      "groupId": "hosting",
+      "type": "A",
+      "pointsTo": "%ip2%",
+      "host": "@",
+      "ttl": 600
+    },
+    {
+      "groupId": "hosting",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "edge.titanshub.app",
+      "ttl": 600
+    },
+    {
+      "groupId": "email",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%dkimp%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "email",
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "email",
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com"
+    }
   ]
 }


### PR DESCRIPTION
# Description

Template for **TitansHub** (https://titanshub.app), an all-in-one business platform for coaches and small businesses.

It connects a customer's domain to their TitansHub website — ownership verification TXTs, apex A records and www CNAME (SSL is issued automatically by our edge) — and optionally their email sending records (DKIM + return-path) via the `email` group.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — https://titanshub.app/titanshub-logo-120.png returns `200 image/png`

The discovery → settings → template-support chain was also verified live against GoDaddy (`_domainconnect` TXT → `domainconnect.api.godaddy.com` → `/v2/{domain}/settings`). Apply URLs are signed RS256 over the query string per spec; the public key is already published at `_dcpubkeyv1.titanshub.app` in multi-part form (`p=N,a=RS256,d=…`).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `titanshub.app`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `titanshub.app`
- [x] no TXT record contains SPF content — the return-path SPF uses the `SPFM` record type
- [x] `txtConflictMatchingMode` is set on every TXT that must be unique — `All` on both ownership TXTs, `Prefix` (`p=`) on the DKIM record
- [ ] no variable is used as a bare full record value — **two exceptions, justified below**
- [x] no bare variable is used as the full `host` label — every host is fixed (`_cf-custom-hostname`, `_cf-custom-hostname.www`, `resend._domainkey`, `send`, `www`, `@`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — no record here is one the end user is expected to edit or remove. There is no DMARC record in this template, and the **inbound MX is deliberately excluded** so the template can never override the customer's existing mail provider.

## Justification for the bare variables

`_cf-custom-hostname` and `_cf-custom-hostname.www` carry `%ownapex%` / `%ownwww%` as the full value because **Cloudflare for SaaS requires the bare verification token** as the TXT content — a prefixed value such as `titanshub-verify=%ownapex%` fails their ownership check.

The risk the rule guards against is mitigated here: both host labels are fixed and vendor-specific, both records carry `txtConflictMatchingMode: All` so a stale token is replaced rather than accumulated, and the apply URL is signed (`syncPubKeyDomain`), so the values cannot be injected by a third party.

## Online Editor test results

**Editor test link(s):**

- Apex (`titanslm.com`, no host): [Test titanshub.app/domain-full-setup titanslm.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPFQkGoC%2F%2B1XW0%2FjOBT%2BK5YlRrvaJiQhbdpISFMow3TZIpiCBpZFlRM7rUWamNhp6SD2t%2B9xGkgz2%2B2wl4dh1afEPj6Xz%2BfyJY9YsamIiWLYf8QiS2ecsqxPsY8VVySRkzwwiRC48SI8JVM4jC8K8cc8AJFk2YyHrFCj6ZTwxIjyODYkU7mo5F9rot9yx7Jd9JkFkiuG3qEj0I1BYcYyydME%2B04Dx%2Bk4vcxiUJwoJaS%2Fu1uLrFoZ%2BqRhO5YpkjEYoUyGGReqMIQP0yRhoZJokeYZWkaJVLpcViHNy1h%2BGA5%2FQVzKnFFEcgXHFQ9JHC9%2BRCShCJBJlAvEdMCwSihPxihjYZpRaWoEJOMkiFmvFkQ6T4hgD7vwnM%2Fn%2FnMYsATAEy4QAOcRONLnIbo7lkgTcWHvcuH4iNExQ%2F0ziaI0Q2rCkA7VRPSOT4WPeif9ARJ5EPMQ3bGFjkIukvAsD07Yold4WpNWfeQToxxiVxsPHcRpeIf9iMSSwc6EZIy%2BLEvk2L95xOMszUVRC5NUKl7kQi1EkfqrC1jobViMwsgIcwl3a%2BidRFcHZI0oAsKd8qp2tLKC7LcsC94eFOQxAoRqQFQ4AeODlGrL3TjGT41%2F5dyElNQDgI3%2F0H9XN1HKEyUvUu0A0rpTBfR%2BxdHfNuT8M0OHp93BUaW5xL9iWdeb%2BXUtrLfNys5dd9cZ0w1ijpbVDqVZ3bLY3ymq9%2BWa975xz2cZi%2FgDXnuklGmreGN0g6sqOB1aHXXEGA1IeGfIqRJmLg1GpDJsk0zJlzSRTJphOi0GIk8zrhbYt62V6Dd6Hp59GPzJtxTRpzxm0D2YJ2GcU%2BbXfT3dPjUwrNmo6rPbRjlqX9o1npaBldbhrYhjxAuFlfQvgwILgmRkKvXof7Z1Uzd2%2B2ztBuv3wt5f2CobVks7TTuww45thLZnGy4hzCCdPdfokI7VcWnLA2GpomsONKi9R23KmnCOgkYUtIxO0GwbkRN5e0HQDgPP1RrQM%2Fq43W6btu2aHc%2B0lttObbu13C5KSwsG%2FeNo0LWOD4f3x8N%2BsNc7Pzronl92u%2B7xabd3eMDPTw7G571zrC%2Baj5M0YyMJT6LyDNKmshxm3DSPFR%2BROam2aDiCpogXkBcJUnAF86%2FWAsmS8zbOuldd1%2BoYGtFQ54wXfGs3W54bWIbX9KjheqRjkKDFjKZFbBaFlFpOtMLea6n9W%2FxdFRSTULOKk7gYeXOykPhJF%2FwrMddH7KuS%2FiZwdyvU7yt8tSr9P%2BBovRUcz8RWYqlV3UZSeyu9tZFSXz3tapz73QIv2LrEXTJmCfW1TL2Csk7abyPZddCzffhesNHaLwX0O%2FyirJTz9wfxtgFfLluS3JLkliS3JLklyS1JbklyDUnCv6skM0ZHRB9zLKdlWG3D8S7spm9ZvmWbnttuNa2f9KIYN0yqJfRH%2BINd%2FXfF14fX4sPD52zuWkfXuy3vKrknB5e%2FfjwL7%2FtXdjwcJIvJz5FrXc%2Fn%2B%2FjpDx1V01URFgAA)
- Subdomain (`titanslm.com`, host `eventos`): [Test titanshub.app/domain-full-setup titanslm.com/eventos](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAINOkGoC%2F%2B1X7W%2FiNhj%2FV6xInTYdSZOQAolUaVB6jLVUpfS0k7oKObEDFiH2xQ4vV3V%2F%2Bx6HtMDBet3Lh3biE9jP2%2B95dx4MRaciwYoawYMhMj5jhGZdYgSGYgqncpyHFhbCqDwTr%2FAUmI3bgvxLHgJJ0mzGIlqIET7FLDXjPElMSVUu1vRvJdHvuWs7HvqNhpIpin5A5yCbgMCMZpLx1AjcipHwEf%2BUJSA4VkrI4Ph4C9n6ZGpO03FtS6QjUEKojDImVKHIOONpSiMl0ZLnGVqhRIqvjmtI8xLLj4PBJWJS5pQgnCtgVyzCSbL8CeGUIPBMolwgqgHDKSUsHaGMRjwj0tIe4IzhMKHtLRB8nmJBF8fwO5%2FPgycYcASHx0wgcJzFYEjzA7oJTaWFmHCOmXADRMmIou61RDHPkBpTpKFaiEzYVASofdHtIZGHCYvQhC41CrlMo%2Bs8vKDLdmFpT1o1yw0lDLCrF5laCY8mRhDjRFK4GeOMkudj6bkR3D0Yo4znoqiFMZeKFblQS1Gk%2FvMtHPQ1HIZRbEa5hNia%2BibV1QFZwwoD8agM1ZEWVpD9mm3Dv4WCPMbgoephFY1BeY8TrbmZJMZj5V8ZtyAl2wDg4j%2B039RNxFmq5C3XBiCtR2tAP28Y%2BtuK3H%2Bm6Oyq2TtfS67839Cs6836thb266Zl5%2B6LdUZ1g1jDVbVDaa6jLE6Piup9DnP1O3G%2BzmjMFsZelpKmtRovout9XoPT0La9jiklIY4mppwqYeXSpFgq07HwFH%2FlqaTSivi0GIiMZ0wtjcCxN9C%2FaHlw%2FbG3Y1uK%2BCZPKHSPwdIoyQkNtm093j9WDDjT4brP7ivlqH1u12RaAiu10xlNFZdwUcAZskJuowpW2ECRwBmeSr0BnlTebeu8f1J696z1vlT7FyrL9tVU%2F8QJnch3zMipO6aHMTWxX%2FVMH%2Fu275FaHYiliK5AkCBOlTiEngAfAYk4rJl%2BeNIwYzeuV8OwEYV1T0tAB2l2p9GwHMez%2FLplr67dreva6rooNE3odTtxr2l3zgZfOoNuWG33z1vN%2Fqdm0%2BtcNdtnLda%2FaI367b6hw85GKc%2FoUMIvVnkGSVRZDhNvmieKDfEcr69INIQWSZaQJQlUMAXTcKsh0tUG3Dd81tkqW%2BNVYdscTkMS6RQyXXauXw%2Fteq1uYts5MT2gmw0vrpueHdNq1afE992Nnb534X9vq%2B%2BUGZVQ0IrhpJiHc7yUxqPuhteGALK%2FG4ZX1cJ7CkNzHYQdZ7cq%2BX%2FnVO2dOfW0HkvH9pbniyvynfXkzp7edVecvnp4bi30tx6H4kVQhqEIwo7nr30VbDi9%2FUB4V6WwPwazU3iqOGjvIwX9AV9HG7X%2FZj2%2Br8Db6bCYD4v5sJgPi%2FmwmA%2BL%2BbCY38hihm90iWeUDLHmdm23ZtoN063fOl7g%2BUHVtwCQXat9sO3ALiYWlWoVgQf4Ut%2F8RjdU9dePi4HDb%2BZnU%2F71S2eiWq2FnGcdSS%2BZWLDebe%2FDZbc%2F4315ajz%2BCV8UkOgHFwAA)

Both were run in the editor with real values from a live domain, both groups enabled, and **no errors reported**.

The apex run produced:

| Name | Type | TTL | Data |
|---|---|---|---|
| \_cf-custom-hostname.titanslm.com. | TXT | 600 | "951b1c91-…" |
| \_cf-custom-hostname.www.titanslm.com. | TXT | 600 | "d13d1de5-…" |
| titanslm.com. | A | 600 | 188.114.97.0 |
| titanslm.com. | A | 600 | 188.114.96.0 |
| www.titanslm.com. | CNAME | 600 | edge.titanshub.app |
| resend.\_domainkey.titanslm.com. | TXT | 3600 | "p=MIGf…" |
| send.titanslm.com. | MX | 3600 | 10 feedback-smtp.us-east-1.amazonses.com |
| send.titanslm.com. | TXT | 6000 | "v=spf1 include:amazonses.com ~all" |

The subdomain run produced the same set correctly rebased under `eventos.titanslm.com`. Note the `SPFM` record resolving into a proper merged SPF TXT in both runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
