### PR TITLE
add oriiion, oriiion website

### DIFF
--- a/oriiion.ai.website.json
+++ b/oriiion.ai.website.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "oriiion.ai",
+  "providerName": "oriiion",
+  "serviceId": "website",
+  "serviceName": "oriiion website",
+  "version": 2,
+  "logoUrl": "https://oriiion.ai/oriiion-logo.png",
+  "description": "Connects your domain to your oriiion-hosted website.",
+  "variableDescription": "target is the site's unique hostname the CNAME points to. verifytoken is the hosting platform's domain-ownership verification value.",
+  "syncPubKeyDomain": "oriiion.ai",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300,
+      "essential": "Always"
+    },
+    {
+      "type": "TXT",
+      "host": "_railway-verify",
+      "data": "%verifytoken%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **oriiion** (https://oriiion.ai) — a Swedish all-in-one marketing platform that builds and hosts websites for small businesses. The template connects a customer's (sub)domain to their oriiion-hosted website: one CNAME at the given host plus the hosting platform's ownership-verification TXT.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated with the official linter: `dc-template-linter -loglevel error -tolerate info oriiion.ai.website.json` → exit 0 (one info-level note: the `_railway-verify` underscore label is not in IANA definitions — it is the hosting platform's fixed ownership-verification record name).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key is published at `_dck1.oriiion.ai` (3-part TXT, RS256) and apply URLs are signed
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — not used
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (`All` on the verification TXT)
- [x] no variable is used as a bare full record value — the verification TXT (`_railway-verify` → `%verifytoken%`) is the hosting platform's fixed contract: the record name is a constant label and the token is an opaque per-domain value issued by the host, so a prefix cannot be added
- [x] no bare variable is used as the full `host` label — hosts are the fixed labels `@` and `_railway-verify`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove (the verification TXT); the CNAME is `Always`

## Online Editor test results

**Editor test link(s):**
[Test oriiion.ai/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADEHmmoC%2F%2B1UUW%2BbMBD%2BK8jStIcE6kC6NEiTlqZbNW3tpjXTJlURMuaSWAWb2iaURfnvs6GE0Hbvm7Qn8N19d%2Ffdd%2FYOacjylGhA4Q7lUmxZAvJjgkIkJGNMcI8wNDx4rkkGnc84FMgto1AjSogVM5kO1n600%2Fm3IJXFh%2F4QpWItvsvUxG20zlV4ctJVbn9dG%2BTlfG2wCSgqWa5rPJoLzoFq5VSikE4iMsK4o0VzbNEboTQkbX3PNkAkI3EKF71kmsg1aIcpR2%2FAsbGvlVNwdl%2BAY3Nww6d2za9nV%2B%2BdXDBuKmvhOYYQW1Va3AFv4RbA%2BNqx010JmZlUTXuuKLnhv2F5A2OU2PrOlqRF3ZyqOP1axJ%2BguqgBT8Ww%2FvNU0DsUrkiqYIhsrW9wXzAJRggtC2OTQIVMFApvd0hXuRWibhs14eb4zgpbc1gIc3zV0H9lrFobPQKMhwiUAq4ZsfrM0pJUCu2Hh4SLn4suXSQJsxFuMwwrFdHEJj6aTj%2B7ftBGwFXKqL4imm7MvK5EAnWtFPWrf%2BGzPE8rtF%2Fuh%2BiX4BB1DJemVjsqeCBmo8GjIut6K8vSHNZSFHnEWkhOJMmUXfwWfNtDL1v4bY03x2ZC1qBYHIPXylKv9bLe65aoDWr3rzG7GpR2R36ALAO25kJCpMyX6EJCK1tWpJpFpCSdKaERsdQNYWW8JvNzSXlz1Rqej3N%2Focfj4UcJtdyZvbrBeBRMYeK7FBLijgMM7hk%2BG7tA%2FdNkAqcTHOOjZ%2BD5A%2FHyO9Cb%2Fkur9GyXHnk82SWvx%2BtPY%2F1byB02db8cmj37L9Y%2FIpa5wIpsIYmIDfWx%2F8bFUxcHCz8Ix2chHnkTH4%2BmwQDjENsmLJmG5s7c6OO7jFacirvTH2mW38wGm3g7HpT4w3j%2B%2BWYyuLjEi2l6vs4v56vRPKFv0f43Uqf0v4cHAAA%3D)

Tested with `hostRequired=true` (subdomain test with host set; apex test not required per the exception).
