### PR TITLE
Add noonapp.com.au.email template

### DIFF
--- a/noonapp.com.au.email.json
+++ b/noonapp.com.au.email.json
@@ -1,0 +1,35 @@
+{
+  "providerId": "noonapp.com.au",
+  "providerName": "Noon",
+  "serviceId": "email",
+  "serviceName": "Noon sending address",
+  "version": 1,
+  "logoUrl": "https://noonapp.com.au/apple-touch-icon.png",
+  "description": "Lets Noon send quotes, invoices and policy documents from your own domain, signed so they reach the inbox.",
+  "variableDescription": "dkimkey is the DKIM public key issued for this domain; region is the sending region of the bounce return path.",
+  "syncPubKeyDomain": "noonapp.com.au",
+  "syncRedirectDomain": "noonapp.com.au",
+  "shared": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%dkimkey%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Noon** (`noonapp.com.au`), an Australian multi-tenant insurance broker platform. It sets up the DNS records our tenants need so their customer email (quotes, invoices, policy documents) is sent and signed from their own domain rather than ours.

Three records, all on subdomains and none on the apex, so a broker's existing mail is untouched:

- `TXT resend._domainkey` — DKIM public key
- `MX send` — bounce/complaint return path
- `SPFM send` — sender policy

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also checked with `dc-template-linter -merge-or-fail -logos` (exit 0).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template

Notes on two of these:

- **Variable scoping.** Both variables are embedded in fixed content rather than standing alone: `data` is `p=%dkimkey%` and `pointsTo` is `feedback-smtp.%region%.amazonses.com`. Only the DKIM key material and the sending region vary.
- **`essential`.** Not set on any record, because all three are required for the service to function at all — there is no record here the user can modify or drop without mail stopping. Happy to add it if you read the rule differently.

## Online Editor test results

**Editor test link(s):**

- Apex: [Test noonapp.com.au/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK1FmWoC%2F%2B1VW2%2FqOBD%2BK1GkPpVAIBxaWPUhlMJSDjncSntaVciJDXGb2KntBNKq%2B9t3zKWUbve8rXS06ps9notnvvlmXkxF4iRCipiNFzMRPKOYiC42GybjnKEkKQY8LqLULLy9eigGbdODd5BKIjIakLUJiRGN9rJ3ioYkDFO2MBDGgkgJShkRkoKLRrlgRnzBr0QEyqFSiWyUSofRS3CMiKV4GoQWDTgrJmwBPjCRgaCJWvsxvxMljbdoxlPKFZEFg7KMw2%2BkgUCY8IgGuYF5kMaEgf5c8NjIeSoMvmQghxRYwZB0wQg2JDdUSHJDEBSE%2BgjOfL4q6u8jQZEfkdbBF%2FAjjR%2FBgMq1dqvX7RtJ6kNMYyOWKbidcwHPoLMJ9wf4X4D9zmpXq62Uz9dSn6csICBUqWBGglSovyFzFgxSv0fy1trXZ8BpnRHBVJBA%2FUIrRIIAinMUSVIwQZkLLM3G3Yup8kQDObmZgF7IpYILoAjfLM42KUByGg6kEDwlZ0fbOhyBUCnA1anZNhxX6pyzOVRD9ZEKQkiyz7F27UaR%2BVp4i9S%2F2QfSYXT3cQpwTThI5oRgHwWPloxVUjzalOmoiGL0zJkkUue07lfKBVU5dJj97hvvwowH7f4%2FAslkPkojApmblAVRiknjo%2Be9r%2FvXgglPZLYv1z3UYVdkskLALrI128aB00LwNJnRnX6CBIqlZuDO8u7A9H5ne2fq87a4%2BtrvduZ91%2B6cj586467vtIYXTXd45brVjue2zpt02Gsuhq3JTR75rtecRqlIVpVOHtqjytALY9%2B7eLjOPZz9KCd8kK2mbS%2BYO%2FxnrTr18bIzGpcEq2ftoV1q1Z9H8Z%2FqdnmbkWlJ1rpjm9Sd9jSPKp3pOZdtr%2F8DITQguPP8EIuruHp8emwn3oO7fB4sauxasN4Tc52we%2B1cTuPHQX18WV%2Fh6AK3b9JWipuVSXrrHQ%2B7LXfoNnWaG1x1liixGBdAAiSVVTZ10YGfXJCZ5ikCQgCaSqTQtnEaKTpDS7QX4WCmx0cOGEl4BYcfW5ptBtUvW%2Fp%2FW%2BkDhs5woNuQ6mle9Ssn6JtTtlCV2FYV12oWquC5VUNB%2BaSKTn1ETt%2Bthc%2BXxmfrYc8D2AQwhCmK1iNgiXJpvn4cA1twtuzc4nE4Ag77o%2FivdP04E36vbA968TDd7AymUtn4dB4Zf6Eo%2Bv1QvC%2FAZPsi2hfRvoj2HxMNVqVEGcEzpNUqdqVm2XXLdiZlu2FXGpVy8ZtzcuKcHNtwt3UCRKpNvi%2BwSd%2FvUNMFZgbHKxe5yW3n6SFrPy57zs%2FTTJwO0QSpbher75dyVM4v5Zn5%2BjdEKFNPPgwAAA%3D%3D)
- Subdomain (host=mail): [Test noonapp.com.au/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAM9FmWoC%2F%2B1VW1PiSBT%2BK6lU%2BSSBAArClA9BhEEmGRBER8uiOukOtHS6Y3cnEC33t%2B8JFxXH3ded2vItOX3u3%2FnOeTY1iWKGNDGbz2YsRUoxkT1sNk0uBEdxXAxEVESJWXh99VAE2qYH7yBVRKY0IGsTEiHK3mTvFA1FOKZ8ZiCMJVEKlFIiFQUXzXLBZGImriQD5bnWsWqWSvvRS%2FDJiKVFEswtGghejPkMfGCiAkljvfZj%2FiBaGa%2FRjMdEaKIKBuWpgGyUgUAYC0aDzMAiSCLCQT%2BUIjIykUhDLDnIoQReMBSdcYINJQw9J5khCQrm%2BSc488WqmKePJEU%2BI%2B29FPCCRgswoGqt3e73XCNOfIhpbMQqAbehkPAMOptw38D%2FDOx3VrtebaUiXEt9kfCAgFAnkhsx0vM8DZXxYJD4fZK1174%2BAy7XuSSYShLof9GaI0kAxRAxRQomKAuJldm8ezZ1FudAjm%2FGoDcXSsMPoAhpFqebEqC4HA6kETzFpwfbPhyAUGvAtVqzbfhc6TPBQ%2BiGdpEO5lCkK3Du2mHMfCm8RnJv3gLlYfLpExTgGguQhIRgHwULS0U6Lh5s2nRQRBF6ElwRlde0nlcqJNUZTJj9Lo13YUaDjvtbIBWHlwkjULlJecASTJofPb%2F5un8pmPBEpm%2Ftuoc%2B7JpMVgjYRbZm2zhbksykSOIp3dnESKJI5SzcWd%2Ftmd%2Fv7O82DvIwmybnIrfXDV3H7p6NHrujnl9tD89bzvDKcY66ntM%2Ba9FhvzUbtsc3GfMdrzVhiYxXlW42ty8rQ28e%2Bd75w3Xm4fRnORaDdDXpeEFYFb9qRxMfL7uXo5LkjbQztEvtxtNl9F3fLm9TMimpWm9kk0a1M8lYpTs5E6rjuT8RQgOCu08PkbyKjg5PDu3Ye3CWT4NZjV9L3n%2FkTnXeu65eTKLFoDG6aKwwO8edm6Sd4FZlnNx6h8Ne2xk6rbzMDb55lSi2uJBABqS0VTbz5gNPhSTTnK8IiAGoapnA%2BEYJ03SKluhNhINpvkYywErBKzj8ONp8s7B%2BG%2B3iFrLX%2Bf7ftnuPrlMc5PNI89Ue1OroqHxSt4LqMbaOyhhZftm3Lb8eVO2w3qhW7Ma7G%2FH5BfnsVuyTAk4DbGWK2HonLFGmzJePe2GL0hqjfWD2F8P%2BtBT%2FkcQfN8WfV%2FbedH5Sd3oKS6tsfLqujL8QY38mrvcFWHxfHPzi4BcH%2FzsOwoFVKCV4inLVil2pWXbDsqvjst20K83j42KtXqvVjw9t%2BLfzIojSm5qf4f6%2Bv7xm11lNuovv3nW77o9u3bMLN0WlkyfXdh5YK%2FyxWPiHrF%2B6feh3Zqfmy9%2F%2FQ8xifAwAAA%3D%3D)
