### PR TITLE
Add EasyDNSConnector default-domain template

### DIFF
--- a/easydnsconnector.com.default-domain.json
+++ b/easydnsconnector.com.default-domain.json
@@ -4,7 +4,6 @@
   "serviceId": "default-domain",
   "serviceName": "EasyDNSConnector Domain Setup",
   "version": 1,
-  "logoUrl": "https://easydnsconnector.com/icon.png",
   "description": "Configures the DNS records EasyDNSConnector uses for the default hosted-domain setup flow: a domain ownership TXT record and a www CNAME target.",
   "variableDescription": "%domain%: the domain being connected; EasyDNSConnector uses it inside the verification TXT value.",
   "syncPubKeyDomain": "keys.easydnsconnector.com",

--- a/easydnsconnector.com.default-domain.json
+++ b/easydnsconnector.com.default-domain.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "easydnsconnector.com",
+  "providerName": "EasyDNSConnector",
+  "serviceId": "default-domain",
+  "serviceName": "EasyDNSConnector Domain Setup",
+  "version": 1,
+  "logoUrl": "https://easydnsconnector.com/icon.png",
+  "description": "Configures the DNS records EasyDNSConnector uses for the default hosted-domain setup flow: a domain ownership TXT record and a www CNAME target.",
+  "variableDescription": "%domain%: the domain being connected; EasyDNSConnector uses it inside the verification TXT value.",
+  "syncPubKeyDomain": "keys.easydnsconnector.com",
+  "syncRedirectDomain": "api.easydnsconnector.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_easydnsconnector",
+      "data": "easydnsconnector-verification=%domain%",
+      "ttl": "3600",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "easydnsconnector-verification="
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "proxy.easydnsconnector.com",
+      "ttl": "3600"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the EasyDNSConnector `default-domain` template for synchronous Domain Connect setup. It creates the domain ownership TXT record and the `www` CNAME used by the hosted setup flow.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (N/A: the optional `logoUrl` property is intentionally omitted)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (N/A: both records are required for this setup)

## Online Editor test results

**Editor test link(s):**

[Test easydnsconnector.com/default-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA7Ck2oC%2F%2B1UW2%2FaMBT%2BK5alPRVQuJZm2kPXdtPWwRBlVaUKRcY%2BgLVgZ7ZDyBD%2FfcckFNqVVtrTNO0hii%2FfuXzfOT5r6mCRxMwBDdc0MXopBZhPgoYUmM2FslwrBdxpU%2BN6QSsPmD5boA29QtRl%2F%2BZih0KEBbOUHLZOBExZGruq0Asm1f7yiDW53OLIDbg0QfQSjJVa0bBeQVeWG5m47Z6iyVTOUgOWuDkQdEIMcG2EJb85TS2iprjwyDIjMtfWgSgTI9YHJNNYZyFhpDzUmcL4c5mQ0d2odE%2BYwo9kWUYu%2Bue9K%2BKYmYGr%2BWSZkWwSw%2BWjRN8Uzt6ERfTC8wSkmpFSWhBvj%2BQsHZHKotpbWxRDTiVn3vE2oyWLU%2FCRba74IJ1cQ17oh2G%2FQ25rR0ro4UMQEhm5BwOWyGP4Ulga3q%2BpyxNfOAyPF15D3ERP7fBKMMeeaaLqIYl3O20Q71yM8GYnCPxm5Xx9Y8ldjzk%2BR7F6Wvi4AwNTuXoeUt69FpRuKg80tiXcE8Gq%2Bg7XUjk70niAzb7Kj8lykPJmvKnQn1pBtNdqjCLsxIUVw1cGpWEZDVczo9Mkkjt8wgxbWP8Sd5b3j0zHO9t7Sn1EOVPaQGTxzxy%2BBRo6k0KFLrDBZcQytj8SPGJJEueYoMVbdPG0mKp4kn9czMcct%2BJ4bSo0EtxTkn4ecM5P64JBtcO6Z9VWE1fdeltUm52zVotDk3E%2BORgyLw2iF8fMXmKwFpSTzNfqPM5YbunmmQ4o2RcdUPJ9vfp%2FLcFxBfvpf4X%2F5QrjMLBsCSJiHtYIGp1q0K02g1HQDptnYaNTO201u%2FXuSRCExVQF6wrea5wdh1OD5r3TfjL%2F0BjeXd0OT9pfB4sv8kf38y3SzG9aysh24%2BLb4P3H6%2BE5zs9fQ9zKCzUIAAA%3D)
[Test easydnsconnector.com/default-domain example.com/customer](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABfCk2oC%2F%2B1U32%2FaMBD%2BVyxLeyphKT9ayLSHru1DtxV1LdrWVShy7At4S%2BLIdoAU8b%2FvHEKhLbR7nLQ9oGDfd9%2FdfXe%2BBbWQ5gmzQIMFzbWaSgH6QtCAAjOlyAxXWQbcKt3kKqWNB8yApehDzxF1Nrg5XaMQYUBPJYeKREDMisR6QqVMZhvjHm9yVuHIDdgiR%2FQUtJEqo8FhA6kM1zK31ZmiSyzHhQZD7AQIkhANXGlhyDPSwiAqxj8OWWdEJspYEHVixLiAJE7ULCCM1JdqlmH8iczJ8Puwpicswx%2BZzWbkdHByeU4s02OwTZcs05JFCZw9SvTNiuxNsIq%2BYo5AZmNSSwvi3Z6cpSUyM6h25YtiyFhy5oirjKYsKcBFNmXGr4roE5Qr%2FTDsLyhNc08LHfwahMSK7IMDy%2BU%2BfC0sDe4W1Ja5axyGR4PTEA%2FhUz80CWbZjiHytot4v9YG8dYmCG8f%2Bb47zK3rbyK5vWSWT1CsSyVc3CsNsZzvhtS214LSZeOhjKqFm0Kwq27ClcysGSq8wGGfl%2Ftk2Up5OVo26L3KINxoNUIR1uLCnOErg9qxjsYLY1UKTq2xVkUeyrVfzjRLjXuRa4a7RxSjNcfdhsRlIMeZ0hAa%2FDKLb4MGVhfQoCkOvAzZjG2uBA9ZniclJmzQilRPm5utnmj4vPpN3n%2FU5cfFV6o50Ro0FNzVKKttc9TrsR4cep0OtLxO79D3ooiDx1rHcT8SnX7c97e2z0sb6sX981x7MAYyK5lr5kkyY6Whyx0jUsuBI7JDgNfn5K%2BveNTAyfs%2FA%2F%2F2DOBiMWwKImQO3vJbR57f89r%2B0O8G7X7Q7jb7%2Fe5xp3Pg%2B8FqU4Oxq%2FoXuH%2B2Nw%2F99gWmg85lye%2FPP%2FbT5DhKv952f04O%2FA%2FTH9FbHpefuxfXQ18Wk1vcyb8BhXK%2Bm4kIAAA%3D)
