### PR TITLE
Fix DMARC record host and logo URL for grundy.app/dominio-unificado

### DIFF
--- a/grundy.app.dominio-unificado.json
+++ b/grundy.app.dominio-unificado.json
@@ -6,7 +6,7 @@
   "version": 1,
   "description": "Conecta tu página y tus correos de Grundy a tu propio dominio en una sola operación.",
   "variableDescription": "hostPrefix = 'mail' fijo. dkim1/2/3 = tokens DKIM generados por SES al momento de conectar. sesRegion = región activa de AWS SES (ej. us-east-2).",
-  "logoUrl": "https://www.grundy.app/grundy-logo-negro.svg",
+  "logoUrl": "https://www.grundy.app/favicon.svg",
   "syncPubKeyDomain": "grundy.app",
   "syncRedirectDomain": "grundy.app",
   "records": [
@@ -17,6 +17,6 @@
     { "type": "CNAME", "host": "%dkim3%._domainkey.mail", "pointsTo": "%dkim3%.dkim.amazonses.com", "ttl": 1800, "groupId": "core" },
     { "type": "MX", "host": "bounce.mail", "pointsTo": "feedback-smtp.%sesRegion%.amazonses.com", "priority": 10, "ttl": 1800, "groupId": "core" },
     { "type": "SPFM", "host": "bounce.mail", "spfRules": "include:amazonses.com", "groupId": "core" },
-    { "type": "TXT", "host": "@", "data": "v=DMARC1; p=none;", "ttl": 1800, "groupId": "dmarc", "essential": "OnApply", "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "v=DMARC1" }
+    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none;", "ttl": 1800, "groupId": "dmarc", "essential": "OnApply", "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "v=DMARC1" }
   ]
 }

--- a/grundy.app.dominio-unificado.json
+++ b/grundy.app.dominio-unificado.json
@@ -3,7 +3,7 @@
   "providerName": "Grundy",
   "serviceId": "dominio-unificado",
   "serviceName": "Grundy — Tu dominio (página + correo)",
-  "version": 1,
+  "version": 2,
   "description": "Conecta tu página y tus correos de Grundy a tu propio dominio en una sola operación.",
   "variableDescription": "hostPrefix = 'mail' fijo. dkim1/2/3 = tokens DKIM generados por SES al momento de conectar. sesRegion = región activa de AWS SES (ej. us-east-2).",
   "logoUrl": "https://www.grundy.app/favicon.svg",


### PR DESCRIPTION
# Description

Follow-up fix for the `grundy.app`/`dominio-unificado` template (merged in #1500). Two issues found while testing the live sync-apply flow against Cloudflare:

1. **DMARC record host was wrong.** The TXT record was targeting the zone apex (`@`) instead of `_dmarc`. Per RFC 7489, mail receivers only look up `_dmarc.<domain>` — the record as originally merged had zero effect on DMARC alignment. Fixed to `"host": "_dmarc"`.
2. **`logoUrl` pointed to an outdated brand asset** (an old leaf-mark logo we no longer use). Updated to our current icon.

Version bumped to `2` per the linter's version-bump check on edits to an already-merged template. No records, variables, groupIds, or apply-flow behavior changed otherwise.

## Type of change

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`grundy.app.dominio-unificado.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — mandatory
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (template uses `redirect_uri` in the sync flow)
- [x] no TXT record contains SPF content — uses `SPFM` on `bounce.mail` instead
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`Prefix` / `v=DMARC1`)
- [x] no variable is used as a bare full record value — all variables are embedded with fixed prefixes/suffixes (e.g. `%dkim1%.dkim.amazonses.com`)
- [x] no bare variable is used as the full `host` label — DKIM hosts use `%dkimN%._domainkey.mail`, fixed suffix
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` request parameter is used instead (tested with apex and with `host=oficina` below)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record (user may need to remove/edit it independently)

## Online Editor test results

**Editor test link(s):**
- Apex: https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJkFkmoC%2F%2B1XbW8aORD%2BK9ZKUVsVNssuBI4qUlGS9tqIJkroXaQ0Qsb2gmHXNrYXQiPut98YFggtlPTuPjQnJCTWO6%2FPzHhm9sGzLFUJtsyrP3hKyxGnTH%2BgXt3r6kzQiY%2BV8gpLyiecAqf3fkaD94bpESdsJkBlygWXxUzwmBNM5Yq%2BJoa%2BZGFQKqNWhnIR9FJ9yYKAlbpcYPQaEak1k69AfsS04VJ49bDgUWaI5srOzt6JFIxYjGyGHgtP4IXJFRhEGcptzhm1VGBtYZUJlIGIkQlGUjGNCXea4kj4zjTWHHcSdrpmtieNvdQs5vfoGL1IMU9eoJj3pY%2FogKelw%2FAwAoKVAyYMOj3%2F0ERdJkA1BW%2BU1Oj67BrhBKUyZcJK5yCZA9E%2BMsxcsS7YAQ0aHnJnECaWj7Djbfx5PdPwkvV9lJkiw8YWw1fO3UR25WedOBetVaZ%2BeDgej%2F1VEg9jDJmQwjejrkvMRJDLrHPOJqcSUIhvE%2B7oV4xyDb5t5gCK1NR49dsHz06Uy28DXrsAweNbVzSSC2taEo7VIx9%2BYQl%2BQLAW%2FIyOgqAAKmWmZuUD2pg3LSyVnXxqNM9WCgHNukoioKh8KBDCkiIVxicy%2FYe6D2a5O%2FDbdIZ0wCa%2By%2By6vQWT%2B%2FNxir9KAQl7bLVU%2B3mr4VOshv%2B11egpVqN%2FY7V5szLZkZkgbIOZmDHawWRQNKlV%2FsGy%2Fg%2B%2Bs6k0l5rbCRgOnujB9eW75jYfjIqvsoRB8XpckCSjrP6txe2KWzetld42TbEmcKbYYjiPjk%2BbjauT0hukjgXc7DfbAraQY8ZAJ%2BDY3dwL0VAqcX3V3ltocHHCiW1iS3pcdJuSOuvz5rOZJaetvPCmd9OCB7hYe3Vd7woeXdxodo%2Bh%2FbMcc45pgb7NZ%2FzzABRyj0FaYY1T4wbGQs%2FtmqK7haZbzz3PdG3SM7tQjjBIRlmUWppm%2FZgMzSBSncEgGVT7HVlWlNgFc%2BiYleFZr6J0x9BRmrBuPx5nkVCDIRmW7bjbWzBHjnksv2o56EtLB%2BVqPBb3vUpH4XAyKQuqZXfmxrLsnMCyqXoucrwrwOe2gX9sM%2FC%2BbnXGCl6aJZa38RivXlHSxi55EGgDVNC13hfFfAS%2BXZXK1p7YpsQFl7syiSuk9lsp7BQ7tYAWy1EpLOIqHKMgruAqqwSkevRoPn8%2FuXdN6FXOH1diIxnjifGmG%2FpIDmTej3Mou3vxs8C0qw43NM08ADsld3XSZxGfXVdve3x2Sv4v4rOr22yPz07J5xmf2RaQB2d9Aue41zeAZfP9EdL1VeDXxD1fEX4EfHQMO0gJbdw%2B0F84SRagoXs%2BD5g%2FuQn9AogW69Z0eleArWg%2Fr%2Ffzej%2Bv9%2FN6P6%2F383o%2Fr3%2Ftee0%2B2%2FGI0TZ2fGEQHhWDWjGstcKwHkT1oOIfVWqVcvA6COpB4JAwY%2BdAH%2BC7%2FvEXvTdp3STxxbDZiy7CyfD9H3HN1Lr36dnHd%2Bpjb9iKo%2FPTExYmZ73fPx97078B4R2%2BTjIXAAA%3D
- Subdomain (`host=oficina`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALUFkmoC%2F%2B1YbW%2FiOBD%2BK1akane1EEJCKWJV6artvnR77PXarm5X3Qo5sUNNEtvYDpRW3G%2B%2FcQhvhS69lw%2FbExISJDN%2BnpnH4%2FGIe8fQTKbYUKd970glhoxQdUKcttNTOSdjF0vpVOaWzzgDT%2BdDYYP3mqohi2ixgIiMcSaqOWcxizARC%2FvKMvQ99716A13mqFyCXsrvuefReo9xjF6jSChFxStYP6RKM8Gdtl9xCNWRYtIUz85bwWlkMDI5Wl48hhe6BNCIUFRyTh2VkMA2Y6Uc5bBEixQjIanCEbNIccBdS40Vw2FKj1dob4Q2Z4rG7BYdohcZZukLFLO%2BcBFJWFav%2BbUADEYklGt0fHrSQT3KAZpANFIodPHuAuEUZSKj3AgbYDRNRLlIU31Oe8ADCAp%2BlMEgHBk2xNb36I%2BLAuEl7bso11WKtan6r2y4qeiJLyq1IRojdbtWG41G7mITazGGnRDc1cOe3Zgxj87y8JSOjwVkwR9uuLWfU8IUxLbZAyxCEe20r%2B4dM5Z2f4%2FgtRUIfv5ii0YwbvSlgMeDpgsfvw4fMBgDcQZNz6sApMhlUT6ARp1JZQ729vNR590CELJZhYw4FJULBRLRtEq4diOR%2FUPsvWLv9twuKTJN6Ni1O7vKN3OyXy7O8J3gsGHLrPXW32f1n8Lq%2F9eswVNYg3%2FD2vm6oAxFziO6gSamlIQ4Sqo6M9Ldm9f%2F3hqnVEwoZsZA7D0xgouz953HYtAyPs9TCsXrMB6lOaHth4yPA19%2BvVzgdkmGVQTPBBsMz8PD487R%2Bdv6GyQPOZzsN48JNltHtYZOwLA9ub%2FxIylT21fNrYEGF6csMh1sohvGex1BLPu0%2BWx2KW2LKJzJ9aTiQF60uziu1xWHzE40vcXQ%2FmmZc5mTgPYNvXQmQpcVy6Y6VMrAAURihTNt740Z3NUK3vUM8GqOeF1CboIrjpc1JOkwDzJDsrwfRwOdBDJMkjQ56IeiIUlkZs6%2BdZaa5Tf7UoWaDLOU9vrxKA%2B4TAbRoGFGvZuZc2CdR%2BJOiaQvDEkaB%2FGI397shxL743GDEyV6RRjzIrQL5i3WsTqyHoeYuxq%2Bsckh%2BrZROa04WZ4a1sUjvHhFoi62Wwmya7AC1mqX5NMLcaF0WT6P9skuiazSrCidsNnEpN6s%2BnGjVW20wkYVx1Gz2myRmFA%2FCJu4sXRnr9%2Fm227ttTpYLtKjdITH2plsaDFlVvbiWctse7t%2BTiluq9GH7XVdj60I23rvc5Jr2yndLtdWhP%2BTXNv61Ha5tiI8a7mK4aLUauliX5dhdcCYd%2FMfJb46afzUMkwHkafoMDyEiaeONs466E%2BcpjMNoBE%2Fq6yn49emhH84hv08Cc5GvsnkugKT2W5K2E0JuylhNyXspoTdlLCbEnZTwvqUYP%2BiwENKuti6%2B57frHqtqt%2B69P22F7SDwA0OWt5%2B87XntT3PJkS1meZ7P4Gclv69cMRAhqNf%2FfD94PZskN1RUj9Jvn047auPfeF%2F%2FFQPf8%2FiQVr75p98OXQmfwEpklCVLBgAAA%3D%3D
