### PR TITLE
mailsoftly.com.email-auth: version 3, add ms102 MAIL FROM CNAME to delivery group

### DIFF
--- a/mailsoftly.com.email-auth.json
+++ b/mailsoftly.com.email-auth.json
@@ -3,7 +3,7 @@
   "providerName": "Mailsoftly",
   "serviceId": "email-auth",
   "serviceName": "Mailsoftly Email Authentication",
-  "version": 2,
+  "version": 3,
   "logoUrl": "https://app.mailsoftly.com/mailsoftly_dark_logo.png",
   "description": "Authenticates your domain for sending email with Mailsoftly: DKIM, SPF, custom MAIL FROM and DMARC.",
   "variableDescription": "dkim1/dkim2/dkim3 are the Amazon SES DKIM tokens generated for the domain; byodkimvalue is the DKIM public key TXT value.",
@@ -47,6 +47,13 @@
       "type": "CNAME",
       "host": "ms101",
       "pointsTo": "ms101.%fqdn%.mailsoftly.net",
+      "ttl": 3600
+    },
+    {
+      "groupId": "delivery",
+      "type": "CNAME",
+      "host": "ms102",
+      "pointsTo": "ms102.%fqdn%.mailsoftly.net",
       "ttl": 3600
     },
     {


### PR DESCRIPTION
# Description

Updates our template from version 2 (#1716) to version 3. One change: a `ms102` CNAME (`ms102` -> `ms102.%fqdn%.mailsoftly.net`) joins the delivery group, same shape as the existing `ms101` entry. It carries the custom MAIL FROM chain for our new domain setups: the MX and SPF for the return path live in our zone behind the customer's CNAME, so the delivery group now installs the complete set. No other group, record, variable or the signing setup changes, and existing installs are unaffected since the new record is additive.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

[Test mailsoftly.com/email-auth mdemir.xyz/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADxsmWoC%2F%2B1WbU%2FjOBD%2BK5alfto25GXpQRAfupS9Q7vdRcBJq0OocuNp8TWxs7ZTCKj%2F%2FcZpS1JKdxcdp5MQXxIn8%2FLMMx7P%2BJ5ayPKUWaDxPc21mgkO%2BoTTmGZMpEaNbVp6icpo%2B0H6hWWoTQcPcpQZ0DORQGUIzrLDCntdCzZsyLHTIj3UAmlFwqxQEvVnoI1bxVGbpmqi%2FtQp2l1bm5t4Z4flubce1079OeRMT4fOyMvlBH1xMIkWeeU5pg0oMKRUhSZcobUkY6WJAcmFnJAqeHIj7DWpg41J%2F9PJoE3OTz%2B2SVIYqzIy6J18Jh%2FPvg4Ik5z0B72zI8%2FFz7RgoxT6a9h8KrJgxz3D6hkRpoFgPKSXsTslyfnxeYVBrJqCNGQCEjQGyqvgnOIi1gMyKpXzMGNpAUSYSlZZ5sUoFQmZQkkuvl2QSsFFZEqZfEhVMqXxmKUGFn9Oi9EnKPuVUxdgtUiUlJBYb2PrncUZcKFR%2BmCzuRmoea2MPYPvBaryB0A0U5obGl%2Fe04lWRV7ViaOBFrbMXWkcfekNjpcO8LNVpazlDReRIStXgUpIay5UQ%2B5eHquSaMAsg7AWiybq%2Bv68%2FTzA8CeA4UsDRj8BjJ4HuCyOGhMroUZsbNYaKGeWoTg%2FbDWLq9WEweWtPVJyjCVmB8wm13hYBoo7jFMNY3FLn1RZypxz%2Big3kAo87OXW%2FGQm8IP1lFS%2FvNb4O5etZulJsD%2FYhF8BCjeBwhcHMsHWzV4TvTxwuB04%2FE%2BBo%2B3A0b8AdnpjrRqFjq15UONKuDGubeXjsyIFbDwUm1tacIh%2F8SBtAgy%2BbbhvsBkD8BFLph2T2dwrTAeYsZ1g49zmWigtbEnjwN%2Be1ozpZMsZHq6Ey0M7O6xGT3BA8kOpJBy86KldeUc1MMZNT%2BbG8VfZy3Oc%2B%2FOreZsiPxjWHf6qvRwmLoscMqG92%2FKuJoCriulQVOrNGlpQQwc50ywz7kaycnXZ9HW1cnZJ3bpyt81VNSZWmlULb35Eq49m41v8Q2ZiIpWGocE3s4VGgdUFjrOsSK0YshtW%2F%2BLJkLmUYCIMStEFjrpHZ0Iu7kCrvrbcwEVPq9n94Ay0cfcTlxXhqmR3xHf5OIRO9FvAO%2B8Zg87eXtfvvOf7AfAoAH93t3Fre%2FpOt%2FXeVu9Wc%2BN76Q0rDZ27et3OLlxnF74edo87%2BJLlevd%2BPWzDp9mGr5Nt9DTb6HWwXUyRJddnTpH%2Fm87DvJlftXHAvLXWt9b61lrfWutba33R1orXYMNmwIfM6YV%2B2O34%2Bx0%2FugjC%2BH033g297j7Gs%2F%2FO92PfdzTA2AXLe7wtN%2B%2FJNOJ%2FnQT9d5Nucvph73jUP5V9pn%2BHv%2FVOUJqjm9IW2d3e3eiPz3u9Qzr%2FB4NEg7OGFAAA)

[Test mailsoftly.com/email-auth mdemir.xyz/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFJsmWoC%2F%2B1WbU%2FjOBD%2BK1akfqINeWFhCeJDjxeJ28su4mWXO4QqN54UXxM72E4hi%2Frfd5y2NKUUdnWctEJ8aWPPyzPPeDzje8dAXmTUgBPdO4WSI85AHTEncnLKMy1Tk1VuInOn%2FSD9THPUduIHOco0qBFPoDYEa9mhpbmeC5ZsyIHVIl3UAmF4Qg2XAvVHoLT9isK2k8mBPFcZ2l0bU%2BhofZ0WhbsY1%2Fp82WNUDXvWyC3EAH0x0IniRe05chpQoEklS0WYRGtBUqmIBsG4GJA6eHLLzTWZBxuR%2FU9HcZucHh%2B2SVJqI3MSd4%2F%2BIocnX2JCBSP7cfdkz7XxU8VpP4P9BWw25Lm%2Fbn%2BD%2BjckVAHBeEg3p9%2BlIKcHpzUGMXIIQpMBCFAYKKuDs4qTWHdIv5LWw4hmJRCua1ltWZT9jCdkCBU5uzgjtYKNSFci%2BSOTydCJUpppmOwcl%2F1PUO3XTm2A9UcihYDEuEtHby1OgHGF0geb5cNAzWupzQnclKjKHgDRTCqmnejy3hkoWRZ1nVgaaGGqwpbG3udufDB1gMtWnbKW25tEhqxsBUoujD6TDbn9c2mdRA16GoQxWDThpueN278GGLwAGLw2YPgCYPhrgNPimGNiJcwRG4e1AMqooSgudlvN4mo1YfDzzuxJkWKJmZia5BovSyyZxThWkPI750mVqcw6dx7lBjKOl71amZ9c%2B56%2FmJJ6y22lN0y0mqUnwDxzCD8DFCwDBa8OpP2Vh70gen3gYDVw8L8Ch6uBw%2F8AbPVSJRuFjq05nuMKuNW2bRXpSZkBNh4Hm1tWMoh%2B8iItA8QXS%2B4bbFIA1qfJsKNzU7il7gDVpuMv3dtCcam4qZzI91anNacqWXGHezPh9NKOduvR4%2B%2BQYldIATuvemtn3lENtLbTk9px%2FEV0iwLn%2Fvhq3HaQH%2FTmHf6qPR0mNosMcq7cu%2Br7Uu5qtj1emzTraEIPnRRU0VzbV8nM3WXT39XM4eXE49XU5Sp39biwwtkiaC7C2aLZACd7yJAPhFTQ0%2FhPTalQYFSJYy0vM8N79JbOt1jSozY1mBCNUnSBI%2B%2FR3RCTt9CkmU3TMT3N%2BZ475%2FrMrWhjPSQ2R9zWTRj4%2FRS2k44XekFnYysNOv0PWxsd3%2FeS7Q%2BsD%2Bwjbbzjnn7lrXzJLZ5fsxy62S2ttDO2Vbyaa%2FAE1%2BANcl1s5Yucl2VvjHvwDPfgjXMPn%2BEevjHuk5k0ZT6ZSY8ovzCYfgdeD2NsfNXGufXeqd879Xunfu%2FU7536d%2B7U%2BEjXdASsR61u4AWbHW8b4znzg2hjK%2FI3XG%2Fz4wcvWPO8yPMsFdBmwvQe3%2FLNV7yTZuuh2Dz%2Fmuji8PjPizNvIP%2F%2Blnj%2FnNKv3%2B7khbxZWxuei4Dn%2F8a7zvgHZ8wdFywVAAA%3D)
