### PR TITLE
add Readstall, Readstall storefront

### DIFF
--- a/readstall.com.storefront.json
+++ b/readstall.com.storefront.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "readstall.com",
+  "providerName": "Readstall",
+  "serviceId": "storefront",
+  "serviceName": "Readstall storefront",
+  "version": 1,
+  "description": "Serves your Readstall storefront on a subdomain of your own domain.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "readstall.com",
+  "syncRedirectDomain": "app.readstall.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/readstall.com.storefront.json
+++ b/readstall.com.storefront.json
@@ -13,7 +13,7 @@
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "%target%",
+      "pointsTo": "cname.readstall.app",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
# Description

New template for Readstall (readstall.com), an ebook storefront platform. Creators attach a subdomain of their own domain to their storefront; the template applies the single CNAME to Readstall's Cloudflare-for-SaaS target. Synchronous flow with signed apply URLs; the public key is already published at `_dck1.readstall.com`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A, no `logoUrl` in this template

Also validated locally with `dc-template-linter -loglevel error -tolerate info` (exit 0).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `readstall.com`; key live in TXT at `_dck1.readstall.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — `app.readstall.com`
- [x] no TXT record contains SPF content — no TXT records in this template
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A, no TXT records
- [x] no variable is used as a bare full record value — no variables at all; the CNAME target is hardcoded
- [x] no bare variable is used as the full `host` label — the only record host is `@`
- [x] no variable is used in the `host` field to create a subdomain — `hostRequired: true`, subdomain comes from the `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` where the user may need to modify records — N/A: the single CNAME *is* the service; removing it is removing the service

## Online Editor test results

**Editor test link(s):**

[Test readstall.com/storefront linkedclaw.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOu0kGoC%2F91SYW%2FaMBD9K5G%2FliAnFNpEmjQYldpNRRvrPkwIRca%2BMIvEzmyHNEX8913IUihj2vd9iu7u3fO7l7cjDvIiYw5IvCOF0VspwDwIEhMDTFjHsqzPdU56r8MZyxFM5t0YRxbMVnI4rFmnDaRGK3ccnK94b0BbMFZqReKgRwRYbmThDjX5iutgvVqXxru07GnlMc%2BWK6FzJpWn0xarK%2BW1rX4jolZ8kmm%2BIXHKMgtt53O5%2BgT19IC6cG0DmYOQBrh7BbGi6J8Df2jr5vCzRCSe70yJ%2FLikjbAkXuyIq4vm9g%2Bz8ePdbziW7xtDtVTOPmksuUKHTqjxIQQ4l5F4MKJ0v9z3yItWkByZl2hWpyuTagOCZ6w6EYX9qqqwWBtdFonstgpmWG6b393tL84Jlh3D4kDRvC7XCl1PLH6ZKw10p%2BZl5mTCKnZsCZ6g%2FqxGsRanyPKnDapNRCtQMMf%2BbUKPJII3smUTM7665gFPAx9WkPrXI5H6t2EIfkADOhhEURCFw5PQXkz0X2P7xj6wFpSTDGWQcVax2pL9ftlDK%2F%2FDs%2FDPW7YFkbAGGdJw5NNbP7x5CsOYjuLBsE%2BjQRDRK0pjSps7wLr20B2m5DQf5Nv47uM95zOhOdPPk%2Fvps7p5iIapkxFcbUorvz8%2Fbidfhnq6fkf2vwCwsrUjigQAAA%3D%3D)

`hostRequired` is `true`, so per the template instructions the apex test is not required; the test above applies the template to host `www`.