### PR TITLE
Add template: heygetfound.com / getfound

### DIFF
--- a/heygetfound.com.getfound.json
+++ b/heygetfound.com.getfound.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "heygetfound.com",
+  "providerName": "GetFound",
+  "serviceId": "getfound",
+  "serviceName": "GetFound Website",
+  "version": 1,
+  "description": "Points your domain at your GetFound website.",
+  "variableDescription": "ip: the address of the GetFound server that hosts your site",
+  "syncBlock": false,
+  "syncPubKeyDomain": "heygetfound.com",
+  "syncRedirectDomain": "heygetfound.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "@",
+      "ttl": 3600
+    }
+  ]
+}

--- a/heygetfound.com.getfound.json
+++ b/heygetfound.com.getfound.json
@@ -4,6 +4,7 @@
   "serviceId": "getfound",
   "serviceName": "GetFound Website",
   "version": 1,
+  "logoUrl": "https://heygetfound.com/assets/brand/getfound-logo.png",
   "description": "Points your domain at your GetFound website.",
   "variableDescription": "ip: the address of the GetFound server that hosts your site",
   "syncBlock": false,


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

New template: `heygetfound.com.getfound.json` (providerId `heygetfound.com`, serviceId `getfound`).

**About the service.** GetFound is a one-person web studio in Los Angeles that builds and hosts
small websites for local trade businesses — plumbers, electricians, roofers, landscapers. The
customer buys a site, and the last step is pointing the domain they already own at it. Today that
step is a support conversation: copy this A record, copy this CNAME, find your registrar's DNS
page. This template is that step done in one click.

**What the template does.** Two records, both scoped to the domain being applied to:

| Type | Host | Points to | TTL |
| --- | --- | --- | --- |
| `A` | `@` | `%ip%` | 3600 |
| `CNAME` | `www` | `@` | 3600 |

`%ip%` is the IPv4 address of the GetFound server hosting that customer's site — the same value
the manual instructions show. There is one variable, no MX/NS/TXT/SPF, and nothing that reaches
outside the applied domain.

**Signing.** The synchronous flow is signed. `syncPubKeyDomain` is set to `heygetfound.com` and
the RSA-2048 public key is published as `TXT _dck1.heygetfound.com`, split across two records in
the `p=N,a=RS256,d=...` form from the spec. Apply URLs are generated with `sig` and `key`
appended last, the signature being RS256 over the transmitted query string excluding those two
parameters. `warnPhishing` is deliberately not set. This matters for this template specifically:
`%ip%` is an open parameter, so an unsigned link would be exactly the "re-configure your service"
phishing case the spec's security section describes — signing closes it.

`syncRedirectDomain` is set to `heygetfound.com` because the apply URL carries `redirect_uri`,
which always points back to a page on `heygetfound.com`.

**Note on the bare `%ip%` variable (Quality Guideline 6).** The `pointsTo` of an `A` record is an
IP address and cannot carry a service-specific fixed prefix, so the variable is necessarily the
whole value. The mitigation the guideline asks for is provided instead by the mandatory
signature: the value cannot be altered by a third party without invalidating `sig`.

`logoUrl` points at the GetFound mark, served from a stable path on the provider domain:
https://heygetfound.com/assets/brand/getfound-logo.png (256x256 PNG).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

> The `logoUrl` asset is live at https://heygetfound.com/assets/brand/getfound-logo.png.

The template was also validated locally against this repository's `template.schema` (passes).

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the points above:

- **TXT / SPF / `txtConflictMatchingMode`:** the template contains no TXT records at all, so both
  rules hold vacuously.
- **Bare full record value:** `A @ %ip%` is a bare variable by necessity — an A record's value is
  an IP address and admits no fixed prefix. Justified in the description; the signature is the
  mitigation.
- **`essential`:** not set on either record, deliberately. Both records *are* the service — if the
  customer changes or removes them the site stops resolving, so a provider treating that as a
  template conflict is the correct and desired behaviour. There is no record here that the user is
  expected to edit independently.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

- Apex (`domain=example.com`, no `host`): [Test heygetfound.com/getfound example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACoGlmoC%2F%2B1TUW%2FaMBD%2BK5GlPi2EhIQWIk0qrO1WVUVd223qKhSZ%2BABvIfZsB5Yh%2FvvOgUBTtXvuw55yufN39913d2tiYCEzaoDEayKVWHIG6pKRmMyhnIGZiiJnXioWxN2HR3SBz8lHMBc2ihENaslTqHA16OB%2B9t75BhPNsaJLlqA0FzmJA5dkYia%2BqMxWNkbquN1%2BxqBNtQaj2xNFc9auIy2L82Q%2Bw3QMdKq4NFVKciN4brRTikI5TCwozx1qtr97KqstFc9yoYrTSQZnjSRcxo6Zg0MZU6C1I6bV7z6BbREU%2BjD1XOi63q4%2FXebpMBPpTxJPaaZh67kpJldQnlWUXhTaProFxhWk5h%2FPMCwU0yR%2BXBNTSqvxAN2WBpqndmKVBPcCf4%2B4PEKPMahweOz7G3cP%2BjAaXJ8fgKvVqgk9beDGG5f8ETkkh%2FJjlL6mCb8pLhTsKO5SojVTopAJr99LquhC26WrkY8N6LjGPhJrc2mtjh96vhcEoRf4xPLgs1woSDR%2BqSkUNmNUgSoviszwhK7owcXShEqZlUhbYxTTNVXLt0tqe2XUUDQb1Z4o4JKEpZY5t%2BtO06g3YZ3j1vQY%2FFbU7bFWP2WdVnjSCyl0T6ZhevLkdl45rVcO6CAf7h7khlN7H4NsRUtNNi%2BMcNfFdoS7PpoTeYNtjF3ciP%2FTeCvTwHPTdAksoabSHWn4vVYY3Hc6cTeKw8jr%2Bv2o33%2Fn%2B7FfzQK02Xa3xpt8eo3k4ar76Rc8RD%2F8JVvq3vnl9XD%2B9Ta%2FvQs%2BX1yMYBRd3bFZngXD7%2BI92fwFzzVi0o4GAAA%3D)
- Subdomain (`domain=example.com`, `host=shop`): [Test heygetfound.com/getfound example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ4GlmoC%2F%2B1T227bMAz9FUNAn%2BaLEidua2BAu7XLLljXDl26tQgM2aYTbbYlSHI8L8i%2FT3LiJC7aPfdhTzZJHfLwkFwhBQXPiQIUrhAXbElTEB9SFKIFNHNQGavK1E1Ygexd%2BIoU%2BjmagHpnojoiQSxpAi2uA%2B3dj95bdxBLqivaaAlCUlaicGCjnM3ZN5GbykpxGXreIwYekRKU9GJBytTrIo7Bubyc63QpyERQrtqU6JrRUkmrYZWwUlYQWlpEbcwdlXpDxTVciKAkzuGil4Ty0FILsEiaCpDSYllr7hKYFkFon069YLKrt%2B1PNmXyJmfJLxRmJJew8VxX8SdoLlpKTwptHn2FlApI1D%2Be6TATqUThwwqphhuNz7Xb0NC%2FZ2ZirQS3TJtHlB9pj1JaYT%2FAeG3vQG%2Bvzj9f7oF1XfehZz3cbG2jP6yEaF9%2BpqXvaMJvohcKthS3KeWCcW3NBat4RDsMJ4IU0ixeh37owWcd%2FmGTQNuUG2uIfRe7g4HvDjAyfOi8ZAIiqb9EVUI3pUSl1S6qXNGI1GTvSpOIcJ43mr7UUZ2ur165WdYt45Qooq1ewQMxbBSliWmAms33cTYCHAfOaZydOqPAj50YDwIniZNsnOFgCP7JwRk9c2XP3FJfSb2KUCpKzLmc5zVpJFo%2FMdFtM3qibr8hY7n9Ub3Qpma2XpX%2FI3rRI9KHKckS0oiodhLDwMEnjj%2B4HQ7DcRD62A1Gp8fH41cYh7idDki1aXOlr%2FfwbtHYuylrORWMyrvbi8no5%2F10co9H34Pcm15Om4%2BL919uysmPIktuXqP1X5K1sv%2FABgAA)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

Both links carry the exact template in this PR. Results produced by the editor:

Apex — `domain=example.com`, `host=` (empty), `ip=203.0.113.10`:

| Name | Type | TTL | Data |
| --- | --- | --- | --- |
| `example.com.` | A | 3600 | `203.0.113.10` |
| `www.example.com.` | CNAME | 3600 | `example.com` |

Subdomain — `domain=example.com`, `host=shop`, `ip=203.0.113.10`:

| Name | Type | TTL | Data |
| --- | --- | --- | --- |
| `shop.example.com.` | A | 3600 | `203.0.113.10` |
| `www.shop.example.com.` | CNAME | 3600 | `shop.example.com` |

No errors or warnings were reported in either run, and the `host` parameter is honoured without
any `%host%` reference in the template.

