### PR TITLE
add Message Kit, Message Kit Custom Domain

### DIFF
--- a/messagekit.app.custom-domain.json
+++ b/messagekit.app.custom-domain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "messagekit.app",
+  "providerName": "Message Kit",
+  "serviceId": "custom-domain",
+  "serviceName": "Message Kit Custom Domain",
+  "version": 1,
+  "logoUrl": "https://www.messagekit.app/main.png",
+  "description": "Points a subdomain custom hostname at Message Kit through Cloudflare for SaaS.",
+  "variableDescription": "host: customer subdomain label, for example bot in bot.example.com",
+  "syncBlock": false,
+  "syncPubKeyDomain": "messagekit.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.messagekit.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Message Kit custom-domain template. It creates a CNAME for the selected host to `cname.messagekit.app` for Cloudflare for SaaS custom hostnames.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test messagekit.app/custom-domain example.com/bot](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMICk2oC%2F91TUW%2FaMBD%2BK5ZfR0KAEmikSaN0DxOiYms7bSAUnZMDLJw4sx2yDPHfZxNYQa2mPe%2FJsu%2B%2Bu%2B%2F7fLenBrNCgEEa7Wmh5I6nqD6lNKIZag1r3HLjQ1HQ1p%2FoA2Q2m06bOJlwY4Ma1Y4neEQmpTYy81KZAc9fYq9xZHzMJPfnzB0qzWVOo06LCrmWz0pYxMaYQkftdlVV%2FjWrtsP5Rb622BR1onhhjng6kzw3mgDRJWuIkIYW2UhtckuFgCGXXMxGyXK9IWMhy3QlQCFZSUUeAR59Rw0UBybw%2FqqNKxadKqO6aCaAoWgdK%2BBPsBYjYdIQG7GHf3ryE5k5f%2Bo8uRMy2dJoBUJj8zIr2QTrkzVvfIdr%2FQV%2FlFyhNd2o0uIUJlKlmkaLPTV14eweP4ymH0%2Fp9vrBfeTRmyfpvso54b%2BqbYz1vRcGwWF5aNFfMsf4pfTSen1mdS3k1MMqtJe1tbOI%2BRlSgIJMuyk7gxdX6OUZvjjiXV%2B%2BzqXCWNsTTKnwrDIrheExVPDylCaxZS5qS1PbqK3y2oG8mb%2BGXQoG%2FkF%2Fi8Zp4khzN9hDYKzHcOAFrDPwbvo95rHV7dBjg4CFnUEHwyC8WJS31%2Bhvm3JloAVibji4FRiJCmpND4dly5r5v2qzM6Bhh2kMLrMbdEMvGHrd26dOGAW9qHPj34Td7nDwLgiiIHBaUJtG7d7Oy%2BWkUPOt9%2Fm%2BfOZ3c5nMnvszU3%2BvsvF8kslKPbV723k9Ff18%2FnU4HL2nh99HlkBaCAUAAA%3D%3D)
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

CC: @codeize
