### PR TITLE
Add Wavelinker, email (Postmark) template

### DIFF
--- a/wavelinker.io.email-postmark.json
+++ b/wavelinker.io.email-postmark.json
@@ -4,7 +4,7 @@
 	"serviceId": "email-postmark",
 	"serviceName": "Wavelinker email",
 	"version": 1,
-	"logoUrl": "https://app.wavelinker.io/logo-square-wavelinker.svg",
+	"logoUrl": "https://app.wavelinker.io/logo-wavelinker-256.svg",
 	"description": "Lets your Wavelinker store send email (order notifications, newsletters and other campaigns) from your own domain: DKIM signing, a custom return-path for bounce handling, and a baseline DMARC policy.",
 	"variableDescription": "%dkimSelector%: DKIM selector issued for your domain; %dkimKey%: DKIM public key issued for your domain",
 	"syncBlock": false,

--- a/wavelinker.io.email-postmark.json
+++ b/wavelinker.io.email-postmark.json
@@ -1,0 +1,38 @@
+{
+	"providerId": "wavelinker.io",
+	"providerName": "wavelinker",
+	"serviceId": "email-postmark",
+	"serviceName": "Wavelinker email",
+	"version": 1,
+	"logoUrl": "https://app.wavelinker.io/logo-square-wavelinker.svg",
+	"description": "Lets your Wavelinker store send email (order notifications, newsletters and other campaigns) from your own domain: DKIM signing, a custom return-path for bounce handling, and a baseline DMARC policy.",
+	"variableDescription": "%dkimSelector%: DKIM selector issued for your domain; %dkimKey%: DKIM public key issued for your domain",
+	"syncBlock": false,
+	"syncPubKeyDomain": "wavelinker.io",
+	"syncRedirectDomain": "wavelinker.io",
+	"records": [
+		{
+			"groupId": "dkim",
+			"type": "TXT",
+			"host": "%dkimSelector%._domainkey",
+			"data": "k=rsa; p=%dkimKey%",
+			"ttl": 3600
+		},
+		{
+			"groupId": "returnpath",
+			"type": "CNAME",
+			"host": "pm-bounces",
+			"pointsTo": "pm.mtasv.net",
+			"ttl": 3600
+		},
+		{
+			"groupId": "dmarc",
+			"type": "TXT",
+			"host": "_dmarc",
+			"data": "v=DMARC1; p=none;",
+			"ttl": 3600,
+			"txtConflictMatchingMode": "All",
+			"essential": "OnApply"
+		}
+	]
+}


### PR DESCRIPTION
# Description

Adds `wavelinker.io.email-postmark.json`. Wavelinker is a multi-tenant order
management system with hosted storefronts (https://wavelinker.io). Each
merchant sends email (order notifications, newsletters and other campaigns)
from their own domain through Postmark. The template provisions the records
Postmark issues for a verified sending domain:

- the DKIM TXT record (`%dkimSelector%` and `%dkimKey%` are issued by
  Postmark per domain; the `k=rsa; p=` prefix is fixed in the template),
- the custom return-path CNAME `pm-bounces` pointing at `pm.mtasv.net`,
- a baseline DMARC policy (`p=none`), applied only when the domain has none.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the sync flow uses `redirect_uri` back to `app.wavelinker.io`)
- [x] no TXT record contains SPF content (Postmark does not require SPF with a custom return-path)
- [x] `txtConflictMatchingMode` is set on the DMARC TXT record (`All`)
- [x] no variable is used as a bare full record value - the DKIM value is `k=rsa; p=%dkimKey%`
- [x] no bare variable is used as the full `host` label - the DKIM host is `%dkimSelector%._domainkey`
- [x] no variable is used in the `host` field to create a subdomain - the return-path host is the fixed label `pm-bounces`
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the DMARC record

## Online Editor test results

**Editor test link(s):**

- [Test wavelinker.io/email-postmark example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP2vmWoC%2F%2B1VXW%2FiRhT9KyNLK7UqJgbzETvKg4FVRFOny5KoUaMIDfYFptgzszNjCBvx33vHhgDdZaU%2BVFpV%2B2R77ue559zxq2Mglxk14ISvjlRixVJQw9QJnTVdQcb4ElSdCaf2ZryjOZyY0aZBrVgCZRzklGWuFNrkVC0Pxl3cH29xpPREhxUozQR3wkbNycRcPKgMHRfGSB1eXFAp6ye9XFgf93DkNtudul7NMVMKOlFMmjKb8xsYTTaiUOSoqDZCAdHA06o%2B%2BUkoREW4MGzGEmpjdY1wWOsMjMHWCEVfYRbolNBcUjbn%2BmcyUyKvkos1J6nAXDwkg9thTDR6MD6vEUqSAuvlRIEpFHclNQsyE4pMRcETIAvMnFWeWIKSKdW2TSCDOPrYJ1JkLNnU7YSoYnSaweAE37t0yfIxZJAgpnf74rtvwrQuIC3LlW1WLV6RMuoWNvsAWUyxDFnC5kyIpXDDk14mkqUTzmimoTr5UEwxz6By%2BlIw1uUjpExhP2ed0Ijz10749OrMlShkqSHbIhrNRlrJ3D%2Fe48cCFfUF6Pqk6hG7t%2FRTQ9Flea00vSLy%2Bg2qzWVQVH7H87a140oVM5aYQ73%2BXRS%2FP1SUuVvxpe0WCMaNvhfleT03VK%2FqHMz5AiluQXIGy2Rv3DW%2Bui6Jb9jeueBwdZwWX19MX%2FAZsmViapIFKicWqc0aZXaPQKOsDaN2e37nkZTZxtk%2Bb2vOZ8w1OUz6GQvu%2BYAXlHQG9UTkh77wrQQwYXt%2FSRXNtb0j9pFPJ6HP%2B9gnx74fc2TPml6z4wWeL%2FO9FVmxhnh4M4sj76Y%2F%2FnQzHk79weh9Lxo9RFHr5i4a9HtsdNubj%2FpdA9ogx199eI2m32p3upcBnSYpzIaDaBQ5FjfuIS77xO4jRZpxUkYVKN68yAyb0DU9HKXJhNqB4Zg0WrE3FOQJZ7y6vw5Qvq29%2Fw7ZiSYmaWJZYVZqjW43CXxI3Van0XRbAXjuZQpNN2mlELT9ZnDZ8I8u8q%2Fe8t%2B8yQ%2FyOJZalK3pRjtbq%2Ft%2FbNBuZicbtBvUue35XiGdiOBfLu53gOjtPtg%2B13Chf4j7h7j%2Fl%2BLG34vGhOmEmp2eXS9wPf%2B%2B0Q39dtju1v3LoOt7v3he6HkWCaqxAvqKf4zjf4XTGz7KuPHXpt8JjLn4tYjHAf%2BQ8xfm6Vn70f9TzkYv6%2BHw82D8cO1s%2Fwb1c81%2FSwsAAA%3D%3D)
- [Test wavelinker.io/email-postmark example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAywmWoC%2F%2B1VbW%2FaOhT%2BK1akSXcaSRPCa6p%2BSGG3F3X0ltG9SFUVmcQBj8T2bAfGKv77PU6ggW7cfZo0afsE8Xl9znke%2B9HSJBcZ1sQKHi0h%2BYomRI4SK7DWeEUyypZEOpRbjSfjDc7JkRlsisgVjUkZR3JMM1twpXMsl7VxF%2FfhKQ6VnuCwIlJRzqzAa1gZn%2FN3MgPHhdZCBWdnWAjnqJcz42PXR3az3XHUag6ZEqJiSYUus1lviFZowwuJDooqzSVBirCkqo%2F%2B4hJQIcY1TWmMTaxqIEbWKiNaQ2sIgy%2FXC3CKcS4wnTP1EqWS51VyvmYo4ZCLBWh4PRojBR6UzRsIo7iAejmSRBeS2QLrBUq5RDNesJigBWTOKk8ogdEMK9MmQcNx%2BHaABM9ovHHMhLCkeJaR4RG%2BF8mS5lOSkRgwvdgX330jqlRBkrJc2WbV4jkqo67JZh8gihmUQUuyORFiVrhh8WXG46UVpDhTpDq5LWaQZ1g5fUsY4%2FKWJFRCPyedwAjzV1Zw%2F2jNJS9EySHTIhj1RhjK3H28g48FMOob0E5U9Qjdm%2FVjjcFleSEVPkfi4gmqyaWBVH7HdbeNw0rVZsxi6nqDm3D8uq4ocrvalzIq4JRpdcfLcyfXWK0cRvTpAgmoID6BJdobd42vLsrFe6Z3xhk5P0wLf7%2FoAWcpbEuPsY4XwJwxT0zWMDM6IgporSk26vmXhUJkG2v7sG1YXyFXVE%2F6AQru90G%2BAKUz4sQ8r%2FtSCy7gqwQR0X2MwBLnytwT%2B%2Bj7o%2FCHffx9lcCUOdiVOW%2B6zY7bd32R762wHWMYj67SceheDaafr6ajmT%2BcvL4MJ%2B%2FCsHV1Ew4Hl3RyfTmfDLqaKA27%2Fu6P6zX9VrvT7fXxLE5IOhqGk9Ay%2BEGPIPrI6BLDumFiWhZA4rzINI3wGtdHSRxhMzgYlwIr9AbEPNodq%2B6xGsoBB53d5J4T8efBOyJIlMRmPbS8hn3P77qttp16bstuxWnLnvmpZ7e7bTclid%2Fv%2Bf7Brf7dK%2F9%2Fr%2FVjrhxyL8zWeKOsrRHCM0nthldL6tnETmnqV8Z2RItK0s9Q%2FUDXvwi0pytj%2B9AAvf%2Fh%2FR%2Fe%2F268h0dJQdIkwnpHddvt265%2F53Wh58BrOl6%2F1%2Bz1Xrlu4LoGDXC0AvsI78zhC2Px95P2Es%2F1h%2BtR%2FE%2Fvby1ui2Ka8am%2BfdX71P0cDnWr82b6fro4G11Y2%2F8ATehc7YkLAAA%3D)
