### PR TITLE
Add EmailWish maileremailwish.com.cmarketing template

### DIFF
--- a/maileremailwish.com.cmarketing.json
+++ b/maileremailwish.com.cmarketing.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "maileremailwish.com",
+  "providerName": "EmailWish",
+  "serviceId": "cmarketing",
+  "serviceName": "EmailWish Marketing DNS",
+  "version": 1,
+  "logoUrl": "https://emailwish.com/favicon.ico",
+  "description": "Configure EmailWish marketing DNS: verification TXT and delegated subdomain nameservers.",
+  "variableDescription": "txtHost/txtData for ownership verification; nsHost/nsTarget1/nsTarget2 for subdomain NS delegation (not apex).",
+  "syncPubKeyDomain": "maileremailwish.com",
+  "syncRedirectDomain": "emailwish.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "%txtHost%",
+      "ttl": 3600,
+      "data": "%txtData%",
+      "txtConflictMatchingMode": "None"
+    },
+    {
+      "groupId": "delegation",
+      "type": "NS",
+      "host": "%nsHost%",
+      "ttl": 3600,
+      "pointsTo": "%nsTarget1%"
+    },
+    {
+      "groupId": "delegation",
+      "type": "NS",
+      "host": "%nsHost%",
+      "ttl": 3600,
+      "pointsTo": "%nsTarget2%"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for EmailWish marketing DNS setup (providerId=maileremailwish.com, serviceId=cmarketing).

Applies:
- A verification TXT record (%txtHost% / %txtData%)
- Two subdomain NS records for delegated marketing DNS (%nsHost% to %nsTarget1% / %nsTarget2%) — not apex NS changes

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set - **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` - the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) - use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary - prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label - the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain - use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Justifications

- Bare `%txtData%` as TXT value: ownership verification tokens are externally prescribed and cannot carry a fixed prefix.
- Bare `%txtHost%` / `%nsHost%` as host labels: this template must write a verification TXT and subdomain NS at different labels in one apply. The protocol `host` parameter would prefix all records the same way, so per-record host variables are required. Labels are supplied by EmailWish (e.g. cmarketing, ew), not end-user freeform input.
- `essential` / OnApply: N/A for verification TXT + NS delegation records; they are the service itself.

## Online Editor test results

**Editor test link(s):**

[Test maileremailwish.com/cmarketing example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP0%2FlGoC%2F%2B1UbW%2FaMBD%2BK5GlSptGIIS3LtM%2BdFCpUwfrWqq9VAgZ5wCriZ3a5m2I%2F75zEkio2n2bpkr9Ese%2B5%2FHdPXe%2BLTEQJxE1QIItSZRc8hDU55AEJKY8AgV2WXE9rzIZk8oBMqAxUsi5NX9HM5o0qCVnkJJZTNU9GC5mheExxenvMU5vcIO4JSjNpSBBvUIiOZO3KkL83JhEB7XaUSS1KcUrpajiB5khaKZ4YlI26Uox5bOFAqfwFZd9BQ664lPOqGU4wx9Dh4rQCSGCGUoROnoxCSVyhSMwaBs%2Fhla1IVLF6SSC3pFDszYXUpsarj1qqDOVypErgZw5T458fXCETqFCD6magakf%2FvyUVnge3OwDsjG%2BEdI4NIH1WxuG3gh2tZhcwqaXgp8tlwVeQ8gVMHOAPgbNMaBreFggCms3pZGGCkGGVKEmwd2WzJRcJGldy7kg02wSW1IUML8GNye5GifWbrCCjbbnYYlQmNxqNUqta2NLFXFm%2BtSwOVanL0N74UAKILtK2XOhReE37Zq920zYR14TyYXRQ5kBcslP%2FtnVPl492lXIb4x%2FXCg4wvQP4q8pPjgoSY%2BH%2BJeGM%2BZ7fEIVjbV9lHvm3RF1tOfeEfufa263paeXGXqp8khfuWn5Nq4BbVwj70FYSJZdhsj2uU72SOh69anWKuH8DOc%2FjUM1%2BExIBWONKzX4LElg1AJbLF5Eho%2FpihZHIRvTJIk2KJ5GK96M7XfUZSKbIkcDJu%2BtJxM8qtk4ZFZSbqveaPo0hPcTF2DScpuswdzTdufUDVnYaXn1DmOTRmng%2FWUmPjv4iuqC1iAMp3agnUUrutFkZ5uw3G15ZliEQ0bPqf%2FCk%2FJfWlKjCr7J10587cT%2F34k4eDVdQjimFuZ7ftv1Tt2GN6w3MeCg2ar6nXarU3%2FneYHn2VSwA7N8tziLy1OYXC1WX%2BLzb5%2BGfPX1oXv2s%2B01TKs%2F8JfxRVdf9n8ltWRy1hXz5u3tR7L7A8eRUNAsCgAA)

[Test maileremailwish.com/cmarketing example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAFAlGoC%2F%2B1UbW%2FaMBD%2BK5GlSptKIAkvKpn2oRptV21FbaFbpwohk1yC1WCntiEwxH%2FfOeElqdp9m7RN%2FUKw73nu5bnzrYmGWZpQDcRfk1SKBQtBXobEJzPKEpBgPhlT03ogZqS2h%2FTpDCnkzJi%2FoxlNCuSCBZCTgxmVj6AZjw%2BG5xTraoexev0B4hYgFROc%2BG6NJCIWdzJB%2FFTrVPmNRiWTRkTRpeB1%2FEFmCCqQLNU5m3wSPGLxXIJ1iDUrx%2FItDMUiFlDDsIb3Q4vy0AohgRilCC01n4QCudzimLTJH1OrmxSpZHSSQK8SUC%2F1Z6F0A789qqkVCWmJjCNnytJKrA8WVzmUqyGVMWh3%2F8%2FLaYfI%2FcEuIZPjOy60RVNYvjdpqBUPrueTL7Dq5eBX22WAtxAyCYHeQ5%2BDppjQLTzNEYW9i2iioEaQIWSoiP%2BwJrEU8zTva7kWZOpValqKAm7d4OFoq8aRsWvsYLPjONgiFGZrNRrl1qU2rUpYoK%2BoDqbYnSsRGod9wYFsauXIBy0OcfOp2YUthH0WNRWMazUUBWAr%2BdEfc%2B2h69GmRn5i%2FuODgiMsfy%2F%2BkuKDg5L0eJllGR7yjMZsR0mppDNl3uWO%2FFBhj3b0h5w%2Fqu3m0NyUHmBh6OX6o4fMzpu4sjUobWvxCNxAihoLRHHeqmWuuHLrLw1YCecVOO9lHGrCYi4kjBV%2BqcbHSXwt5zhos3mi2Zhm9HAVBmOapskKJVRoRc84hJVZ48UuOVRZLyTcTtmLRVa6Nw4Doywz%2FW861Ju0wsDutlywW1EE9km7C3Zz0uwGbtR0g1antPp%2Bsx1fXYGVPoNSwDWjZrudJhldKbIxE1kevW2BkFULe60R%2F0dt3j9Y26iGb%2FVtPN%2FG8y8dT1zRii4gHFOD9ByvYzsndtMZui3M2W91657jtp3useP4jmOqwZEsSl7j1i7vazI8b8uby8Hp9f2P9sXljddstq5VTz05bus0%2Fva1Mzi%2Bu2hH52cRjz%2BSzS9r0vcOXAoAAA%3D%3D)
