### PR TITLE
Add hicurb.com website template

### DIFF
--- a/hicurb.com.website.json
+++ b/hicurb.com.website.json
@@ -1,0 +1,49 @@
+{
+  "providerId": "hicurb.com",
+  "providerName": "Curb",
+  "serviceId": "website",
+  "serviceName": "Curb website",
+  "version": 1,
+  "logoUrl": "https://hicurb.com/favicon.svg",
+  "description": "Points the domain at the website Curb built for the business, and adds the ownership record its TLS certificate is issued against. Email and every other record are left alone.",
+  "variableDescription": "%cf%: the Cloudflare custom-hostname ownership token for this domain, minted per domain when the hostname is created. It is an opaque single-purpose UUID at a fixed underscore host and cannot carry a prefix.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "hicurb.com",
+  "syncRedirectDomain": "app.hicurb.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "172.67.196.198",
+      "ttl": 600,
+      "groupId": "site",
+      "essential": "Always"
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "104.21.12.247",
+      "ttl": 600,
+      "groupId": "site",
+      "essential": "Always"
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "preview.hicurb.com",
+      "ttl": 600,
+      "groupId": "site",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%cf%",
+      "ttl": 600,
+      "groupId": "verify",
+      "essential": "Always",
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Curb (hicurb.com), a hosted website service for local businesses. It points the customer's domain at the Cloudflare for SaaS edge that serves their site (two apex A records, www CNAME) and adds the Cloudflare custom-hostname ownership TXT.

Notes on the checklist items that need a word:

- Apex `A` records rather than an apex `CNAME`: registrars refuse a `CNAME` at `@`, and Cloudflare for SaaS routes by hostname, so its edge IPs serve the custom hostname directly. Same pattern as the existing `1hoursites.com.website.json`.
- `%cf%` is a bare variable value on purpose: it is the Cloudflare custom-hostname ownership token, an opaque per-domain UUID that Cloudflare requires verbatim at the fixed host `_cf-custom-hostname`; it cannot carry a prefix. Same as `%cf%` in `1hoursites.com.website.json`.
- The TXT is in its own group (`verify`) because Cloudflare satisfies ownership automatically once DNS points at it; the service only requests that group when it has minted a token ahead of cutover.
- `syncPubKeyDomain` is set; requests are signed, key published at `_dcpubkeyv1.hicurb.com`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 

[Test hicurb.com/website acmeplumbing.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAItpmmoC%2F%2B1VXW%2FbNhT9KwSBPtVSZEWTYgEDmiXdEGxpu85ZtwWBQZGUzYUiGZKy4wb577uUFX8kbhdgD%2BtDABu2yHvPuefyXOoOe94YSTzH5R02Vs8F4%2FaM4RLPBG1tFVPd4MF65x1pIBKfwA6sOm7ngvIufMErJwBmvboVijabc26d0AqXwwGWeqovrAxc3htXHhxsOA9qAiBaxW4%2BhTTGHbXC%2BC4Vf9BCeYf8jCOmGyIUIr576nlQR1q1QnpUa9ttVa0Tijs3QEQxRBhb5euFgopmwiDLqbYMCQAe%2F%2FIbotx6UQsKrUHCwce1HPKmwOZ8jN4CreygOEhaIg1g9gGDWI4krz0iUiseB9nEClJJfrqj4xWtX5VdGSdSt6yWIZG2zusmmmnnFbRwq0Kvr7nqBUFJK%2BkD1EAzoDQD%2FH03FjOIC7BrEAinloMWFqMzHx6JQtqQm5Yj6MtU8si01mjH0cXF2WnoJ0G1uAXcVsG5O9C1gus0U6KU9vBjQTpBxnKIDTrdUtEfpKbXuKyJdHy18qGtfubL0664x84K%2Bx85E9A6v44gxsQ7UYH5I79pIYytoVfddri8vMN%2BaYLbjvtY%2BPsm2LYzyljD47BI47yIh6Mcvkew5z04L0%2BSAZ5a3ZrOxL1JwSZceUGCNY%2Flgiwdvh88hyPJ4nQYD9M4zYr%2FQnHy7vj87YZmsVjsEkHD54Ivdnv0TLb36tgYudymG%2F8x3pBNaB098mAYQOJJ79gvUMEYiHq5Xxpk3PoTrWopqD8nns7Ac%2Beade2UEt9f3Q%2FwZ5iVyeZMr4B07QfacCPbpoK0LUfADu5LmIguCW%2BumVAMYBhiSePC7faAdvkU7uoB7xKH%2Fx3iXjRah%2BU8GR1l1SiJaJ4XUXZUkIgc1aOooFmS1MN0%2BF2S4CBJTBXMzcTBL%2FGtBbnetuDcppVeTMiCbJYYnZBwLtABB7tAs%2BtqtbpO32zO4iuOnjAaFAvWmbLKMl7z6LAekSirq2FU0bqIDvOc0cMipVlRb93wT%2B%2F%2B%2Fbf8pv%2F7rPxoXPYU%2F8VR%2BZZqf5jDvv7VHPYK%2FmUG%2FzcZ6%2Fl%2BMuC9iq8O%2BLOs%2FW0d19UA7oqXYXkZlpdhecawwEvMkTlnExLC0iTNo2QUJdk4ycusKA9HcZoUySh5nSTlqnru%2FErvHbzRtt9leMk%2FF7fm71%2FnF6M%2Fb17%2FWPz0%2B82p%2BWQ%2FXbP3J8Q1VZ4Ync7o%2FC%2Frvsf3%2FwDNFaWibAwAAA%3D%3D)

[Test hicurb.com/website acmeplumbing.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPdpmmoC%2F%2B1V72%2FbNhD9VwgC%2FVRLkVRbsg0MWOp0WNDFKVpn6BYYBk1RNhGKZEjKihvkf99RVvwjcbcAG7B%2BCGDDFnn33r3jO%2BoeO1ZqQRzDw3usjVrxnJnzHA%2FxktPKzEOqStzZ7oxJCZF4BDuwaplZccqa8JrNLQeY7epeKNptrpixXEk8jDtYqIW6MsJzOaft8ORkx3lSEABRMrSrBaTlzFLDtWtS8SfFpbPILRnKVUm4RMQ1Ty0PakjnFRcOFco0W%2FPKcsms7SAic0TyfJOvagkVLblGhlFlcsQBePLbF0SZcbzgFFqDuIWPrRjkLYDNuhB9AFrRQDGQtEYKwMwjBjEMCVY4RISSLPSyieFkLtjZgY43tHgzbMoYCVXlhfCJtLJOlcFSWSehhXsVOnXDZCsIStpI76ASmgGlaeBvu1EvIc7DbkEgnBoGWvIQnTv%2FSCRSmtxWDEFfFoIFujJaWYaurs7PfD8JKvgd4FYSzt2Crg1co5kSKZWDHwPSCdKGQazXadeSvheK3uBhQYRlm5VP1fwjW581xT11lt%2F%2FzHIOrXPbCKJ1eBDlmT%2Bz2wrC8i30ptsWD6%2FvsVtr77bTNhb%2B%2Fuxt2xhlouAxzpIwzcJ4kMK3D3vOgfPSKOrghVGVbkzcmhRswqTjxFvzVNRkbfFD5yUcUTdM4jBOwqSb%2FRuK0fj04sOOpq7rQyJo%2BIqz%2BrBHL2S7lKdai%2FU%2B3eTrZEc2o0XwxIN%2BAIkjrWO%2FQwVjwIv1cWmQcedGShaCU3dBHF2C5y5U3rRTCPwwfejgbzArs92ZToF06wdaMi2qcg5pe47wApdK47aMGW8S8e6q8QUBjiaGlNbfcI%2BI188hp4%2BY1xvQaYt6FJEWfjmNBv3ufBAFNE2zoNvPSED6xSDIaDeKijiJe1GEvTS%2BkDA%2FMwu%2FxFUGZDtTgYPLSjg%2BIzXZLeV0Rvz5QCcs7ALNobvl5lptdbfH8jfmnuXUC%2Bf%2BiAhLB2nOKBQ4p0G31yuCQZHnQS9m70g%2FedfrJ2zvsn%2F%2BGjh%2B4R8exTFnP5me4xq%2BOzw%2FmoTH6WxlwHSGh1L%2BYTz%2FVz3b8X82%2F62cI%2FP%2FRN6LbP%2FjHeC0A3fK6zC9DtPrMP0HwwQvQUtWLJ8RH5pESRpEgyDqTqJ02B0MkyxM4yjL4rdRNNwoYNZtNN%2FDG3H%2FXYj1bT97vxbJR1aP%2F%2Fj662W1uHt7svj257h%2Fcyl%2Bp%2BNfiqsvl%2F3zajRQP%2BGHvwCgJfthtAwAAA%3D%3D)
