### PR TITLE
Add backlinkhell.com ownership template

### DIFF
--- a/backlinkhell.com.ownership.json
+++ b/backlinkhell.com.ownership.json
@@ -1,0 +1,24 @@
+{
+  "providerId": "backlinkhell.com",
+  "providerName": "Backlink Hell",
+  "serviceId": "ownership",
+  "serviceName": "Backlink Hell Domain Ownership Verification",
+  "version": 1,
+  "description": "Adds the TXT record that proves you control this domain to Backlink Hell.",
+  "variableDescription": "token: the one-time ownership challenge value issued by Backlink Hell.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "dckeys.backlinkhell.com",
+  "syncRedirectDomain": "backlinkhell.com",
+  "records": [
+    {
+      "groupId": "ownership",
+      "type": "TXT",
+      "host": "_backlinkhell-challenge",
+      "data": "backlinkhell-verify=%token%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "backlinkhell-verify=",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New synchronous template for Backlink Hell (backlinkhell.com), one TXT record. A Backlink Hell member proves control of a domain by publishing `_backlinkhell-challenge.<domain>` TXT `backlinkhell-verify=<token>`. The template writes that one record and nothing else. Requests are signed (syncPubKeyDomain dckeys.backlinkhell.com, key _dck1); `txtConflictMatchingMode` is Prefix with the `backlinkhell-verify=` prefix so a member's other TXT records at that host are left alone. No logoUrl yet.

Contact: b.akdogan@850it.com

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (no logoUrl in this template)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
[Test backlinkhell.com/ownership example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF3bmGoC%2F%2BVU227bMAz9FUNAnxYHyrWugT6064YV621FV2wtAkOWmESILLmSnNYN8u%2Bjcmuypi973ZMp8lDk4aE8Ix6KUjEPJJ2R0pqpFGDPBUlJzvhEST0Zg1JNbgrS2MSvWIF4crpCRN8QgmEHdio5LLLNswbrxrJ88%2B%2FLis5MwaSOrtfw6B6sHErOvDQac6foDlbaahABjltZLiIpORHCRX4M0d2vu8gCN1bgkfkodAkuqk0VcaO9NQr90kViWcqbaKeFZqjCrGS5grOdCt5MQKeLGkZD7GWBxqZRPmZKgR5BNGWqgkg6V4GI8vr99a7W%2FFQZPiHpkCkHS89NlX%2BHejkArCb4BGrX3DP2AL4FIZGk38D34JZDcCR9nJGRNVX5Tglfl0ECnBgexsZ5PGTbN8UbVggQzLO%2FKsXTIE99fLCYzUG40iuSdihF68V%2FNnqoJPeXzPOx1KNLI0K9GwtD%2BUL2Qlax%2FWUwBZwD7SXDKuRan5Slqsl8MG%2BQV9Qke6M8wH7Xs4EXhksNq7GseKK1GEom1%2FiSWVa4sPjrzMed1ME695EEe0E5HFjOW%2B2OgGG31yehFTnSxkLm8Mt8ZZGytxWqXFTKy4w9szeX4BkLHLBzh1G8DsXakUUvn8k%2FybLT2bY2meCBpwwL0UpE3qGtPE4SweMupZ04oXkv7h316LCTHELeE1uP%2FaOfwUev%2FW3ce6WbDxo4%2B%2F%2BONO6PY1MQGQu4Nm33Y3oU084dbaftJO32mq1ev3t4%2BInSlNJAA5xfkp7hhm3vFkl%2B%2Fr65uC%2FO1cWrkD4fF1fs%2FvmJ6y9fRycPrz8ebun5ZTVK%2Bk%2Bt5JjM%2FwDS47IH4wUAAA%3D%3D)
[Test backlinkhell.com/ownership example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJLbmGoC%2F%2BVU227bMAz9FUFAnxqnvqRpY6APTQu0w9AtKLqhWxEYssQkWhzJkOQ0XpB%2FH%2BVcmqzpfmBPFslDkYeH8pI6mJUFc0DTJS2NnksB5pOgKc0ZnxZSTSdQFG2uZ7S1i39hM8TT%2FgZB7hGCYQtmLjk02fpVgbETWb75j2WRWz1jUpGvWzj5DkaOJGdOaoW5c3T7Uxq1qADLjSybSEqvhbDETYA8PT8RA1wbgSZzxHcJltS6IlwrZ3SBfmmJWJdymhy00PZVmJEsL%2BD2oILTU1BpU0MrCJyc4WHXKJ%2BwogA1BjJnRQVEWluBIHn9%2FnpbK94vNJ%2FSdMQKC2vPoMo%2FQ70eAFYTfAq1bR8Zuwc%2FgpBI0u3gR3DrIViavizp2OiqfKeEq0svAU4MjYm2Do1s%2F6ZgxwoBgjn2V6Vg7uWpr06a2Zz4K11B0yQM8bRwN1qNCsndA3N8ItX4QQtfb2BgJBf0KGQTO14GU8BaUE4yrEK%2FquuyLGq6Gq5a9Ddqkr1RHmK%2F29nAguFSw2YsG562ytFo5pLJbUrJDJtZv%2Fvb5JeD7OE2%2FaXJR7Mh7m2W8yhOBIw6513qG5JjpQ1kFr%2FMVQaJO1Oh1rOqcDJjr%2BzNJXjGPBPs32IUr0PJDsRR68fygTjtNZl%2FCHTQ3b5KmeCermyeeCe5PO92L4JOZ8SCTn4ZBT3RiYIkT6JeF%2FhIXPC9Z%2F%2FRb%2BGjd38w%2BKM6roYtVOF%2F5Y7bZNkcRMY8NA7jbhD2gjB5CuM07qXJZRtpJL3wNAzTMPRMwLo17yXu2%2F6m0ds4Gj9XcTQf%2FzI3j4%2F9nw%2Bn93A%2BMD%2Fuzs76d9HgG0BdPywuxvHrFV39AVolE6%2F3BQAA)
