### PR TITLE
mailsoftly.com.email-auth: version 2, add s3 DKIM CNAME to delivery group

### DIFF
--- a/mailsoftly.com.email-auth.json
+++ b/mailsoftly.com.email-auth.json
@@ -3,7 +3,7 @@
   "providerName": "Mailsoftly",
   "serviceId": "email-auth",
   "serviceName": "Mailsoftly Email Authentication",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://app.mailsoftly.com/mailsoftly_dark_logo.png",
   "description": "Authenticates your domain for sending email with Mailsoftly: DKIM, SPF, custom MAIL FROM and DMARC.",
   "variableDescription": "dkim1/dkim2/dkim3 are the Amazon SES DKIM tokens generated for the domain; byodkimvalue is the DKIM public key TXT value.",
@@ -61,6 +61,13 @@
       "type": "CNAME",
       "host": "s2._domainkey",
       "pointsTo": "s2._domainkey.%fqdn%.mailsoftly.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "delivery",
+      "type": "CNAME",
+      "host": "s3._domainkey",
+      "pointsTo": "s3._domainkey.%fqdn%.mailsoftly.net",
       "ttl": 3600
     },
     {


### PR DESCRIPTION
# Description

Updates our merged template (#1334) from version 1 to version 2. One change: a third DKIM CNAME (`s3._domainkey` -> `s3._domainkey.%fqdn%.mailsoftly.net`) joins the existing `s1`/`s2` CNAMEs in the `delivery` group. Our new domain setups serve the third selector's key from our own zone behind the customer's CNAME, so this group now installs the complete signing set. No other group, record, variable or the signing setup changes, and existing installs are unaffected since the new record is additive.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

[Test mailsoftly.com/email-auth mdemir.xyz/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAnjl2oC%2F%2B1XW0%2FjOBT%2BK1akPk0vuXQpBPHQ4aIdDQFUuiu0CFVu7LRWEztjO4WA%2BO9z7LYkpXRYtOyuhHhpnJzLdz77%2BLP74Gia5SnW1AkfnFyKOSNUfiNO6GSYpUokOi3bscic5pP1DGfg7URPdrApKucspjaQmsgWLvS0MmzEoGPjhfrgRblmMdZMcPCfU6nMKPSbTiom4g%2BZQtxU61yFnQ7O8%2FZ6XZ3qdUSwnI1MUDvnE8hFqIoly23m0KlBUYVKUUhEBERzlAiJFOWE8QmyxaNbpqeoKjZER9%2B%2FRU10eXHSRHGhtMhQ1P92ik4G5xHCnKCjqD84bJv6sWR4nNKjNWwyY5nXMb%2B%2B%2FQ0QlhRBPaif4XvB0eXxpcVAWswoV2hCOZVQKLHFGcdFrftoXAqTYY7TgiKmrM1G5sU4ZTGa0RINr4bIOpiKVMnjr6mIZ06Y4FTRxZeLYvydlkc2qSnQDmLBOY11e2PpTcSAEibB%2BhSzuRjgORVKD%2BiPAlzJEyCECUmUE14%2FOBMpitz2iaEBEbrMTWscnvWj42UCeG3YKWu0R4vKgJXpQMG4VkNRs5tHG9tJVFQti9AamibYcd3H5tsA%2FVcA%2FfcGDF4BDN4GuGyOChM6oUKsLdYaKMEagzk%2FaNSbq1GHgeGdPhQ8gRbTEdbxFDZLJIjBuJA0YXfOiy5Lm0nuPJsbmjLY7OXW%2BcmU53rrU2I%2FtRvJD8Ib9dbjVP9iEV4DUt7WNVgzvT%2Bwvx3Y%2F1eBg%2B3AwT8ANn6JFLX%2BA8WMKlxOb5VRkzwZFCkFPXBAc9KC0PBv9vcmQHS1kb7GJqGUjHE8a6lM5%2B1CtShWuuVtbKdcMiGZLp3Qc7dPa4ZlvGVrjVbG5V6aH9gTwdtH%2BQEXnO6%2F62ZaZQc3qpQ51LA5Jc95P8%2FhOH68eWw6wI%2BOKuG9aS413swioRmT7bvyviIAI8t0xKx7vYcW1CBBjiXOlLkorFJd13PdrJJdO2Zs021LZdV75WmVtf4SrF7qerT4BszYhAtJRwqeWBcSDFoWcMpkRarZCN%2Fi6hOJR9hMCUyEAiukgBPo2Z7gi6vJSm6WC7iQmordL%2FZAE1Y%2FNrPC7O3Hp72eFyetgOz2Wl0P77V2E%2BK1%2FHgcdHd6e7u7Sbd2mXr5qrX1OlWtVn3h%2B%2BktLpXzaPr1ZXbPNW7Jcl3fPg5b%2F2W2%2FsdkG7zMNvgYbBc6u%2BT6Rp39v%2Bk8KfLjTRMk%2BFN8PsXnU3w%2Bxec%2FFx%2B4Sik8p2SEjZ%2Fv%2Bjstd6%2Fl%2BkN3N%2BzuhV7Q9n7r7fV2vrhu6LqGBlV6wfIBblz1u5Zzf35Kr%2BjJ8JQPu1%2BjL%2BfRced3%2FyS5O5t1Tv8M1Lk3%2Fuu005sOvGEX%2FvP9BD2Lrx5hEgAA)

[Test mailsoftly.com/email-auth mdemir.xyz/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABHjl2oC%2F%2B1XbU%2FqSBT%2BK5MmfLpQ%2B%2BJypcYPrC%2BJuaIGNGtiDBnaU5zQzvTOTIFq%2FO%2F3TAtSRHRv1k12jV%2BA9rw85zlz5pnh0dKQZgnVYAWPVibFlEUgTyMrsFLKEiVinRR2KFKr%2BWw9pyl6W71nO9oUyCkLoQwEE9miub5fGTZiyLHxIl30Aq5ZSDUTHP2nIJX5FXhNKxFjcS0TjLvXOlPBzg7NMnu9rp3V4zCicjI0QXbGx5grAhVKlpWZA6sGBYoUIpckEhjNSSwkUcAjxsekLJ7MmL4nq2IDcvTjtNckg8uTJglzpUVKet3TM3LSv%2BgRyiNy1Ov2D21TP5WMjhI4WsOOJix1d8ynV376hEogWA%2FppvRBcDI4HpQYRIsJcEXGwEFioVFZnHGsat0no0KYDFOa5ECYKm1lZJaPEhaSCRTk6uaKlA6mIlXw8M9EhBMriGmioHpzmY9%2BQHFUJjUFlj9CwTmE2t5YehPRh4hJtD7HbC4Get4LpfvwM0fX6BkQw4SMlBXcPlpjKfKsnBNDAyN0kZnRODzv9o4XCfCxUbasYQ%2BrypCVmUDBuFZXomY3XzYtm6hALYrQGofGbzvOU%2FP3AL13AL2PBvTfAfR%2FD3AxHCtMnIQVYm2x1kAjqimas4NGfbgadRj8OdeHgsc4YrpHdXiPm6UnIoNxKSFmc%2BtVl4XNJLde9AYShpu92NqfVLmOu96S8pXdiH9GvFEfPQ76jUV4D0i5W9dgzfTxwN52YO9fBfa3A%2Fv%2FANj4xVLU5g8Vs7fC5TBTRk2yuJ8ngHpgoeYkeQTB35zvTYDezUb6GpsYIBrRcNJSqc7sXLWAKt1yN7ZTJpmQTBdW4Drb25pSGW7ZWsOlcbGXpgflieDuk%2ByACw77H7qZltnRDZQyhxo1p%2BQF72YZHsdPd09NC%2FnBcCW8d82FxpsuRpAyac%2BLh43elWyHrAypz1FFD5NkVNJUmcvCMt1tPd%2FdMuFtlfFukXJbulLFjXH54NUf%2FOVDXZeqd8iQjbmQMFT4TXUu0aBljqdNmieaDemMrl5F4ZCa1mBDFFoxBZ5EL%2FYGr64olcYs2rFYzdU7e8X1jV3RxHkITY%2BYmZtdx%2Fdcf6%2FTCiPfa%2B3GnT9aHfrdbbVdCp7jh3tOe1S7Xr1%2B%2Bdp6wVpfv%2Fo4dJMZLZT1ZKb4da7r8rbOedP2ybh7b3D3Pjl3%2Fw3u%2FifjXun0gnml0y8ovyPW%2FwVez9L%2BdNdELf9Sry%2F1%2BlKvL%2FX6%2F6kXXuYUnUI0pMbXc7x2y%2Bm0HO%2FK2Qt2O4Hn2t%2B9ttP2vjlO4DiGCihdMX3EO1%2F9tmd9ux48KO9yfnNzAvFF6hy2zwYX04fLQfLXdXc2S%2Fvzrtu5OD9zpmP89%2FkLa1j7p%2BsSAAA%3D)
