### PR TITLE
Add Krafter Mail template (krafter.dev / mail)

### DIFF
--- a/krafter.dev.mail.json
+++ b/krafter.dev.mail.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "krafter.dev",
+  "providerName": "Krafter",
+  "serviceId": "mail",
+  "serviceName": "Krafter Mail — sending domain",
+  "version": 1,
+  "logoUrl": "https://app.krafter.dev/images/krafter-mark.svg",
+  "description": "Configures a domain to send email through Krafter Mail (Amazon SES underneath): SES domain verification, three DKIM CNAMEs, and a custom MAIL FROM subdomain with its MX and SPF. DMARC is intentionally left out so an existing _dmarc record is never duplicated.",
+  "variableDescription": "sesToken: the SES domain verification token. dkim1, dkim2, dkim3: the three SES Easy DKIM selectors. mailFrom: the MAIL FROM subdomain label (default 'send'). region: the SES region (eu-central-1).",
+  "syncBlock": false,
+  "syncPubKeyDomain": "krafter.dev",
+  "syncRedirectDomain": "app.krafter.dev",
+  "records": [
+    { "groupId": "verification", "type": "TXT",   "host": "_amazonses",           "data": "%sesToken%",                                "ttl": 3600 },
+    { "groupId": "dkim",         "type": "CNAME", "host": "%dkim1%._domainkey",   "pointsTo": "%dkim1%.dkim.amazonses.com",             "ttl": 3600 },
+    { "groupId": "dkim",         "type": "CNAME", "host": "%dkim2%._domainkey",   "pointsTo": "%dkim2%.dkim.amazonses.com",             "ttl": 3600 },
+    { "groupId": "dkim",         "type": "CNAME", "host": "%dkim3%._domainkey",   "pointsTo": "%dkim3%.dkim.amazonses.com",             "ttl": 3600 },
+    { "groupId": "mailfrom",     "type": "MX",    "host": "%mailFrom%",           "pointsTo": "feedback-smtp.%region%.amazonses.com",   "priority": 10, "ttl": 3600 },
+    { "groupId": "mailfrom",     "type": "TXT",   "host": "%mailFrom%",           "data": "v=spf1 include:amazonses.com ~all",          "ttl": 3600 }
+  ]
+}

--- a/krafter.dev.mail.json
+++ b/krafter.dev.mail.json
@@ -11,11 +11,48 @@
   "syncPubKeyDomain": "krafter.dev",
   "syncRedirectDomain": "app.krafter.dev",
   "records": [
-    { "groupId": "verification", "type": "TXT",   "host": "_amazonses",           "data": "%sesToken%",                                "ttl": 3600 },
-    { "groupId": "dkim",         "type": "CNAME", "host": "%dkim1%._domainkey",   "pointsTo": "%dkim1%.dkim.amazonses.com",             "ttl": 3600 },
-    { "groupId": "dkim",         "type": "CNAME", "host": "%dkim2%._domainkey",   "pointsTo": "%dkim2%.dkim.amazonses.com",             "ttl": 3600 },
-    { "groupId": "dkim",         "type": "CNAME", "host": "%dkim3%._domainkey",   "pointsTo": "%dkim3%.dkim.amazonses.com",             "ttl": 3600 },
-    { "groupId": "mailfrom",     "type": "MX",    "host": "%mailFrom%",           "pointsTo": "feedback-smtp.%region%.amazonses.com",   "priority": 10, "ttl": 3600 },
-    { "groupId": "mailfrom",     "type": "TXT",   "host": "%mailFrom%",           "data": "v=spf1 include:amazonses.com ~all",          "ttl": 3600 }
+    {
+      "groupId": "verification",
+      "type": "TXT",
+      "host": "_amazonses",
+      "data": "%sesToken%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "MX",
+      "host": "%mailFrom%",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "%mailFrom%",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
   ]
 }


### PR DESCRIPTION
# Description

New template for **Krafter Mail** (`krafter.dev` / `mail`) — configures a domain to send through Krafter (Amazon SES underneath): SES domain verification TXT, three Easy DKIM CNAMEs, and a custom MAIL FROM subdomain with its MX and SPF.

Synchronous flow only (`syncBlock: false`), signed (`syncPubKeyDomain: krafter.dev`), `syncRedirectDomain: app.krafter.dev`. DMARC is intentionally not in the template so an existing `_dmarc` record is never duplicated; the Krafter dashboard recommends it separately.

## Type of change
- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — results pending, will be appended before requesting review
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems
- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the synchronous flow uses `redirect_uri`)
- [x] no TXT record contains SPF content — the `SPFM` record type is used
- [x] `txtConflictMatchingMode` — not applicable: the only TXT (`_amazonses`) is unique per label by construction, and DMARC is not in the template
- [x] no variable is used as a bare full record value except `_amazonses TXT %sesToken%`, which is the value SES issues and must be published verbatim
- [x] no bare variable is used as the full `host` label — DKIM hosts are `%dkimN%._domainkey`, MAIL FROM host is `%mailFrom%` (a single label, default `send`)
- [x] no variable is used in the `host` field to create a subdomain — subdomains use the `host` parameter
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` — not applicable: every record in the template is required for the service to work

## Online Editor test results

- apex (`domain=example.com`, no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALasmWoC%2F%2B1XW2%2FbNhT%2BK4QAoy1mK5J8SwT0IU2cSxO3WS5Aui4wKOlIZk2JCknZtYPst%2B9QsmM7c2sU20M75EkWea4fP37HerA0pDmnGiz%2FwcqlGLMI5Glk%2BdZI0liDtCMYW%2FWnrQ80RVPrrNrEDQVyzEIoXVLK%2BHJp3ZT0cZP8WXiO2yIKsohlCYkEumToMgapmMgs361bXCTiRnJ0HWqdK39nh%2Ba5vVLODktpAmpnvtRIqRzZapxgnAhUKFmuy1jWgchilhQSFKHzXESLMjsBUyzRQymKZEjWiny9n9KZyMhV74oUGTadAdXDN365MA%2BDBbOYhdRkqpswAOTw7LRPDj7s93uqTijmoCQslBYp6e%2BfnpOjy499oopgHmHC9JAwrUj%2FtjS%2BujiyyWF%2F%2F%2FKAMEVYpiEzwSnnU8Ih1kQUmiiBtgS%2BMqUNfoMIew%2BJhFDIyLhlgIWRqMi5qQ0i22BLJaMBh8M1bBSoazGCzMfi4VudIVpoYpNoxFK3Xj686tGs%2FKrGjXePqmmFgAIOoRZS2cRgfCRFWhlvQoHTABDxCGJacE1embN59cbGlhLMvyyueievoWiECIykvOG%2BMd2paRa%2B4yIcWX5MuYJq5aIIzmB6WNHrOZeNwSVEDGHTTybPOIZmFarK8j8%2FWAnSJC85vgoPGulpbkh%2BfXuNL0OhNL4MaMkfRNgwkmqKa7UF3jXjpJHdzY7jPNZXQxtclyFLIi2D1sozqNmDCrgRTM2tFMgTjLuybx72UwF2KNJ%2Fk9DbktD7rxM2tyRs%2FlhCQ8BYipWk%2FduVjAt%2B1tYzxQBRQMNRQ6U6t2sV92r%2FyJlLJiTTU1Qt5wcqwIve%2F0YNKo8vC4688S2WhbyIwP92o3ePdQu3YLAk6h3ybUFo%2BEpR2WHuNs%2BGv8rSBmxhn1NJU2XUf%2BH5ec31buH72TK%2FFzQ273n67vjDTrf%2FJYuH12c3fzidXnZ%2F717A8Q39OJrs8uNhGE8gDk9u3hrfkqHGkXrjdKL5ZDzuzIpJPr7PZmKWxmGXR22ZDIOFsWeMZTptcdkMsmSYjpJZJ47y9lCmX2cTGXhczBbGTWM8u2%2FL7D7Pck%2B3i6I1Uno0CjgPvC98ls4oM8YLwI29kRuzVh1x2fuKwFgGYpZkQsJA4ZNqnCWWr2WBMpOiXrEBndDlUhQOUEb4FE9E4S6GQ%2BlYU4ismombFOKH0FzhQd0aRKE5P2bo1oo9r9Pp7jaizq7TaAW70NiDJm14bdrqtt3I7Xa9lXG%2BYdJvGOhL8oBSZixRM533%2BYROlfVo%2BP7sRs%2Fb3HbO61d9jsNWp%2B%2Ff%2F58Yjm1M3gjHVqdfFo5td3UjHFudfh04ykk0x6LUoacm1%2BfPqiJ9r7P1cfTz9LmmfOuNjt%2FixHPJxllH%2FsK%2Fvj%2FX2d3VcWK%2BSPqLpL9I%2Boukv0j6%2F0LSzTcNHUM0oMbMc7xOw9lrOM1rt%2Bt7rt%2FetTue63aavzmO7zimeFC66vUBvw5WvwusZJq5J0F8XuwVdHJwdPIp%2B3TrHfwesPc66TknznnvS947Hs%2BCk%2F231uPf4JOQSHwTAAA%3D
- subdomain (`domain=example.com`, `host=mail`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOGsmWoC%2F%2B1XW0%2FjOBT%2BK1akagZNG9L0BpF4YLgNyxZYoBK7LKrc5CT1xImD7bS0iP3te5y0tGVhKrT7wGh5SmOf6%2BfP52seLA1JxqkGy3uwMilGLAB5HFieFUsaapB2ACOr%2BrR1ShM0tU7KTdxQIEfMh8IloYwvllZNSRc3yZ%2B569SbREEasDQigUCXFF1GIBUTqeXVqxYXkehJjq5DrTPlbW7SLLOXytlkCY1Abc6WagmVsa1GEcYJQPmSZbqIZe2JNGRRLkEROstFtCiyEzDFEj2UIo%2BGZKXIz7sJnYqUXB5ckjzFplOgerjhFQuzMFgwC5lPTaaqCQNA9k%2BOu2TvdLd7oKqEYg5K%2FFxpkZDu7vGv5PDirEtUPphFGDM9JEwr0r0ujC%2FPD22y39292CNMEZZqSE1wyvmEcAg1EbkmSqAtgXumtMGvH2DvPpHgCxkYtxSwMBLkGTe1QWAbbKlkdMBhfwUbBepKxJB6WDy81hmihSY2CWKW1KvFwy0fjdKvbNx4H1A1KRFQwMHXQiqbGIwPpUhK45dQ4HQAiHgAIc25Jp%2FM2XzasLGlCPMviivfyWfIaz4CIymv1TdMd2qS%2Bl%2B58GPLCylXUK6c54MTmOyX9HrOZWNwAQFD2PSTyTOOoVmJqrK8mwcrQppkBceX4UEjPckMya%2Bur%2FBlKJTGlz4t%2BIMIG0ZSTXGtMse7Ypw0srvRdpzH6nJog%2BsiZEGkRdBKcQYVu18CF8PE3EqBPMG4S%2FvmYT8VYPsi%2BTcJ3TUJ3f86YWNNwsbbEhoChlIsJe1eL2Wc87OymikECAbUj2sq0ZldKblX%2BUfOTDIhmZ7g1HLeUAFe9O4rNagsvMg58sazWOrzPADv9UZvH6sWbkF%2FQdRb5Nuc0HBPcbLDzG2WbTahi%2FL6bO6TUUkTZRRg7n2z4n47978pA9xWn8aHWcuSr0enm53u9zQcXp30%2FnDaB%2BndXf0cjnr0LB5v8aOhH44h9L%2F1doxvwVTjSN1RMtZ8PBq1p%2Fk4G92lUzFNQr%2FDg5aMhoO5sWuMZTJpctkYpNEwiaNpOwyy1lAm99OxHLhcTOfGDWM8vWvJ9C5LM1e38rwZKx3HA84H7nc%2BTaaUGeM58MbejB2zVh510f%2FSoLEM1CxKhYS%2BwifVqCmWp2WO4ybBucX6dEwXS4Hfx3HCJ3gyCncxHI6QlUmRltq4mBT27GRm4%2BJNkC6Romr1A98cJDPca4edrXbY8mvUbWzXmvizRreanVrdpVsDCrTRaLpL2v6C7L%2Bg7qtMAqWMTlEj17t8TCfKejQX4NkVn%2FW77sCX7v4zQNZ6%2FngqvHNc1nH7dVzWev7UuKy7xq%2Fjstbz58KlUK0ZKGZWPet2VbCWR9ePWlzVr%2FfV8MqYfKHj0Q5qZZ28qJLkL%2FzT%2FP5O87aKWvshBB9C8CEEH0LwIQT%2FYyEw3090BEGfGlPXcds1Z7vmNK7qHc91vWbd3t52Gu72F8fxHMc0AEqX%2FT7gl8jyN4hF9xr%2BOGqd9dRR8%2FfN%2B9ZxXcF2dHq0f9K7OIx%2FuWB3Xw6%2Bud9it%2FPbjvX4N3Yic8jwEwAA

