### PR TITLE
Create rinpush.com.mail.json

### DIFF
--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -22,12 +22,12 @@
     {
       "type": "SPFM",
       "host": "@",
-      "spfRules": "v=spf1 mx a:rinpush.com -all"
+      "txtData": "v=spf1 mx a:rinpush.com -all"
     },
     {
       "type": "TXT",
       "host": "rinpush._domainkey",
-      "txtData": "%dkim_key%",
+      "txtData": "rinpush.dkim=%dkim_key%",
       "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
@@ -36,6 +36,7 @@
       "host": "_dmarc",
       "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
       "txtConflictMatchingMode": "Prefix",
+      "essential": "OnApply",
       "ttl": 3600
     },
     {

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -19,21 +19,22 @@
       "ttl": 3600
     },
     {
-      "type": "TXT",
+      "type": "SPFM",
       "host": "@",
-      "txtData": "v=spf1 mx a:rinpush.com -all",
-      "ttl": 3600
+      "spfRules": "v=spf1 mx a:rinpush.com -all"
     },
     {
       "type": "TXT",
       "host": "rinpush._domainkey",
       "txtData": "%dkim_key%",
+      "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
     {
       "type": "TXT",
       "host": "_dmarc",
       "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
+      "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
     {

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -15,26 +15,26 @@
     {
       "type": "MX",
       "host": "@",
-      "pointsTo": "rinpush.com",
+      "pointsTo": "mail.rinpush.com",
       "priority": 10,
       "ttl": 3600
     },
     {
       "type": "SPFM",
       "host": "@",
-      "txtData": "v=spf1 mx a:rinpush.com -all"
+      "txtData": "v=spf1 mx include:rinpush.com -all"
     },
     {
       "type": "TXT",
       "host": "rinpush._domainkey",
-      "txtData": "rinpush.dkim=%dkim_key%",
+      "txtData": "v=DKIM1; k=rsa; p=%dkim_key%",
       "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
     {
       "type": "TXT",
       "host": "_dmarc",
-      "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
+      "txtData": "v=DMARC1; p=quarantine; rua=mailto:dmarc@%domain%",
       "txtConflictMatchingMode": "Prefix",
       "essential": "OnApply",
       "ttl": 3600
@@ -42,7 +42,7 @@
     {
       "type": "SRV",
       "host": "_submission._tcp",
-      "pointsTo": "rinpush.com",
+      "pointsTo": "mail.rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 587,
@@ -51,7 +51,7 @@
     {
       "type": "SRV",
       "host": "_imaps._tcp",
-      "pointsTo": "rinpush.com",
+      "pointsTo": "mail.rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 993,
@@ -60,7 +60,7 @@
     {
       "type": "SRV",
       "host": "_pop3s._tcp",
-      "pointsTo": "rinpush.com",
+      "pointsTo": "mail.rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 995,
@@ -69,13 +69,13 @@
     {
       "type": "CNAME",
       "host": "autodiscover",
-      "pointsTo": "rinpush.com",
+      "pointsTo": "mail.rinpush.com",
       "ttl": 3600
     },
     {
       "type": "CNAME",
       "host": "autoconfig",
-      "pointsTo": "rinpush.com",
+      "pointsTo": "mail.rinpush.com",
       "ttl": 3600
     }
   ]

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -27,14 +27,14 @@
     {
       "type": "TXT",
       "host": "rinpush._domainkey",
-      "target": "%dkim_key%",
+      "txtData": "%dkim_key%",
       "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
     {
       "type": "TXT",
       "host": "_dmarc",
-      "target": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
+      "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
       "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -1,19 +1,81 @@
-Create rinpush.com.mail.json #1688
-Preview 
- · Feedback
- Open
-DTATCHUM wants to merge 7 commits into Domain-Connect:master from DTATCHUM:master  
-+81 −0 
- Conversation 4
- Commits 7
- Checks 0
- Files changed 1
-Sorry, this diff is unavailable.
-The repository may be missing relevant data. Please contact support for more information.
-
-Footer
-© 2026 GitHub, Inc.
-Footer navigation
-Terms
-Privacy
-Security
+{
+  "providerId": "rinpush.com",
+  "serviceId": "mail",
+  "providerName": "Rinpush Mail",
+  "serviceName": "Configuration automatique de la messagerie Rinpush",
+  "version": 1,
+  "syncPubKeyDomain": "rinpush.com",
+  "variableDefs": {
+    "dkim_key": {
+      "desc": "Clé publique DKIM générée par Rinpush",
+      "required": true
+    }
+  },
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "rinpush.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "v=spf1 mx a:rinpush.com -all"
+    },
+    {
+      "type": "TXT",
+      "host": "rinpush._domainkey",
+      "txtData": "%dkim_key%",
+      "txtConflictMatchingMode": "Prefix",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
+      "txtConflictMatchingMode": "Prefix",
+      "ttl": 3600
+    },
+    {
+      "type": "SRV",
+      "host": "_submission._tcp",
+      "pointsTo": "rinpush.com",
+      "priority": 0,
+      "weight": 1,
+      "port": 587,
+      "ttl": 3600
+    },
+    {
+      "type": "SRV",
+      "host": "_imaps._tcp",
+      "pointsTo": "rinpush.com",
+      "priority": 0,
+      "weight": 1,
+      "port": 993,
+      "ttl": 3600
+    },
+    {
+      "type": "SRV",
+      "host": "_pop3s._tcp",
+      "pointsTo": "rinpush.com",
+      "priority": 0,
+      "weight": 1,
+      "port": 995,
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "autodiscover",
+      "pointsTo": "rinpush.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig",
+      "pointsTo": "rinpush.com",
+      "ttl": 3600
+    }
+  ]
+}

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -15,7 +15,7 @@
     {
       "type": "MX",
       "host": "@",
-      "pointsTo": "mail.rinpush.com",
+      "pointsTo": "mail.rinpush.com.",
       "priority": 10,
       "ttl": 3600
     },
@@ -27,14 +27,14 @@
     {
       "type": "TXT",
       "host": "rinpush._domainkey",
-      "txtData": "v=DKIM1; k=rsa; p=%dkim_key%",
+      "txtData": "p=%dkim_key%",
       "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
     {
       "type": "TXT",
       "host": "_dmarc",
-      "txtData": "v=DMARC1; p=quarantine; rua=mailto:dmarc@%domain%",
+      "txtData": "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@rinpush.com",
       "txtConflictMatchingMode": "Prefix",
       "essential": "OnApply",
       "ttl": 3600
@@ -42,7 +42,7 @@
     {
       "type": "SRV",
       "host": "_submission._tcp",
-      "pointsTo": "mail.rinpush.com",
+      "pointsTo": "mail.rinpush.com.",
       "priority": 0,
       "weight": 1,
       "port": 587,
@@ -51,7 +51,7 @@
     {
       "type": "SRV",
       "host": "_imaps._tcp",
-      "pointsTo": "mail.rinpush.com",
+      "pointsTo": "mail.rinpush.com.",
       "priority": 0,
       "weight": 1,
       "port": 993,
@@ -60,7 +60,7 @@
     {
       "type": "SRV",
       "host": "_pop3s._tcp",
-      "pointsTo": "mail.rinpush.com",
+      "pointsTo": "mail.rinpush.com.",
       "priority": 0,
       "weight": 1,
       "port": 995,
@@ -69,13 +69,13 @@
     {
       "type": "CNAME",
       "host": "autodiscover",
-      "pointsTo": "mail.rinpush.com",
+      "pointsTo": "mail.rinpush.com.",
       "ttl": 3600
     },
     {
       "type": "CNAME",
       "host": "autoconfig",
-      "pointsTo": "mail.rinpush.com",
+      "pointsTo": "mail.rinpush.com.",
       "ttl": 3600
     }
   ]

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -41,7 +41,7 @@
     {
       "type": "SRV",
       "host": "_submission._tcp",
-      "target": "rinpush.com",
+      "pointsTo": "rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 587,
@@ -50,7 +50,7 @@
     {
       "type": "SRV",
       "host": "_imaps._tcp",
-      "target": "rinpush.com",
+      "pointsTo": "rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 993,
@@ -59,7 +59,7 @@
     {
       "type": "SRV",
       "host": "_pop3s._tcp",
-      "target": "rinpush.com",
+      "pointsTo": "rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 995,

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -1,81 +1,19 @@
-{
-  "providerId": "rinpush.com",
-  "serviceId": "mail",
-  "providerName": "Rinpush Mail",
-  "serviceName": "Configuration automatique de la messagerie Rinpush",
-  "version": 1,
-  "syncPubKeyDomain": "rinpush.com",
-  "variableDefs": {
-    "dkim_key": {
-      "desc": "Clé publique DKIM générée par Rinpush",
-      "required": true
-    }
-  },
-  "records": [
-    {
-      "type": "MX",
-      "host": "@",
-      "pointsTo": "rinpush.com",
-      "priority": 10,
-      "ttl": 3600
-    },
-    {
-      "type": "SPFM",
-      "host": "@",
-      "spfRules": "v=spf1 mx a:rinpush.com -all"
-    },
-    {
-      "type": "TXT",
-      "host": "rinpush._domainkey",
-      "txtData": "%dkim_key%",
-      "txtConflictMatchingMode": "Prefix",
-      "ttl": 3600
-    },
-    {
-      "type": "TXT",
-      "host": "_dmarc",
-      "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
-      "txtConflictMatchingMode": "Prefix",
-      "ttl": 3600
-    },
-    {
-      "type": "SRV",
-      "host": "_submission._tcp",
-      "pointsTo": "rinpush.com",
-      "priority": 0,
-      "weight": 1,
-      "port": 587,
-      "ttl": 3600
-    },
-    {
-      "type": "SRV",
-      "host": "_imaps._tcp",
-      "pointsTo": "rinpush.com",
-      "priority": 0,
-      "weight": 1,
-      "port": 993,
-      "ttl": 3600
-    },
-    {
-      "type": "SRV",
-      "host": "_pop3s._tcp",
-      "pointsTo": "rinpush.com",
-      "priority": 0,
-      "weight": 1,
-      "port": 995,
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "autodiscover",
-      "pointsTo": "rinpush.com",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "host": "autoconfig",
-      "pointsTo": "rinpush.com",
-      "ttl": 3600
-    }
-  ]
-}
+Create rinpush.com.mail.json #1688
+Preview 
+ · Feedback
+ Open
+DTATCHUM wants to merge 7 commits into Domain-Connect:master from DTATCHUM:master  
++81 −0 
+ Conversation 4
+ Commits 7
+ Checks 0
+ Files changed 1
+Sorry, this diff is unavailable.
+The repository may be missing relevant data. Please contact support for more information.
+
+Footer
+© 2026 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+Security

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -4,6 +4,7 @@
   "providerName": "Rinpush Mail",
   "serviceName": "Configuration automatique de la messagerie Rinpush",
   "version": 1,
+  "syncPubKeyDomain": "rinpush.com",
   "variableDefs": {
     "dkim_key": {
       "desc": "Clé publique DKIM générée par Rinpush",
@@ -26,21 +27,21 @@
     {
       "type": "TXT",
       "host": "rinpush._domainkey",
-      "txtData": "%dkim_key%",
+      "target": "%dkim_key%",
       "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
     {
       "type": "TXT",
       "host": "_dmarc",
-      "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
+      "target": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
       "txtConflictMatchingMode": "Prefix",
       "ttl": 3600
     },
     {
       "type": "SRV",
       "host": "_submission._tcp",
-      "pointsTo": "rinpush.com",
+      "target": "rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 587,
@@ -49,7 +50,7 @@
     {
       "type": "SRV",
       "host": "_imaps._tcp",
-      "pointsTo": "rinpush.com",
+      "target": "rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 993,
@@ -58,7 +59,7 @@
     {
       "type": "SRV",
       "host": "_pop3s._tcp",
-      "pointsTo": "rinpush.com",
+      "target": "rinpush.com",
       "priority": 0,
       "weight": 1,
       "port": 995,

--- a/rinpush.com.mail.json
+++ b/rinpush.com.mail.json
@@ -1,0 +1,79 @@
+{
+  "providerId": "rinpush.com",
+  "serviceId": "mail",
+  "providerName": "Rinpush Mail",
+  "serviceName": "Configuration automatique de la messagerie Rinpush",
+  "version": 1,
+  "variableDefs": {
+    "dkim_key": {
+      "desc": "Clé publique DKIM générée par Rinpush",
+      "required": true
+    }
+  },
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "rinpush.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "@",
+      "txtData": "v=spf1 mx a:rinpush.com -all",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "rinpush._domainkey",
+      "txtData": "%dkim_key%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "txtData": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; pct=100; fo=1; rua=mailto:dmarc@%domain%; ruf=mailto:dmarc@%domain%",
+      "ttl": 3600
+    },
+    {
+      "type": "SRV",
+      "host": "_submission._tcp",
+      "pointsTo": "rinpush.com",
+      "priority": 0,
+      "weight": 1,
+      "port": 587,
+      "ttl": 3600
+    },
+    {
+      "type": "SRV",
+      "host": "_imaps._tcp",
+      "pointsTo": "rinpush.com",
+      "priority": 0,
+      "weight": 1,
+      "port": 993,
+      "ttl": 3600
+    },
+    {
+      "type": "SRV",
+      "host": "_pop3s._tcp",
+      "pointsTo": "rinpush.com",
+      "priority": 0,
+      "weight": 1,
+      "port": 995,
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "autodiscover",
+      "pointsTo": "rinpush.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig",
+      "pointsTo": "rinpush.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
### Description
New template for Rinpush Mail service.

### Type of change
- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

### How Has This Been Tested?
- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern <providerId>.<serviceId>.json
- [x] resource URL provided with logoUrl is actually served by a webserver

### Checklist of common problems
- [x] syncPubKeyDomain is set — this is mandatory; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] warnPhishing is not set alongside syncPubKeyDomain — the two must not appear together
- [x] syncRedirectDomain is set whenever the template uses redirect_uri in the synchronous flow
- [x] no TXT record contains SPF content ("v=spf1 ...") — use the SPFM record type instead
- [x] txtConflictMatchingMode is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. @ TXT "%foo%") unless necessary — prefer @ TXT "service-foo=%foo%"; if bare, justify in the PR description
- [x] no bare variable is used as the full host label — the non-variable parts are fixed to limit misuse (e.g. %dkimkey%._domainkey, not %dkimhost%); if bare, justify in the PR description
- [x] no variable is used in the host field to create a subdomain — use the host parameter or multiInstance instead
- [x] %host% does not appear explicitly in any host attribute
- [x] essential is set to OnApply on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Justifications for exceptions
- **SPFM instead of TXT**: The SPF record uses the SPFM type as required by Domain-Connect to avoid conflicts.
- **Variable in TXT record**: `%dkim_key%` is used with the prefix `p=` in the DKIM TXT record (not as a bare value), which is acceptable.
- **DMARC essential**: The DMARC record is marked with `essential: "OnApply"` because end users may need to adjust the policy from `quarantine` to `reject` over time.

### Online Editor test results
Editor test link(s):
https://editor.domainconnect.org/template/DTATCHUM/Templates-mail-rinpush/rinpush.com.mail.json

### Additional technical notes
- All `pointsTo` values use fully qualified domain names with trailing dots (FQDN format) as required by DNS specifications.
- The mail server infrastructure uses `mail.rinpush.com` as the primary endpoint.
- DKIM selector is fixed to `rinpush` to match the provider's standard configuration.
- DMARC reports are sent to `dmarc-reports@rinpush.com` to avoid variable substitution issues with `%domain%`.