### PR TITLE
Add template podless.app.pod.json

### DIFF
--- a/podless.app.pod.json
+++ b/podless.app.pod.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "podless.app",
+  "providerName": "Podless",
+  "serviceId": "pod",
+  "serviceName": "Custom domain for a Podless app",
+  "version": 1,
+  "logoUrl": "https://podless.app/images/logo.svg",
+  "description": "Points a subdomain of your own domain to the application you run on Podless.",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "podless.app",
+  "syncRedirectDomain": "podless.app",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%pod%.podless.app",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `podless.app.pod.json` — a template for Podless, a managed hosting service for
self-hosted applications. It points a subdomain of the customer's own domain to the
application they run on Podless, using a single CNAME.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `podless.app`, key id `_dcpubkeyv1` (RS256), published and resolving
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `podless.app`
- [x] no TXT record contains SPF content — the template has no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — not applicable, no TXT records
- [x] no variable is used as a bare full record value — `pointsTo` is `%pod%.podless.app`, the root is fixed
- [x] no bare variable is used as the full `host` label — `host` is `@` and `hostRequired` is true
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — not applicable: the single CNAME is what the service depends on; removing it takes the application offline, so it must not be treated as optional

## Online Editor test results

**Editor test link(s):**

[Test podless.app/pod — ryvelia.com/test2](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE8WlGoC%2F91T246bMBD9FWRpnwoEcgepUrOXVlW72zSiD1UUIcdMEncBs7YhS6P8e8chbLJN9wf6FA1zzpmZ45Md0ZAVKdVAwh0ppKh4AvJzQkJSiCQFpVxaFMR%2BaT3QDKFk2jSxoUBWnEFLOX05Im9KpUVmJSKjPLdWQlrUOrKtRroCqbjISejbJBVr8UOmyNtoXaiw0zlbo8MzugbVMSBXVWvkJqCY5IU%2B8HErnmuUtVS5PA4UK6sWpbTENm930MLSGzDDU86ooRqIJUtE5%2B1urjmkztl1KtgjCVc0VWCTjVB6Bk8ll4D3allCg5qWyy9Q3x70L6wzgBkkyGH6DQi2hEwUCec7ouvi4NvD5P6ONCOx%2FGDe4HBeJLC8Qv6V%2B1pEa%2FSt53n7xd4mv0UO8Ul2gVa1o2VdQcqpy0R20tegdBfLtRRlEfOWVFBJM2Wy0dLnr%2FiLVmB%2BVDAcTAHWPMs42zjPPjH78HUuJMQKf6kuJbTuZWWqeUy39PQpYbF5mxrXV9hFrUtX8iZc7dYJ1RTLl5FvOGOTOGHmGG7S2gOvywYBc4ZsGDj9YMgc2veXjh%2F0k6W39NioOzpL%2Fj%2F%2BFJfZ%2F8tNhEKuOTWBnqRbWiuy3y9sdPY%2FOwmfXdEKkpgabNfrDh1v7PS8yPfD3jgcDNxh0BuN%2B%2B88L%2FQ8sz%2FKNSfuMB3nuSCfqqhTTW4eo4g9f9v8nDypMvr4dUYjOZ3B9T2dZnk9C25%2Fjb7fvSf7PzNn68DCBAAA)

Applied result for `domain=ryvelia.com`, `host=test2`, `pod=immich-x1`:

```
test2.ryvelia.com.  CNAME  300  immich-x1.podless.app
```

Only a subdomain test is included: `hostRequired` is `true`, so the template can never
be applied at the apex.
