### PR TITLE
Add juudd.com.site

### DIFF
--- a/juudd.com.site.json
+++ b/juudd.com.site.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "juudd.com",
+  "providerName": "juudd",
+  "serviceId": "site",
+  "serviceName": "Point a domain at a juudd site",
+  "version": 1,
+  "logoUrl": "https://juudd.com/logo.svg",
+  "description": "Adds the CNAME that makes a domain serve a site deployed on juudd.",
+  "syncPubKeyDomain": "domainconnect.juudd.com",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "sites-fallback.juudd.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a template for [juudd](https://juudd.com), a deployment platform where an assistant publishes a site over MCP. Customers point a domain they already own at the site they deployed.

**One CNAME, and no verification TXT.** The platform uses Cloudflare for SaaS with HTTP validation, so the hostname-ownership and certificate challenges are both served from the edge and there is no second record to add.

`hostRequired: true` is deliberate rather than conventional: the apex is not supportable here at all, because Cloudflare does not support `APEXCNAME`. Customers on a bare apex use `www` and redirect at their own provider.

No variables, so there is nothing for a caller to inject: the CNAME target is a constant.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`https://juudd.com/logo.svg` answers `200 image/svg+xml`.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `domainconnect.juudd.com`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — not set at all
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — not applicable, no `redirect_uri` is used
- [x] no TXT record contains SPF content — there are no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — there are no TXT records
- [x] no variable is used as a bare full record value — there are no variables
- [x] no bare variable is used as the full `host` label — there are no variables
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not applicable: the single CNAME *is* the service, so there is no record a user could remove without breaking it

## Online Editor test results

**Editor test link(s):**

[Test apply — domain `example.com`, host `www`](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJuDlWoC%2F91SXW%2FaMBT9K5Ffm0A%2BNkgjTRodU9dVrdDEJm0IRY59AY8kTm0nNEX8911D%2BKi6hz3vKfG959x7fHy2xEBR5dQASbakUrIRHNQdJwn5Xdec95gsiHtqPNICji0sa1CNYLCHa4EzTqUOOJGiNA51uCyoKB1q%2F%2Fdkp4M3oLSQJUkCl%2BRyKb%2BrHGkrYyqd9PsnCX3b6%2BlmiRQOmilRmT2NjDjXjlmB8%2Blx9PAZ%2F3BHQdegz1utJMCjXelwqHLZAndkeVDSs6Lbkk3q7B7a8Z6Ccw9cJssSmOldemHBN7lka5IsaK7BJSupzTd4qoUCdMKoGmsKmFRck2S2JaatrBl7heQAx%2BNH66v1R09l55%2F2cGKeUbbuNtKqQpQxaEo08P3dfOeSF1lCeh4%2FdzutOAOeKT4mdEK7PZvNBg9LJesqFUdKRRUttH3zI3n2ij0%2F0md7vt0rlqVUkGr8UlMrON60qHMjUrqh5xJnKSrPW5SpsYtT3rpQHhJyUMepof%2FogUtSzqxwYVMXhtcBAA28OI597911zLxswYdesMjCOIsXPh2GF%2Fl9E%2By%2FJPiVbaA1lEZQm8pRvqGtJrvd3EUL%2F68b4Xtr2gBPqUWGfjjw%2FNiLgmkQJdEwiYKeH7%2F3g%2BjK9xPft%2BpBm8Mdt5iNy1SQwTT4cVfHwTi7%2BfkSTb5u6MOvNasb9QXi%2FngQ9adX97e3T0G7ZB%2FI7g9VBi%2ByggQAAA%3D%3D)

Result: `www.example.com. CNAME 3600 sites-fallback.juudd.app`, no errors.

Apex test omitted because `hostRequired` is `true`.
