### PR TITLE
Add Mailflow373 email sending template

### DIFF
--- a/mailflow373.software373.com.ses-sending-domain.json
+++ b/mailflow373.software373.com.ses-sending-domain.json
@@ -1,0 +1,65 @@
+{
+  "providerId": "mailflow373.software373.com",
+  "providerName": "Mailflow373",
+  "serviceId": "ses-sending-domain",
+  "serviceName": "Mailflow373 email sending",
+  "version": 1,
+  "description": "Configures email authentication for a Mailflow373 sending domain using three Amazon SES Easy DKIM CNAME records, a custom MAIL FROM MX/SPF configuration, and a starter DMARC policy when requested.",
+  "variableDescription": "dkim1, dkim2 and dkim3 are Amazon SES Easy DKIM selectors. region is the AWS SES region used for the custom MAIL FROM MX target.",
+  "syncPubKeyDomain": "domainconnect.mailflow373.software373.com",
+  "syncRedirectDomain": "mailflow373.software373.com",
+  "syncBlock": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "mail",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "mail",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "mail",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "mail",
+      "type": "MX",
+      "host": "mf",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600,
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "mail",
+      "type": "SPFM",
+      "host": "mf",
+      "spfRules": "include:amazonses.com",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for Mailflow373 sending-domain authentication.

The template configures three Amazon SES Easy DKIM CNAME records, a custom MAIL FROM MX record, SPF using SPFM, and a starter DMARC policy.

Mailflow373 uses the synchronous Domain Connect flow with signed RS256 requests.

Validation completed:
- Domain Connect dc-template-linter: PASS
- Cloudflare-specific dc-template-linter: PASS
- Online Editor apex-domain test: PASS
- Online Editor subdomain test: PASS

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test mailflow373.software373.com/ses-sending-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADlRkmoC%2F%2B1XYW%2FbNhD9KwSBfKrkylKSOirywY0TLGvVJHaGGgsCgxbPDmFJ1EjKjhdkv71HWY7tVItTbBjWzZ9Eio%2BP907He9ADNZDmCTNAwweaKzkVHNQ5pyFNmUhGiZwF74KGliMzYwrsOJYpdZ6gn1mKW2m0AuOiBjUVMZQ0GrSrIeMiG7tcImm2Any7mYA9llQbEDkFpYXMaNh0KAcdK5Gbck5PZDYS40KBrjaxwtxBZkTMLIKMpCKMrHNXrGQRBim0nZg7BUDaKfsd9%2FROe%2BSU6TnpfDyPyMnndnRKFMRSce0gWVxoI1MStc8%2FkbPuRUSi%2Ftve5RmJq1DKgxGYcQRrw5QBRTpRu3tCcpmIeE5mGCEy%2FlaANsAbViBTgg0T6GyI4xORNh1iH37JZ0cBwU9QH6qGBGIjlW4g%2B9jKFxqlIfpLr4RWbwsNvMyMXauRQzDoMRgbmJ5n8WUx%2FAjzzuKzYVTlANVmeFjj5QKx27vABabPPBFs3%2FIhkfGEhiOWaHDondSmi9lCFv70svogNLx5oGMli%2FypXJHDzHNbUuWnowsCnO6V%2BdxrDBYKJjC3JSxFZvS1XFu3jwYrE4x1W4VlTELD4NDzHApa2wpj%2BIJeZO08T%2Bb00fm%2BMPwtYfj%2FTBjBljCCvz%2BMqL%2BKIR1tnjkC4EMWT1ydmryxtyjXvW9Oz5WQSpg59gPvL8WC1zZ6Fo3OR90iASwsikWeFBzC58dvP4WnTMWrY67716tTBstFzgzD%2BfS47A3N9yQ%2FzmQG7zfTa%2B6N7XHYN0zETHyH3SqS3LJeKhiJe1oLqdZW7H8W9u2jQ1EcDFb36daprjji4J6hMUAlvFKAo1LqQJT4ZU4XunB3zhRLtbWSJc%2FNBtHtkumG2nHJVcdTXke7YLBPlpO1zrEE%2BOsAvwYQrAOCZ4BFhVkEy10trXcwbVyf2ryIcSYVDDQ%2BmUGLoaFRBbaetEiMGDDbtpaveDxgNqGYRo2rSIht6dm9yxY%2BVydm8xJWhVEL3HYbBzy2iRdlFXoM3gHjbtNvHbr7zea%2B2xryI9cbAhzwo1bgjfw1E3%2BF32%2B19FWF1FabvSUvZ8V%2FbVb8%2F1NWgtdmJfhPZqW0jColZZOuVG%2FaxeYNfkn4pn%2F8MGlY2EhNHqbH6FpNUutX5A%2BWJEv5qP6HFfydvvkvF3nroM%2FuPGLnETuP2HnEziN2HlHnEfiDotkU%2BIBZnO%2F5h67Xcv2jay8I%2FYNw%2F6DRagWH%2FtEbzws9z2qzV7yU%2FoD%2FL%2Bt%2FLjS7igsYNzuz7s%2B%2FNn%2Fqnl8mH%2BJJMDubdj%2FNvvR%2BuWoy0786FRf9A%2B%2BYPn4FR51N8RIUAAA%3D)

[Test mailflow373.software373.com/ses-sending-domain example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKdQkmoC%2F%2B1X8U%2FjNhT%2BVyxL%2FHRJL02AlZz4oQNux45wqHQaE0KVG7%2B0Hkmc2U5LD7G%2Ffc9JSlvo0aGdJrH1p8Tx58%2FvfX5%2Bn3JPDWRFygzQ8J4WSk4EB3XKaUgzJtIkldPgh6ClZWKmTIF9j2VGnUfoOctwKY0WYJzUoCYihopGg3Y15FzkI5dLJM0XgOeLCdhtSbMAkRNQWsichm2HctCxEoWpxvRI5okYlQp0s4iVZgy5ETGzCJJIRRhZ5m5YSR0GKbUdmLECIN2MfcU1lyeX5ITpGTn%2BfBqRo%2FNudEIUxFJx7SBZXGojMxJ1T8%2FIx96XiERX7y8vPpK4CaXaGIE5R7A2TBlQ5Djq9o5IIVMRz8gUI0TGP0rQBnjLJsiUYMMUjleS47ciazvEPvyKz74FBI9gfagaUoiNVLqF7CObvtCYGqJ%2FvaygzddSA6%2BUsXNr0iEY9AiMDUzP8viiHH6G2XF9bBhV9YLZ5rhZ6%2BUCsct7wAXKZx4JNi%2F5MZXxLQ0Tlmpw6Fhq00O1kIU%2FfmwOhIbX93SkZFk8litymFlhS6o6OloT4HCn0nOnNagzuIWZLWEpcqP7cmnePlqsEhjrtgnLmJSGwb7nORS0thXG8AP9kneLIp3RB%2Bd1YfgbwvD%2FnTCCDWEE3z%2BM6GoRQ5as7pkA8CGLb12dmaK1U5frzrPdCyWkEmaG%2FcD7R7HgtY2eRKOLpFemgIVFscjTkkP4dPvNu%2FCMqXixTf%2Bqv9hlMJ%2FkzDAcTw6r3tD%2BQIrDXObwYVVec2dsj8O%2BYSJm4jF2q0hyy3qhIBF3dC2kmVuwfyvsmweHYnIwWNynG6e54oiDO4bGAE3iTQY5TDWOqnQHoloz17XODRkKplimrZ3Mua5XyG7mbNc13U3Dt46rupZ2wmC%2FrAZLHWQO8JcB%2FhpAsAwIngDqSrMIVrhaWg9h2rg%2BtfqIUS4VDDQ%2BmUGroaFRJbagrEyNGDDbvuafeDxgVliUU%2BMsEmJ7enL%2F8trv1iWzdBlbjcpNlaxFb7qaAx7bExC2JP0DaPvcY663D8zdTZI9l7Fhx%2B1wzjvDJMAOzJcc%2FW%2BY%2F0Z%2FXy2XteVnr83L8vivksf%2Fv8kTvEqe4D8rT%2BUqjTZZ8iT9VVtZveEvKbDqM29Kj9pyviXI5BBtrk3WGhz5k6XpXAeU4U1nXpvts%2BxfdNw3kO2Ngy69dZats2ydZessW2fZOsv3cxb8GdJsAnzALNb3%2FH3X67j%2BQd8LQj8I2wet%2FV1%2Fz99753mh59n8bAeo0r%2FHf6XlvyT6%2B%2FTo6uyXd52ffi4%2FfS2TPp9OjoJbOTp4f8GjbKL2dkef0vOz6Gz82yF9%2BAtfpoA1hhQAAA%3D%3D)
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
