### PR TITLE
add Orbit, Suggestions

### DIFF
--- a/orbit.buape.com.suggestions.json
+++ b/orbit.buape.com.suggestions.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "orbit.buape.com",
+  "providerName": "Orbit",
+  "serviceId": "suggestions",
+  "serviceName": "Suggestions",
+  "version": 1,
+  "logoUrl": "https://orbit.buape.com/logo.svg",
+  "description": "Connect a custom hostname to an Orbit suggestions board.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "orbit.buape.com",
+  "syncRedirectDomain": "orbit.buape.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "orbit-cname.buape.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add the Orbit Domain Connect template for custom suggestions subdomains.

The template requires a host and points customer subdomains at `orbit-cname.buape.com`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- [Test orbit.buape.com/suggestions example.com/suggestions](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACICkWoC%2F%2BVSXW%2FaMBT9K5FfR8AJDNJIk9ZPaaroEANtEkLRTWxSr4md2g5dhvjvu4ZmwNpOe5%2FykMT33HPPPT4bYnlZFWA5iTek0motGNefGImJ0qmw3bSGinczVZLO7%2FIdlAgnnx0Ajw3Xa5HxXZOp85wbK5Q0h8oz%2FstJbc21wU8SBx1SqFzNdYGYe2srE%2Fd6fwzvOUTXrHNsZNxkWlR210wulZQ8sx54WW2sKr17ZazEgZ5VHkhvJ9I7kuWlCjTrOnWNzC4KlT2QeAWF4fuTSZ3e8uZKlSDkqy440JQzoXHsX2BOx5Q%2F1ohDY6yukR9blGaGxIsNsU3lTLm8Ox9fP8Px96OzWQlpzUy1tH7m9jkhtxbN6g8p3S63HfJTSZ4cuJfoUauL%2FwC83mNNLy4p16quEtG2VqChNC4NLcnihGXZ0ixOeJwOkUuleWLwDbbWvF27rAsrEniCwxHLEqiqokHZBqvI9tISuY%2FNqVoGFv7FmA5JWOa2EC6W%2FTCMover1A%2FSLPIH%2FVHgQzgAn4XR4Ayf0RnAUcDfyP%2FbQX%2FVWG4Ml1aAy%2FV58QSNIdvtsoMm%2Fy%2B7YlYMrDlLwHWENBz6NPLDaEb7KDymYXdER4Ng%2BI7SmFK3EjLut95gno6TRGgQrq6mPNSP42Isvzbpd3Wn7fxCf7u5vZkMazXLew8mDSbX8w9k%2BwshmYfT2AQAAA%3D%3D)

CC: @codeize
