### PR TITLE
Update fingerprint.com.custom-subdomain.json

### DIFF
--- a/fingerprint.com.custom-subdomain.json
+++ b/fingerprint.com.custom-subdomain.json
@@ -3,7 +3,7 @@
   "providerName": "Fingerprint",
   "serviceId": "custom-subdomain",
   "serviceName": "Custom Subdomain",
-  "version": 2,
+  "version": 3,
   "logoUrl": "https://fingerprint.com/img/email-assets/fingerprint_logo_with_name.png",
   "description": "Connects a custom subdomain to Fingerprint, verifies ownership, and provisions the SSL certificate",
   "variableDescription": "Use groupId=base normally, or groupId=base,caa when CAA is required. %ip1% and %ip2% are two ingress for the customer. %dcv% is the dcv address needed for each customer",
@@ -27,7 +27,7 @@
     {
       "type": "CNAME",
       "groupId": "base",
-      "host": "_acme-challenge.%fqdn%.",
+      "host": "_acme-challenge",
       "pointsTo": "%dcv%",
       "ttl": 300
     },


### PR DESCRIPTION
# Description

Update host for CNAME to fit Cloudflare parsing of template

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test fingerprint.com/custom-subdomain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABeHlWoC%2F%2B1WUW%2FbNhD%2BKwQBP1VWZCmJHQMFZjjpkK0rhqV9SgOBJk8WC0lUScquF%2Fi%2F70jbkRTHWbGHYQMKP5g83n13993xxEdqoawLZoFOH2mt1UoK0LeCTmkmqyXoWsvKhlyVNHg6%2FsBKVKfvWgU8NKBXkoM35Y2xqhyaZiFUyWTVHu9N516B3HUUVqCNVBWdJgEt1FJ90gUq5tbWZnp29iyYM1kuzwAtiyEzBqzpKqTOPF1Lm6cVugvraon4AgzXsrbeB52rqgJuDWFkFyx5CpZYRTqpBQQjk5kEQ9S6wiBzWQeEVYJ4OlzMhtgcyN3de8JBW9Tljk9MiWnJFgVc91x%2FMkCWWjX1rXi7YLiplC5ZUWwConTvJOCMkXUOFZnPZkQaouFrIzWIkAxkPRr4KHAV40oDsWtFMG4NxpAMoVxQu%2BRAo4Xgq4EDcWJcEyaEV60ABAhvAYznTyauaJuK%2FwECXXJ7vSvUUV8Egpl8oZgW4XHHOIDfm8WvsGnN6y8mROrwFGGVFoZO7x%2Bp3dSuMWYo3lOAO0cCCnJlLO5%2Bci2oENx8VLj1FKDIWmyUJIq2wT9EiU%2BgzD%2FMfrt5BSllvIQhz7F2gIk%2Fw3V0n8Cd9ePDKvfDE8wyXEZYLdMA%2BUwHqJL6jR58pl3Uh21A%2F1QVpC2XDwhwIBu%2BMbzdsK%2FG3sXBeSq9%2Fi4rtKqZZqVxc%2BBgf98DeDgg3FO39hhde6yH246u4nDkfjtZ7GWTjgyZcbLJ1eQqxHXIC9WIrMAWPrhp0905wyTlEq8JpAb%2FmW008mh1AwEtm8LKlK1ZKxI8ZXVdbJATg6cI0e%2BvajeDOky3IbfUBjQV3JEhXY2EyPh4ko2H0fk4Gp5fnidDNhpj9bMRW0TJ1cX44rIzIU8M0L%2BZkW198F5CZSVzI3BWrNnG0O2z%2Fn4hi8n%2FK4vD%2Fdpncnyd9nmdapT%2FcpYPAd7DH233o%2B3%2B5bbD4WnYCkTKnFocxZfDaDJMRh9HyfQinsZJeJEkcRK9iaJpFLlcwNhdwo9%2B7ec%2Fvsvc3%2BH94mV%2Buvda1s%2F2Xvn9ZH%2BFuNe%2FSyVYLbmhR5%2BWrXsquFF%2B9FTY13BvGXZgw16dji7cy1393TiTF3Be76vwe7FPsYef%2Bq1rjwLfYlhfVyvUdpVCcfe7SMXXm%2Fn77Mttef3u%2Bpe4eZOsamETO5dydPMzu%2FmW1ckM32QNvkPe0u1fcSPyvgIMAAA%3D)

[Test fingerprint.com/custom-subdomain example.com/metrics](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADSHlWoC%2F%2B1WbW%2FbNhD%2BKwQBf6osy3KTygYKTEg6rMsSFE06dEgNgSZPNjtJVEjKrhv4v%2B8o25EUz8naTytQyIDJ493De3nI4z21kJcZs0An97TUaikF6LeCTmgqiznoUsvC%2Blzl1HtYvmI5qtNfGwVcNKCXkkNtyitjVd431UyonMmiWd6ZntUK5LqlsARtpCroZOTRTM3VB52h4sLa0kwGg0fODGQ%2BHwBaZn1mDFjTVkicebKSdpEUuJ1fFnPEF2C4lqWt96BnqiiAW0MY2TpLHpwlVpFWaB5Bz2QqwRC1KtDJhSw9wgpB6nQ4nw2xCyDX138QDtqiLnf5xJCYlmyWwXln6w8GyFyrqnwrXs8YTgqlc5Zla48o3VnxOGNktYCCnMUxkYZouKukBuGTniyHvdoLHIU40kDsShH0W4MxJEUo59Q2ONBoIfiy50CcGMeECVGrFgACRG0BjC8eTFzR1gV%2FDwK35PZ8W6gDXniCmcVMMS38Q8Y4gHfV7ALWjXn52fiYOlxFWKWFoZPbe2rXpSNGjOJdCnDmkoCChTIWZ784CioENzcKp3UKUGQtEmUUBBvvO1HCIyhnV%2FHlmyeQEsZz6PMF1g4w8Ee4Lt1HcOOuf1jlrnuCWYbDAKtlKiCfaA9Vknqie59oG3W68ehXVUDS5HKKAPtkwxeGpxt21dhtkYPVkpu9D4mszbbBoXHJNMuNuw72MLcdnOke6PYBabqDasNgddx0OA79ofu2srCWRS0Z5snJonE09nHs80xVIs2Q0PvdmuCdInUhyzkeGkgM%2FjNbacyq1RV4NK8yKxO2Yo1I8ISVZbbGDBlcRYgu24rtjdQkZZf9xvEm3R5NBHeZkXXd0tMT%2FKA%2FhHDYfxnyk%2F5szKI%2Bh%2FFMQCrGaRC1bs0jl%2Boz9%2BZBzfDIQmElc7djnK3Y2tDNI%2BofDSn6IUPan8NdWI%2BOnX8Q5jEq%2FQBBTz08vj%2F5%2BZOf%2F1d%2B4nVs2BJEwpx2GISn%2FSDqj4Y3w9HkJMSffzIeRqfjF0EwCQIXEhi7jfu%2BHteNBd997m%2F%2FPqpldb%2FosLruFh1S1L3iifx9U99rmtXGPUVcczh4inSZ6rdg%2FU65Ds7kk4x%2FHif6F5z%2FRrNnsY9lD58SG8eSDN96WF9XK9R2lUJxu9PS3%2F4cXfw1XwXn%2BhVcvBHy5d3H5Tob%2FP355t3qdxGnd69uZpdxeh5fXb6mm38AVNzAl2IMAAA%3D)