### PR TITLE
Add bandmajor.com website template

### DIFF
--- a/bandmajor.com.website.json
+++ b/bandmajor.com.website.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "bandmajor.com",
+  "providerName": "bandMajor",
+  "serviceId": "website",
+  "serviceName": "bandMajor website",
+  "version": 1,
+  "hostRequired": true,
+  "logoUrl": "https://bandmajor.com/logo.png",
+  "description": "Points this domain at your band program's bandMajor public website and adds the record that proves you own it.",
+  "syncRedirectDomain": "bandmajor.com",
+  "syncPubKeyDomain": "bandmajor.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_bandmajor",
+      "data": "bm-verify-%verify%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "bm-verify-"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for bandMajor (bandmajor.com), a website platform for school band programs. The template connects a subdomain to the program's hosted public website with one CNAME, and adds one TXT record (fixed `bm-verify-` prefix plus a per-customer token) that proves domain ownership to our verifier.

One justification per the quality guidelines: the CNAME `pointsTo` is a bare `%target%` variable because the connect target is a full hostname that differs per hosting environment/region and cannot carry a fixed prefix or suffix. Every apply URL we issue is signed (`syncPubKeyDomain` is set), so the target cannot be tampered with in transit.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on two rows: the TXT record's value uses the fixed prefix `bm-verify-` with `txtConflictMatchingMode: Prefix` so a re-application replaces a stale verification token instead of stacking duplicates. `essential` is not set because both records are integral to the service; neither is meant to be user-modified independently.

## Online Editor test results

**Editor test link(s):**
[Test bandmajor.com/website bdmj.us/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC1tlGoC%2F%2B1TUW%2FaMBD%2BK5Glag%2BQNCEUSqRJa7s9TB0Va5naqUKRY1%2BCq8TObAeaIf77bAKkrHTPm7SnxL67z9%2F33d0KaSjKHGtA0QqVUiwYBfmZogglmNMCPwnpEVGg7j54gwvYhsc2bEIK5IIR2JQtIVHMwO1vf8932owFSMUER1HQRXOh9C38qJgEA6NlBV2Ui0x8k7mpnmtdquj09IDUqY17Jc8MFAVFJCv1Bg5NBONaOXrOlENFgRl3sHZqUUnHIjhGSyZx8U45La2ySnJGduwcm4YptSDgSCBCUvNrUKwPoCyYI5bcYdqzWmtOboEa8kR%2F3Dx4xEGbNKmSa6jfTGkeUih6XCFdl9a4q5uL8SfUGGSOH2wrNvKmwhxPNJYZ6BNzq7VxKhz4%2Frq7L54%2BTNvSeP%2BaNQxrbAkUrukCS2v3pPkeIJnfZ30leGqc0WOsyZzxbCyohZ5ISNkzOpqyjb2ER%2BvZuot%2BCg5xK3JmeOytoMWTV6mW7nK5NIdMiqqM2S69xKZvyg7rrvBxXznblT5uas2xMWdzAYmrQWmXwhnxqtKTmOVLXHu4LG1mw9JmDoeE4HQUprR%2Flo4COqD9YJAEI2T5s4wLCbEyX6wrCbtJLapcsxgvcXtFSWyw89rIVSZqoF%2F3lDe70SjdduSPTA96E1NijWB27TD0BqQXYPd8mARu3x%2BE7ihJiEspBCmkNOifkRdLfHTDj6%2FxQTdAKeCaYbuTF5aVQutX47ZV1Y6bdyCwnYk3rf4rZc66ZgD%2F9%2FDf7qFZdYUXQGNsM3t%2Bb%2BD6527oT4Nh1B9FYegNg3A47Hd8P%2FJ9K8K0sRG9Mvv%2FcvPRoFM%2B87CTXtIL9aV3%2F5Dd1fWtnND86SvvZB%2FvlPqO%2BfX1%2FeVV%2Fz1a%2FwJZz9l5awcAAA%3D%3D)
