### PR TITLE
Add Prosu email template (prosu.org / email)

### DIFF
--- a/prosu.org.email.json
+++ b/prosu.org.email.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "prosu.org",
+  "providerName": "Prosu",
+  "serviceId": "email",
+  "serviceName": "Prosu Email",
+  "version": 1,
+  "logoUrl": "https://www.prosu.org/favicon.ico",
+  "description": "Set up Prosu email (MX, SPF, DKIM, DMARC) on your domain",
+  "syncPubKeyDomain": "prosu.org",
+  "syncRedirectDomain": "admin.prosu.org",
+  "hostRequired": true,
+  "records": [
+    { "type": "MX", "host": "@", "pointsTo": "mail.prosu.org", "priority": 10, "ttl": 3600 },
+    { "type": "SPFM", "host": "@", "spfRules": "mx ip4:185.207.107.167", "ttl": 3600 },
+    { "type": "TXT", "host": "%dkimselector%._domainkey", "data": "v=DKIM1; k=rsa; p=%dkimkey%", "ttl": 3600, "txtConflictMatchingMode": "All" },
+    { "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=quarantine; rua=mailto:postmaster@%domain%", "ttl": 3600, "txtConflictMatchingMode": "All", "essential": "OnApply" },
+    { "type": "TXT", "host": "@", "data": "prosu-verify=%verifytoken%", "ttl": 3600, "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "prosu-verify=" }
+  ]
+}


### PR DESCRIPTION
﻿Add Prosu email template

Successor to the Mailname template (https://github.com/Domain-Connect/Templates/pull/1371) after rebranding to Prosu. Same hostRequired email flow: MX, SPFM, DKIM, DMARC, and an ownership TXT.

File: `prosu.org.email.json` (`providerId` **prosu.org**, `serviceId` **email**).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `providerId.serviceId.json` (`prosu.org.email.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://www.prosu.org/favicon.ico` returns 200)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
[Test apply mail.example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL7pl2oC%2F%2B1WbU%2FiShT%2BK80kJHuzUNuCvNSQiOiyLtsVBa9EY8jQDjjSdsrMlFKN%2B9vvGV6Lssnulxs38QOlPXNen3POk3lGkgSRjyVB9jOKOJtRj%2FBzD9nqQ8Q642OU3xz8wAEooo46ArEgfEZdslAnAab%2BVpbV1M5WZzPCBWUhss088tmYXXMfdB6kjIR9cJAkib4JejDC4IaFOjzA0iPC5TSSC2vUJVKLI23pfBFY%2B%2BT081q38yWvnbbPHXg6javmPxoLtZTFXPMYaIUqvTR0O%2FGwTdLTpWi3UHV8RTzKiSs3CtgLaKhn1R6YkFdkGoMe1C55TPIITBj3BLLvnpFMI1W901%2FpwvuxgpHRUIoeg0%2BVtL4LMWWcyhTAMfJISkCmWDaMl%2FzGG1Tn7PoT0egq9olQ%2FuYajUq2WT3ULaOim%2BpXrqD9nnr93tZRzpvQQBAfKmY8pw%2BWUE1IqmDHEoPKrK5ANY%2B0SZ0LfKRF9YUR6OSyEeB1LpssHPnUlQ6W7gMNxw7zVMiG76NfZTDwAszdnXCqe6YKNI0xx6GkITnSeIzrCjfJ7AgsAywk4ce5ZcJ%2FlEkeESEIuMVqAC%2FCRhT56S%2FzO96mtuhYAeaYjtJ6bvkv2YT8fvgOJyM6R3tVVmevwqCX%2B5c8emIhGWxn7B5SWs8nmWPYYaK7LNgmvVq5MWdxNKBrmwjQDITa9bX13Y75%2Fdr%2BbulAhcmMh5LDBKzFakhA4py3Rk7DaDW701b3fFg8vTw7aVxeNxql1o%2FGafOEXrZPxpfNaasdTy7MU1J5erh9LH%2F%2BakzlY2%2Fy7zzpNaNZm5RI89b40plyarhD69vt9KJzFn0v3dDE9CoqZAZuFVYSITMi0yoiBRQdh4yTgYB%2FLGNO1vsZxL6kA5zgrchzB1h1HnAVcApOX%2B1uuGSxFZarGXizupm%2B727xwHMV1FTxY63qVqtFo1aoGZ5ZKGGrXBga2CyUPatctGquZ1WsDNO%2BoeB9XLvb6uxIN%2FwEpwK9vBnpvRXN6sAkprafQ7SfeLExmSrfb10wnBkG01%2BX%2BZrG%2FpfJ%2FUugW7LwW8j%2BgIp3iehdVL3h9t%2FbhB3i3UMw762X93lg9Q%2FS%2BiCtD9L6IK2%2FhrTgLifwjHgDrFQtA%2BJCEobVM2q2WbEPDd06LJcPS58NwzYMlT8UtSz2GW542bsdGk5uDoLU%2BXZz25pZrcdq%2F6tDg4T0rd6ETP2np26SOF7tunjSOoOb9H%2BE4lke8A4AAA%3D%3D)
