### PR TITLE
Add myserv.ge and myemail.ge mail templates

### DIFF
--- a/myemail.ge.mail.json
+++ b/myemail.ge.mail.json
@@ -1,0 +1,58 @@
+{
+  "providerId": "myemail.ge",
+  "providerName": "myemail.ge",
+  "serviceId": "mail",
+  "serviceName": "myemail.ge mailboxes",
+  "version": 1,
+  "logoUrl": "https://myemail.ge/myemail-logo.svg",
+  "description": "Point this domain's email at myemail.ge and turn on DKIM signing and DMARC.",
+  "variableDescription": "token: the ownership value from the customer’s panel. mailhost: the mail server their plan was provisioned on. dkimselector and dkimvalue: the DKIM key generated for this domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "myemail.ge",
+  "syncRedirectDomain": "my.myemail.ge",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "@",
+      "data": "myserv-verification=%token%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "myserv-verification=",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "delivery",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mailhost%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "delivery",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "mx"
+    },
+    {
+      "groupId": "signing",
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "%dkimvalue%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    },
+    {
+      "groupId": "policy",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=reject; rua=mailto:postmaster@%domain%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/myserv.ge.mail.json
+++ b/myserv.ge.mail.json
@@ -1,0 +1,58 @@
+{
+  "providerId": "myserv.ge",
+  "providerName": "myserv.ge",
+  "serviceId": "mail",
+  "serviceName": "Email hosting",
+  "version": 1,
+  "logoUrl": "https://myserv.ge/icon.svg",
+  "description": "Point this domain's email at myserv.ge and turn on DKIM signing and DMARC.",
+  "variableDescription": "token: the ownership value from the customer’s panel. mailhost: the mail server their plan was provisioned on. dkimselector and dkimvalue: the DKIM key generated for this domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "myserv.ge",
+  "syncRedirectDomain": "my.myserv.ge,my.myemail.ge",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "@",
+      "data": "myserv-verification=%token%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "myserv-verification=",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "delivery",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mailhost%",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "delivery",
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "mx"
+    },
+    {
+      "groupId": "signing",
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "%dkimvalue%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    },
+    {
+      "groupId": "policy",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=reject; rua=mailto:postmaster@%domain%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two templates for **myserv.ge**, a Georgian hosting provider, and **myemail.ge**, its mail-only brand. They publish the same five mail records — an ownership TXT, MX, SPF, a per-domain DKIM key and DMARC.

They are two templates rather than one because the brands are sold separately, and a customer approving a DNS change should see the name they actually bought from in their provider's confirmation screen. Each signs with its own key.

Records are grouped by consequence rather than by type: `delivery` holds the MX and the SPF together, so a customer who already receives mail elsewhere can approve the ownership, DKIM and DMARC records and refuse the pair that would move their mail.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content — the `SPFM` record type is used instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [ ] no variable is used as a bare full record value — **`%dkimvalue%` is bare; justified below**
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove

**Justification for `%dkimvalue%`.** A DKIM record's content is defined end to end by the DKIM standard (`v=DKIM1; k=rsa; p=…`), so there is no prefix to place in front of it, and hardcoding one would pin the template to RSA and break the day the mail server issues an ed25519 key. The host is constrained (`%dkimselector%._domainkey`), so the variable cannot be used to write an arbitrary TXT record elsewhere in the zone.

`essential: OnApply` is set on DMARC and on the ownership record. A customer may reasonably remove either — DMARC is a policy of theirs to choose, and the ownership record has done its job once the domain is verified — and neither removal breaks mail delivery. The MX, SPF and DKIM records are left essential, because removing those is not a preference.

Both signing keys are published and match their private halves:

    dig +short TXT _dcpubkeyv1.myserv.ge
    dig +short TXT _dcpubkeyv1.myemail.ge

## Online Editor test results

**Editor test link(s):**

[Test myserv.ge/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJSckGoC%2F%2B1Xa2%2BqSBj%2BK4TE7AdvgFc8MTl4qcXWa7W1nm3MCANOBQZnQMXm7G%2FfGaxVe9rt7maTczbpN5j3%2Fr7P%2BzA8iQF0fQcEUKw8iT7Ba2RCoptiRXQjCsk6Y0Mx9SLoAhe%2BEvEnZMC9CUDO8ehZuclPhQWmAfJsJl1DQhH2xIqcEh1s4zFxmNYiCHxayWZfXGeRgb0MXXMTE1KDID%2BIzcQ%2BRl4gBAtEBRMz595vVIBxEBAIL%2FYC8EwhCIknYE9oXOkdgSLbYynEgkZHG9YzPBtAEJg7sHEWIsBL6FVYDCjgjccSXiBfWAMnhIJFsBsLjJAG2IXk91CRZJUKPvCgkxF4IrzYvXWcFs8IEv6OiMCa7QkbwPR5T3knoMlSzAjmErkUOtAIMIlz5AdxzL2ruIYljAQbsozYxEzBwuS0D7weGnlGzcHGUqxYwKFwf9IP51cwasRar%2BfHxENoIsICnyhkXnRS8Uvc4L0Fr24IVyEzMV%2BiMHNMTCpWvj2JNsGhHwOClY0sZIC4rSkxiHyOiNFk9OyGvXzl8wUBeEkrfWpUTcSjSHDjbVDHnuUgI%2BiAwFiwUXawyf31CbTQ9m2VZ9nbzrlJwNCXK0pSSoSUQi9AgMOx52m%2B70Ti99RpOSZ0EHMQHUvpTM4r8Tk26Qiz18QBCYl4gRAmKIgY6qWToB%2B5v%2BlfdM4DUN8ahg6kvKLtq%2FSeAf5OoxOnAEtkZnvMMEAdB5B4gdxfN1xzHPHdKnzMLKJ3kpiZLiDGMeK6Gm%2Bi%2FEXwqwQ%2Bsty%2BCCQEVd67AFd8ZuUCGkDyNbHP9z9AwiHm35j%2Bw%2FeUuGMbOjvC%2B4HlflgTuAWMPGHGwO6xRPYUN2OGYv3XO3Ay5OO8nnvGfPuAAJdyMj5E%2BXYW5uEQ55vIn%2BNI%2FzxKvFTcDJSLZq5Yzs8LclGVZFgCFlQVSVGtuVUuGwWufMAx16fyKRfwXpyAKs5DThMK0sxFUSorpYNKDKpYXuU8xua9rDI9PvaOrtf0R61bs5erxRK11I1U0wbNC03r1bVBWePyun3FnptaZNN53fauBxOMKBkVLjTFm%2FdxVm4%2B%2BoarF%2BSBnJzWRyHMhuqw1qxvJzd23tsZtavLkhzJjYl5AfKerFzndn1jVF4Hlgq7rr7rTR%2BXkdIbrhrbtn1F%2BuPm8mK8aNcnt8NiS2%2FJ%2BVy%2BFRk1Pa8M59twpE7vcLYeksht32hr3C2WI2PTKYDL9k0tm2w1vHvlUXObXcmqa%2Ferx8u7SJ%2F018VyvbDaEDO67VzoW3QrTxvla6k1tOq91c6dSp3FdVK5Ham3hf54LLV3yq6xyF7pBW1Nk1FJ7Q0GxB2DvFq0S0Vdm9r%2BYnXfs67xnTYCnVYtDOVOye9nR1atmSOaTe%2F6q%2By8kWw7Jb2m1m0Qdu9tOr2UesnW7WTQRa3CvXkpr7SN3tAGWu2LyNHOwIIJnHHQAPb1ZDMLSMj43Q2dAM3ABhyPTGMG%2BJqw5aBMyqbLuP9s6b39DeADiv8Qg2d7OjMNvh2IU02upJoA5NR0TgH5dB7ISrpsmuU0KBuGCnIFS5Ksk9vLD9eaN%2B4uxyV%2BkxA41Z1S%2F48Vnm%2FIWernH4GfUojmbEBEz%2Bp4b1TrKvvWyIK7Ff4AR75nhfyqub%2Binje%2FcJ%2F08%2BvSz89f848Q9u9vL%2Bc3hV%2BHzh5S7ELzSduftP1J25%2B0%2FUnb%2FxvaZr9VFKyhOQNcj%2B9OWiqnldJIkSqKUsnnM6ViTs2pSUmqSBLPHdJgX%2F4Tu%2BWf3u9FOgbz0bTWIK4%2FRDWVEOjIhUtoy0m%2FY%2Fl9qJJdsd2nVJ7kq%2BL3PwHYRxP%2BMhQAAA%3D%3D)

[Test myserv.ge/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKOckGoC%2F%2B1Xa2%2BqSBj%2BK4TE7Id6AbziiclBvJRar7Wt9WxjRhhwKjA4Ayptur99Z9BW7em5bLLJNpt%2BA977%2Bz7vM8OTGEIvcEEIxeqTGBC8RhYkhiVWRS%2BmkKyzDhTTr4Ie8OAbEX9CJtyZAOQePu2Vm%2FyrsMA0RL7DpGtIKMK%2BWJXToosdfE1cprUIw4BWc7lX1zlkYj9L19zEgtQkKAgTM3GAkR8K4QJRwcLMuf8HFWASBITCq70AfEsII%2BIL2BcaHaMrUOT4LIVE0OhqIz3LswEEgbkLGychQryEfpXFgALe%2BCzhBQqENXAjKNgEe4nAjGiIPUj%2BjBRJVqkQAB%2B6WYEnwovdWSdp8Ywg4e%2BICKzZvrABTJ%2F3lHcCWizFrGAtkUehC80QkyRH%2FiGJuXOV1LCEseBAlhGbmCXYmBz3gddDY9%2Bsu9hcilUbuBTuvgyieQfGjUTr7fyYeAQtRFjgI4Xsq046eUkavLPg1Y3gKmIm1msUZo6JRcXqtyfRITgKEkCwspGNTJC0NS2GccARMZ6M927Yy1c%2BXxCC17Qyx0a1VDKKFDfehjr2bReZYReE5oKNsost7m9AoI2276vsZe875yYhQ1%2B%2BJElpEVIK%2FRABDse%2BrwWBG4vP6eNyLOgi5iA%2BlNKdnFYScGzSMWavqRckpJIFQpigMGaol46C%2Fsr91aDVPQ1AA3sUuZDyirZv0tsD%2FAeNTh0DLJWd7TDDAHUYQOoVcj9vuOa64g%2BrCDCziH%2BQxMzyADEPEde1ZBPlL0JQI%2FCB5fZFIBGo8d6FuBowKw%2FQEJKvqV2%2B%2FwISXmL%2BxvTvn9PiI9vQ2QHe9yz3lzWBW8DIE2ZN7B1K3JNg0pAZSmze7sHRoA8z2%2FeN%2BQ8AAR7lhPwS6dtJqPuXWN92we730f55pGS5uBmolKx8qVKYF%2BWSKsmwDGyoKpKi2nO7UjGLXPkFz1yfysecwHtyBK4kDzlDKMgwFyWpopRfVBJwJfIa5zM292WN6fHxdw2jbjxovbqzXC2WqK1upLo2bLY0ra9rw4rG5brTYc9NLXboXHf8y%2BEEI0rGxZam%2BPMBzsnNh8D0jKI8lM%2Bm%2BjiCuUgd1Zv6dnLlFPxHs945L8ux3JhYLVDwZeUy%2Fzgwx5V1aKuw5xmP%2FenDMlb6o1Vje%2BF0yOC6uWxdLy70yc2o1DbaciFfaMdm3Sgoo%2Fk2GqvTW5zTIxJ7F1faGvdKldjcdIvg%2FOKqnjtrN%2Fw75UHzmj3J1rW71cP5bWxMButSRS%2BuNsSKb7otY4tu5Gmjcim1R7beXz16U6m7uDxTbsbqTXFwfS1dPCqPjUWuYxS1NT2Ly2p%2FOCTeNSioJadcMrSpEyxWd337Et9qY9Bt16NI7paDQW5s15t5ojn0drDKzRtnF27ZqKu6A6LenUOn51L%2FrH0zGfZQu3hnncsrbWM0tKFW%2FyJy1DOwYAJnHDSAnaJsZiGJGM97kRuiGdiAwyfLnAG%2BLmxJKJOy6bIz4GT5%2Ff21YbcZP2H7X8LwZGVnlsmXBHHWKch5hatn5BI0MwW5PM%2BA4tzKFIplpagqdr6gmEcXme9uOO9cY073%2BV1%2B4Mx3fBK8W%2BjprpxUcHos%2FGf1aO4GxPSknJ8Mbl1jh5AseFvhL3A4CFg9H7mEN3x0dPxl31b3SUwflZg%2Bxvb%2FCmq7O873sPrNi87ppeJj0d19mt1%2FPtn9k90%2F2f2T3T%2FZ%2Ff%2FG7uwnjYI1tGaA6%2FJtykiVjFIeK1JVUapFNVtQy2WlcCZJVUni%2BUMa7lrwxP4Zjv8WxPHUiIeL%2FkpVW%2BVg1MR607lFU9QZtL3mMp7OidoxXWx47SuzJj7%2FDQlurRWIFAAA)

[Test myemail.ge/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAedkGoC%2F%2B1Xa2%2BqSBj%2BK4TE7AerAt7AE5PFa2nrtdbanm3MCANOBQZnQMXm7G%2FfGaxH7WW7u9lku0k%2FCfPe3%2Fd5H8YnMYRe4IIQipUnMSB4hSxIDEusiF4MPYDcrAPFs5%2BSLvDgSxmFZIVMuDNip4ejV9oC%2F53hDaRMaQUJRdgXK%2FKZ6GIH3xCXKc%2FDMKCVXO5gtH%2FMcKUsXTnM1oLUJCgIE3uxj5EfCuEcUcHCTNX%2FhQqJiQBC4Sg68C0hjIgvYF9oXBodgSLHR76TCBodfVjP8rwAQWDmwsZJjBAvoF9hQaCA1z5LfY4CYQXcCAo2wV4iMCMaYg%2BS3yJFkjUqBMCHbjYpeo5puLNO8uINgoS%2FIyKw%2FvvCGjB93mXeE2ixFLOCtUAehS40Q0ySHPlBEnPnKqlhAWPBgSwjNkRLsDE5bgSvh8a%2BWXOxuRArNnAp3J30o9kljBuJ1quJMvkQWoiwyEca2RMlXtEQLiOmZf30zCwwsahY%2Bf4kOgRHQYIKViqykQmSVp6JYRxwWIwmo2c37OVXPlQQgiQQ707m2KiaStqf4sabsI5920Vm2AGhOWfj62CL%2B%2BsTaKPN2yrPsredc5OQYS9fkqQzEVIK%2FRABDsaerweBG4s%2Fzo7LsaCLmIP4UEpnclpJwAFJR5i9pvbTTyVrhDBBYcwwLx0F%2Fcj9db%2FVOQ1AA3sYuWyNWEWbF%2Bk9g%2FqdRqeOQZXKTnc4YSA6DCD1E2Z%2F3nDddcV3qwgws4jfSWJqeYCYh4irarJ98jchqBL4yHL7JpAIVHnvQlwJmJUHaAjJr6ldvv8CEvYx%2F8L0H36ciVu2ldMDvB9Y7vvNgBvAOBRmTewdSmRPSTOmKNF%2FuQNHQz7M67lnzHcACPAo5%2BR9lO8nYR72cb6L%2FDmJ9PejJEvFzYBasvIltTAryiVNkmEZ2FBTJEWzZ7aqmkWuvMcx16fyMRfwXhyBKslDzhAKMsxFSVKV8l4lAVUir3LuYvNeVJkeH3vHMGrGo96tOYvlfIHa2lqq6YNmS9d7dX2g6lxedy7Zc1OPHTqrO%2F7VYIIRJaNiS1f8WR%2Fn5OZjYHpGUR7I6fv6KIK5SBvWmvXN5Nop%2BFuzdnlelmO5MbFaoODLylV%2B2zdH6iq0Ndj1jG3v%2FnERK73hsrG5cC5J%2F6a5aN3ML%2BqT8bDUNtpyIV9ox2bNKCjD2SYaafe3OFePSOxdXOsr3C2psbnuFMH5xXUtl243%2FDvlUfeaXcmu63fLx%2FPb2Jj0VyW1XlyuiRWPOy1jg8byfUO9ktpDu95bbr17qTO%2FSivjkTYu9m9upIutsm3Mc5dGUV%2FRdFzWeoMB8W5AQSs55ZKh3zvBfHnXs6%2FwrT4CnXYtiuROOejnRnatmSe6Q2%2F7y9yskb5wy0ZNqzsg6t459P5c6qXb48mgi9rFO%2BtcXupro6EP9No3kaOdgQUTOOWgAeyLyWYWkojxuxe5IZqCNTgcWeYU8DVhy0GZlE2Xcf%2FJ0vu7a8AHFP8hBk%2F2dGqZfDsQp5qSqlqKKWsZGyggU7BsLaMVVJgplkuanFflPHs5usO8vt28cYM5bPGbjMC57pj7X5d4uiInuZ9%2BBf6bSnR3DWJ6Ush7w1pV2ddGFryN8Ds4MD6r5NMm%2F4J93vzIfTHQ52WgT7DpH0Hsn99gTm8Ln4jSHs7YreaLu7%2B4%2B4u7v7j7i7v%2FX9zN%2FmBRsILWFHA9vj0ZSc0o5ZEiVZRCJa9lS1qxlJfSklSRJJ48pOGu%2Fid23z%2B%2B6Yud5QA0vZxqlNreGKWdll8My3S%2BlSZRYe2SuK1edlvjyMWwWRV%2F%2FAGZ7heyQxQAAA%3D%3D)

[Test myemail.ge/mail example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABadkGoC%2F%2B1Xa2%2BqSBj%2BK4TE7IdWBSqCnpgcvNSi9VrbWs82ZoQBpwKDM6DSpvvbdwbrUdueyyabbLPpJ4X3%2Fr7P%2B8zwJEbQDz0QQbH8JIYEr5ANiWmLZdFPoA%2BQl3OhePpd0gU%2BfC2jkKyQBbdG7O3%2B1Rttgf%2FO8AZSprSChCIciGX5VPSwi6%2BJx5TnURTScj6%2FN9r9zXKlHF25zNaG1CIojFJ7sY9REAnRHFHBxkw1%2BIMKqYkAIuEgOghsIYpJIOBAqLfNjkCRG6DATQX1jjGs5XhegCAw82D9KEaEFzAosyBQwOuApT5HobACXgwFh2A%2FFVgxjbAPyZ%2BxIsklKoQggF4uLXqOabS1TvPiDYKEPyMisP4Hwhowfd5l3hNosxRzgr1APoUetCJM0hz5izTm1lVawwImggtZRmyItuBgctgIXg9NAqvqYWshlh3gUbh9049nbZjUU603E2XyIbQRYZEPNHJHSryiIVzGTMv%2B7plZYGJTsfztSXQJjsMUFaxU5CALpK08FaMk5LAYjUcvbtjDVz5UEIE0EO9O9tCokknbn%2BHGm6iGA8dDVtQBkTVn4%2Btgm%2FvrE%2BigzfsqL7L3nXOTiGHvrChJpyKkFAYRAhyMvcAIQy8Rn08Py7Ghh5iDZF9KZ3xcScgBSUeYPWZ208%2Bka4QwQVHCMC8dBP2V%2B6v%2Beec4AA2dYeyxNWIVbV6l9wLqHzQ6cwiqTG66xQkD0X4Ame8w%2B3nDDc8Tf1hFiJlF8oMkprYPiLWPuKqk2yd%2FEcIKgQ8sty8CiUGF9y7C5ZBZ%2BYBGkHzNbPP9F5Cwi%2Fkb079%2FPhUf2VZO9%2FC%2BZ7nvNgNuAONQmLOwvy%2FxhQnThkxRavN6Dw4GvZ%2FZS9%2BY%2FxAQ4FPOy7tI345C3e9ifdsGu3%2BJ9s8jpcvFzYBetM%2BKemGmysWSJEMNOLCkSErJmTm6bqlceYdnrk%2FlQ07gPTkAV5qHnCUUZJmLoqQr2k4lBVcqr3AOY3NfVJgeH3%2FHNKvmg9GtuovlfIGapbVUNQaNc8Po1YyBbnB5zW2z%2Fw0jcems5gaXgzFGlIzUc0MJZn2clxsPoeWbqjyQTya1UQzzcWlYbdQ24yu3EDxa1faFJidyfWyfg0IgK5dnj31rpK8ipwS7vvnYmzwsEqU3XNY3LbdN%2BteNxfn1vFUb3wyLTbMpF84KzcSqmgVlONvEo9LkFudrMUn81pWxwt2inljrjgouWlfV%2FEmzHtwpD4bf6EpOzbhbPlzcJua4vyrqNXW5JnZy0zk3N%2BhGntT1S6k5dGq95aM%2FkTrzyxPlZlS6UfvX11LrUXmsz%2FNtUzVW9CTRSr3BgPjXoFAqulrRNCZuOF%2Fe9ZxLfGuMQKdZjWO5o4X9%2FMipNs6I4dLb%2FjI%2Fq5%2B0PM2slmouiLt3Lp1cSL2T5s140EVN9c6%2BkJfG2qwbA6P6ReSoZ2DBBE45aAA7OdnMIhIznvdjL0JTsAb7V7Y1BXxd2JJQJmXTZWfA0fIHL9eB7Wb8hO1%2FCcOjlZ3aFl8SxFlHLWm6Jmt69kwqSNmCYklZXZmVso6q6aoty8yhfXCdeXvReecyc7zQ7xIEp77Do%2BDdSo%2BX5aiE43PhvyvI8NYgoUf1%2FGR0qwo7hmTB3wh%2Fgf1RwAr60DW8oqSDEzD3urxPbvqo3PRBCOBXWNvec97i6jcvO8cXiw9Gefen7BL0SfGfFP9J8Z8U%2F0nx%2F0uKZ59rFKygPQVcl%2B9TVtKzijZSpLJSKKuFnKzJslY8kaSyJPECII22PXhiXw%2BH3w3i3aZefNDn3bHaIrDaCDbt1mom3a0uJ2is9atNLM8cl6pEaV9XxOe%2FAboYIcmZFAAA)

Both templates validate against `template.schema`.
