### PR TITLE
Add taskruler.com hosting service template

### DIFF
--- a/taskruler.com.hosting.json
+++ b/taskruler.com.hosting.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "taskruler.com",
+  "providerName": "TaskRuler",
+  "serviceId": "hosting",
+  "serviceName": "TaskRuler custom domain",
+  "version": 1,
+  "description": "Point a subdomain at your TaskRuler workspace so your public pages (booking, checkout, e-signature, landing pages) serve on your own domain.",
+  "syncPubKeyDomain": "taskruler.com",
+  "syncRedirectDomain": "taskruler.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%host%",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a signed Domain Connect template for **TaskRuler** (`taskruler.com`), service `hosting`.

It points a customer's subdomain at their TaskRuler workspace with a single `CNAME %host% -> cname.vercel-dns.com` (TaskRuler's public pages, such as booking, checkout, e-signature and landing pages, are hosted on Vercel), so those pages serve on the customer's own domain. The template is signed: `syncPubKeyDomain`/`syncRedirectDomain` = `taskruler.com`, and the public key is published at `dc1._dck.taskruler.com`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`taskruler.com.hosting.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A: no `logoUrl` in this template)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`taskruler.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (set; no `redirect_uri` used)
- [x] no TXT record contains SPF content (no TXT records in this template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (N/A: no TXT records)
- [x] no variable is used as a bare full record value (N/A: no TXT records; the only record is a fixed CNAME target)
- [x] no bare variable is used as the full `host` label (the `%host%` variable maps to the Domain Connect `host` apply parameter, `hostRequired: true`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` is used only as the standard host-parameter placeholder (`hostRequired: true`)
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (N/A: single required CNAME)

## Online Editor test results

Checked with "Check template" (schema + consistency: passed), then "Test apply template" on a subdomain. `hostRequired: true`, so no apex test is required.

**Editor test link(s):**
[Test taskruler.com/hosting example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKz2kWoC%2F91TXU%2FbMBT9K5YlpE1LKlPaUiLtAQECNvEhVmlMqIoc%2BxKsJnbwR0Op%2Bt93TSiFwaQ97ynyPeden3t8sqQe6qbiHmi2pI01cyXBnkqaUc%2FdzIYKbE%2BYmiYv4DmvkUwnCF9FGCEHdq4EPLXdGeeVLjfVP%2FlEBOdNTaSpudLIm4N1ymiabSdUghNWNf7pTC%2BN0p5w4kLRsQn3ZGGCJZtprbEz13ABxJkOa0JRKUEaXoIjnwpjZqgnIeIOxMwEnxBInSo198FCQiquJeId%2FTOJooEY3Y0yrX7W2YsLLbS4DMV3WBx22t%2BbFClXIJUF4f9KihZdwX1AFjrmbYCEYoOx0tHsZkn9oomOHZzvnx090%2FG4Fb9b8SGiK25isCY0mttDAwVUqdTu%2BQLvK5rtjBhbTVcJfTQa8s38Kbq8VgYPHF8fXunCYtu2eCitCU2u1i0Nt7x2MSTr5ps33dN1%2B81Tf7wXPTYW8hev16vWofIq5y3flKTIedNUC5TpEMUp723QXY5weq9TKLnn%2F%2BBBQnMponAV43m7Ox4Ph3uDFLahnw4GkqVc7N6mhRR8sDvi8nYoX4X9wz%2Fh47i%2FcQ%2BcA%2B0VRw10v2r5wtHVapqgk%2F%2FlYvj6js9B5jwy%2B6w%2FStk47Y8nfZYN97L%2BoDdiO2ybfWEsYywuAc53ay4xKa8zQvnorPjWqJM7Pz%2B%2Bt7%2BuH8r650E4OilGxcXO6fnF8eGkHJ4x9%2BO6%2FEpXvwGg%2BmfAwQQAAA%3D%3D)
