### PR TITLE
add Postboi, Postboi hosted forms on your own domain

### DIFF
--- a/postboi.email.forms.json
+++ b/postboi.email.forms.json
@@ -1,0 +1,29 @@
+{
+	"providerId": "postboi.email",
+	"providerName": "Postboi",
+	"serviceId": "forms",
+	"serviceName": "Postboi hosted forms on your own domain",
+	"version": 1,
+	"logoUrl": "https://postboi.email/logo.svg",
+	"description": "Serves your Postboi form endpoints from forms.<yourdomain> instead of postboi.app: a CNAME handing that subdomain to Postboi's edge, plus the TXT record that validates its TLS certificate.",
+	"syncPubKeyDomain": "postboi.email",
+	"syncRedirectDomain": "postboi.email,postboi.app",
+	"syncBlock": false,
+	"shared": false,
+	"hostRequired": false,
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "forms",
+			"pointsTo": "forms.postboi.app",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "%dvlabel%.forms",
+			"data": "%dvvalue%",
+			"txtConflictMatchingMode": "All",
+			"ttl": 3600
+		}
+	]
+}


### PR DESCRIPTION
# Description

Postboi customers can serve their hosted form endpoints from a subdomain of their
own domain instead of ours, so the HTML on their site posts to `forms.<domain>`
rather than `postboi.app`. That is a Cloudflare for SaaS custom hostname and needs
two records: a CNAME handing the subdomain to our edge, and the DV TXT that
validates its certificate.

`syncRedirectDomain` lists both `postboi.email` and `postboi.app`: the two serve the
same application and the return URL is built from whichever host the customer is
signed in on.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [ ] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify

Two points need a comment rather than a tick:

- `%dvvalue%` is a bare full record value. The DV token is minted by Cloudflare and
  is opaque — it carries no fixed prefix that could scope it, so there is nothing to
  put in front of it.
- `essential` is set on neither record. Both are load-bearing: remove either and the
  hostname stops serving or its certificate stops renewing, so there is no record here
  the end user may modify independently.

The TXT host is `%dvlabel%.forms` — the variable is the leaf label only, the
subdomain it sits under is fixed, the same shape as `%dkimkey%._domainkey`. Both
halves of the CNAME are literals rather than variables for the same reason.

## Online Editor test results

Applied against `example.com`, with `dvlabel=_acme-challenge` and a sample DV token.

- [Applied at the zone apex (no host)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMQvmGoC%2F%2B1VbU%2FbMBD%2BK5YltA9rS%2FpCodE2ibeJsQEByhhCVeXGl9bCsTPbCZSq%2F33nhtAW0KR926R9SnJ3z708j8%2BZUQdpJpkDGs5oZnQhOJgvnIY009aNtGhAyoSktWfnKUsxmEalGx0WTCFiWIASbVK7tK3Hkgk%2BgZNFENGKTHVuiL5XhGssohBXgLFCKxo2a1Tqsb4yEvET5zIbbm6utbTp%2FQ1bjBHGwcZGZG4BpZdYHGyZvSrtaxJQPNNCOUsSo9Oyj8YHH1c28IkIhR0yTnRCqmIsy0LCyP7p7skhmTDFhRoTN2GO2HxU4ojTVaF3lgAfQ41kMrcYBqT%2Fo08MxNrwElUwKTgSbonARvrfLkkMxolExGhseO6mKo7y0VeYHpS0vNbCh1wAF5jXvR1UW2n%2FCbAndXxHw4RJC2iZMAP8%2BdNLcwE%2Fc7FqLNu2NLydUTfNvJQLGmgZv6J3SWtfV6bGennnUMZ2NwjmtedMyMsyzwYvJBuB3GhUGZEiVjqQsBw2fJYHt69VIkXsTpiLJyjEieY%2B166Ua1UG8xp91AqGywkGmLJiCh4YHnpoxDpdtoBvY6PzbCiq%2BIwZhr3gYlTI2zXooMLeUv%2F%2BNIL%2FHLI4hXo8YVKCGkPpXczhvVk%2Fii6ObXDe4%2BlNTx2YPhrSk7vzptpVW7plrqOo3W9H3%2FevqJ9EjJU2MLT4ZC43mMOZHOVJc%2BnEkN2zpYnHQ2RcTnFwi16s9lo6VS7lC6J%2FK1uNDnnsiRB%2ByTs7rTbf3g7qva0kqHe6SbO%2BE8dJnUOrFyQJA97bXrkw3rxN3ro0lkKAtaCcYHKh7T2bWjp%2FdXSe5njB9csD9Cdk%2F20TD2p4DP8L%2BA8LiItvWQF8yHxYK2h160GvHrT6zU7Y7GKjjW7Q3W7tvA%2BCMAh8%2F2BdOfgMN39156kQ10eG7xVZdjM6bEedgzTqRebsOIq2Ho4CM%2BXF5Wf8pTQfz%2BxHOv8FVHr2D9oHAAA%3D) — yields `forms CNAME forms.postboi.app` and `_acme-challenge.forms TXT <token>`
- [Applied with `host=sub`](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALQvmGoC%2F%2B1UTW%2FbOBD9KwSBoIfaCm3HgSNsF3CTPfTDqZ067XaDwKDIkcyWIlWScuoG%2Be8dmVFsN8ECeyuKPQmamTcz7z2StzRAWWkegKa3tHJ2pSS4V5KmtLI%2BZFYlUHKlaechec5LLKbTmMaEB7dSAjag3LrSb2P7tWSJX5BkU0SsIWtbO2JvDJEWhxjErcB5ZQ1Nex2qbWEvnUb8MoTKp4eHeysdNvnErwqESfDCqSpsoPQ9Dgcfu7ejm5kEjKysMsGT3Nky7pH80dTFBf4kyuCGXBKbk3YYr6qUcHJ6Pp78RZbcSGUKEpY8EF9nEUeCbQc98wRkAR1S6dpjGZD533PiQFgnI2rFtZIouCcKF5m%2FfU8EuKByJTCYNNqtjZjW2RtYn0VZHnvRlFyAVNg3PF3U2Vn%2FHvBSW%2FGFpjnXHjCy5A7kw29jzQV8rdVuMK7taXp1S8O6aqzcyEBj%2FY7fUda5bUPJ%2FvgQ0MbBMWN3nYdOqMu2z4FcaZ6BPkjajigRjwkUrIaDpsu3cGpNrpUIEx7EEo2YWNn0Gmu9N%2BX6rkO%2FWwOLLYNrbNkqBd84HnpIhC23K6Cb%2BFM4W1cL1UIq7jiug3ejBV%2Ftoa9b%2BNUG3wyJRJrIgosSumLJtQZTQMxu2DTZaj6dXrz2bHYiy08n5szNMVBOvsx6ZmyGtu8%2BTqeD%2BWD64fSSNnxUYayDhccvD7XDHsHVaFJZ66AW%2FIZvQ1IsUHe9RvoeszjtsYEmXs3oVuR%2BL%2Fm%2FGtihCykaPVRz3WU%2FOx4Oh6IrByzvHsHRsDs6yrLukAk2GHAxYL1s5%2Bl48l156vnYswS8BxMU1xujb%2Fja07tH5%2Biezk%2BSJ0%2FQ%2By%2B6%2F4LErzt4Lv%2B387exEx8Fz1cgF7yp7LP%2BcZeddFl%2F3jtKe8dpnyWj4YiNRs8ZSxlrKIAPkfstvgq77wF9V8BklrPxqn%2FW%2B6f3UWXry5PPL8enlfn%2Byc0KB5M3mZ3ls%2BfZ7AW9%2BwEu4%2Fr4%2FAcAAA%3D%3D) — yields the same pair under `sub.example.com`