### PR TITLE
Update shopdeck.com.website-service-id template to v3

### DIFF
--- a/shopdeck.com.website-service-id.json
+++ b/shopdeck.com.website-service-id.json
@@ -3,7 +3,7 @@
   "providerName": "ShopDeck",
   "serviceId": "website-service-id",
   "serviceName": "ShopDeck Website Hosting",
-  "version": 2,
+  "version": 3,
   "logoUrl": "https://pro.shopdeck.com/logo192.png",
   "description": "Website Hosting with ShopDeck",
   "variableDescription": "Website Hosting with ShopDeck",
@@ -16,13 +16,13 @@
       "type": "A",
       "host": "@",
       "pointsTo": "%arecord%",
-      "ttl": 3600
+      "ttl": "%arecordttl%"
     },
     {
       "type": "CNAME",
       "host": "www",
-      "pointsTo": "dwbw2ozui8j03.cloudfront.net",
-      "ttl": 3600
+      "pointsTo": "%cnamerecord%",
+      "ttl": "%cnamerecordttl%"
     }
   ]
 }


### PR DESCRIPTION
# Description

Updates the existing **ShopDeck Website Hosting** template (`shopdeck.com.website-service-id.json`) from **v2 → v3**.

Changes in this update:

- **Parameterise the `www` `CNAME` target** — the previously hard-coded `dwbw2ozui8j03.cloudfront.net` is replaced with the `%cnamerecord%` variable so the CloudFront/CDN distribution can be provisioned per merchant.
- **Parameterise TTLs** for the `A` and `CNAME` records via `%arecordttl%` / `%cnamerecordttl%`.

No provider/service identifiers, `syncPubKeyDomain`, or filename change — this is a backward-compatible enhancement of an already-published template.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — apex + subdomain apply tests, links below
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`shopdeck.com.website-service-id.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://pro.shopdeck.com/logo192.png`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`domainconnect.shopdeck.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`pro.shopdeck.com`) for the synchronous flow
- [x] no TXT record contains SPF content — *N/A, this template has no TXT records*
- [x] `txtConflictMatchingMode` is set on TXT records that must be unique — *N/A, no TXT records*
- [x] no variable is used as a bare full record value **unless necessary** — the `A`/`CNAME` targets (`%arecord%`, `%cnamerecord%`) are IP-/hostname-valued and have no meaningful fixed prefix, so a bare variable is required here (same pattern as other hosting/website templates in this repo)
- [x] no bare variable is used as the full `host` label — all `host` values are fixed (`@`, `www`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute
- [x] `essential` is set to `OnApply` where required — *N/A: both records are required for the storefront to resolve and there are no optional/user-modifiable records (e.g. DMARC), so `essential` is intentionally omitted*

## Online Editor test results

Both tests were run through the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit): "Check template" passed with no errors, followed by "Test apply template". Sample values used: `arecord=3.5.140.2`, `arecordttl=3600`, `cnamerecord=dwbw2ozui8j03.cloudfront.net`, `cnamerecordttl=3600`.

**Editor test link(s):**

- **Apex** (domain `example.com`, no host) → `example.com A 3.5.140.2`, `www.example.com CNAME dwbw2ozui8j03.cloudfront.net`:
  [Test shopdeck.com/website-service-id example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMTClmoC%2F%2B1TXW%2FTMBT9K5WlPS3JkvQ7EhKDTmICNrQVFTRVkWPftt7SONhOQ1f1v3PdZG1WJhBvIPGU63vPObmfG2JgmafUAIk2JFdyJTioS04iohcy58AePCaXxNnHrugSseQWoyOMYkSDWgkGO1IJiRYG3NrnCn4AHDFbkwrbeie1EdkcgStQWsiMRG2HpHIuP6sUCQtjch2dnWEGXjOpMwsJhqGX78gcNFMiNzsBciTeKoVZtBpJr6gSNElh9Ecsvc7Ym1SiHc1oqqHyfCqS97AeySUVVoTvDCazDJjxjtpo8TfAhcLYnnFcGeIWmMENfCsQyPc%2FQ5JUXJPobkPMOrfdPK%2BxaL62U5IiM3os8XlCK%2FgJuo1JGx58nZCts9d4e3X%2B8eKgU5blkRLLcHQ%2FqTW8leJ065BHmUF8yHPq1O1AAnynuGrQKBCdaM2VLPJYPOFzquhS23V8Yt49o06fuHfE2nVN9tn2ul7Q8b2w4d%2FliqGe71tvI2fr5mVShvKxEIN7v%2B2xVBZ8pmRmvAzMEfyZEBYq5plUEGv8UlMo7KNRBc5oWaRGxLSkBxdnMc3zdI190RhFmefzy6rDsPPj1FA0D5XU3ba%2FdUjMme2LsJcGjPaGnWTgsgEkbofyvkuTWdcNE9pvg89mwYA3zvalk%2F7t4R5mBFpDZgS1gz9PS7rWZPvCBtWVVBtU1%2FLLHv%2FN5U0dXMf%2Fk%2FoXJoWnqukKeEwtLPTDnusPXT8YB2EUDKOg53W63X5%2FeOr7Ed4v1gLaVFVv8JabV0wMe%2FhwuWKF718zNRqOvkwgOE0%2FFvfj26%2BTazW4KGVRsHwy7s1fke0PXyQ5O0EHAAA%3D)

- **Subdomain** (domain `example.com`, host `shop`) → `shop.example.com A 3.5.140.2`, `www.shop.example.com CNAME dwbw2ozui8j03.cloudfront.net`:
  [Test shopdeck.com/website-service-id example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFnDlmoC%2F%2B1TXW%2FTMBT9K5WlPZGkaZqkJBIShQ02sU1TGZrQVEVufNuapXZmOw1d1f%2FOTZO1aZlAvIHEU3zvPefkfq6JgUWeUQMkXpNcySVnoC4YiYmey5xB%2BuCkckGsXeyaLhBLPmP0FKMY0aCWPIUtqYSJ5gbsxmdztgccMTt3NbZzLrXhYobAJSjNpSBx3yKZnMkvKkPC3Jhcx90uZuC0k%2BpWkF7kOfmWzECniudmK0COxDslN%2FNOK%2BklVZxOMjj9I5ZeifRdJvEdT2mmofbcFJNPsDqVC8orEbZ9pFIISI1z1MYKPwLGFcZ2jOPKEDfHDEbwWCCQ7X6GJKmYJvH9mphVXnVz2GDx%2BbaakuTC6FuJ5gmt4SfoNiZredA6IRtrp%2FH%2Benh1ttcpy%2FJIKRU4up%2FUWt5acbyxyJMUkOzzHFtNO5AA3ymuGrQKbLYMrZmSRZ7wZ05OFV3oaiWf2fcH9PEz%2F74WQLuprXL1ncDp%2Ba7jtfzbnDEUum7lbeVeuVk5KT35VPDX39y%2Bk2ayYFMlhXEEmCP4gRAWzGdCKkg0fqkpFPbTqAJntSgywxNa0r2LpQnN82yF%2FdEYRZnDOYr6QJqWMGooWvtimsZXf7ZIwtKqPbw6usHEDyFyPTsMg8D2%2B9HApoHv2X44CaJg4Ac0hdYFv3Tdv73hw3GB1iAMp9UeDLOSrjTZvLBQTUG4UM5hUb%2Fs999e59jCFf0%2FuX9xcnjKmi6BJbSCeq4X2m5ku73bnhd7vdgPnCgI%2B5H3ynVjvG%2BsB7SpK1%2FjrbevnAzAu5hmN8HXBz%2B71KOyf3kXnUdn3UsB9DHnH5Yfh6wnoxGdum%2FI5gd4qp%2F3aQcAAA%3D%3D)
