### PR TITLE
Fixes for Clerk's Secondary Email provider CNAMEs

### DIFF
--- a/clerk.com.app.json
+++ b/clerk.com.app.json
@@ -3,7 +3,7 @@
   "providerName": "Clerk",
   "serviceId": "app",
   "serviceName": "Clerk Application",
-  "version": 2,
+  "version": 3,
   "description": "Enables a domain to work with Clerk",
   "syncPubKeyDomain": "domainconnect.dashboard.clerk.com",
   "syncRedirectDomain": "dashboard.clerk.com",
@@ -54,14 +54,14 @@
       "type":"CNAME",
       "groupId": "secondary_mail",
       "host": "pdk1._domainkey.clkmail2",
-      "pointsTo": "clk3._domainkey.%mailtoken%.clerk.services",
+      "pointsTo": "dkim3.%mailtoken%.clerk.services",
       "ttl":3600
     },
     {
       "type":"CNAME",
       "groupId": "secondary_mail",
       "host": "pdk2._domainkey.clkmail2",
-      "pointsTo": "clk4._domainkey.%mailtoken%.clerk.services",
+      "pointsTo": "dkim4.%mailtoken%.clerk.services",
       "ttl":3600
     },
     {


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->


Hi, Clerk developer here! We've made updates to our secondary email CNAME destinations and this PR reflects those changes:

- `pdk1._domainkey.clkmail2` -> `dkim3.%mailtoken%.clerk.services` from `clk3._domainkey.%mailtoken%.clerk.services`
- `pdk2._domainkey.clkmail2` -> `dkim4.%mailtoken%.clerk.services` from `clk4._domainkey.%mailtoken%.clerk.services`

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**
- [Test clerk.com/app example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFpDmGoC%2F%2B1XXWvbMBT9K0HQpzqZI7vpYthD2VpWSrdutJRSgpElpRF2JE%2BSk3oh%2F31SbCcOSbswGrqAn2Luh849N%2BIcewY0HacJ0hQEM5BKMWGEyksCAoATKuMOFmPgLBPf0NgUgs82ZcKKygnDdFGO0nQVqde1ztI0YRhpJripmFCp7FPgOYBQhSVLF5kAnHMUJVS1UIuIMWK8pUVrKswBU6ZHrSVmzvFNFl3R%2FMuiyjQW5VhwTrHuEKRGkUCSdOoMbNtPSpg0JavGraWmREiiQPA4AzpPF0S%2BnV2fm9STFFla0M30yARGQulqV3ZPgnGtboUJDaXgmnLSRikrjy%2BXo0yh1onZQM91587OIAhjkZnj13Gq6L9imFUkdSJxJyz2GdN8HYnEbNztHNkGLWLKj94MEr6KCfeCWQZqWDbyFlDK3B9OkMzDraBwHbWK7hM5JXG3tuLO9knsrr09jwF3G8Pf5xhaIhy%2FAL6eew15MHfAb8FpuJKLgVNKkTmIPiOjq7SUlBK5Gi9kVX2KJBorq71V5%2BNa66DqfQT2ebkUG0AR7kIP2EHYExeShsr8Ip1Jsw8tM2rqs0SzEE3RKkRwaKQ6yc3cymTNQZsyxwv5rlSNII12VzQHhARbRsz%2BCa43hN3esN8eDn3a9j3aa0fRKW5T3Ceuf4ooHPZrBrPhPJsWs9olVYpyzZABBmfJFOUKzLfciJJNTT5LQjtI5%2F9KZkOnS0qFRhc34zBpwRd5wYPmVWpQyWfhNYdOB674LBXzYDm94pG1O%2BgdNEH4d4L%2B4RLc8PWS1s6e%2Fs7EBo55I2jMuDHjxowbM27MuDHjxozf0YzN17ZCE0pCZMugC3ttt9924W33JPDdoOt2Tnz4EcJj1w1c105OlS5IzswXef1bHPzQxw8fSHThff%2Ba3sDLqzt1fSd%2B9Xx8kZ%2Be3z%2FcZM9xNr0jJ%2FG9%2BATmfwDIeyPalBUAAA%3D%3D)
- [Test clerk.com/app example.com/foo](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIZDmGoC%2F%2B1YXW%2FaMBT9K8hSnwY0mDBKpD2wrpumbqyb2kpbhSInvhQvwc5sA0sR%2F303hK8MWqGpaGPiCbgfPvdcrHMCE2JhkMTMAvEmJNFqJDjo95x4JIxBR9VQDUh5meiwARaS8yyFYQN6JEKYlbMkWUXW60rtJIlFyKxQEitGoE32zquXCQcTapHMMh65kCyIwZRYiasBE7JkVWms8ICxsP3SEjOV4dUwuIT0zawKG%2FPyUEkJoa1yZvqBYppX1xlkbV%2BAC40lq8atpViiNDfEu5sQmyYzIp32xwtM3Ws1THK6Q9vHQF8Zu9hVticlpDXXCkM9raQFySssEfPj58sxWGhtjBt46TjT8s4gLAzVEI8v4iyif4qBq4jXiURVP99nBGkRiUdiUKueZA1WRSBPng2SPolJ94I5D6xhZZHngDJ4fyRnOvW3gtIi6iK6T%2BSER7W1FVe3T5Ltur7nMehuY7j7HMNqFkaPgBdzTyF3p2XyoCT4K7noludShAfBT4a6CnNJmSP3lFpM6ItFS8I0G5hMfhfNd4Xu7qL9btaPH5eryWIsCGu0TrJxxL1UGnyDr8wONW7F6iFg%2FTC2wmdjtgrx0EfBjlOc3mAWD9oUO5mLeL6DfHTOLNtd28rE52FGTGRfR%2B%2BsyaHJexWou1BxuQOVoAXNSrN31nDqgdPgrdqa1Wx40KbZFLYKxoC0giE2acdjlhoy3XI95qSWqlngtYOW%2FsOcitpdZJZrd35XDpYdfZIePXR6M%2F8p0JpF%2FgNWtEhrGT1kao956ubFrB86T7obT%2Fegef7m%2FAV2Oz8V%2FH1%2B3TI%2BUxy9%2FOjlRy8%2FevnRy49efvTyw%2FVy%2FK1v2Ai4z7JK6tCXFadVceh1reG5jtdwq2dOs0XpC8fxHCcbHozNeU6mOP%2FaPwEk6sjTq4cP5zd9%2BpVfJ6c339vvLt1vr4OR%2BfSj797ePoybSdD5nL6NXpHpL0tYLT0YFgAA)
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
