### PR TITLE
Add template: fieldblasters.com website

### DIFF
--- a/fieldblasters.com.website.json
+++ b/fieldblasters.com.website.json
@@ -7,8 +7,6 @@
   "syncPubKeyDomain": "fieldblasters.com",
   "logoUrl": "https://fieldblasters.com/img/logo.png",
   "description": "Connects your domain to your Field Blasters website. Adds an A record for the root of your domain and a CNAME for www; nothing else on your domain is touched.",
-  "syncBlock": false,
-  "shared": false,
   "records": [
     {
       "type": "A",

--- a/fieldblasters.com.website.json
+++ b/fieldblasters.com.website.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "fieldblasters.com",
+  "providerName": "Field Blasters",
+  "serviceId": "website",
+  "serviceName": "Field Blasters Website",
+  "version": 1,
+  "syncPubKeyDomain": "fieldblasters.com",
+  "logoUrl": "https://fieldblasters.com/img/logo.png",
+  "description": "Connects your domain to your Field Blasters website. Adds an A record for the root of your domain and a CNAME for www; nothing else on your domain is touched.",
+  "syncBlock": false,
+  "shared": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "75.2.60.5",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "fb-tenant-sites.netlify.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Field Blasters (fieldblasters.com), a CRM platform for home-service companies. The template connects a customer's own domain to the marketing website the platform generates and hosts for them: one A record at the apex and one CNAME for www. It is deliberately additive — nothing else on the customer's zone is read, changed, or removed.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (not applicable — the template does not use `redirect_uri`)
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in this template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (no TXT records in this template)
- [x] no variable is used as a bare full record value (no variables in this template)
- [x] no bare variable is used as the full `host` label (no variables in this template)
- [x] no variable is used in the `host` field to create a subdomain (no variables in this template)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (not applicable — both records are the service itself; removing either disconnects the website, which is the expected way to stop using the service)

## Online Editor test results

**Editor test link(s):**

[Test fieldblasters.com/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL1ylGoC%2F%2B1UXW%2BbMBT9K5ZfFwghCU2ZJi3tOqnb2lVTpn1UETL4QlyBjWwTwqL8910SkjRbK%2B2xD3vi%2Bvqc63vuB2tqoShzZoGGa1pqtRQc9DWnIU0F5DzOmbGgjZuogvYOgFtWIIG%2BbyHkosPgvQG9FAls%2BTXERmDcg%2FdJEvl2gC3xKJSk4QApjUzuqvgjNO9UwYR8Jp9cZeqrzvF2YW1pwn7%2FL1RfFFm%2FxbmlzJDCwSRalHb7Er1UUkJiDWlUpQnfvkWs2h3%2FyLQT5JIp54YwSaZEQ6I0J6nSxC6AaKUsUelJMCY5YeTydnpztcXVdf2aSGUXQmYEcgNEyROCMJhAlSyAu5ju7gVDw%2Fs1tU3ZFnCK7oUyFs23bU%2BUkNbMFB7Pxq7vBp47Rre1WJZh4Hmb3oG5zeLIxlRO%2BWnsWJBMWqcValwJNhdp47KyPIk43%2FToLyUhOmY3x8ruOwUrhjMFXY%2B6x9DKtKrKSOzxJdOsMO3c7Zn3J9T5nntPW5vtDVPFezOROFOPQXZ1MIvVwcl0Bp0fMxeZVBoig19mK42FsboCJFS5FRGr2dHFkwi15w0KNXiLIU7bIHcj3baBM8uea0GPRjxphYp2MTjjXnIeB07AuO%2BMkmHgxKOUO8Fg7EMwCThPJ4927dllfHrZjuUGY0Bawdr1mOY1awzdPDEMnYbdMHQq%2FnEQXpCueQ9H6n9zXmhz2q1lS%2BARa2G%2B5weON3GG3mwwCQfDcHDm%2Buf%2B2XjwyvNCz2tVgLE7uWvc2Me7in%2FEmv9cig%2FLks2%2Bf75%2BWH35NOEjfVF5dxf1aFY%2FTEa%2Bd%2FVjWBT1G7r5DQ6CbJnhBgAA)

[Test fieldblasters.com/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANVylGoC%2F%2B1TbWvbMBD%2BK0JfFztykrqex2Bpu63vrCOlsBKMbF0SgSMZSY7rhvz3nfPWemtgHzfYJ1vS89w9d8%2FdkjqYFzl3QOMlLYxeSAHmQtCYTiTkIs25dWCsn%2Bk57ewBt3yOBPqlgZCTLQbfLZiFzGDNryC1EuPub98kkYc9bIFHqRWNA6TUKvtWpldQn%2Bk5l%2BqAnlxP9b3J8XXmXGHjbvc3VFfOp90G5xdqihQBNjOycOtM9FQrBZmzpNalIWKdizi9Of6idFuQT4ZCWMIVGRIDmTaCTLQhbgbEaO2InrSCcSUIJ6e3w5vPa1xVVR%2BI0m4m1ZRAboFo1SJIiwLKbAbCR7mbDJbGj0vq6qJp4BCvZ9o6%2FP3UeKKlcnak8Xh85Pf8kPlHeO0ctqUfMrbq7JlrFS9slNLmT1LPgeLKeU2h1lfgcjmpfV4UrYjjVYc%2BawXJi7oxdnbnFDxxnCnYerRNZme6CTI1uiwSueMU3PC5bWZvx35s0cc7%2FuMmQJNZTpU2kFj8clcaLMyZEjp0XuZOJrziL1ciS1B7XqNQi68Ypt1GtRnJrTbBHT%2FUxQ5NRNbolM1sRzwMAgiZd3wU9LyBiEIvhcHACyCK%2BmGYpangr9bl4D69vS%2FtjoG1oJzkzZQP84rXlq7e8HRbCnrqt8v5Q1P%2FsgLHHRyP%2F2b9I2bhmlq%2BAJHwBtpjvdBjkddnoyCKg348CPygd8zeh%2B8YixlrKgHrNiUvcaNf7zI9H9Wlvcyuv0a1Vk%2FsbHQ3On2%2BepDn%2Bv57dVJfqusLywY33R%2Fndx%2Fp6idUoBAjwQYAAA%3D%3D)

---

The public key for `syncPubKeyDomain` verification is published as `p=N,a=RS256,d=…` TXT records at `_dcpubkeyv1.fieldblasters.com`, and our apply URLs carry `sig` and `key` parameters per the spec's "Digitally Sign Requests" section.