### PR TITLE
Add zuppi.io.tracking template

### DIFF
--- a/zuppi.io.tracking.json
+++ b/zuppi.io.tracking.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "zuppi.io",
+  "providerName": "Zuppi",
+  "serviceId": "tracking",
+  "serviceName": "Zuppi link tracking",
+  "version": 1,
+  "logoUrl": "https://zuppi.io/icons/icon-512.png",
+  "description": "Connects a subdomain of your domain to Zuppi so links in your outreach emails can be tracked on your own domain.",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "zuppi.io",
+  "syncRedirectDomain": "zuppi.io",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Zuppi (`zuppi.io`), service `tracking`. Zuppi is an outreach tool for creative freelancers; this template connects a subdomain of the customer's own domain (typically `track.<customer-domain>`) to Zuppi's hosting with a single CNAME, so link tracking in the customer's emails runs on their own domain. `hostRequired` is set — the record is always written at the host offset supplied via the standard `host` parameter, never at the apex.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key is published as TXT records at `_dck1.zuppi.io`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the template has no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A, no TXT records
- [x] no variable is used as a bare full record value — the template has no variables
- [x] no bare variable is used as the full `host` label — the template has no variables
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set on records the end user may need to modify independently — N/A: the single CNAME **is** the service; changing or removing it disconnects tracking by design

## Online Editor test results

**Editor test link(s):**
[Test zuppi.io/tracking example.com/track](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADaHlGoC%2F91T207bQBD9ldW%2BEofNnViqVEgvUNS0RfDQosia7A5hhbO77K4DJsq%2Fd%2BzEJdBW6nNfbM3MOXM5Pl7ziEuXQ0SerrnzdqUV%2BjPFU%2F5UOKfb2vLWr%2FwUloTjP6oKpQP6lZZYo6MHeafN4jm9D2a5NndsD7NCH7Q1PO20eG4X9srnhL2N0YX08LAZfailNaF%2BJoNOt%2B1qrsIgvXax5vOJNQZlDAxYKObKLkEbZm9YaQvPdmG0bLtGsPUmgVGyBtgiegR5y5CAeWASDJvjdlNUzDawB7Pr1a4OLI08ya284%2BkN5AFb%2FNaGeIH3hfZIYkRf4Bb1tZifY%2FmuZr6UtKpeoCKCjH%2BqU956FXh6veaxdJWSk%2Bnx5%2Fd8O4zCt9WHsdrEcGkplIb0bpOuEvNEmdCWdkmIGEnY3lCIzWzT4k%2FWYPbcekZiNrPxEcgIuKPtZtQ6ULjwtnCZbkgOPCxD5ZiGfv2CP2saXO86VLP1wliPWaA3xMJjo9OyyKPO4AGeU0pm4Fxe0qqBqtTndxXM1l7Nhgoi%2FIMKLZ4pWS2uK9OOQY3kUBwloxvRT%2FogIZkr2U%2FUYNAZjFRXjGG%2BZ%2F%2FXv8Vf%2FP9KOwwBTdRQGfw4f4Ay8M1m1iId%2F7uj6LsHWKHKoMJ2RXeY0B49cdkZp32R9o7avZ4Y9cYHQqRCVCdgiNsj1%2BSQfW%2FwxZeT6ffJ4Pxgenp%2FObGDs6t48GG%2BOlmZMPr0eDbUpcjd6dH96OO3N3zzExo45ZDIBAAA)

*(`hostRequired: true` — per the instructions, the apex test is not required; the host test above covers the only supported configuration.)*
