### PR TITLE
add DriveReachAds, DriveReachAds Dealer Website

### DIFF
--- a/drivereachads.com.hosting.json
+++ b/drivereachads.com.hosting.json
@@ -1,0 +1,51 @@
+{
+  "providerId": "drivereachads.com",
+  "providerName": "DriveReachAds",
+  "serviceId": "hosting",
+  "serviceName": "DriveReachAds Dealer Website",
+  "version": 2,
+  "logoUrl": "https://drivereachads.com/favicon.ico",
+  "description": "Connect your domain to your DriveReachAds dealer website.",
+  "variableDescription": "cluster is a signed DriveReachAds edge label; ipv4_1 and ipv4_2 are signed fixed edge addresses.",
+  "syncBlock": false,
+  "hostRequired": false,
+  "syncPubKeyDomain": "drivereachads.com",
+  "syncRedirectDomain": "staging.drivereachads.com,drivereachads.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%cluster%.drivereachads.com",
+      "ttl": 1800,
+      "groupId": "apex"
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4_1%",
+      "ttl": 1800,
+      "groupId": "apex"
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4_2%",
+      "ttl": 1800,
+      "groupId": "apex-ha"
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4_1%",
+      "ttl": 1800,
+      "groupId": "subdomain"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%cluster%.drivereachads.com",
+      "ttl": 1800,
+      "groupId": "subdomain"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the signed DriveReachAds dealer-website hosting template for apex domains and explicitly requested subdomains. Apex connections create `www` as a CNAME and the bare apex as one or two fixed edge A records. Subdomain connections create the exact requested host as a fixed edge A record and its `www` alias as a CNAME.

The bare `%ipv4_1%` and `%ipv4_2%` values are necessary because an A record's complete value must be an IP address. They are restricted by synchronous request signing through `syncPubKeyDomain`. The subdomain A record also avoids the registry-invalid root CNAME/optional-host combination while preserving the exact requested canonical hostname.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

- [Staging apex (`example.com`)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEu6kWoC%2F%2B1UTU%2FbQBD9K9ZKnLAd23ET46oSAXqgFahCVEigyBp7J8kK2%2BvurhNClP%2FeXTufENoLlTj0Yq1n572defOxIAqLKgeFJF6QSvApoyguKYkJFWyKAiGbAJVuxgtibxyuodAAcmFcbozLgEp9LVFMWYYNfMKlYuV4az2EsS4QchTWHaaS6Rhsop%2BUjJckDmyS8zH%2FKXJDplQl407nVUydEWhuXrr6o9EUZSZYpRoGcs7LEjNlzXktLMoLYKWlePu7HwZtw5i1YbgmDhAM0hwv9hizvJZKOzJpgSXZuET6ggnpGK0cUsw%2FW6yaholvQUnbY2CBwDVsxJ70t3EHSgVKidI8LOdldpbz7JHEI8gl2o2SN%2FirZgLpxmjcftTpd5xfNIm9UTDjdoNUQzO1cZQKxro07iuAfYhCQ7nQ5Y0fFkTNK1PD8%2BvB1VfSRqZ%2FZ7OZ6Q3OSiVvuTYcrXQ6cg8RKqVL6keeZ5Ox4HXVtAtU%2BESW9uaJwZb%2B9AV5K%2BvRezEFf2RyJvA%2BYck6bVtwl%2B4fCLnzznBpk2deYrIt4VDPyLoN8An06OOKbBUCWXElrPFv1dSoCgQU0iyJNf5hj2C4Zngg5txw7OJXiRjTqv2cLGeoEzW3rXbmMgzdIIhc%2FyR0%2B8HmKmh5dT56eLjAxAwRqFpoEZWo9TwUda5YAjPYmmiWQFXlc52%2B1Lea4nUHl%2B1SaoWnoGA7Huv4%2FiZ9QjMjCzPiB71R5mfQc056XXDCLoIT9aKR04%2Bifj8aYdBL%2FZ01%2BuaePbxItyUy26JUDMxuHOQzmEuyfNGlq8xOt3ntS%2FsxcxjaukX%2Fl%2BnDl0kPpoQp0gSMW%2BAFPceLnCC69Xtx6Mdh3%2FW6of%2FJP%2Fa82PNMFihVm%2BBCT%2FHu%2FJLJ5eP91TNAOFURu%2FWO%2B1iMOpfjs8Hdt4ynePXt%2Bfy%2BW8zS2udfyPI3dMpYHbIIAAA%3D)
- [Staging subdomain (`inventory.example.com`)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADS6kWoC%2F%2B1U227TQBD9FWulPtVxbNfkYoRESHlAiLbqDdooiibeSbrC8ZrddS6t%2Bu%2FM2rm2KbwUCSFerGQuZ8%2FMmZkHZnCSp2CQxQ8sV3IqOKpPnMWMKzFFhZDcAddeIifMXQecwIQS2LENObchHa7JrVFNRYJl%2Bp3URmTjjXVfjnOMkKJyvuJQC%2BLgMnpSC5mxOHRZKsfySqUWzJhcx%2FX6M071ERC2zDz6UDZHnSiRmxKBdWWWYWKchSyUw%2BUEROYYWf3dpcErGrOKhmd5gBIwTPF4BzFJC20oUGgHHC3GGfInSMjH6KQwxPStI%2FJpNAgcyHj1M3RA4SptJOb0LcOBc4Vao7YP60WWfEhl8p3FI0g1umUnz%2FFHIRTytdGGnRXDz7g4Lgt7QTAbdo6cUhOzDtQGxiSN9yzB3QdBqVKRvHHvgZlFbjXsnnS%2BfGQVM%2Fo7m83sbEiRGX0pyXCw7NOBtw%2FQGJI0aPm%2By8ZKFnk5LpDjnD266yc6G%2Fj3T8Crth68FlL4S6TaHbwOLV0MqxHchvsDjdx6p%2F%2FosnuZ4WAjYZ92ZDUGOAdafVyCLSmIbIqZkWrBlqADUSZu4RJGDgom2p6MFVpvB66%2FwuttAfaXiM%2FQlkWW9mo0a0kqKEtbb9VX64wiLwxbXtCOvGa4doXWxWyttFhS4cAuGJhCUYONKmhXJkVqxABmsDHxZAB5ni6oNZq8BNHb0TirjtV2NzgYINMuiR0RBjyxLRFWhqB91EoaYaMW8iCpRRFAre3zsDbiwag94vxNMzjaOqgvXtz9J3WPWPaAZEaAPZeddAYLzR73TNqyMJo0b09xT9r%2Fu6n7%2BwruuzTi%2F6X8J6SkBdcwRT4AGx%2F6RMhv1cLWZdCIoyAOI6%2FRaIfN1qHvx75vy0Ftquof6Bps3wE2b57czQ6bsh11YXh7%2FS2Ut91uR9zo%2B5uzs%2FpHcTG5Or2un%2BSnF%2Fode%2FwJbgzRFhYJAAA%3D)
- [Production dual-IP apex group](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALK6kWoC%2F%2B1UyW7bMBD9FYFATpVliXG8qCgQN%2B4haJqtSVMkMISxOLbZyqJCUl5q%2BN9LSt6SOO0lAVogF4Eazjy%2BebPMicZRloBGEs5JJsWYM5THjISEST5GiRAPgSkvFiPirh1OYWQCSMe6XFqXNlPmWqEc8xiL8KFQmqeDjXVXjNNBSFA6N9hT3HBwiXlScZGSkLokEQNxLRMLpnWmwmr1CadqHwy2SD3zMdEMVSx5pgsEciTSFGPtzEQuHSZGwFNHi%2FL3IQ1W0piUNDzLAySHXoKdB4hxkittHLlywFF8kCJ7hIRsgE4CPUzeOzwb16LAgZSVR%2BqAxFVYn0%2FNt3AHxiQqhco%2BrGZp%2FDER8U8S9iFR6BZKXuJ9ziWytdG6nee9zzjrFIk9UzDrdonMhMZ67ag0DExpvCcB7i4IEyqkKW94Nyd6ltkaHp22v3wiJTPzO5lMbG8Inmp1JYxhb6nTnrcLUGtT0qDp%2By4ZSJFnRbtAhlOycNdPtDfwh4%2FAS1n3XgqJ%2FhGpMoSXoaXyXtmC23CvIOTWO92FS36JFKNNCbtmRlZtgFMwo49LsCUFssSKeOFfqumupTDxGUgYKbsuVkh3D6C6K6w7Ys8F2m6kZXL2Mk44mqSttdTRGoMW9XyPesHaTLfNlNgEzTQJiZGdKtC5NKpqmZsBGeWJ5hFMYGNicQRZlsyMHsrcGqynLZ2WW6qsBAMNxdQX5P5Wg4jFVhVuq9BsNWi%2FFjcqrUbNr9R6rFVp9bFZialfPwhYEPQCurVPn124uzfqplZ2baSag12S7WQCM0UWj9p1mdHhJp%2BNrv83f%2FqP8u%2B6Zs7eWuuttV6htcwmVDBGFoF1oz6tV%2FxmhTavgnpY2w%2F3fa%2FZqjUP6u98P%2FR9mwUqXSY3N9tye0%2BS79%2BC1n4fprcnY5pfqOPbenBP09kZnMTB1x%2FnZxfX1en0JqHpcPCBLH4DSANBjisKAAA%3D)
