### PR TITLE
Add omucloud.co.email.json

### DIFF
--- a/omucloud.co.email.json
+++ b/omucloud.co.email.json
@@ -1,0 +1,56 @@
+{
+  "providerId": "omucloud.co",
+  "providerName": "Omucloud",
+  "serviceId": "email",
+  "serviceName": "Omucloud Email",
+  "version": 1,
+  "logoUrl": "https://www.alano.ai/domain-connect-logo.png",
+  "description": "Publishes the DKIM, SPF and MX records that let a domain send and receive mail through Omucloud.",
+  "variableDescription": "dkim = this domain's DKIM public key, without the leading p= tag. region = the sending region, e.g. us-east-1.",
+  "syncPubKeyDomain": "dcsig.omucloud.co",
+  "syncRedirectDomain": "omucloud.co",
+  "syncBlock": false,
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "receiving",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound-smtp.%region%.amazonaws.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Omucloud, a hosted email service. It publishes the four records a
customer's domain needs to send and receive mail through us — a DKIM key, a custom
MAIL FROM subdomain (MX + SPF), and the inbound MX — plus an optional DMARC policy.

The records are split across four `groupId`s (`dkim`, `mailfrom`, `receiving`, `dmarc`)
rather than applied as one set. That is deliberate and is the main thing worth reviewing:
our service probes the zone over DNS before building the apply URL, and names only the
groups whose records do not yet exist. A domain that already receives mail never gets the
`receiving` group, and a domain with an existing DMARC policy never gets the `dmarc`
group — so the template cannot displace a working mail server or downgrade somebody's
`p=quarantine` to our `p=none`, regardless of how a given DNS provider resolves conflicts.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `dcsig.omucloud.co`, published and resolving
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the `SPFM` record type is used
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove

Three points a reviewer may reasonably query, raised here rather than left to be asked:

1. **`SPFM` is on `send`, not the apex.** Rule 4 says to use `SPFM` on the apex, and the
   intent — never a raw `v=spf1` TXT — is met. The host differs because this is an Amazon
   SES *custom MAIL FROM* subdomain: the SPF record has to sit on the same name the
   bounce MX does, and putting it on the apex would neither authenticate our mail nor
   belong to us. `auridigital.com.email.json` uses `SPFM` on a non-apex host for the same
   reason.

2. **`logoUrl` is on `alano.ai` while `providerId` is `omucloud.co`.** Alano Tech Pte.
   Ltd. operates Omucloud; both domains are ours. The logo is served from the host with
   the more reliable static hosting, and returns a real 404 for a missing file rather
   than a 200 with an application shell, so a broken logo cannot pass a status check
   unnoticed.

3. **Both TXT records carry a conflict mode, for the same reason.** A DKIM selector and a
   DMARC label must each hold exactly one record — two at either name is not a weaker
   configuration but a broken one (RFC 6376, RFC 7489). `All` on the DKIM record because
   every TXT at a `_domainkey` label is a DKIM record; `Prefix` on `_dmarc` because the
   label may legitimately hold other TXT content. Neither can fire in our own flow, since
   the group is withheld when the label is occupied — they are set so the template is
   safe standing on its own, not only safe because the service driving it is careful.

## Online Editor test results

**Editor test link(s):**

Apex, the three groups a domain with an existing DMARC policy would receive:
[Test omucloud.co/email alanotes.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADAbkGoC%2F%2B1W227iSBD9FctStA%2FLxQTCbRRpDA4MAySBhAlJFKG2u20a7G6Pu80tyn77VhsIkCG7M2%2Bzq7zZruqqOnWqT%2FlZlyQIfSSJXn3Ww4jPKCZRC%2BtVnQex4%2FMYZxyup15NlygAV%2F1qYwSLINGMOiQ5QwJE%2Fd23N87axcY8I5GgnOnVXEr3uccHkQ9uYylDUc1m5%2FN5BvmI8QyiWczhDEs7nDHiyLTyzoTMgyCYCCeioUwC6dex7VMxJkKTY6JZ7VY3pd1cNzTEsNYdahFxeISVEUnNJ1JD2jqyJgh4KC9wIXRGNFUj%2BEU89sbatvSMqhpFFNk%2BsQ4S4ykNtHM4QMUm5B8iya%2BFqiRHm5JlSptTOeaxTIrzCcKUeVoIp5CXgcQehEpikKQcZVx%2FTGkkAx6xSBMkZDqnyhBL5gDaNllaSTpVgyOolzkkTLn1CaYAS746%2FuhS87kz1asu8gVJ6Zs26dXHZ92DDoQJqwoiuMtlqNi8Hd7Cy5gLCS8RUQVnRmvkAFURgyQCU3h%2Bog6eqJMS%2BM0XDQMeF7LOmQuNkV0knTFg7XKs4pq%2Br7%2Bk9vMqJtyI7%2BXuDnepVWI1mJwyKW45fHEJwTZypmkRyDBzsm7hSQYFaMWZIAJQB8koUx5RuYTxM%2FZq%2B7fcME3dH7KL0O3HPoGO6ZQ5foxJ9W26dxKsx40mo3wE3edDaJTZPGb4KDI0%2FyVkOECR8w6do61xw%2BHs3Oqa%2FXruEwwr44x8%2BlkyryPi0oV%2B1GVj20UHNyKgoZIipQNXzAxDf6m%2FPL2kdMBHRruxfILStsOcaIR87fMGAjwlWEc0ObAd3j0%2Bd52HaCGKUCCU%2BG3jPh4GftpGftTVcxL7J%2BImZnDrtppu1zSa9ZvvzZuWnbd6FzWzNzDNQvPStOo12mvXvJ7lr8I7MbCNvksq%2Fen9GS8%2B1IqhfVmojVf4Yh43O7PhuFC4dDtf7idXZ3aeRQ0bG%2BX2N2vu1RszVhSTWrvhdj0nd9ObrKzabGFPVj337rsMSxUzyOeuOyu3ReoT28bxXcFx78qX1pcr2zv72slis5Pn%2FUGlRO1CK3JNa9F3pzLbbBsN13HKOXvQ79wLOWiPG72WZfbMmsK4HkOF8lWgdMUZ9RiPyAg0iSEZRzAPMopBXYLYl3SE5mj3CTsjpMgGigVYIRYoz8FksvUO%2BUeh%2Bd82%2BeC2jbCj5pSqS5wrnzmVs0ol7eRJOV3IG266bBRLabdC8gXXRvlcGe9t7SML%2Fdja3l2h%2Ffto%2BnO0FPqLkpF9pdows1HCDRmHGrxbXO%2Bq4lvV%2Bo1QHgzgIczZOSh%2FTjuq%2BdpfyPf%2FE9R93gE6WDBvadttmN%2BXtqcULIcP8fgQjw%2Fx%2BBCPXxYP%2BJsRaEbwCCm3U%2BO0mDbK6dPSbS4HFVYLRuY0XzAKlT8No2oYCgsRco3%2BGf549v91dPHw1aSTs4flt1J22M8SPh8uKgZt0i7DeFnzOotOo%2BRa2WJTnOsvfwNQYeDWgg8AAA%3D%3D)

Apex, all four groups — the virgin-zone case:
[Test omucloud.co/email alanotes.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADwbkGoC%2F%2B1WbW%2FiRhD%2BK5alqB8KxuY1cIp0BkKO4yWBQJNcFKG1d2022F6fd20CEf3tnTUQIEfa5lN7bb7Znmdn5pmZfcbPqiB%2B6CFB1NqzGkYsoZhEbazWVObHtsdirNlMzbyY%2BsgHqHq5MYKFkyihNknPEB9Rb%2FftFVg535gTEnHKArVmZFSPuWwceQCbChHyWi43n8815KGAaYjmMIMzQdZmQUBskZVoLQxccIIJtyMaitSRehVbHuVTwhUxJUqz0%2B5llOurloICrPRulYjYLMLSiITiEaEgZe1Z4QQQEgUQQhOiyBwBF7HYnSrb1DWZNYoosjzSPAiMZ9RXzuAA5RuXv%2FA0vhLKlGxlRhYZZU7FlMUiTc4jCNPAVUI4hVwNArvgKvVB0nSkcf0xoxANEDHPEsRF1pBp8EVgA9sOWTTTcDIHm1NXO2yYhA0JpkBLvAB%2FhNQ9Zs%2FUmoM8TjLqpkxq7f5ZdaECYdpVSRHgYhHKbo5uR%2FAyZVzAS0RkwtpkzRyoysYggcAUnp3IgyfypID%2BFsq6Do9PosECBwojekjYU%2BDaY1j6NT1PXWX248pOOBHbi9273YWWgeVgMhoIPmLwxSEEW8ieZbkvQu1kXcITDfloyQJOOLD201GmLKJiAeOn7%2BX2V7Fhmno%2FROehM4w9AhVTaWB7MSa11%2BHeCLAeN5qO8hF2nw%2Bp0cBicYCPMkPzdzHDPorsN9o52Ro3PUzOmj1z2DA%2BwbAGLCCf%2Fm4zryLi0Cf1KGRj23kHGOFQUEGR1IHLwAxDb6GuHlYZFfiRyW4sHyC17TCnGiFe6ryhAE8p1wlND2yHd6%2Bf%2B5Vf8wWvIYqQz6UIbv3fHwZ42Ea4V%2BVzGuMd%2FlMYwHvtC6dn6heN6%2B8X122r0Byc183B2DSLF32z2ajTQafuDpreMrzhY0sfOqQ6nN2VWPlbvRxa%2FWJ9usTn8%2Fiim9xOi8W%2B0%2F1y93hZsgpB1LKwftr5rTl3G60kKPPHeqfl9FzbuB48Lpv15Ml6XA6cm%2B8irFRNv2BcdZdOmzQeLQvHN0XbuTntN79cWm7pazeHzW6BDcfVCrWK7cgxm09DZyZyFx295dj2qWGNh907LsadaWvQbpoDsy45rsdSsnwRLFX2kLoBi8gENCpAIo5gPkQUg9r4sSfoBM3R7hO2J0g2H1rOwQq%2BQIkOJjVY75Q%2FFZ7%2FbJEPbt8E23JeqbzURt5xyqTkZAt6vpQt5o1K1qoWcJY4xXK%2BYlWrJaOyt8WPLPhja3x3pfbvp%2BnN0YKrKykr%2B8q16cxGGTfNONTk3SJ7UyVfq9i%2FiOXBAB7STM5gExjK0R2g%2FI4876do3ecdoYOF87ptu43z07XtnRvun6LxsgNXDxlYeh8i%2BCGCHyL4IYL%2FWxGEv0uOEoInSOLyer6c1U%2Bz%2BcrIMKDStVJeM%2FRyuar%2Fqus1XZfpEy7W7J7hD3T%2F31P1knw%2F359VZyO3%2BC25aySDqm%2B5108tSgZshF0c5q4a41IdlWdn6uoPujPZVyIRAAA%3D)

Subdomain (`host=mail`), the same three groups:
[Test omucloud.co/email alanotes.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEgbkGoC%2F%2B1WUW%2FiRhD%2BK5alqA8FxwZDgFOkGnxwHDgJTmiSRhFa22uzwfY63jUEovS3d9ZAwAlRrw%2BVrlUkHvDO7Mx8842%2F8bPMcZSEiGO59SwnKZ0TD6d9T27JNMrckGae4lK59Go6QxG4yucbI1gYTufExfkdHCES7s7eOEtfN%2BY5ThmhsdzSSnJIAzpOQ3Cbcp6w1vHxYrFQUIhiqiBy7FG4E5ddGsfY5WXhrSRxAEE8zNyUJDwPJF9kTkjYFDOJT7FkDvpWSbq86Eoo9iTrRkqxS1NPGBGXQswlJK0jSwyDh%2FACF0zmWBI1gl9Ks2AqbUtXRNUoJcgJsVlI7M1IJJ3CBcI2IX9heX4pESW50gwvS9KC8CnNeF5ciJFH4kBK4BYKFEgcQKg8Bs7LEcb1YUnCCnhkrIwR42VNlMGWsQtoB3hp5ulEDS4jgVIkTLjZ2CMAi786vndph9SdyS0fhQyX5E2b5NbdsxxAB5KcVQER3PkyEWxe3VzBw5QyDg8pFgUrkzVygCqIQRyBKTk9EhePxE0O%2FFbrqgp%2Fn3iHxj40hluIu1PAalFPxDXCUH4p7ecVTPgp3ctt3exSi8RiMCmJObuicOJj7DnInZVZxBPlaN3CIwVFaEVjhhmgjvJRJjQlfAnjp%2B7V9ne5YZqsd9lZ4ttZiKFjMondMPNw6226DxKsx43ko3wA3W9FaCR2aBZ7B5GhxT9C5kUodT%2Bgc7I1bjicn5qWYXe0LzCsMY3xlx8l8yLFPnmSD7psbLvo4IYZNJQTJHTgPDaSJFzKL%2FcvJRnw4cluLO%2BhtO0w5xrBX%2Fu8gbCRmBzvhOSXtgO8x%2Bmu%2BxAxQSmKmBDAbey7YvD7bfS7dfj7TfwfiJ2bwc3q93zLUHudy8feZd%2BpmqOvbWM0Ngy9d2aYnTYZDdrByAxXyTUbO6rt46Y9u63R%2Bh%2FteuKc6e3pyvu6yHrD%2Bc1U18%2F84bfbh%2FOaU43TruOpjcHv5iLodOdxnT20B13fClztcvSwMtvzJ%2BdhNfKvH3ly0jSiqnYxXPl93HlwHC%2B71l3%2FunFmfjt3gtr34bFnDKvUHjdPiKP3U98wn2x%2Fxo97A7Xru25Dc8b28Jbx8WDaHfVNY2S0Bcb1OAqUr0IlC%2B5IENMUT0CbYsSzFOaCpxmoTJSFnEzQAu2OPHeCBOlANQMrxAIFKkxovN4l7wRH2RD%2Bqjr%2F204XXr2J54qBJeKN9rUTTa%2FWvHLNdeplvaqpZQfVa2W9UW3WKmqz3lQreyv8wHY%2FtMOL79P%2BC2qEC7Rk8ovQlX3p2lCUE1RkpajMu3X2oVa%2B1bKfDG5hJA%2FgnZ%2FCYtCkgytB%2BhOF4X%2BGzCKuwhp6S%2BNuD%2F3cNN6XYI18ysunvHzKy6e8%2FAvyAl9EDM2xN0HCtaJW6mW1Ua6cXGlaC36qrtRrjZNq5VdVbamqwIMZX3fgGb6a9r%2BXZIdc3gSWnaLrRNeHYTWy9Xrwvd1rNmzmz4OBNbxIbx8pOh%2FdnsovfwF3T%2F2%2Fzg8AAA%3D%3D)
