### PR TITLE
Add Arivette web-del-club template

### DIFF
--- a/arivette.cat.web-del-club.json
+++ b/arivette.cat.web-del-club.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "arivette.cat",
+  "providerName": "Arivette",
+  "serviceId": "web-del-club",
+  "serviceName": "Web del club",
+  "version": 1,
+  "logoUrl": "https://arivette.cat/icons/icon-192.png",
+  "description": "Serveix la web del teu club a la teva pròpia adreça.",
+  "variableDescription": "ip: adreça del servidor d'Arivette",
+  "syncPubKeyDomain": "arivette.cat",
+  "syncRedirectDomain": "arivette.cat",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "arivette.cat.",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Arivette**, a management platform for grassroots sports clubs
(https://arivette.cat). Each club gets a public page hosted by us; this template
lets a club point its own domain at that page instead of using our subpath.

Two records: an `A` on the apex with our server IP, and a `CNAME` on `www`
pointing to `arivette.cat`. Nothing else is touched — in particular, no MX
records, so the club's email keeps working.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `arivette.cat`. The public key is
      published as TXT records at `_dcpubkeyv1.arivette.cat` (two parts, `p=1`
      and `p=2`) and requests are signed with RSA-SHA256 over the query string,
      excluding `sig` and `key`.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `arivette.cat`
- [x] no TXT record contains SPF content — the template has no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — not applicable, no TXT records
- [x] no variable is used as a bare full record value — see justification below
- [x] no bare variable is used as the full `host` label — both hosts are fixed (`@` and `www`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — not applicable: both records *are* the service, and removing either one is exactly the "stop using it" case rather than a user adjustment

**Justification for the bare variable (`%ip%`):** the single variable is the
`pointsTo` of an `A` record, whose value has to be a bare IPv4 address — a fixed
prefix is not possible for this record type. The variable is supplied by us at
request time and the request is signed, so it cannot be set to an arbitrary
value by a third party.

## Online Editor test results

**Editor test link(s):**

- Apex (`host` empty): [Test arivette.cat/web-del-club clubritmicalagranada.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABjll2oC%2F%2B1TUU%2FbMBD%2BK5EltIc1aZo2pYk0ad3KJDRAbHQgwarqYh%2FFIo2N7TTrqv732aGl6QY887CX5M733Z2%2F73wrYnAuczBI0hWRSiw4Q3XMSEpA8QUagwEFQ1pPsTOYWywZbqI2olEtOMU6qcLMZ5j7NC%2BzXWiTc4WZZ4PeJrhApbkoSNppkVzMxA%2BVW9CdMVKn7XazfZtTUej663eSKJDFzOYz1FRxaeoa5MK2Qv7Ly8GrNn0MlnUvD9ypwQV4Uv0sw%2FA2khw8YAqdh4cQuOvYjpDlONory2XaBNZ1a1ZMKI%2B9a8qwLOh5mX3F5UjMgRf%2FSugQ35FxhdS8hvmUC3pP0lvINbaIRQvFNElvVsQsZS2%2BBd4Jbaz50Y1G8MLosbDuAZcH9sQYK2W3H4br1lPS57Ph6dEusaqq%2FdTmRYK9GpN1i%2FwWBU53V5lY%2BbcMnMSKmzmnkMNMQQEMAirmu17WmilRyinfJktQMNfuzW3L3LxcZ7ItdEOczaWzOnEUxN2gczgIok6PuDvyWSEUTrX9gymVJW1UaRWcl7nhU6hgd8ToFKTMl5aStlFbcF%2Fd4vHFOnUZGLDmX%2F0a%2BrTIlFFHhbsNwF7I%2Br3%2BwO9GlPq9LO75WT9D6yaYJayXsS5rrNNzq%2FbKQu0ERa2xMBzczgzzCpaarJ%2BZ9obI47Q3VF6c9BtiMmnZZ%2FJ%2FJm9rJnb5NCyQTcHBojDq%2B2Hih9E4HKTxIA3DIInjQZK8D0PrOBaozSPBld3P5maS%2FlX3VFSjE%2FVwcX%2F5ZZjFNB6Pr8POeXGkOheXo5Nld0iP298ervUHsv4D4n2r%2BKgGAAA%3D)
- Subdomain (`host` = `trofeu`): [Test arivette.cat/web-del-club clubritmicalagranada.com/trofeu](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEnll2oC%2F%2B1TbU%2FbMBD%2BK5EltA9LUielaRtp0oBOCE1jiDI2iVXRJT6KtzS2bCehq%2Frf54SWpgz4vEn70vTenrvn8d2KGFzIHAySeEWkEhVnqM4YiQkoXqEx6GdgiPsYO4eFzSVHm6iNaFQVz7AtqjH1GOZelpfpLrSp%2BYqpY4POJlih0lwUJA5ckou5%2BKJym3RnjNRxr9dt3%2BOZKHT76wXj0JfF3NYz1Jni0rQYZGpbIb93cnDqTR%2BDZdvLgcZrsAJHqu8lpbeh5OAAU9hYOAS%2FGcd2hDTHyR4sl3E3scVtWTGhHPamK8OyyC7K9CMuJ2IBvPhTwibjEhlXmJnXco5zkf0k8S3kGl1is4VimsQ3K2KWshXfJt4Jbezf983TCF4YfSWsecDlgfUYY6XsR5Su3ceik%2FOjTx92hXVd75d2B%2FH3MGZrl%2FwSBSa7UWZW%2Fi2DRmLFzYJnkMNcQQEM%2FEwsdr2MErdYWnuuRCkTvoWQoGChm83bgt28jDbbwt1s8ayHy8YOBqE%2F6PvBcOSHwSFp5uXzQihMtP2CKZUVwKjSqrkoc8MTqGHnYlkCUuZLS0%2FbqAXcV7p42N5HEgwMWPtJ045gLklY1rDizUkgDXE8GmZeFDH0DoNx4KW2wItYNhhiSof9aNy5r%2Bdu75ULe6owao2F4dCc0lFew1KT9TNLsOFkl8B%2FyuvFPfjraM1cu0T%2F3%2BrfeCt7rBoqZAk0ySENI4%2BOPRpe0VE8GMWHYz8aDMNB%2Fy2lMaUNF9TmgebK3nP3ksn9GR2cfMNyWdWn02o4neRnp9gznyeXwcX19Erwc476elr9OJ6%2FI%2BvfnlOcT%2BQGAAA%3D)

Both were run with the real service IP (`152.53.178.214`) and with the exact
template file included in this PR.
