### PR TITLE
Amelia's Agent, 2 templates

### DIFF
--- a/ameliasagent.com.custom-domain-subdomain.json
+++ b/ameliasagent.com.custom-domain-subdomain.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "ameliasagent.com",
+  "providerName": "Amelia's Agent",
+  "serviceId": "custom-domain-subdomain",
+  "serviceName": "Amelia's Agent Custom Domain (subdomain)",
+  "version": 1,
+  "logoUrl": "https://ameliasagent.com/img/mark-96.png",
+  "description": "Point a subdomain you own, such as www, at a site built with Amelia's Agent.",
+  "hostRequired": true,
+  "variableDescription": "token is the ownership challenge Amelia's Agent issues when a domain is claimed in the dashboard. The site is not served on the domain until the published TXT record matches it.",
+  "syncPubKeyDomain": "ameliasagent.com",
+  "syncRedirectDomain": "ameliasagent.com,www.ameliasagent.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "edge.thxamelia.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_amelia",
+      "data": "amelia-verify-%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "amelia-verify-"
+    }
+  ]
+}

--- a/ameliasagent.com.custom-domain.json
+++ b/ameliasagent.com.custom-domain.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "ameliasagent.com",
+  "providerName": "Amelia's Agent",
+  "serviceId": "custom-domain",
+  "serviceName": "Amelia's Agent Custom Domain",
+  "version": 1,
+  "logoUrl": "https://ameliasagent.com/img/mark-96.png",
+  "description": "Point a domain you own at a site built with Amelia's Agent.",
+  "variableDescription": "token is the ownership challenge Amelia's Agent issues when a domain is claimed in the dashboard. The site is not served on the domain until the published TXT record matches it.",
+  "syncPubKeyDomain": "ameliasagent.com",
+  "syncRedirectDomain": "ameliasagent.com,www.ameliasagent.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "APEXCNAME",
+      "host": "@",
+      "pointsTo": "edge.thxamelia.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_amelia",
+      "data": "amelia-verify-%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "amelia-verify-"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two templates for Amelia's Agent (https://ameliasagent.com), a service that builds and
hosts websites. Both point a domain the customer owns at our edge and publish the
ownership token our verifier checks before anything is served on that name.

They are split apex/subdomain deliberately. The apex template needs `APEXCNAME`, which
the linter rightly flags as not widely supported; at a subdomain a plain `CNAME` works
everywhere, so routing subdomains through the apex template would trade universal
support for none, for no gain. The editor test below shows why: applying the apex
template with `host=www` produces a record at `@`, not at `www`.

The TXT value carries a fixed `amelia-verify-` prefix rather than a bare variable, and
`txtConflictMatchingPrefix` is scoped to that same prefix so re-applying replaces only
tokens we issued and can never touch an unrelated TXT at the same label.

`syncPubKeyDomain` is set and the key is published and live at
`_dck1.ameliasagent.com` (2 fragments, RS256). Signed apply requests have been verified
end-to-end against it.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Note on the last point: neither record is optional — remove either one and the site stops
being served or stops verifying — so there is nothing here a user could safely change
independently, and `essential` is left at its default rather than set to `OnApply`.

## Online Editor test results

**Editor test link(s):**

- `ameliasagent.com.custom-domain.json` — domain `example.com`, host `(apex, empty)`: [editor test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANhelGoC%2F%2B1UW2vbMBT%2BK0Iw9rA4cS5NU8OgWduN0bVkJWOFEoIsndgisuVJctIs5L%2FvyLk1Xdq9brAnWzrf%2BfSd65I6yArFHNBoSQujZ1KA%2BSxoRFkGSjLLEshdneuM1nb2W7Qhol8h3lrS9xi0WzAzyaFy56V1OguEzpjM97ajruSiApPLLXgGxkqd06hZo0on%2BptR6JQ6V9io0XiurCGzpJExMw3OuvUiT5BAgOVGFq4ioQMt8RFG1mLIQpdEz3PC%2FJ2VDkhcSuXIXLqUHCqrezHMSBYruDzgdHoKOZGWuBQ8GypOZUF4ypSCPIFnRIi0JVgyT9FrpwTduWIyA0Hw5JkEs2msmRF1MsRjpQ5RuXbEZxCBegNcM5S5k6q6KMpYSZsiYng%2FJAa4NoJkzPEUn5VVJHaR80EZX8Nik%2BmjVfaoOxASKdyLuNp8Pq%2B%2F4PxBaT6l0YQpCzW6VmJp9LCkblFU1R9c3V%2Fc9m%2Bu0CHV1uHVuW8vXyY71HgEkUDdpY%2FrFzbczmEXtLthuKrtqDDWPcl4Dff1Z47tVAfYTnKyCN5UNXvzlAl%2FH92FzidKcnfjkyXz5EYLTz0wMJGP9ChkY3v%2BAl2NVjX6U%2Bcw3oc9QjnbNAJGVCjYBLSRjX%2BJ0WUxllt8wQzLrB%2FJrefDgeto6%2FtA%2FX8Vlz%2BwmDdbbQGTzkmXeikyybWBscUvc6XBsJwpsShZqZwcsznbXwk%2BZkWhFqjcohXpjhcsX0%2Fw%2BT7LrxerRseC%2B1CkXwshnDZPWXgaQLsjgs4EwuCs1%2BwGJ2E8ER0uRCzCJ5vmpU302qbZZxWsRRfJ%2FPLoqzlbWLr6rXc28fyhdw4y%2BxdHN6ph%2F%2Fwv3D9YOJxjy3DBj5mHtcJWNwh7QTscNrtRpxe1OvXwrHvabL4Lwyj0YhxYtw55iZP%2BdMap%2FJQxHp70Zu0vU3Xfk5df%2B1f88fpOde4%2Blt3baWv24%2Fsw6w%2FiZvKern4BkdbPJwUIAAA%3D)
- `ameliasagent.com.custom-domain.json` — domain `example.com`, host `www`: [editor test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANlelGoC%2F%2B1Ua2vbMBT9K0JQ9qFx4rwTw6BZH7CVlFBS1lFCUKwbW6tsuZLc1Av577tyXk2X9vMG%2B2RLOufo3IfuklpIMsks0GBJM62eBQf9ldOAsgSkYIZFkNpqqBJa2Z3f4BkiBiXikyEDh8FzA%2FpZhFDSw9xYlXhcJUyk%2B7OjVHJegsnFFvwM2giV0qBeoVJF6k5LJMXWZiao1d46q4kkqiVMP3r9TjVLIxTgYEItMluK0JESeAkjazOkUDlRi5Qwt2eEBTLLhbRkIWxMDp1VnRmmBZtJuDjQtOoRUiIMsTE4NXQci4yEMZMS0gjeCCHS5GDIIkbWzgnSQ8lEApzgyilxZuKZYppXyRiXpTtEpcoSl0EEqg1wrZCnVshyI8tnUpgYEeP7MdEQKs1JwmwY47WijMQUaTjKZ9dQbDJ9tMoOdQtcoIR9F1dZLBbVd8hfpAofaTBn0kCFrp0YGjwsqS2ysvqjy%2Fvzm8HwEgmxMha3zlx7uTKZscIl8AiqNn5Z37DRtha7oNnx%2FVVlJ4Wx7kWma7irP7Ns59rDdhLzwjspa3byWgl%2FX%2By5SudShHbokiXSaKi4kx5pmIsXehSyOXt7A11NVhX6S6Uw3Yc9QTvbNAJGlEnYBLSxjanERaRVnk3FlpIxzRLjXuWW%2FHDAnmzpDyUfl2V0bs1mYb3R5DBvtTvUGRJRqjRMDX6ZzTUGZ3WOpUlyacWULdh%2Bi4dTlmWyQP8GT1HueNnS9Ts%2B2%2Bf645JV6JSHLhrhhkOr1203fGh4vXa%2F57XqYd%2Frd7tzr8mg2ZgD6%2FT81qt58948%2BmjeHOQWjEGWYG6KDOSCFYau%2FmiiTUibJqqumUcb6SDBf3eQkwo20%2F8S%2FtMlxLdtGI7%2BKXPIht%2FoeH7Pa%2Frjeido9YJGu9rtdpqt%2FqnvB77vogFj11Ev8fW%2Ffve0c3GZP%2F24aue99BavvhoNTls%2Fr7%2Frp273zk9E3L%2Fm8ZDzb4WMPtPVb6%2BilYUfCAAA)
- `ameliasagent.com.custom-domain-subdomain.json` — domain `example.com`, host `www`: [editor test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANtelGoC%2F%2B1VbW%2FbNhD%2BKwSBohsqOYpfFEfAgGVpNnSduzTzsAJBYJyos8SFElWSiqwG%2Fu87vdiJ02TY1w37ZJ34PA%2FvuTud77nDvFTgkEf3vDT6TiZo3iU84pCjkmAhxcKNhM65tz%2F%2FQGeEOOsQry07azF0btHcSYEdXVTW6dxPdA6y8G0V908PqGdF2HlHY287MPtmz%2FuWiHdorNQFj449rnSqfzeKBDLnShsdHT3N90jm6VEO5tY%2FDUdlkZJAglYYWbpOhF9qSRcC29%2FBGl0xXRcevRIZA8vquvYYdCDpkMWVVI7V0mXsMO0RiWfauiv8XEmD5N%2BZCiljMBJihW8PLnb6FgsmLXMZtveRrUyWTGSgFBYpPhEnpK2QksmIBWzIlehCgcwxYRS1SgnYLNZgkhFbUthlTKhCO9aWnIB6APYKVeGk6l6UVaykzQix%2FLRkBoU2CcvBiYyulZ072xTisorfY9O35vkBaVFXmFAJhHsR51FVRy%2BQf1Ba3PJoDcpS%2BfpMLI%2Bu77lrynZczj%2BcLS6GalP4fTuVbR%2FtUlOISYojl2169UHXORqTSRgEW28vQz4fRFY9vB0QcLDP2Kd5k%2BvGf9X169VjJXrcuHNdrJUUbtEWShbpQiet9KXBtdzwZyHD2dMb%2BPZm6%2FEvusDVg%2BUbSmdXQiRHpcLB0JA2lZGC1OiqXMkdpQQDuW0%2F5h35%2BoB9s6Nfd3wKO3dtDLE4Hk8SXE9nIW8TkmmhDa4s%2FYKrDO6mOq%2BUkyuo4eFVIlZQlqqh%2FC2dktzXLSv6D75Pe6j03zfM46tEtF5kt1Hms5NwMkF%2FfIKhPx2HEz%2BeJKf%2BfA4QBHMRzEA8WlIvLbF%2FtqQOaozWEl9Cu27OVA2N5duvhmmwNwzT6MDmYbsPCv1vsXvj0Xj939T%2FWFPp%2B7dAfw0raJHjYBz6wdyfBMvjMJrOo%2FHJaDo7nYbjN0EQBUHrC63r%2Fd%2FThni8G%2FiyWfxik1ndvGviYvPH%2B8sNfMptdvHz1ec303ry529fFr%2BeXMQ%2FrX%2F8%2BB3f%2FgUncRh7eggAAA%3D%3D)
