### PR TITLE
Add smtpfa.st inbound template

### DIFF
--- a/smtpfa.st.inbound.json
+++ b/smtpfa.st.inbound.json
@@ -10,6 +10,8 @@
   "syncPubKeyDomain": "smtpfa.st",
   "syncRedirectDomain": "smtpfa.st",
   "syncBlock": false,
+  "warnPhishing": false,
+  "hostRequired": false,
   "records": [
     {
       "groupId": "inbound",

--- a/smtpfa.st.inbound.json
+++ b/smtpfa.st.inbound.json
@@ -1,0 +1,23 @@
+{
+  "providerId": "smtpfa.st",
+  "providerName": "SMTPfast",
+  "serviceId": "inbound",
+  "serviceName": "SMTPfast Inbound Email",
+  "version": 1,
+  "logoUrl": "https://smtpfa.st/logo.png",
+  "description": "Routes incoming email for the domain to SMTPfast inbound receiving by publishing the MX record.",
+  "variableDescription": "region: the SMTPfast receiving region (e.g. eu-west-2), shown in the SMTPfast dashboard when receiving is enabled.",
+  "syncPubKeyDomain": "smtpfa.st",
+  "syncRedirectDomain": "smtpfa.st",
+  "syncBlock": false,
+  "records": [
+    {
+      "groupId": "inbound",
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound-smtp.%region%.amazonaws.com",
+      "priority": 10,
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a second Domain Connect template for SMTPfast (https://smtpfa.st), providerId `smtpfa.st`, serviceId `inbound`. SMTPfast now receives email for customer domains; enabling receiving in the dashboard asks the customer to publish one MX record pointing at the receiving endpoint in their region. This template publishes that record so Domain Connect users can do it in one click, the same way the existing `smtpfa.st.mail.json` template publishes the sending records.

- One record: MX at the apex (or the chosen host), priority 10, `inbound-smtp.%region%.amazonaws.com`, TTL 3600.
- Variable: `region`, the receiving region (for example `eu-west-2`), shown in the dashboard.
- Kept separate from the `mail` template on purpose: publishing an MX record changes where the domain's mail is delivered, so it must stay an explicit step apart from enabling sending.
- `syncPubKeyDomain` and `syncRedirectDomain` are `smtpfa.st`, as in the existing template; the `_dcpubkeyv1.smtpfa.st` key record is already published.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test smtpfa.st/inbound example.com/inbound](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPtRmGoC%2F%2BVUYW%2FTMBD9K5alSaA1WZp27RYJiaEhQKijKhsMpqq6xNfGLLGD7bTLqv537GRNuw5%2BAZ%2BS3N17fvfu4jU1mBcZGKTRmhZKLjlD9YnRiOrcFHPwtaGdNnEFuS2kX0fX4znUGY1qyROsEVzEshRsFz0oJ5%2BaAvI%2BB57ZsiUqzaWgUbdDM7mQNyqz5akxhY5OTloBJy7nF2JhIQx1onhhahidyNKgJlwkMudiQdARk7lUxKRImLSfghhJWgVPEonCBPnSQeKKFGWccZ26Lwcb3bq0VMx3EkFxiDO8fHauwoV9ierylnvH2aTJK%2FQXPsHSW6E2Xvi6Q3QqV4I4TftABjqNJShGVimKPR6uCQp3ei1FVyIZl%2FFnrC7rxg5m5NITZNzCzT8L3mUyuafRHDKNHboCJcZp03obTKU2E%2FxdWiLWBhtDNI3u1nShZFkcDNxUhZv06JY2BPb9rdsbyYXR13JX6zlF%2FlHj0JEPOTxKASvt2wnWi8al4qayKxFYVmP3oTcIgs1006G2EGc7IVO7DNs28QHsFuMTyZOAnbpa8YzXsDZs8QUoyLXb%2FC3T3TOq6ZbrGapmO4g1%2FdT47bip08wXQiqcafsEUyrrkVGl9TMvM8NnYAfQhlgyg6LIKtuitlnLZb3e91U0f9OuLQYGDp1tj39hbWvmocszljgLuJsoJBDCMEEPw%2FOe1z8763kx9hOvO%2ByxPvTjuBeGe%2FfBi4vi79fBi4Gg1igMB%2Fe7X2QrqDTdbKYdO9P%2FrWe7OxqWyGbgqsMgHHjBuReE191B1A%2Bj3qnf7Q5OB8PjIIiCwLVkO21MWNv92t8s%2BkUNJo%2FlUFTjpPiQfgvwZn5sforRx%2BHgykiW%2FDAj89C7%2BP6rf%2F%2BGbv4A2S3VEfsFAAA%3D)
[Test smtpfa.st/inbound example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGBSmGoC%2F%2BVUYW%2FaMBD9K5alSptGQqBAIdKktWqlVR1b1bG2UoWQEx%2FEamJntkOgiP%2B%2Bc1ICpdsv2KfYvnfP796ds6EWsjxlFmi4oblWS8FBX3MaUpPZfM58Y2mrCXxnGQLpz%2FHkds6qiAG9FDFUGUJGqpB8f3oEJ9c1gFxlTKQIW4I2Qkkadlo0VQv1S6cIT6zNTdhuNwLaLubncoEpHEysRW6rNHqnCguGCBmrTMgFAUdM5koTmwDhCreSWEUaBa8SiYYYxNKlRGuSF1EqTOJ2Lm386MJKc99JZFqwKIXLN%2FdqWOAirOAN956zDpMP4C98AoVXgrFe92OLmESVkjhNh4mcmSRSTHNSJiAPeIQhIN3tlRSzlvFtEd3A%2BrIq7KhHLnwHXGC6%2FSfgIlXxMw3nLDXQoiXT8japS28OE2XsHfwukIg3h7UhhoZPG7rQqsiPGm7Xuev0%2BJHWBLj%2B4uZGCWnNRO2xnlPkn9QOnfgsYy9KstL42MFq0ITSwq5xJAJktTgPp4Mg2E63LYpAmO2FTHEYdmXCiuEUwyvJqwBcVVJnosI3ajExZ5plxo38juLpDcd0R%2FJE3bqiOaKoK6gSdw2mTqVYSKVhZvDLbKHRFasLdDArUitmDC1vjng8Y3merrEog1HkQncPnZT1%2B3FOcmbZsYvNxe9sbIw7dnTGY1e1cN2bB%2Fz0bNgZeXFnOPR6o7jvsWDY8%2BJet9Pr87NhdBofvP13P4W%2FP%2F29%2BWAMSCuYe9PnacnWhm630xY27j8oEyfEsCXwGXOwbtAdeMHIC7qTziDs9cLOwO%2BOzgaj%2FqcgCIPA1YIl1tVvcIoO54dOblZfy%2FaPixe%2BgqvVfZSUZfch%2Br36NhhfPavH8%2FLhPuq%2F9G%2BK6Pwz3f4B22reoNMFAAA%3D)
