### PR TITLE
Add ururu.store.storefront template

### DIFF
--- a/ururu.store.storefront.json
+++ b/ururu.store.storefront.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "ururu.store",
+  "providerName": "ururu",
+  "serviceId": "storefront",
+  "serviceName": "ururu storefront",
+  "version": 1,
+  "description": "Connects a subdomain to your ururu store.",
+  "syncPubKeyDomain": "ururu.store",
+  "syncRedirectDomain": "ururu.store",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "_saas.ururu.store",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for ururu (ururu.store), a multi-tenant storefront platform for small makers and artisans. The template connects a merchant-chosen subdomain to their storefront with a single CNAME to our shared ingress (`_saas.ururu.store`). Subdomain-only by design (`hostRequired: true`) — apex connections use a manual ALIAS path outside Domain Connect.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (n/a — no `logoUrl` set)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `ururu.store`; the key is published at `dckey.ururu.store` (TXT, `p=1`/`p=2`) and resolves
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`ururu.store`) — the sync flow passes `redirect_uri` back to our dashboard
- [x] no TXT record contains SPF content (template has no TXT records)
- [x] `txtConflictMatchingMode` — n/a, no TXT records
- [x] no variable is used as a bare full record value (template has no variables)
- [x] no bare variable is used as the full `host` label (the single record's host is `@`, applied at the `host` parameter; `hostRequired: true`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — n/a; the single CNAME is the entire service, removing it disconnects the domain as expected

## Online Editor test results

**Editor test link(s):**

[Test ururu.store/storefront example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFG3mGoC%2F91S72%2FaMBD9VyJ%2FbcIcQ%2FgRadIY69RtajchPqxCKDL2Udwldmo7dBnif98FyAB11b5P%2BRCd79279%2B5uSzwUZc49kHRLSms2SoL9JElKKotfx3ljgYR%2FUne8gDaJzw7sRgnYF%2ByhK2u0PyXO4cEFYAPWKaNJGodEghNWlX4fk4nRGoR3AQ9ctZSm4EoH3gS1qWxwxtRp2tRafKuWX6D%2BsMe90N0ApiCVRcZXIGvj%2FBSeKsSgDW8rCAnCjZWOpPMt8XXZeJjcjW%2Bvj3AM3zVDMUp7NzMYZo5z17kk9j4nabdP6W6xC8kvoyE78S7QdqsHfnJcAnSEKU4N3NqUGD1YU5WZamtKbnnhmmW11fOL8kVbPz8QNJ3Vg0ZBmcM%2F9xVKO5osqtyrjD%2Fz05MUGS%2FLvEahDrNI83IA%2BrDToz7JPf%2BX%2F5BkUjSaVXMnQJO4v0wgYgllUU%2BKYTSMQUZiBbAaMcZiKc8u7i%2FH%2BOrVXY4OnAPtFUcVZJw%2F89qR3W4R4hj%2FO1O4dsc3IDPeQBll%2FYiOIspmrJsmvTQZdEY9OmTDK0pTShsb4PzB5RYv5Pw2yFoMnKhF%2F%2BZ2%2FLXrk%2BtZHb%2BZiN7gns1%2B3Dw9Tqvv768e649MfL5%2FS3a%2FAQ5KD49CBAAA)

(`hostRequired: true`, so per the instructions no apex test is included; the subdomain test above covers the template's single configuration.)
