### PR TITLE
Add guzli.com ses-sender-domain template

### DIFF
--- a/guzli.com.ses-sender-domain.json
+++ b/guzli.com.ses-sender-domain.json
@@ -1,0 +1,46 @@
+{
+  "providerId": "guzli.com",
+  "providerName": "Guzli",
+  "serviceId": "ses-sender-domain",
+  "serviceName": "Guzli Email Sender Domain (SES)",
+  "version": 1,
+  "logoUrl": "https://guzli.com/favicon.svg",
+  "description": "Authorizes Guzli to send email on behalf of your domain via Amazon SES, with DKIM signing and a custom MAIL FROM domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.guzli.com",
+  "syncRedirectDomain": "app.guzli.com",
+  "variableDescription": "%selector1%, %selector2%, %selector3%: the three Easy-DKIM selectors issued by Amazon SES for this domain",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%selector1%._domainkey",
+      "pointsTo": "%selector1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%selector2%._domainkey",
+      "pointsTo": "%selector2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "%selector3%._domainkey",
+      "pointsTo": "%selector3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "bounce",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "bounce",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Domain Connect template for Guzli (guzli.com), service id `ses-sender-domain`.

Guzli is a SaaS platform whose tenants bring their own email sending domains, verified through Amazon SES. The template applies the standard SES record set: three Easy-DKIM selector CNAMEs and a custom MAIL FROM subdomain `bounce` (MX + SPFM). Synchronous flow with signed apply URLs; the public key is published at `syncPubKeyDomain` `domainconnect.guzli.com` (key id `dck1`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (https://guzli.com/favicon.svg returns 200, image/svg+xml)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `domainconnect.guzli.com`; public key TXT is live at `dck1.domainconnect.guzli.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — not set
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — `app.guzli.com`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the SPF record uses the `SPFM` type
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — not applicable: the template contains no TXT records (SPF is expressed via SPFM)
- [x] no variable is used as a bare full record value — DKIM `pointsTo` values combine the selector variable with the fixed `.dkim.amazonses.com` zone
- [x] no bare variable is used as the full `host` label — DKIM hosts are `%selectorN%._domainkey`, anchored by the fixed `._domainkey` suffix; the selector values are issued by Amazon SES for the specific domain, and a signed apply URL binds them to the request
- [x] no variable is used in the `host` field to create a subdomain — the only fixed subdomain label is the literal `bounce` MAIL FROM host
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not applicable: all five records are required for SES sending (DKIM verification and the custom MAIL FROM); the template adds no optional records such as DMARC

## Online Editor test results

**Editor test link(s):**

[Test guzli.com/ses-sender-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL2fkGoC%2F%2B1W227jNhD9FYJAgBa1HF28yVrAPjiNkw12nWRjF0gRBAYljW0ilKiSlFIlSL99h5Yv0sbbTYE%2BpEUeDJg8ZzhzOMMDPVIDaS6YARo%2B0lzJkiegzhIa0nnxIHg3lintbIBzliKRnloItzWoksewpGvQjoYMSU4iU8azLd6MIkPEBBkvmeR4ySQ%2FjYfjn5FfgtJcZjT0OlTIufxNCYxbGJPrcH9%2FU9D%2BjOGxMuvqco5RCehY8dwsI%2BmgMAup%2BANoUic0kti6CCwTy4xEsGBiRuSMVLJQpK6WlJyRQcoekIDVdMg9Nwty%2FOlsRDSfZzybE4aHMBIX2siUjAZnn8nJ1cVoFd%2B1cqssPhIyvqPhjAkN9c5lEX2CqlaK9dV0rD6D2HSbl2zJV5BwhcCGzvK8RSqZ4iwScNwSvadBYJRU3l6HbBZ%2BcxHshcQsAH8KgAyZrpxa3QrXhGtdQEKiqnEPZCYVhnBNNk3F8qRKNA1vHqmpctvZX88HoyFCC6lNu5rutI67g8qOkeSZ0RP5DSe542mXLXPiFK2EGoO9Dw5c96nzwzz%2BC%2FL4%2F0Ke4AV5gn%2BQZ3S9TRLJIouhfegMIIlYfOfo1OTdQjvAtHG8Z2fniuPImwofjrs70%2FjyZLQjl85nV4UAbCbFmRRFAuH367596lCEYLqdgNvOap7xAPiToZPAKmyVCf%2FNlSzyKV%2Fzc6ZYqq3brCNvWqG369gbav9vxsRuMMa26wboWzCKou26AQYWjON4u7ZC8E1LBVP7tpkpFN6RUQW%2B2LQQhk%2FZPdtuJfEUX6GoULdGFI97PvlZbXHNAtujkjDDviX8%2FZx06DSJ7T1xa6%2B%2B13vHksRzIq8%2Fc3qB%2B95h%2FfeHThAn3qEHbgT9XsOonzn4j6x62y%2FQiBnOrPUOxD2rNH3a8TZWipu3vlNxi%2FB%2FUNwcpZ2KW4T%2FpOKlL60bvPaKlbqXelJDY9ueXqXiyfXk%2B5LLD%2BiTHtnpkOQvJsSrbeltBy33za3e3OrNrd7c6vW7lf1qYyUkU2ZpvusfOFiCfzjxXaw29IKu%2B%2B6g33N%2Fcd3Qda0O0KaW%2FYjfdM2vORr35x%2F3TyauJ8%2F9Ye%2FiCzf5%2BeXvpx%2BPJvOjPwJfX5eHwakaX3Ax%2BkCfvgI68hLXCA8AAA%3D%3D)

[Test guzli.com/ses-sender-domain example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADigkGoC%2F%2B1WXW%2FbNhT9KwSBAC0q2ZLs2rGAPniLuxmNsyLO1g6BYVDSlU1EEjWSUqYE2W%2FvpaXYcj6WFOhDW%2BRBD%2BQ99%2BPw3nuga6ohzROmgfrXNJei5BHIaUR9uiquEt4JRUqtreGEpQikvxkTXiuQJQ9hA1egbAUZguxIpIxnO3vbi0zQlpD5BkmONkjyaj6Zv0Z8CVJxkVHftWgiVuJPmaDfWutc%2Bd3utqBuzDCsyDqqXKFXBCqUPNcbTzou9FpIfgWK1Am1IKYuApvEIiMBrFkSExGTShSS1NWSkjMyTtkVArAai1xyvSZHH6Yzovgq49mKMAzCSFgoLVIyG0%2BPyfvTP2aNf8fQrbLwl0SEF9SPWaKgvvlYBB%2BgqplifTUcq88g1J32IxvwKURcomELZ3m%2BByqZ5CxI4GiP9IGCBL2EdA8ssj147UPvwCd6DfhJADJhqrJrdo1dEa5UAREJqtY7kFhIdOGKbJuK5QkZKeqfX1Nd5aazv56MZxM0rYXS%2B9V0lrXfBVRmjATPtDoTdzDRBU87bJMTp6ghqjX2vjdwnBvryTzeM%2FJ43yBP7xl5el%2BRZ%2FZ5lyQQRRbCftAYIApYeGGrVOedQtnAlLbde7FzyXHkdYWL4zycaf7x%2FeyBXCqPT4sEsJkUZzIpIvAfr3txY1E0wXI3AQurmWcMAP8yVBJo3JpMZufwtJKiyJf81idnkqXKKM6t9%2Fme%2B%2BLW%2F7wOsDBS0oyLuWSM7c4to2eMQRDszi1jzxjDMNydDSHcbSFhaXac6ULiW2lZ4OamRaL5kl2y3VUULnEbkwr5K7RiuPsbkNVS1y6wNTKd5jkiptld1P8PjUWXUWgejButjUeHXj8c9GzWd5ndD3sje3ToxnYweDvy%2Bq4TBzBqqfY9OX9Kt%2FebBwrtmjOjxePkklWK3jywLA319vM%2FTn0P9bNQbw%2FX49T3UD8s9Y103bZ8Iyd3aD5Xu1pk92Xsu6V%2B9vnsCe7lOxRWlzwoqeQ%2FliTfdZMXFmr0i7S9SNuLtL1I208mbeZ%2FkJUQLZmBeo43sJ1D2xueeY7fO%2FTdQeftaOiOhm8cx3ccwwWUrqlf499i%2Bz%2BRlsmnI3E8mjl%2FX3rV7931m9XJ1V8nw0h3j8v5fDKc9v85TqefVtJ13tGbL65Y21JqDwAA)
