### PR TITLE
add aser.tr, aser.tr Business Email

### DIFF
--- a/aser.tr.eposta.json
+++ b/aser.tr.eposta.json
@@ -5,7 +5,7 @@
   "serviceName": "aser.tr Business Email",
   "version": 1,
   "logoUrl": "https://aser.tr/statik/favicon-32.png",
-  "description": "Connects the domain to aser.tr business email: MX, SPF, DKIM, DMARC, MTA-STS, TLS reporting and automatic client configuration.",
+  "description": "Connects the domain to aser.tr business email: MX, SPF, DKIM, DMARC, MTA-STS and automatic client configuration.",
   "variableDescription": "%dkimselector1%: DKIM selector Ed25519; %dkimdata1%: DKIM key record; %dkimselector2%: DKIM selector RSA; %dkimdata2%: DKIM key record; %stsid%: MTA-STS policy id",
   "syncBlock": false,
   "syncPubKeyDomain": "aser.tr",
@@ -61,14 +61,6 @@
       "ttl": 300,
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "v=STSv1"
-    },
-    {
-      "type": "TXT",
-      "host": "_smtp._tls",
-      "data": "v=TLSRPTv1; rua=mailto:tlsrpt@aser.tr",
-      "ttl": 300,
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=TLSRPTv1"
     },
     {
       "type": "CNAME",

--- a/aser.tr.eposta.json
+++ b/aser.tr.eposta.json
@@ -1,0 +1,92 @@
+{
+  "providerId": "aser.tr",
+  "providerName": "aser.tr",
+  "serviceId": "eposta",
+  "serviceName": "aser.tr Business Email",
+  "version": 1,
+  "logoUrl": "https://aser.tr/statik/favicon-32.png",
+  "description": "Connects the domain to aser.tr business email: MX, SPF, DKIM, DMARC, MTA-STS, TLS reporting and automatic client configuration.",
+  "variableDescription": "%dkimselector1%: DKIM selector (Ed25519); %dkimdata1%: DKIM key record; %dkimselector2%: DKIM selector (RSA); %dkimdata2%: DKIM key record; %stsid%: MTA-STS policy id",
+  "syncBlock": false,
+  "syncPubKeyDomain": "aser.tr",
+  "syncRedirectDomain": "panel.aser.tr",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx1.aser.tr",
+      "priority": 10,
+      "ttl": 300,
+      "essential": "OnApply"
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.aser.tr",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimselector1%._domainkey",
+      "data": "%dkimdata1%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimselector2%._domainkey",
+      "data": "%dkimdata2%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:dmarc@aser.tr; fo=1",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "mta-sts",
+      "pointsTo": "mx1.aser.tr",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_mta-sts",
+      "data": "v=STSv1; id=%stsid%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=STSv1"
+    },
+    {
+      "type": "TXT",
+      "host": "_smtp._tls",
+      "data": "v=TLSRPTv1; rua=mailto:tlsrpt@aser.tr",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=TLSRPTv1"
+    },
+    {
+      "type": "CNAME",
+      "host": "autoconfig",
+      "pointsTo": "mx1.aser.tr",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "autodiscover",
+      "pointsTo": "mx1.aser.tr",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "mail",
+      "pointsTo": "posta.aser.tr",
+      "ttl": 300
+    }
+  ]
+}

--- a/aser.tr.eposta.json
+++ b/aser.tr.eposta.json
@@ -6,7 +6,7 @@
   "version": 1,
   "logoUrl": "https://aser.tr/statik/favicon-32.png",
   "description": "Connects the domain to aser.tr business email: MX, SPF, DKIM, DMARC, MTA-STS, TLS reporting and automatic client configuration.",
-  "variableDescription": "%dkimselector1%: DKIM selector (Ed25519); %dkimdata1%: DKIM key record; %dkimselector2%: DKIM selector (RSA); %dkimdata2%: DKIM key record; %stsid%: MTA-STS policy id",
+  "variableDescription": "%dkimselector1%: DKIM selector Ed25519; %dkimdata1%: DKIM key record; %dkimselector2%: DKIM selector RSA; %dkimdata2%: DKIM key record; %stsid%: MTA-STS policy id",
   "syncBlock": false,
   "syncPubKeyDomain": "aser.tr",
   "syncRedirectDomain": "panel.aser.tr",


### PR DESCRIPTION
# Description

New template for **aser.tr**, a business email hosting service. Applying it
connects a customer domain to our mail infrastructure in one step: MX, SPF
(via `SPFM`), two DKIM selectors (Ed25519 and RSA), DMARC, MTA-STS, and
`autoconfig`/`autodiscover` so mail clients configure themselves from the
address alone.

The synchronous flow is signed: `syncPubKeyDomain` is `aser.tr` and the RSA
public key is published as TXT records at `_dcpubkeyv1.aser.tr`. Signature
generation and verification were tested end to end — the query string signed
with our private key verifies against the key reassembled from those DNS
records (`openssl dgst -sha256 -verify` → `Verified OK`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Note on the bare-variable rule (DKIM):** the two DKIM records use
`"data": "%dkimdata1%"` / `"%dkimdata2%"` as the full record value. A DKIM
key record has no fixed prefix that can be hard-coded — the whole value is
`v=DKIM1; k=...; p=...` and is generated per domain and per selector. The
host labels are scoped (`%dkimselector1%._domainkey`, not a bare variable),
and both records carry `txtConflictMatchingMode: "All"`.

## Online Editor test results

**Editor test link(s):**

- Apex: [Test aser.tr/eposta example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACgyl2oC%2F%2B1YbU%2FqSBT%2BK5NJ7qcFbMtra0isyN0lpIqIrrvGkLGdwlxKp3aGKte4v33PALWAVe%2Fmmr2a8AWGmTPPeT%2FzhAcs6TQKiKTYesBRzBPm0bjjYQsTQeOSjHHhafuYTOnGASwS5tKFOI24kCTb3BRGhzPBQioEak8JC0AsobFgPMSWXsABH%2FHzOADxsZSRsPb2Vtf2AFKyyZ5PAJKHxbJRisIR3PaocGMWyQUCbvEwpK4USI4p8jhoCJHkKNV9k%2BqmSreFnMsCOut9LaCjbseBT8futwrIGdjFs8EZIqGHyEwCimQucgNGQ4lAuc9Gs5gojSVlPokZuQno0YYhX7wJmwoagDE81r9YCw0o3UBtz6hWdXMfLeQ8IsmTzITOUUxdHnur0%2FSS8Qylf2avIRi5CEIK5sFJ6lTEA%2BbOEfNUguahexhwd4ItnwSCLnd6s5sunR8tgreZZDjsU48Btnw6jkhIg1ImtFQssHX1gOU8Upl3LmF%2FDEUB6wNVRZyFUgw4%2FJze66X18mI8ZnIOpaAVsJRQB2UNVpAxCD0jqi5OQjuKgjl%2BLDzhQwadTQ0i8vuzgIIVmIVuMPOoNYS9NVUp%2BBrM4HKQoWzlrzRcFhOEVtUcRDuVWeYOr5sr7yXUoQ9xlg6R7piFI4d7SoUdBPiHNBpvaDTeQ%2BPQm5LYzdCT5qIB9H0UNUMe0n0Uz0hTdYrk1kL2YBXAfeTzpv6DJvRi6rN7nCuyOst04zez3Tq2nXbmxFSSItT4a2X1Vq6HGcZTJKBVEggE85qrDnpfZxfwr3ilxs5y0vxHx3JwPCZcDkP255BWw3oNYTHm8zCuHwv4O9TPMJsF1xDadGLQewIPDS25fJrBw2oU81k0ZKl8RGIyFeoxSm9ebVy9Tu9eYbXe6Fe1mehFupyyRUMzalqjrKdyi55dyDTVwIQ8T5o0ncjjphgTo1pTXXCb0ECw08TstOqt9m2rfj5PTo%2BT%2FkXvYuqczs89%2FcTvaXp0ZormthHGyohYkFwDjC0DQG5TudPpHHa%2B2ceHo8nteMJ%2BN%2B%2B0Q%2Fu0%2FdW2T1r2acNW561RF9ZtWwEv6lSBmuCIVqmber3SqDbqjbIJiiEnbBTymA4FfBM5iyHJMp7B0J%2FOAsmG5I5kW547JKrxIIUCTgF1a5yHy0f9IOuZ%2FILaHupDz1UpVYbiSsMnfs2oFqtlzyhWNK1WNF2NFLWGr%2FmGW65V6voa6djiIrmUI6um3CnybAI8dyNpwkOho7xnA%2F1DgmDDt1%2FijR3ckbl42Zmcws99TN61%2BD9DVNY78a2I%2FFw3fvhovOvT%2F2F6On2yVk4%2Be9ZfGlEfM0WvspK8Gf8RXdpKyQav%2BSRZyXFhjVJ9TidWbG5l%2FEtM7lebf10AIrgjHjvisSMeO%2BKxIx474rEjHjvi8b8QD%2FV3CkmoNyRKTM3uomYWNX1gaJZescpGyayZZVP7TdMsTVOWUyGXTj08gvVr%2F7Fg5%2BKy9pfx9%2Fe98c2532t0L46%2B3f3Jq5Vug1%2F0vg3uu12DXPZvR60%2FeBM%2F%2FguBk0MQiBkAAA%3D%3D)
- Subdomain: [Test aser.tr/eposta example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJEyl2oC%2F%2B1YbW%2FiOBD%2BK5al%2FXRAk%2FCeCmkDZfe6vbRAadVVVSGTGPAR4jR20nJV77ffOJASaHbbu610rcQXSOzxM%2FPMm0d5wJIuAo9Iis0HHIQ8Zi4Nj11sYiJoWJIhLjwtn5IF3dqAh5g5NBGnAReSbBa3hVE7EsynQqDugjAPxGIaCsZ9bOoF7PEpvwg9EJ9JGQjz4GB97AAgJZsfTAhAcr9YNkqBP4XTLhVOyAKZIOAO933qSIHkjCKXgwYfSY5S3eNUN1W6TWRfFdB570sBHZ0c2%2FBrW4NOAdlDq3g%2BPEfEdxGJJKBI5iDHY9SXCJRP2DQKidJYUuaTkJGxR4%2B2DPnkztlCUA%2BM4aH%2ByUw0oHQBdV2jWtWbhyiRc4kkTzJzukQhdXjornfTQ8YzlMG5lUEwchGEFMyFnZRUwD3mLBFzVYCWvtP2uDPH5oR4gq5WetH4hC6PEudtBxk2B9RlgC2ftgPiU6%2B0EVopFti8fsByGajI21ewPoOkgOfPKos486UYcnhd3OulbHoxHjK5hFTQClhKyIOyBk8QMXA9IyovznwrCLwlfiw84UME7W0NIpgMIo%2BCFZj5jhe51BzBWkZVCp6BGV4NNyg78SuNVskErlU5B95OZVaxw1lz5b2EPJyAn6VNpDNj%2FtTmrlJheR5%2BlUbjBY3GW2gcuQsSOhv0uJUUgH6IgpbPfXqIwoi0VKVIbiayn9cOPEQT3tJfaUIvpBN2j3NF1nsb3fjFaHdOLbu7IbGQpAg5%2FrO0einWow3GkyegVGJwBHNb6wp6W7IJ%2FE9Yqbaz6jT%2FklgOjsuEw6HJ%2FhrSullnEJI2n4dx81jAf0H%2BjDa94AZcm3YMek%2FgoqElhy828CIaw8s05FEwYumRgIRkIdR9lB6%2B3jp9kx6%2FTs4rJdmqVeuxXqSrXls0NKOmNcp6KpdUbiLTUm0Toj1v0bQvz1piRoxqTdXCbUw9wfpx87hT73RvO%2FWLZdw%2FjQeXvcuF3V9euPrZpKfpwXlTtHaNMNZGhILkGmDsGABy28rt4%2BP28Z%2FWaXs6v53N2dfmnda2%2Bt0vlnXWsfoNS%2B13pifw3LUUcJKtCrQJRLRKvanXK41qo94oN0ExRIZNfR7SkYB%2FIqMQQi3DCFr%2FIvIkG5E7sllynRFR5QeBFLALqDtN3V9d7avgrWsnP7F2m%2FvIdVRclam42dRqulEZF6turVysNGi9SJxxvVh1ynSiVSpOo0Eyw8fOTJI7emxlVW5DedYM8rjELbg1dJR3h6C%2FiedtEfy%2FKFneHVmKHzPKKYHM5VLaIfyGpfBBnJMtzdc45tdK9CM4ZTUYPHPAfx8O3lO1p%2Ffamuv67i%2B9qoe924DlsshOMXm3wTtlthOgzSj04WKUwyQdxj46F1X42xx%2BNA6%2BAxY3BZgm96PLfnTZjy770WU%2FuuxHl%2F3osh9dPsjooj7pkJi6I6IkVbMvas2ipg8NzdRrpl4v1Rr1arXxm6aZmqaMp0KueD08AoHMdx48sJf9QfXkkn33LkJe%2Fv5Hu2af%2FD63v9nVy0b8tUq%2FWRdOr0sp1Vr48R8hM0d2EhoAAA%3D%3D)

Both runs render all 10 records with variables substituted; the subdomain run
scopes every record under `sub.example.com`.

