### PR TITLE
Add Kilo Routes, Kilo branded link domain

### DIFF
--- a/kiloroutes.com.link-domain.json
+++ b/kiloroutes.com.link-domain.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "kiloroutes.com",
+  "providerName": "Kilo Routes",
+  "serviceId": "link-domain",
+  "serviceName": "Kilo branded link domain",
+  "version": 1,
+  "logoUrl": "https://kiloroutes.com/domain-connect-logo.svg",
+  "description": "Points a subdomain at Kilo so short links and QR codes resolve on the customer's own hostname. Writes an ownership-challenge TXT record and a CNAME to the Kilo edge. The CNAME must be DNS-only / unproxied: it terminates at a Cloudflare-for-SaaS custom hostname, and proxying it produces a 1014.",
+  "variableDescription": "txtvalue: the per-domain ownership token, 32 hex characters. It is the only variable; the record prefix and the CNAME target are fixed in the template.",
+  "syncPubKeyDomain": "kiloroutes.com",
+  "syncRedirectDomain": "app.kiloroutes.com,kiloroutes.com",
+  "hostRequired": true,
+  "multiInstance": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_qr2r-challenge",
+      "data": "qr2r-domain-verification=%txtvalue%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "qr2r-domain-verification="
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.link3r.link",
+      "ttl": 300
+    }
+  ]
+}

--- a/kiloroutes.com.link-domain.json
+++ b/kiloroutes.com.link-domain.json
@@ -3,14 +3,13 @@
   "providerName": "Kilo Routes",
   "serviceId": "link-domain",
   "serviceName": "Kilo branded link domain",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://kiloroutes.com/domain-connect-logo.svg",
   "description": "Points a subdomain at Kilo so short links and QR codes resolve on the customer's own hostname. Writes an ownership-challenge TXT record and a CNAME to the Kilo edge. The CNAME must be DNS-only / unproxied: it terminates at a Cloudflare-for-SaaS custom hostname, and proxying it produces a 1014.",
   "variableDescription": "txtvalue: the per-domain ownership token, 32 hex characters. It is the only variable; the record prefix and the CNAME target are fixed in the template.",
   "syncPubKeyDomain": "kiloroutes.com",
   "syncRedirectDomain": "app.kiloroutes.com,kiloroutes.com",
   "hostRequired": true,
-  "multiInstance": true,
   "records": [
     {
       "type": "TXT",


### PR DESCRIPTION
# Description

New template for Kilo Routes, a QR and short-link platform. Customers point a subdomain of their own domain at the service so short links and QR codes resolve on their branded hostname. Today they copy two DNS records by hand; this template writes both.

The template applies an ownership-challenge TXT record and a CNAME to the service edge. `hostRequired` is set — the service only ever runs on a subdomain, never the zone apex.

Only the ownership token travels as a variable. The `qr2r-domain-verification=` value prefix and the CNAME target are both fixed in the template, so a misused apply URL cannot redirect a customer's hostname anywhere or write an arbitrary TXT value.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`https://kiloroutes.com/domain-connect-logo.svg` returns `200 image/svg+xml`, 511 bytes.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the last point: neither record is optional — removing either one breaks the branded hostname, so both correctly keep the default `Always`. There is no record here the user can safely drop while the service continues to work.

On variables generally: the only variable in this template is `%txtvalue%`, the ownership token. Both record hosts are fixed literals and the CNAME target is a fixed literal.

## Online Editor test results

**Editor test link(s):**

[Test kiloroutes.com/link-domain example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACWPrWoC%2F%2B1U72%2FbNhD9VwgCxT5MsiXFdmwNA9Y5xVA0CRrHSzIEhkGRZ5uLRKok5dgJ8r%2FvSP9Ml7Vfh2GAAVm8e8d3757umTqo6pI5oPkzrY1eSgHmo6A5fZClNrpxYFtcVzTaRy9Zhdn0E8bJKCRg0IJZSg4BWUr1EAtdMakOkWNUYZgSIIhPJPvEJRgrtaJ5FtFSz%2FXvpkTAwrna5u32azrtDSrmWingLvb5LbucYxkBlhtZu1CKftZSOUsYsU2xwRDmSGBh8bfQxgUamKIEuRoRrrEAMWB1uQSiFXELILyxTldgfrBEPyqy0NYp7KdFbo1ERoj158h%2FIeuYL1hZgpoDGd%2BNsRLXRoTqjAwv3198IE6HooEEiDmWGePrJlbhTaQAcnZ5HWtVrkmbNAqVX0kQOZGOODCVVCzc6nzJUjdiVjID8Uyb%2BJqx6y3dPc0o3O6LrKWa%2ByL4XzTclyBpknZaXn1mJCtKOHsln1u5JSsbyAPjGsx2rod2sZsHUBE5ycgCVgSbN4wjSdsiHx2RNgBDJ7sbfgpHW11qAzO5CgTdXgTHzBywOQMEg2gUuRnDzquer10r%2FrkpPsH6bGOgNxzrc0YgJN7l9lmsrluvM6O%2FAb1yI%2FjSIBIN7UwDEd0QtjS%2Ff6ZuXXsz43y3yfgy%2FWIycxi%2BdyJzDAPhfOtX9LicSc68vD%2B%2F26n7DpOdQ7efJEnkNR9qNSsldxfM8QXO7AJN6c0cxKJvpmxj37iOvkR75kHnA%2Fdf%2FOcdvpSxxlcezO0%2FixMTHkf8XiYvEX3SCqYHQSbY605eWDEcEhwJiYdzjf%2FnKHE9lTtEjUaprF87O%2Bz9K%2FBkh7738Em096I%2FSU%2BymZjBgBcZsKxXpJ2EiS6wXsp5f8CAepZyrrSBqcUnc42B3SSrpnRyyh7Z4UjwKfqiXGNTFqN4xddTVpv99dWUW6Gz7w36u2yPxz8V3Isi%2FSbl3dNOLxNJ3Eu7PO4kRRqzjPdjDt3TrDuD044ojjbz23v7n1fz8XTAWlBOMr9z35ePbG3pyxuG2cpw3Pa33PLvamcSofH%2BH%2Bx%2FcLC4Hixbgpgyn5glWS9OBnHaH6eDPEvzZNDqd7v90%2BTHJMmTxPcB1m3afMZNcbwj6NWA3dw8nf8xuxXmw2%2B%2FalfBeHi3PJfDh7vbYfem8%2FS4gPM%2F2yO4wp36F1CXb7hCCQAA)

```
_qr2r-challenge.go.example.com.    TXT      300    "qr2r-domain-verification=132fdfe9cb2ea26b140ad5ea61cc89ae"
go.example.com.                    CNAME    300    cname.link3r.link
```

`hostRequired` is `true`, so per the template instructions only the subdomain test is included; an apex run is not applicable.


