### PR TITLE
add 1HourSites, Website and Email Sending Domain

### DIFF
--- a/1hoursites.com.email.json
+++ b/1hoursites.com.email.json
@@ -1,0 +1,60 @@
+{
+  "providerId": "1hoursites.com",
+  "providerName": "1HourSites",
+  "serviceId": "email",
+  "serviceName": "Email Sending Domain",
+  "version": 1,
+  "logoUrl": "https://1hoursites.com/apple-touch-icon.png",
+  "description": "Sets up m.<domain> as a dedicated sending domain so the customer's automated email leaves from their own domain, SPF-authorised and DKIM-signed.",
+  "variableDescription": "%selector%: the DKIM selector minted for this domain (commonly k1, but not guaranteed). %dkim%: the full DKIM TXT value for that selector. Both are minted per domain by the mail platform and cannot be pre-filled.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "1hoursites.com",
+  "syncRedirectDomain": "1hoursites.com",
+  "records": [
+    {
+      "type": "SPFM",
+      "host": "m",
+      "spfRules": "include:mailgun.org include:spf.leadconnectorhq.com"
+    },
+    {
+      "type": "TXT",
+      "host": "%selector%._domainkey.m",
+      "data": "%dkim%",
+      "ttl": 3600,
+      "essential": "Always",
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "MX",
+      "host": "m",
+      "pointsTo": "mxa.mailgun.org",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "MX",
+      "host": "m",
+      "pointsTo": "mxb.mailgun.org",
+      "priority": 20,
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "CNAME",
+      "host": "email.m",
+      "pointsTo": "mailgun.org",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc.m",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}

--- a/1hoursites.com.website.json
+++ b/1hoursites.com.website.json
@@ -1,0 +1,45 @@
+{
+  "providerId": "1hoursites.com",
+  "providerName": "1HourSites",
+  "serviceId": "website",
+  "serviceName": "Website",
+  "version": 1,
+  "logoUrl": "https://1hoursites.com/apple-touch-icon.png",
+  "description": "Points the domain at the 1HourSites hosting platform and adds the two ownership/validation records the TLS certificate is issued against.",
+  "variableDescription": "%acme%: the ACME DNS-01 validation token for this domain, minted per domain when the certificate is ordered. %cf%: the Cloudflare custom-hostname ownership token, minted per domain. Neither can be pre-filled; both are opaque single-purpose tokens at fixed underscore hosts.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "1hoursites.com",
+  "syncRedirectDomain": "1hoursites.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "5.78.205.126",
+      "ttl": 600,
+      "essential": "Always"
+    },
+    {
+      "type": "A",
+      "host": "www",
+      "pointsTo": "5.78.205.126",
+      "ttl": 600,
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_acme-challenge",
+      "data": "%acme%",
+      "ttl": 600,
+      "essential": "Always",
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%cf%",
+      "ttl": 600,
+      "essential": "Always",
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for **1HourSites** (`providerId: 1hoursites.com`), a small-business
website + CRM platform. They replace a manual step where a customer is asked to
hand-enter eight DNS records at their registrar.

| file | serviceId | what it does |
| --- | --- | --- |
| `1hoursites.com.website.json` | `website` | points the domain at our hosting platform and adds the two ownership/validation records the TLS certificate is issued against |
| `1hoursites.com.email.json` | `email` | sets up `m.<domain>` as a dedicated Mailgun sending domain (SPF, DKIM, MX, tracking CNAME, DMARC) |

**Why two templates and not one.** The two halves are not known at the same
moment. The website values come out of our certificate pipeline; the DKIM value
and its selector are minted per domain by the mail platform and are not
available until the sending domain has been created there. Because every
variable a template declares is required on the apply URL, a single combined
template asked to run before the DKIM was in hand would write an empty TXT at
`<selector>._domainkey.m` — a record every DNS provider accepts and no mail
server can use. `groupId` could stage a combined template, but that means
re-applying the same template a second time, and we would rather not depend on
per-provider re-apply behaviour on a customer's live apex A record. Two
services, applied independently, at most two clicks — against eight records
typed by hand.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`https://1hoursites.com/apple-touch-icon.png` was fetched directly: `200`,
`image/png`, 12911 bytes. `dc-template-linter -logos` also resolves it.

Both files additionally pass the official linter:

```
$ dc-template-linter -loglevel error -tolerate info -logos \
    1hoursites.com.website.json 1hoursites.com.email.json
$ echo $?
0
```

`-merge-or-fail` returns non-zero on one INFO only — `DCTL1021 missing from iana
definitions` for the host `_cf-custom-hostname`. That label is Cloudflare's
custom-hostname ownership record and is not in the IANA underscored-node-names
registry; it is spelled correctly and cannot be renamed. Flagging for human
review rather than auto-merge is the right outcome, and no other finding is
reported at any level.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the two rules that need a justification:

**Bare variables as full record values.** Three exist, all TXT, all at fixed
single-purpose hosts:

- `_acme-challenge` = `%acme%` — an ACME DNS-01 token. The validator specifies
  the exact value; a prefix cannot be added.
- `_cf-custom-hostname` = `%cf%` — a Cloudflare custom-hostname ownership token,
  same constraint.
- `%selector%._domainkey.m` = `%dkim%` — the DKIM record. We deliberately carry
  the whole value rather than `k=rsa; p=%key%`: our mail platform prints the
  record as one string, region variants differ, and splitting it is how the
  value gets truncated in transit.

In all three the *host* is a fixed literal, so the variable cannot be steered at
any other name, and requests are signed (`syncPubKeyDomain`).

**The A record is not a variable.** `5.78.205.126` is written into the website
template literally rather than passed as `%ip%`. A variable there would mean a
link capable of pointing any customer's apex at any address, presented to them
by their own registrar. We would rather re-register the template if the origin
ever moves.

## Online Editor test results

**Editor test link(s):**

Website — apex:
[Test 1hoursites.com/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC0qkmoC%2F%2B1VbU%2FjOBD%2BK1YkPm1TkvQ1PZ20PThpORaWhcJWIFQ59qSxNrFzttPQQ%2Fz3G%2FeFtly51b184ANSpTqemWfenhk%2FehaKMqcWvMGjV2o1Exz0CfcGXpipShthwTSZKrzGs%2FScFuDkn1B%2B5eQoM6BngsHCsIbEmW1uVwbfnu9ngMBKeoOw4eVqqq51jvLM2tIMDg93HR%2FSsszBt6pimS%2BYks1SThGDg2FalHaB410oIa0hNgPCVUGFJNQuvjZRkkwZK%2BSUuHRTpQtCJSeU86WZrRVRtcTIMlEezmguOHXgRANTeqU0%2BnxFGGgrUsGwZkQY%2FJkKEGeKTo1tuuyoFjTJ4XgnwgPKCjgYLGCGR2e%2FkuPzKz8IyZYnq76DJBgaKiHyMpEGKTA19FCCXudWZ6jngF7EgnGCBt4kByxduTrKVcXTnGpUroxVhe%2FKILEjm2yXjvc4apJzEIiiCaOSJEBKDX4q8hz4TyRRNiMOV5X09wqIwdpio8pKl8rAEtO4NqTiAVEribEZLCUsGmFcpcxcsl9yxb57g5TmBpY3F1VyCvPjRQT7eOh0LoELbIx9XWvVNm9w9%2BjZeekIOMRr5xuPHx2fF5wZKfzsNHv9ZhR0mmHURYm1yMduEDQ8MAakFdTxc5jXdG68p8Y%2BwLqu%2FwXkFzlEds%2B3MUfj0QZ14kjjs4xiyeXUjQ5ShT6z6UehovjBHimZ5oLZM2pZhj06U3wRe56%2F7pal%2Fgu2bLlGbv1nx%2FdPDe8PJWGyadM9elh3Ex4obiVYtXIVFZ6mWlXlRKz1S6ppYdzmWlve7Zjer23vPHd2NXPnWxvTr%2F2x%2FlycB%2BVXuGybUXVTj%2Be3QRi12p1urx%2FThHFIp5kzY6kzomESsRZvQyftBr2wH8Ut2k46rMt70E%2FjwHMpialEgk8M%2FlNbafRmdYW0Lqrcigmt6eaKs4nbbHOsgEEputglqlwuzY%2Bbwr%2FKqAlnrgbCLV9g3RiifuK3w7DttxlPfdqKY591gnYvTNo0ijpbu3z%2Fpt%2B%2FzTdt2DcVL8ZiFf5yLN50As8z%2BJdpWOXw6hD%2BEx695X7tZvt3s%2F%2FDIXh7ad43cFO8j9b7aL2P1v8%2BWvg4GjoDPqFOLQqirh%2F0%2FSgeBcGgFQ%2BCuNkOW2E%2F%2FIDfwSIDMHaZ7yO%2BltvvpHdSxePrL8NvpzOWnpkw6nw4YXnn5kreXvR7v6Xs5mF8Gl1OP13Prn%2F2nv4EtKvDnLgMAAA%3D)

Website — subdomain (`host=shop`):
[Test 1hoursites.com/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGorkmoC%2F%2B1VbW%2FbNhD%2BK4SAfKplS7Ityx4GzE06tEjjtom3Bg0CgyZPFhGJVEnKihvkv%2B%2Fol%2FilDoptH9YBAQI45PGeu%2BfuudODZ6Eoc2rBGzx4pVZzwUG%2F497ACzNVaSMsmCZThdd4so5oAc7%2BFu1Xzo42A3ouGCwda5g6t%2B3t2uHz0%2F0cEFhJbxA2vFzN1B86R3tmbWkGrdZ%2B4BYtyxx8qyqW%2BYIp2SzlDDE4GKZFaZc43kclpDXEZkC4KqiQhNrlaZslyZSxQs6Io5sqXRAqOaGcr9xsrYiqJWaWibI1p7ng1IETDUzp9aPx%2ByvCQFuRCoY1I8Lgn6kAcWYY1NimY0e1oNMczvYyPKGsgJPBEmZ4evGGnI2u%2FCAkO5GsugNJMDV8hMgrIg1SIDWMUILecKszfOeADnLBPEEDb5ITlq5Dneaq4mlONT6ujFWF78ogsSNbtqvARwI1yQgEomjCqCRTIKUGPxV5DvwXMlU2Iw5XlfRrBcRgbbFRZaVLZWCFaVwbUnGPqJXE3AyWEpaNMK5SZiHZ61yxO2%2BQ0tzA6uZjNT2Hxdkyg2M6dG8ugQtsjH3%2B1bpt3uDmwbOL0glwiNcuNv77m9PzUjNjhcdus5c0o6DbDKMYLdaiHuMgaHhgDEgrqNPnMK%2FpwniPjWOAdV3%2FA8gPcojqXuxijq%2FHW9SJE43PMoollzM3OigV%2BqSmH6WK5nt7qmSaC2YvqGUZ9uhC8WXuef58WJb6B2rZCY3a%2BteBbx8b3jclYbJt0y1G2HQT7iluJVi3cp2VyVSJp5lWVTkRG5%2BSaloYt7023jd77rcb%2F5sVAJ5d7dz5i%2B3TT8m1fl%2BMgvITXHbMuPqzvl58CcKo3enGvaRPp4xDOsucG0udEw2nEWvzDnTTOOiFSdRv0860y2LegyTtB56jJmYShT4x%2BEttpTGa1RXKu6hyKya0ptsrziZuwy2wEgatGGJfsHK1PNfk1z14VlwTzlwphNvD6bSfdNow9SFOuN%2BJWOgnUdDzw7ibdvu8H7Xj%2Fs5aP770jy%2F2%2FY4cG5KDKVmzwClp%2Fl%2BYPM3md1OyJnMwnAfE%2Fo64fvYO7tP%2BfjkcUP%2FhiPycfG8buE9ehu9l%2BF6G7z8YPvzAGjoHPqHuaRREsR8kftQfB8Gg0xlEcTNoR1HcfYXnYMkCjF1xfsAv7u631tPnoTpftAJ6mb67u%2BrEszF%2FdW7Gr8VodCbfvB0mrP7aCn%2Bn3z6bX73HvwCXMlXABA0AAA%3D%3D)

Email — apex:
[Test 1hoursites.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFQskmoC%2F%2B1WbW8iNxD%2BK9ZKUVsFNgvkBbim0gJJDkUkIRBd1ChCxjZg4bX3bC8JiXK%2FveNlN8Al3EtVtamUb2t7PDPPzDOP99GzLIoFtsyrP3qxVjNOmW5Tr%2B6VJirRhltmfKIir%2FB8eoYj5s4%2FwnnPncOZYXrGCUsvsghzsdzLzI%2FcLuoxSbkco5aCpQSjGYMYSnr1UsETaqyutADjibWxqe%2FsrOewg%2BNYsKJVCZkUOVHSj%2BUYfFBmiOaxTf14PWYNSmIU%2Bb%2FTNMofCBuEEWWUEwBKkcmSWBwjo5CdMEQSY1XE9C9gnMBXappiQYLhGTNopFXkTLlG6k5m1wuod3FchBsTpbmBK1hS1Dptd4qGjyWjvgOJNcdDwVpriW4ZJhixSm%2FV0wTcJZTvoYhLl8AIPu2EmzzZX6EOkZJijqalAhomFkll0TjBGoM9o7%2F5aItOeZT5HCVCLBz3r%2FtohkXCMpfYPsfyUUPZCcKa5VFjpvOAw3nqKK2DIwrcjlKMBEsXeshQrFlxxIVYgDVzSRpCkalXH2Fh2GLnIhmesnnW9lfI5WwuoUMaMtpsBadKU%2BPVbx49O48dr6D6HTiZKGNhlbqKR5eJAFrWPS6JSCiru%2BzHifSVHqN8D8x8aCwFHsm0DJPPaZSnwrNvqNnS9bJd%2FmBRmymb%2By4gxRY7g7TusLYWOFzZD4KCxwyQzXLsSB2KOzx3w2LvbVPJkeDEdrAlE%2BBiR1GWmojV%2BJ3rdWSxgvaYvnLLe%2ByvoErHkwMD7RxGKfheDj8aY7gxRvlnYjTPws7RMkw6VP7XwdYCbXB9LkOQgPnGHg1ohDVZbcrssNUJL5ulDyg%2BlEqyD993%2Fq0GXWg24vevm2Rny5je0%2B1TwXuAqIMlcW8htZzf7B6D%2BLKM3BkG%2BBprlcQDntvHMNyRcQKd37xZu3qb373x3HfOU7eeltyOI2a6OtQGu0p02iejThicNHufT3rtYaXVPWqE3asw3D05C1vNBu%2BeNsbdZhbk7LyPLxkWMMDnoDzHSveZsYC4VK7s7u0fVGsBHhLKRt12K%2ByGDc%2FBBvFTmg2cCGKbaCie1QmIQZQIywf4Di%2B3KBk4ZZ9DlQycQqY3X7VXLt6Qtb7C%2FJbQ3xhw9AULkbMASAAsGFDiqsvd60UrBwdVUt4t7lNKirsYs%2BIQk%2F0iobUqxUGlUquWVx7D15%2FK157DZXtfG5YXjM4gT0sb1Obf6uXauLytQqXS9ZIaL6VxBcG6Sv5P8Ax%2FBE%2F5zeHJZT%2BDtJT9HNgmUP8hjOcXZtNA%2FvQT8ybA3BbgIXlX1XdVfVfVd1V9V9V%2FSlXd3zaeMTrAzq4clPeLQbVYrvWDoL5bBfL45b1qtVbahnUQOAQgCwuAj%2FCPvPp37D1cXxw35dX5ybYKVXL00G2V9ac5t3sfSacmL67%2BnG23bbdVquL2off0F%2Fe8Zqq5EQAA)

Email — subdomain (`host=shop`):
[Test 1hoursites.com/email example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHkskmoC%2F%2B1WbU%2FjRhD%2BKytLqK0uMU5iIORKpYQAl9IAIbnqWoSijXeSrLL2mt11wIfob%2B%2BsY5MEyN21H3pU4pt3Z3Zmnnl5xveOgTAW1IDTuHdiJeecgeowp%2BFUpjJRmhvQbiBDp%2FQoPaMhWPkHlPetHGUa1JwHkD2EkHKxvMvVj%2Bwt6UPEeDQhbYnHCJXmgD5k5DQqJUfIifyoBCpPjYl1Y3t7PYZtGscCykYmwbTMAxm5cTRBGwx0oHhsMjtOH4wmSUxC92eWefmFUE0oYcB4gEAZ0XkQCzHRkpgpkCDRRoagfkDlBL8y1QwLEUDnoMlYydCqckXkbZQ%2FL5H%2BxXEZX0yl4hqf0IiR9mmnW9Z8EgFzLUiqOB0JaK8FuqVBQGCk2mpkAdhHpLgjIY9sAGP8NFOui2B%2FxDyEMhIpmVVKZJQYEklDJglVFPWB%2FeSSLTbjYW5znAixMDz4NCBzKhLITVLz6MslLWmmhCoovMagCoejNDOU5cE2Cr4OM4wBjazrEZBYQXnMhViA1WkUtIQMZk5jTIWGxc1FMjqFNC%2F7C81ldS6xQgoj2qyFUqmYdhpX945JY9tXmP0uSqZSGzxlpuLxZSKwLRsOjwKRMGjY6CdJ5Eo1IcUdqrlYWIZ9FGVpmN5kXh5Kj7YxZ0vTy3K5w0VuZpC61iGjhlqFLO94NgZ7uLbreSUHNDab4dQ2dVPc0tQOi7kzhzIaCx6YLjXBFHuxKxlkKmLVf%2FfTOrJYYnn0QNrjHXVXUGXjybEDTYqj5H0thm%2F1Mdroo%2FpPfByeNbtHSzfZULlPna052mD6PGoiBaQbazRkIVXBalHmB%2B1u8%2FKw8p7EB5GM4P3XjX%2BpQBcKxvzuZZVctvTpPFw%2FlJzP6HW4bNxrDK3ob7ijSL6QN3eOQU9ljKeJkkk85MWbGAc81Jaki9dXa8%2Bvi%2FdXCwPXln8X%2FWrvZhV7Yxs0Ox0oTW1Gup2TcbfpnRz2b076nVGt3TtqNXsfm03%2F5KzZPmzx3mlr0jvMHZ2dD%2BglUIGDfI4MdCzVALRB5JVqzd%2FZ3avve3QUMBj3Ou1mr9lyLHwkQalgaMmQmkRhEo1KkBTCRBg%2BpLd0ecWCoWX4FLOlUYqRXj0pc7TYJaGbJ%2BmxyDjMFfIvpp38RYUoWgI7AltiyAKbZm5XmVerAXhsXK5XvN2yTyEo0x2%2FWvZH9brv%2B%2BAj3JXN%2BPLefGk3rtf6pel51uI59llljX6eZOK%2FquzaEL2%2BjGWktqFZnjPnCpR1Ev2%2FARt9C7DqqwRWrIgcW74iniLchO4743lcS5uGtthLz3jri8vp1aC6LuEKeuPiNy5%2B4%2BI3Ln7j4u%2FLxfbPns6BDanVrXrV3bJXL1f3B57X8OuNnT13f8%2Bv1nff4dnzLAqkjwXIe%2FwfX%2F0Td87%2FrP36%2B828NopvP%2BuAbtc76UUvNcnRTmgG8ZHPjo89xn%2Bbdd%2F9ceA8%2FA3Hhi1ELRIAAA%3D%3D)

The email tests confirm the `SPFM` merge produces exactly the record we already
run in production on our own sending domain:
`v=spf1 include:mailgun.org include:spf.leadconnectorhq.com ~all`.

## Public key for `syncPubKeyDomain`

The RS256 public key is published as TXT at `_dcpubkeyv1.1hoursites.com`
(two records, `p=1` and `p=2`), and apply URLs are signed over the query string
excluding `sig` and `key`, which are appended last.
