### PR TITLE
add DTM Suite, Company domain verification

### DIFF
--- a/dtmsuite.xflixq.com.domain-verification.json
+++ b/dtmsuite.xflixq.com.domain-verification.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "dtmsuite.xflixq.com",
+  "providerName": "DTM Suite",
+  "serviceId": "domain-verification",
+  "serviceName": "Company domain verification",
+  "version": 1,
+  "syncPubKeyDomain": "dtmsuite.xflixq.com",
+  "syncRedirectDomain": "dtmsuite.xflixq.com",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_dtm-verification",
+      "data": "dtm-verification=%verification%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "dtm-verification="
+    }
+  ]
+}

--- a/dtmsuite.xflixq.com.domain-verification.json
+++ b/dtmsuite.xflixq.com.domain-verification.json
@@ -12,6 +12,7 @@
       "host": "_dtm-verification",
       "data": "dtm-verification=%verification%",
       "ttl": 300,
+      "essential": "OnApply",
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "dtm-verification="
     }


### PR DESCRIPTION
# Description

Adds a signed synchronous Domain Connect template for DTM Suite company-domain verification.

The template creates only a TXT record at `_dtm-verification`, with the fixed prefix `dtm-verification=` and a per-registration verification value. Prefix conflict matching replaces older DTM proofs without targeting unrelated TXT records. No A, AAAA, MX or NS changes are requested. `essential: OnApply` permits removal after verification.

DTM Suite independently checks the exact public DNS proof before accepting ownership; administrator email verification is separate. Requests are RSA-SHA256 signed. Public key: `_dcpubkeyv1.dtmsuite.xflixq.com`. The callback is restricted to `dtmsuite.xflixq.com`.

Public template: https://dtmsuite.xflixq.com/v1/onboarding/domain-connect/template.json

No `logoUrl` is specified, so the logo availability check below is not applicable.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)
# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: no `logoUrl` is specified; this check has been reviewed.

The editor's Check template completed without a validation error. Apex and subdomain application tests use a non-empty `verification=dtm-test-123456` and produce the expected TXT name, value and TTL. The application type-check, production build and 42 API tests pass. The live template matches the submitted artifact.

Official dc-template-linter version 120 also passed with `-loglevel error -tolerate info -logos` (exit 0).

These editor tests simulate template application; an actual registrar consent flow remains pending provider onboarding.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.
- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)
## Online Editor test results

<!--
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->
**Editor test link(s):**

[Test dtmsuite.xflixq.com/domain-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIw7lGoC%2F%2BVTXW%2FaMBT9K8hSn0hQgCSESHuAdtKqibXd0NQNociJL9QqsTPboUkR%2F33XC4wPsVV73lN8c8%2Bxzrn3eEMM5MWKGiDxhhRKrjkDdctITJjJdckNdKrFilc%2FOpnMifMb8onmSCE300nri0VhS4Na8wwasswpF%2B4aFF%2FwjBouxQGx417LvKCibjXY1hkWS21PcRd5tcjuy%2FQj1De%2FsH9UZ4GfgXEFmXkDihCpmCbxbENMXVhB08cpNp6kNlgkSDvXz6ihzYUnnXdXx9UVAo1ZkbjveQ4BrUEYTrEmd2JUFKva9itzLQXKycyEmuyJi%2BVEMqvhXsGCV5chu94FAWQ73zrkVQpIDr7mzm4NyICK4pph531nEU9LJcsi4Xt8QRXNtY3Cnjk7oc733Bmx55Px4D%2Bry4A2brfX94OQWFF8KaSCROOXmlKhR6NKcEhergxP6As9%2FGJZQu2A0IPGLt54vhvRJOdfdnOu6Xg5CcusV24TG%2FjM64UQujQbRK7v9QZuFHZTlw6DFNIgoFlEj%2FL%2Flyfy9js4zP9SPLbbuYPL%2BF%2B9Y640XQNLqMX1UJjrRW7fm3b9uDuI%2FagzDEPfi9qeF3ue9YQOmwlsMG%2FHSSNs0f76%2Bhx9v3uGD%2BNhW%2FXG%2BftgWS9Tvk4fHvNRWA1vv43GpmYv%2BIZ%2BArSEKCUNBQAA)

[Test dtmsuite.xflixq.com/domain-verification example.com/warehouse](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJw7lGoC%2F%2B1T0W7aQBD8FXRSnmLTMzi2a6kPDaFRFdFGLaoSELIuvgWutX3O3dlAEf%2FevQDBoaT5gT7BeWdWMzu7a2IgLzNmgMRrUipZCw7qMycx4SbXlTDQXk4zsXxspzInzjPkC8uRQq6Gg9Z3i8KSBlWLFLZkmTNRuDUoMRUpM0IWB8SO25N5yYpVa4ttHWHxqe2%2F2EPeqkhvq4cbWF09YV9VZ4HfgAsFqXkDihCpuCbxeE3MqrSChndDLMylNvhIkHasnzPDtg1fVD6cNV9nCDQmI3GXUoeA1lAYwfBNvhYfyzJb2frS9GSBclIzYCadi2I2kNxquFUwFcvTkF3thACymWwc8lsWkBx8TZxdDMiAJcOYYed9Z3HBFMxlpW14MyWrMhF7YskUy7XdiX2L8Ysek32TcaPL5Cm1w8CwaJUa0Mb1Ol3%2FIiBWppgVUkGi8ZeZSqFroypwSF5lRiTM9tt%2F4mnC7MjQlcYqdjxOq9ju0l9ptZvmXsvtWF0zuISn1r6w2xyxCwg8L3Wp%2F77r%2BiEwN6IscsMweuA0DPyQe43b%2BMf5vH0jJ7I5tUObzcTBoP6P43kcuH2a1cATZgkd2glcGrldOvT82Iti6reDThRG9JzSmFJrDq1uR7HGrWzuI8l%2FXl5fj%2Bp6Mco8%2FkiLy%2BrmfPQj64f39%2B%2FuxOLTL%2BBBf9Gvgl6Kt%2FcHpXIr7UUFAAA%3D)