### PR TITLE
Add Sequenzy templates (mail, dmarc, click-tracking, landing-page)

### DIFF
--- a/sequenzy.com.click-tracking.json
+++ b/sequenzy.com.click-tracking.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "sequenzy.com",
+  "providerName": "Sequenzy",
+  "serviceId": "click-tracking",
+  "serviceName": "Click Tracking",
+  "version": 1,
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "sequenzy.com",
+  "syncRedirectDomain": "sequenzy.com,www.sequenzy.com",
+  "description": "Configure a custom domain for click and open tracking.",
+  "logoUrl": "https://www.sequenzy.com/logo.png",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%trackingCnameTarget%.sequenzydns.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/sequenzy.com.dmarc.json
+++ b/sequenzy.com.dmarc.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "sequenzy.com",
+  "providerName": "Sequenzy",
+  "serviceId": "dmarc",
+  "serviceName": "DMARC Policy",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "sequenzy.com",
+  "syncRedirectDomain": "sequenzy.com,www.sequenzy.com",
+  "description": "Publish a DMARC policy record so mailbox providers can authenticate your mail.",
+  "logoUrl": "https://www.sequenzy.com/logo.png",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/sequenzy.com.landing-page.json
+++ b/sequenzy.com.landing-page.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "sequenzy.com",
+  "providerName": "Sequenzy",
+  "serviceId": "landing-page",
+  "serviceName": "Landing Page",
+  "version": 1,
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "sequenzy.com",
+  "syncRedirectDomain": "sequenzy.com,www.sequenzy.com",
+  "description": "Configure a custom domain for Sequenzy landing pages.",
+  "logoUrl": "https://www.sequenzy.com/logo.png",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%landingPageCnameTarget%.sequenzydns.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/sequenzy.com.mail.json
+++ b/sequenzy.com.mail.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "sequenzy.com",
+  "providerName": "Sequenzy",
+  "serviceId": "mail",
+  "serviceName": "Mail",
+  "version": 1,
+  "syncBlock": false,
+  "syncPubKeyDomain": "sequenzy.com",
+  "syncRedirectDomain": "sequenzy.com,www.sequenzy.com",
+  "description": "Authenticate email sent from your domain with Sequenzy.",
+  "logoUrl": "https://www.sequenzy.com/logo.png",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "TXT",
+      "host": "sequenzy._domainkey",
+      "data": "p=%domainKey%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "groupId": "outbound",
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "%bounceLabel%.sequenzydns.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "outbound",
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:%spfLabel%.sequenzydns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds four new templates for Sequenzy (`providerId: sequenzy.com`), an email marketing platform. They cover one-click DNS setup for the three things a customer configures on their own domain:

| serviceId | Records written |
| --- | --- |
| `mail` | DKIM TXT at `sequenzy._domainkey`, plus bounce MX and SPFM at `send`, all scoped to the sending domain |
| `dmarc` | DMARC policy TXT at `_dmarc` on the organizational domain |
| `click-tracking` | CNAME for the customer's click/open tracking subdomain |
| `landing-page` | CNAME for the customer's landing-page subdomain |

All apply URLs are RS256-signed. The public key is published and resolving now at `_dck1.sequenzy.com` (`syncPubKeyDomain: sequenzy.com`).

Notes on a few deliberate choices:

- **No A/AAAA records anywhere.** Every record is TXT, MX, CNAME or SPFM.
- **CNAME targets are pinned to `.sequenzydns.com` in the template**, with only the leading label travelling as a variable (`%trackingCnameTarget%`, `%landingPageCnameTarget%`). A bug in our URL builder cannot point a customer's subdomain outside DNS we control. Same idea for `%bounceLabel%` and `%spfLabel%` in `mail`.
- **`click-tracking` and `landing-page` use `hostRequired: true`** with a single record at `@`, so the customer's subdomain travels as the `host` parameter rather than a host variable.
- **`mail` uses literal hosts** (`sequenzy._domainkey`, `send`) relative to the applied scope, so subdomain senders work through `host=` without variable hosts.
- **The DMARC policy value is pinned**, not a variable, so the template can only ever write `v=DMARC1; p=none;` at `_dmarc`. We offer it only after a pre-check finds no existing DMARC record, so we never overwrite a customer's stronger policy.
- **`txtConflictMatchingMode: "All"`** on the DKIM and DMARC TXT records: both must be unique per label, and re-applying after a DKIM key regeneration should replace rather than append.
- `dmarc` sets `essential: OnApply` since a customer may legitimately tighten or remove that policy record later.

A fifth template covering landing-page domains that additionally need an ownership-verification TXT will follow in a separate PR. It writes records at two different zone levels, so it cannot be `host=`-scoped and needs a bare host variable; keeping it out of this PR avoids blocking these four.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Test sequenzy.com/mail example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM%2BnkGoC%2F%2B1VW2%2FaMBT%2BK5Elngo0XEpLpD6kZUOsSwWFTu2qCjmxAa%2FGTm0HSBH77TvmmlK2aW%2Bd1Kc25%2F595ztmjgwdxxwbirw5ipWcMEJViyAPafqcUPGSFiM5Rvmt7xqPIRZ1117waKomLKLLpDFmfGdaxwYr44QqzaRAXgkCUhFdcBk9IW%2BAuaYrSzsJr2jakFBFvJ3ARtxQwhSNzMGY%2FHQ6Le4lEaojxWKzbIz8xIyoMCwCwA61wzoavp2BkmMnlYlyyLKwM2Vm5GwwFqEOl0N5qzjUGBkTa%2B%2F4eL%2FZsQ0pxmII0TCiVEQj72GOhkom8ZIc8sTsSCaNLSu9ux58jKQ2WRj91QBP1DJLsMHgjM9zKyuQk7MFDMxRqbku%2FDszl1IMOItMgE00YmIYSGLL%2B5yjRT7bXiYmlIkguxGCu%2BwES08smTC6J8GSs9ER%2FYpDynNbqETorSKYVMyksFA3M9Tfmnbbn4M3bXU8uEk4BcYQExFPCPVyYPtt7123x0UevUhB%2BzvOH4G5jT7oDIO%2B6Tpt3VTQqYav5ZR9tsmJscJjbe9gk%2F3wKv1xk%2F%2BwKrBtA2uxxqDVHAS%2B27zsPje7rbDS6Hy68Du3vl9tXvuNywvWuboYdgzVxm4XsjP82nwcRqVyxTo2yLNWgMmGQira1%2FAXm0QBmUYlcDrjhBvWx1O8M5Goj%2BOYp8CKBi8UAiW%2BEp5Y3eYB4RXX9GzV92%2FAXumzTyJLKLNSCOvlExxW3UKpUi0Xqjg8KdRrZFCoVM5OwxKtlusnOPPQHHqEDjw1r1dKtb1nhvnyAqY41WhhBZkV%2FBa5IHtQV1z%2FSW77qn9n%2BPZW%2Bwbg5BykVXI2J3YYr%2FMTc%2F4O1%2FiYhyv9kPGHjP9zGdsHHk8o6WMbWnbLtYJ7Viif9solWIZXqRdLZ9XSSfXIdT3XtQhAkivkc%2FgVyL7%2FqOG6E9X%2BcXRf472If3%2BZzWI9afu3E5x%2BGXwLbu9bEXbv236t1TlHi1%2B0yJRI7gkAAA%3D%3D)
- [Test sequenzy.com/mail example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANOnkGoC%2F%2B1UW2%2FaMBT%2BK5Elngo0JAy6SH0IvaCqoysFtGoVipzYgIWJU9uBpoj99h2HW9qyVXvrpD4Rzv37zuezRJrOEo41Rd4SJVLMGaHyiiAPKfqY0vg5q0Zihso73w2eQSzqbbzgUVTOWUTzpBlmfG%2FaxHbWxjmViokYeTUIyOKoxUU0Rd4Ic0XXlts0vKbZuYAq8dsJTMQdJUzSSB%2BMKS8Wi%2BqrJEJVJFmi88bIT%2FWExppFANiiZlhLwX9rJMXMykQqLZIXthZMT6wtxirU4WIsBpJDjYnWifKOj183OzYh1SQeQzSMKCRRyHtYorEUaZKTQ6bMjKSzxLDSv%2B%2FDn4lQuggjWA8wpYZZgjUGZ3JaWluBnJIpoGEOt2Hb8Pmkz0Q84izSHayjCYvHHUFMeZ9ztCoX24tUhyKNyX6Ezn1xgtyTCBZr1RdgKZnoiH7DIeWlHVQSq50imJBMZ7BQuzDUe017t5edN21VMrpLOQXGEIsjnhLqlcD2x977bsNVGT2LmAZ7zofA3FYf9AmDvukmbdMUvvIJA7aNT7DEM2XewDbz4UXqcJv7gNCuPKzDGDpX7VHHt9tnvcd27yp0z7sXLb878P16%2B8Y%2FP2ux7nVr3NVUabNVyC7wavJxGNUc1zi2iItWgMfGsZA0UPCLdSqBRC1TeDKzlGsW4AXem0gU4CThGbChwAuFQIEvBBev3%2BQ7gvs3TC8kGZDI8MjM9mukYeOmbVdO3HpUqY9IvYIdSituc%2BRgEtqR2yCF23Lo7hy4LvstUmWeL8M8F%2FwCZwqtjP6K%2Bt4BzoW2Qbhm92%2FCeq3vDwTr1SKLuOanoKGatX1Dh2FavzDnH2xpwzI8w0%2Btfmr1f9CqOdV4TkmATZhjO42KfVJxmn2nBvx7dbd68tV1m7Uj2%2FZs20wP4lujXsI9L15y5Pw8mn95HNQbT8SPb%2B4xdnrh9NKd3qr%2BncLfLy%2FC3o9BW3YWte4pWv0GC8lbq7AJAAA%3D)
- [Test sequenzy.com/dmarc example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANinkGoC%2F91TyZLaMBD9FZeuYTFm9xQHMlxSM8wWqCwU5RKSAFVkSSPJGA%2FFv6eFIcwQDjnnZKv79evXT60dcizVAjuG4h3SRm04ZeYLRTGy7DVj8q2oEZWiyp%2FcA04Bi74es5CxzGw4YYcimmJDzrEjeDQevtwGT0pw4gs2zFiuJIobACwk%2BSwU%2BYXiJRaWlZGnbHHHipFKMZd%2FS%2FGIF0a5YcRdxVTyPK9dFFFmieHaHRojaCC4XQc4KLXpg7YAGJWhgVUBsIqF2gansW1AsAxw5tZMOk7AsKBQmTngakAv1EpNjQDqtXPaxvX6pYa6h9S0XAG67GNRPNshV2jv0eT7BBJrZR0ckpOPFDsM583gILNxE%2BiBVJLdQMo56NbshCH8bt2tkksYwY2xI2suV2NFPetQCIAya71q7OU9yqHWokD7%2Bb6C3oArOYuZQ8OTn2yLYTHY0b2jLslyC6eVUZlO%2BKlGY4NT6xfoVD37UD4%2F1c9KAt%2BZr6QyLLHwxS4zoNWZDG4%2FzYTjCc7xOURJgr1kEGohCzSXrslyzUrXakeR%2F2ZdQokXzv3yNqJoScOQVtvNdrPawq1%2Btb9YdKodgOJ%2Bly7osvHuJVx7Jdfewkfvrt7Ffl4BI%2F%2FDseDqLd4wmmCPjcKoUw171ag7iRpxI4xbvVq72e%2B2o09hGIehn4FZV464gy15vx9ostTPm3b9vlDru6554j8yInqq%2Fjr61u8%2BmvtoWhcPU77g3Z%2F5AO1%2FA7azV7vaBAAA)
- [Test sequenzy.com/dmarc example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAN2nkGoC%2F91TTW8aMRD9KytfA8R8BjbKgZKqrSLaKCUSVYRWxh5Yt7u2a3sXNoj%2F3jEfJaVceu1p7Zk3M2%2Be326Ih9xkzAOJN8RYXUoB9pMgMXHwswD1WjW4zkntd%2B4zyxFLvh6ymHFgS8lhVyRyZvkpdgDfj4dPo%2BhRZ5KHghKsk1qRuInASvF3meY%2FSLxgmYN95LGYP0B1r3Mm1d9UAuIJhLTA%2FUVMbbVaNc6KBDhupfG7wQQHZNKlEYv23MyOW4QdtRWR0xF2zeZ6HR3XdhFnKmKFT0F5yVGwqNKF3eEa2D7TS%2F1sM2ydem9cfH19zuE6QBpGLRG9n%2BNI%2FLIhvjJBo8l0golUO4%2BX5KijYJ7hvbzb0WzeRuZOaQW3mPIep7V7lOJx7UdaLXAFP2aep1Itx1qErsMsQyg4F1izQO%2BLGhqTVWQ729bIK%2FZKTmRmOPCoJ6wZGgMO6h144WlpdWESecQbZlnugnmOlS9%2FlM6OtS%2BEhIlyqbSFxOGX%2BcIiR28LfPW8yLxM2IqdQoInLFBFgg6z2OJcLbW31z%2BqlQge%2BMqdXxn0YTBY1BdN2ql3OG%2FV2YDf1OfzZp%2FeQK8jWvSN%2BS%2F9GJfsf5LrovTbWQ21%2B3%2B2wUd2rASRsIBr0VavTvv11s2k1YybNO62G7RPu93OFaUxDQw8OL9fb4OeeOsGouZtX61GA5m2p3b8XNKPtpd21Xv1Pf9QXolpWqYTA6uHybfxHdn%2BAqoS0fjABAAA)
- [Test sequenzy.com/click-tracking example.com/track](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOGnkGoC%2F91TYW%2FaMBD9K5GlfhqhDtDAIk1ayyatqtaylm2VKhQZ%2B0gtEjuzHdKA%2BO%2B7BFK6FvUH7FPkvHvv7j2fN8RBlqfMAYk2JDd6JQWYS0EiYuFPAWpddbnOSOcZu2YZ1pK7PYqIBbOSHBoSTyVf%2Bs4wvpQqOYB71riGvekBXoGxUisSBVhaKX6Rar4k0YKlFjrkUVt3i42kARR3poBd1aSYX0H1RWdMqreT1hW3IJDE3dGaTlmW3VckAZYbmbtmGDLWaiGTwoDHPF5YpzNPNEreQhuvMekxJTydg%2FJat12USXWif5oUJR6dy210evq612ld0s0b9zihNsKS6GFDXJU3CV2ff%2F9Kdtbx%2BLlOXkvl7FTj8aTtNVYY6JSZBNzJs7xQdu%2FGORyhH1K6nW07ZK0VxIdeM3TbxgJPDK8f9rR906YJHhOjizyWLSlnhmW23pOW%2FvAPf9YKPOwV8MeReWuczXnQ65N6OJkobSC2%2BGUOE2%2FvOStSJ2NWssMvwWOW52mFXiyiKPQ2N7VbtNaCYI7hcdfvvaA6JBa89ibrNR4shv0wZNwXdMT9AQ2YPx%2FNwe8vBsFHSgfhnMOLN3Hsvbz7Kl4FDdaCcpLVe3OelqyyZLuddTD0%2F9og7odlKxAxq2t7tBf6dOT3htNeEAU0Oht2wwHtB6MPlEaU1mbAup3hDW7Oy50h5d2YptWPnusv5dV08nj%2FLfm95k9nUgzvpytzc%2FH0i6nJJVUh%2FUS2fwGFvrHM9wQAAA%3D%3D)
- [Test sequenzy.com/landing-page example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOankGoC%2F91TYW%2BbMBD9K8hSPzUkQJqEIU1am1Xdmq7r2mzqVEXIwQe1BjazTTIS5b%2FvHEiTtVV%2FwD6Bee%2Fd3Xuc18RAUebUAInWpFRywRmoz4xERMPvCsSq7iayIJ0n7JoWyCV3LYqIBrXgCWxFORWMi8wtaQZ7qNVcNaBz04ALUJpLQSIfibVIznKZ%2FCJRSnMNHfIotbnFJlwBFjaqgoZ1U80nUH%2BUBeXi5ZSWcQsMRYl5ldNZLpfdZyIGOlG8NNthyFiKlGeVAoc6SaWNLBy2reSkUjk7307r1LFOdRer5DKT31WOFR6NKXXU6z1v1bOUbikyZOOAUjFNooc1MXVp4xlfn345J41zPH6woUsujJ5KPB61DW14Y4GBTqnKwBw9dWBCt36MwSn6Q8%2FbzDYdspIC4n27GfrdBQN%2FKP58aGVt30zie6ZkVcZ8pyipooW2K7LTPvwjnu3UD1aOp9eHtTidJ37QJ3YyngmpINb4pAYD3%2F3mosoNj%2BmS7j%2BxJKZlmddoRCOKhV7mJpot287PqKH43jR7K6IOiVlijXG7vids7g%2B8wdAdpQPmnoySkUsHo9Qdhek8TNm7dNjvH9yF1%2B7JG7fhMGDQGoTh1O7Lab6ktSabzayDYf%2BXxnAlNF0Ai6klBl4wdL3QDUbTwI98P%2FKCrt%2F3wmF47HmR51kfoE3jdY2bcrgj5P4%2BFHxcLS6%2F1Rc%2FBnfHcjgJk8sJ9b6eX5zlwc95cccnq09T%2FzF7TzZ%2FARMeGbPiBAAA)


## Linter output

`dc-template-linter` (generic pass) — clean, exit 0 on all four:

```
$ dc-template-linter sequenzy.com.mail.json
(exit 0)
$ dc-template-linter sequenzy.com.dmarc.json
(exit 0)
$ dc-template-linter sequenzy.com.click-tracking.json
(exit 0)
$ dc-template-linter sequenzy.com.landing-page.json
(exit 0)
```

`dc-template-linter -cloudflare` — exit 0 on all four. The informational notes are Cloudflare capability gaps we are aware of and accept: it validates the signed `redirect_uri` instead of `syncRedirectDomain`, ignores `txtConflictMatchingMode` and `essential`, and does not act on `hostRequired`. DCTL5007 is raised because the record host is the literal `@`; at apply time these templates are always invoked with a `host` parameter, so the CNAME lands on the customer's subdomain rather than the zone apex.

```
$ dc-template-linter -cloudflare sequenzy.com.mail.json
{"level":"info","code":"DCTL5003","dctl_note":"syncRedirectDomain is not supported"}
{"level":"info","groupid":"dkim","record":1,"type":"TXT","key":"txtConflictMatchingMode","code":"DCTL5008","dctl_note":"conflict matching is not supported"}
(exit 0)
$ dc-template-linter -cloudflare sequenzy.com.dmarc.json
{"level":"info","code":"DCTL5003","dctl_note":"syncRedirectDomain is not supported"}
{"level":"info","record":1,"type":"TXT","key":"txtConflictMatchingMode","code":"DCTL5008","dctl_note":"conflict matching is not supported"}
{"level":"info","record":1,"type":"TXT","code":"DCTL5011","dctl_note":"essential is not supported"}
(exit 0)
$ dc-template-linter -cloudflare sequenzy.com.click-tracking.json
{"level":"info","code":"DCTL5003","dctl_note":"syncRedirectDomain is not supported"}
{"level":"info","code":"DCTL5006","dctl_note":"hostRequired is not supported"}
{"level":"info","record":1,"type":"CNAME","code":"DCTL5007","dctl_note":"domains must use Cloudflares CNAME flattening setting"}
(exit 0)
$ dc-template-linter -cloudflare sequenzy.com.landing-page.json
{"level":"info","code":"DCTL5003","dctl_note":"syncRedirectDomain is not supported"}
{"level":"info","code":"DCTL5006","dctl_note":"hostRequired is not supported"}
{"level":"info","record":1,"type":"CNAME","code":"DCTL5007","dctl_note":"domains must use Cloudflares CNAME flattening setting"}
(exit 0)
```

`dc-template-linter --merge-or-fail` — exit 0 on all four.

