### PR TITLE
add Mailafiniti, Mailafiniti Email

### DIFF
--- a/mailafiniti.com.email.json
+++ b/mailafiniti.com.email.json
@@ -1,0 +1,44 @@
+{
+  "providerId": "mailafiniti.com",
+  "providerName": "Mailafiniti",
+  "serviceId": "email",
+  "serviceName": "Mailafiniti Email",
+  "version": 1,
+  "logoUrl": "https://mailafiniti.com/Mailafiniti-Logo-04.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "mailafiniti.com",
+  "syncRedirectDomain": "app.mailafiniti.io",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx.mailafiniti.io",
+      "ttl": 3600,
+      "priority": 10,
+      "essential": "Always"
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:spf.mailafiniti.io",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "dkim._domainkey",
+      "data": "%dkim%",
+      "ttl": 3600,
+      "essential": "Always",
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "%dmarc%",
+      "ttl": 3600,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Mailafiniti's hosted email. Publishes the four records a
customer domain needs to send and receive mail through the service: MX, SPF
(as SPFM), a DKIM public key and a DMARC policy.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated with `dc-template-linter -merge-or-fail -logos` (exit 0).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
- [ ] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify

Justification for the bare-variable rule: `%dkim%` and `%dmarc%` are bare
because both record values are prescribed in full by an external standard --
DKIM by RFC 6376 and DMARC by RFC 7489 -- and neither can carry a
service-specific prefix without becoming invalid. This is the exception the
guidelines allow. The DKIM key is generated per domain and the DMARC record
carries a per-domain `rua` address, so neither can be fixed in the template
either. Both records are constrained by their fixed hosts and by
`txtConflictMatchingMode`.

MX and SPF take no variables at all: they are identical for every customer, so
`pointsTo` and `spfRules` are written out in full.


## Online Editor test results

**Editor test link(s):**

- Apex (`host` empty): [Test mailafiniti.com/email mailafiniti.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPRMmGoC%2F%2B1YbVPqOBT%2BK0xn7icEWsq7w4wtqCAUCiLqeh0mtCmEvqQ0aQUc9rdvgigo4ujs3V13Lp%2Ba5jzJOSfnnCcvjwKFru8ACoXSo%2BAHOEImDOqmUBJcgBxgIQ9RlDSwKxy9iFvAZXBB2wCYkMAgQgZcDYV87KZvFx87XSMiGBCEPaEkHQkOHuGrwGHIMaU%2BKaVSb0xIbc2QaDJ0QswkSTTimuaeoTrYsIWSBRwCn3r0cNiA8ypm83jvesRBXWiiABr0BQZ8P7kNRZghGQIHJhFKd48Cnfsrf25Y%2FxgTytonfHkw8ijpYa5ptjsDpcw1OSeKfCERDhCdM7fZHyQEehQB7rniPIA5EZZHL1ou9TPttR7iW93QgcwWAXmGE5qwxLo%2BULg1W%2B%2Bmt5nMtJGbHJgrv204ZwITUMAEP7jkx2ub37GSyWe0gj3LQQbVADXGyBtp2IQriCPs0zswXRAY2%2Br4%2Fwf62p7i%2B878Q4V6AC00ex%2BylpWEqFzVlG5FEpb3yyNhgT042AT2nhm0P1XWtrPWKMChP0DPY3wQAJfw8nkefbcz%2FP55%2FJ3A23x5eZuZ06hr0nHMLgcEHMf8slavq%2FWJ0lJH9nRso%2FPig6gqndMzRWlXlE5B4fLKqMHap8qiabYyeXVSTEmLnhn3dSkdVUMawppYOL%2Fqt2pmL0yDC2lCLGkaTG9bxZHbyp7Xh47T1i8s3%2Bx1rqZ%2BMHPjqGpl%2BzU5pLARqfn6VDufnP0hZ%2BQavGmYN5EV1%2BP4VBlZC31uRXpezerqpHvbNJuXWb3t9uMTOa5fZ6toKOlqY5Eqnvlt3JKCdq6miE2tJw2vMuOKGHWmYwiJIRdu%2B7VWv2iO57V8qj33LmHWgqHcnHog71GsTE6rFWq0vciSLougdg3DRjPtNd1id5bRod6dBFezQNQfChcNPz6RYFPWIlm9jtin1x7Xa3ZHE50MzHSGokbmtkchqdqdLrFBDjeKcqpHVTzTca4pNYu109sUqV4UHNGOX4E5eqhXlY6irqK0ytKnMK2yhgdoGrJws7z04HEsCEGZR5ri0gp78ibsDG%2FQsiSKxwJPNzTycAAHhH0BDQOWtDQIGVO5oUPRADyATZdpDADPeJadhEmZEW9ox3ui1JNNEX2JcgamwRMWcbKWYU628plMIisNrURGLKYTw5wsJtISkCSpkM4W89IW%2Be%2FZG96j%2F03JvEdxO%2Byw61NUZsQmxfazXOxP4DivHf3Oru0l3AMRfFsi%2BN8k19td9Rew1rfx%2FfkAsFzeH7E990CGBzI8kOGBDH97MmSnVAIiaA4Ax6XFdC4hFhNiuiflSmmpJBaSciGbLhTiolgSRe4CJPRpSR5X7dW9ZcsY%2FhuBAIHh6oL5uL6qHGryO9fk%2BqLya5L8gyvw6uLLL71L%2Fh7CLya77yHr%2BnszOPm6etZFKYmx3Y16X0V%2Fasafn9wlfwrCJ7el5Kf1HgrkexbIB7F%2B2iW%2BEOK%2FWV7cFF48W4AECYc7pOvO9pxhD2x8YOM3D5Lro8IXuTn5zxB08r9k6QNV%2Fx5U%2FW%2Fz9ZIfzh1oUHbO5mfm19XILBa233QFfJuzh2bFylh15dpdzBYXmtY3mt5UuQC2%2BDAuqJf9s459OW5kysLyL0ED9suBGwAA)
- Subdomain (`host` = `mail`): [Test mailafiniti.com/email mailafiniti.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABNNmGoC%2F%2B1YW2%2FiOBT%2BKyjSPFHAAQqECmnCrVBugUIvM1MhkzhgCHGInZS0Yn%2F72iltoVCmo9lLV8tTYp8v52Kf8x07jxJDc8eCDEn5R8lxiY8N5NYNKS%2FNIbagiW3McFwnc%2BnkRdyGcw6XWq8ALqTI9bGOwk%2BR%2BPZ1bhcfqawRPnIpJraUl08ki4zJwLU4csKYQ%2FOJxBsXEhsaYk2OjoF0nPpjYSmw9aJF9JmUN6FF0dOM5o0aKCgTrsfeG5EA9ZCBXaSzFxh0nPgmFBOO5AjiGlTKf3%2BUWOCE8dzw%2BQmhjL9%2FFctDsM1onwhLy10NjPHQUhkAxEJi4mIW8LD5CFGKbIahiFy17mFApdXJi5VLrdratkMds%2BdZiPsiYVu3PAPl%2BdQBgxva%2Bjf9V2XGDM%2FjQyOMe4YCLjAgg1zwRUi%2BbPu8x0suX7ISsU0L66wFmT7B9rhFDBRCLOk9u0NjDl1905wYH7DXsVXHsYKDBjUXmXi5H7KW5SW%2FUG6pvZIsre5WJ9IDsdHwdWPvuEPvp8ra93Xejl3iOUP8%2FJ0DXTinooSeNXzfUXH3rONJJMZimcWYu9Wot%2BSzyKzgUngWcQqter1Yn6rt4ni2mMzwuXIPimq3UlXVTknt5lQhL40b%2FL2iPjSNdjpbnCoJ%2BaFvRB1NTvplj3moBnLng6t2zeh7SXghT6kpL9zFbVsZz9un5%2FWRZXW0C9Mx%2Bt3BwnGX8ygum6dXtZTHUMMvZuuL1vm0%2Bi2VTtXQTcO48c2oFiUVdWw%2BaIHpa9niqVac9m6bRvPyVOvMr6LTVFS7Pi3jkawVGw8Jpep0SFt2O5maCpqtvjwapCcl4HcXE4SonsrdXtXaV4oxCWrZRCewL9GpibxUc2HDrM2IOq2US0zv2L4pXyqwdo28RjNpN%2BdKb5nWkNabuoOlC7T73EXDiU5l1Ey1%2FFTx2uePfmdSr826LWClUbo7Ai0azGyGaHnW7dEZzJCGkkr0WZEsNZJpyk2lVrlN0PJFzgKz6AAG%2BL5eVrtqMdylMFuftinMHrFBC49vOc9PG51FXA8WxJYykg%2BxX99sPcfrrCADcCaJtMNjm7hoSPkTMs%2FlyctcjzPW3LMYHsJ7%2BDpl6EMoMp9nKeVS7sQb%2BrGfqHWdlet6%2BiX2GRq6yFsseNvMmTkAAYplFV2OpTMjFBvlMnxowJGSNkEWmMpGH3inTezrBNvVs4%2Fxdshib2h%2BgVOdHHmf9yJ%2FQMvajvezR%2FiGhuNvIz5ywyflhv9Ulj013d3k%2Bl1G%2B1SL8HxQWK3uTnhfPpLlkSyPZHkkyyNZ%2FoQs%2BSmXQh8ZQyiwSZDMxIASA8m%2BnMkn5XxKiQOQVJRsFIA8ACIMRNnTsjyG7%2BHdZ8MhMfShi%2BEovKg%2Brq86xwL9zAW6vuj8NYl%2B4CodXp7FxXkl%2FquIi83uf5WNhrbxcXy7gtaFKYPIbhc%2F1CJ%2FqvHHB3vnD0n6lUb1IbvHAvmcBXJgrzfaxce2%2BDfLS7giimcDEKPe6Ei6R9L9lf%2BXH6fg%2BN%2FDw%2FF%2Fk4yPjPz%2FYOR%2FmpZX4hxuIZ3x47Q4Gm9XY8jTHLL5%2B1ciFZPJwchOz5qXmWoU0XapKidz15l%2BVknAW%2F1bJ3O5JBfVhD4uSKs%2FAbA0mMu0GwAA)
