### PR TITLE
Add lumitra.co.qr template

### DIFF
--- a/lumitra.co.qr.json
+++ b/lumitra.co.qr.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "lumitra.co",
+  "providerName": "Lumitra QR",
+  "serviceId": "qr",
+  "serviceName": "Lumitra QR custom domain",
+  "version": 1,
+  "description": "Points a subdomain at Lumitra QR so your QR codes carry your own domain, and delegates certificate validation so HTTPS renews on its own.",
+  "syncPubKeyDomain": "lumitra.co",
+  "syncRedirectDomain": "qr.lumitra.co",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.whiz-art.com",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%fqdn%.8904d4f880bfebc2.dcv.cloudflare.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Lumitra QR (dynamic QR code service, qr.lumitra.co). Lets a
customer connect their own domain/subdomain to Lumitra QR with one apply:
a CNAME to our edge (Cloudflare for SaaS) plus a delegated-DCV CNAME so the
TLS certificate for their hostname issues and renews without them touching
anything again after the initial setup.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (no `logoUrl` is set in this template, so N/A)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`lumitra.co`) — public key published as two TXT records at `_dcpubkeyv1.lumitra.co` (`p=1,a=RS256,d=...` / `p=2,a=RS256,d=...`, split at the DNS 255-byte string limit)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`qr.lumitra.co`)
- [x] no TXT record contains SPF content (no TXT records in this template)
- [x] `txtConflictMatchingMode` (no TXT records in this template)
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label (both `host` values are fixed literals: `@` and `_acme-challenge`)
- [x] no variable is used in the `host` field to create a subdomain — this template uses `hostRequired: true` and the `host` apply parameter instead, per this exact guideline
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential: OnApply` — not set; both records are core infrastructure for the service (the CNAME to our edge and its DCV validation record), not something the end user would selectively remove without breaking the connection entirely

## Online Editor test results

**Editor test link(s):**
Domain `example.com`, Host `go` (hostRequired=true, so an apex-only test is not required per the template guidelines): resolves to `go.example.com CNAME cname.whiz-art.com` and `_acme-challenge.go.example.com CNAME go.example.com.8904d4f880bfebc2.dcv.cloudflare.com`.

https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEqokmoC%2F%2B1TbW%2FaMBD%2BK5GlflqIEqAUIk1atVZttbWiDKnaKhQd9hGsJXGwHShF%2FPedgVBaNk37NE3al8R399zLcy8rZjEvM7DI4hUrtZpLgfpGsJhlVS6thoAr5u8td5ATkn3e2rz7AdkM6rnkuHGa6RfFEdbjlbEq94TKQRYEnKM2UhUsjnwm0HAtS7uRWV%2FJwhoPPFONt3APrHcQyihvqSq9iarI1%2BOg9XKrU4til8P3oBCewAxTokgg1FZOJCfBm0MmBbh8Ltj1cNj%2F4mkscGE8UknKTnECR2dZ8H41%2FoTLi23hb3rj7AMUUiO3e8RMB69AU2XsAGcVoahPVlfoM3JQWhgWP66YXZauWR%2Fvzm8vd3ASP7jWb1oxVCTygloaLKbyuQHaUuCc7NZmLG51wnDt%2FypMAjzHBp9ClmGR4uugJ5OZKE6Cbi9si%2Fak2w3HExzzZiD4POCZqsQkA41HyUZrnz2rApMXFiOaYs0fn4D2qnbb1ZG6TqRaVWUia48SNOTGbV%2Ft%2B%2FjKeVR7Pzp3ksA93YNWo35uGlPDnMI%2B7Z%2F5014JOsWdnqqXaaE0Job%2BYCuN9VjyKrMygQW8qARPoCyzJZE1ZKUQxyMrtuu%2B4Uh7Bb%2Bdl88SwR1x6S4HJtAUURQ2Oq1Or9FuQavRFWdN%2BkQtPg5FV2D34BCPT%2FToDA%2BbjsZgYSVQanaeLWBp2Pon%2B7Lj8GZfgkNOqQoOxvOna%2FPXOY98Wrr%2Fw%2FtHh%2BeuHuYoEnDAZtjsNMJuo9kbhr24dRZH7eC03YpOz96FYRyGrnY0dst9RRd%2FeOusGH67mjVhridT%2BGpm0d34%2FEH28%2FD28rQor%2Fqz67PeIPp%2Bf3PxkL5n6x9Sq8tWKQcAAA%3D%3D
