### PR TITLE
Add naulon.app templates: verify (ownership TXT) and route (traffic CNAME)

### DIFF
--- a/naulon.app.route.json
+++ b/naulon.app.route.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "naulon.app",
+    "providerName": "naulon",
+    "serviceId": "route",
+    "serviceName": "Traffic routing",
+    "version": 1,
+    "logoUrl": "https://naulon.app/brand-kit/naulon-mark.svg",
+    "description": "Points this subdomain at the naulon gate, which serves the site and tolls AI citations of it. Apply this only after the domain has been verified.",
+    "syncPubKeyDomain": "dcsig.naulon.app",
+    "syncRedirectDomain": "naulon.app",
+    "syncBlock": false,
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "customers.naulon.app",
+            "ttl": 3600
+        }
+    ]
+}

--- a/naulon.app.verify.json
+++ b/naulon.app.verify.json
@@ -1,0 +1,23 @@
+{
+    "providerId": "naulon.app",
+    "providerName": "naulon",
+    "serviceId": "verify",
+    "serviceName": "Domain verification",
+    "version": 1,
+    "logoUrl": "https://naulon.app/brand-kit/naulon-mark.svg",
+    "description": "Publishes the DNS record that proves you control this domain, so naulon can be authorised to toll AI citations of the content on it.",
+    "variableDescription": "%token%: the one-time verification token naulon issued for this domain",
+    "syncPubKeyDomain": "dcsig.naulon.app",
+    "syncRedirectDomain": "naulon.app",
+    "syncBlock": false,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_naulon-challenge",
+            "data": "naulon-verify=%token%",
+            "ttl": 300,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "naulon-verify="
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Two new templates for **naulon** (https://naulon.app), a citation toll for publishers. A site owner proves they control a domain, then optionally routes it to our gate.

- `naulon.app.verify.json` — publishes the ownership TXT at `_naulon-challenge`, with the one-time token as the only variable.
- `naulon.app.route.json` — points a subdomain at our gate with a CNAME. `hostRequired: true`, since a CNAME cannot sit at a zone apex.

They are split rather than combined because Cloudflare applies default proxy status per template, and the routing CNAME must be onboarded DNS-only while the TXT is unaffected.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`https://naulon.app/brand-kit/naulon-mark.svg` returns 200 `image/svg+xml`. Both templates also pass `dc-template-linter` with `-cloudflare` (exit 0) and validate against `template.schema`.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — key published at `dc1.dcsig.naulon.app`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — `Prefix` on `naulon-verify=`, so re-verifying replaces the old token rather than stacking a second one
- [x] no variable is used as a bare full record value — the TXT is `naulon-verify=%token%`, fixed prefix
- [x] no bare variable is used as the full `host` label — hosts are literal (`_naulon-challenge`, `@`)
- [x] no variable is used in the `host` field to create a subdomain — the `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is not needed — neither record is one a user edits in place; re-applying is the intended repair

## Online Editor test results

**Editor test link(s):**

- `verify`, apex — [`example.com`](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJuCmmoC%2F91UTW%2FiMBD9K5alnpbQQICWSHugRSt1t62qltVWqhAanEnwYuLIdmiziP%2B%2B4%2FDd9rDnlXKwPV%2FvvZnJijtcFAoc8njFC6OXMkFzk%2FCY51AqnTehKHhjb7mHBe5t9G7RLKXAOmCJRqbV4XHrO9QLkDmrrVKAk3UgXa0%2Fxa0GVzrTP40i35lzhY3Pzw%2B1z6cG8iSYS7d9DBZg5k27zChJglYYWdQpY%2F5QTpW0M7TMzZAN75%2BYQaFNQldwzDMgU6VLJnTujFb0Li1LangNZjXbFGACcjZFBqWbaSMtUgJNn1JscMOEdDUFy3Ra1%2FHJMHeMAqVremZgJEwVDk%2FAnTk9x%2FwsrmN0joGTCzwRhdUeOxDS2pIqp9ocw%2FTiVrkgpj%2Bw2ghLuRNhZdY86Zf3esREkgJu7%2FfB40ppMedxCspig2%2FUsjx%2BWXFXFb53o%2BcRuc60dXSZbBsgZqAU5hn6DoCDfeZgMwFft1zJ7Bx1NQpDOr25a52nSgp3B07MZJ7d6cTXeDCYyjf%2BqcvW9r4AX4%2FXDf6HZJwcQI8JzY4pvgFNNTaFXhzw0ykzuiwmcudfgIGF9ZO%2Fi3w5CR3vYl%2B4P9e0%2FAVa07aIkg520x73UGSWa4MTakMOrjREy5mSJF2UyskJvMLhKRETaoCqCLklK6V7L3e%2B2Zt%2FlvsEzbHmk0R4btIvZ5rARYKtTtAVrcugc9GdBpfdqBWkUdiNoA8RQv9ozz%2F%2BAT7d9IOyaC1tgQS%2FxQP1CpXl6%2FW4QSr%2Fx%2FRoJiwsMZmAd2uH7V4Q9oOwMwov46gTR91mFPZavfaXMIzD0INH6zYkVzQ1x%2FPC7x%2Bxun5%2B7VX3usgeBiLrXP%2B6%2FT1U%2BP1O3bSfrkatfruobr9V2YDm%2Fy%2BK2LYiuAUAAA%3D%3D) → `_naulon-challenge.example.com. TXT 300 "naulon-verify=a1b2c3d4e5f6"`
- `verify`, subdomain — [`example.com` / `www`](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOWCmmoC%2F91U224TMRD9FctSn8gmm2ublXgoFESBlNKGQqmiaOKdTUy865XtzYUo%2F854c2%2F7BUh52PHczjkzkxV3mOYKHPJoxXOjZzJGcx3ziGdQKJ1VIc95Ze%2B5gRT3Pnq3aGZSYJkwQyOT5eFxG3ulU5AZK71SgJNlIpnWf0X1Cld6rH8YRbET53Ib1WqH3rWRgSwOptJtH4MUzLRqZ2MqEqMVRuZlyYjfFiMl7QQtcxNkVzf3zKDQJiYTHPMMyLXUBRM6c0YrepeWxSW8CrOabRowARkbIYPCTbSRFqmApp9S7PKaCelKCpbppOzji2HmGCVKV%2FXMwEgYKbw6AXfm9BSzs6jM0RkGTqZ4IgorI3YgpLUFdU60OYbpxV1mgph%2BweVGWKodCyvH1ZN5%2Bag7jCUp4PZxLyLeKS2mPEpAWazwjVqWR08r7pa5n13%2FV59CJ9o6MobbAYgJKIXZGP0EwMG%2BcrDZgLdbruR2jqbaDEP6Wrj3OkuUFK4HTkxkNu7p2Pe4NZjIBX81ZOt73oCvB%2BsK%2F0syDg%2BgB4RmxxQXQFuNVaHTA%2F75fE7G2OgiH8pdSg4GUuuXf5f8dJI92KU%2FlflkluS8DfVRQzTjFraTDveA5DjTBoc0jAxcYYicMwUJmxbKySHM4fAUiyGNQS0JvyUvlXsuera5nheiVzc0XhX%2BBNGx%2BsNYeIrSn2kHoQsUEbTCBgatpH0eQLsLwXm9MWpis9OBJh5d%2FMv%2Fgldv%2FkRjtJZOQoI%2F6Us1h6Xl6%2FWgQnr%2F%2FyxpQyzMMB6Cj2yEjU4QdoOw1Q8vomY7anWr9bDbanfehGEUhh4%2FWrfhuaIdOt4efi1ajYfFY69%2Fc%2Fu7fje%2FUMm3L%2BdfHz4%2F3t336v2PtU%2FTn9fz75Pln9EHuol%2F6p93EswFAAA%3D) → `_naulon-challenge.www.example.com. TXT 300 "naulon-verify=a1b2c3d4e5f6"`
- `route`, subdomain — [`example.com` / `www`](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOCFmmoC%2F91TUW%2FaQAz%2BK6d7hUAglNJIk8bWVuqmVRWjSFuFkJNzwpUkl95dyBjiv88XChR1D3ve253tz%2F782d5yi3mZgUUebnmp1VoK1HeCh7yAKlNFB8qSt4%2Bee8jx6CO7Qb2WMTYArSpKc7S9hk41JImMmfPKIiX%2FGrWRhA57bZ6pVD3qjOKW1pYm7HZPZbuRhkJ4K2lfjV4OetUxa5dEoIm1LG2TiD8oWVjD7FIaZqpIqBxkwcCSBdkezFJqss3qpYyXzFFE03iNtMioDrMqywwb37FYWnB5DVMJk7bDxmWZbfbJVUEvSCzqBvxaaAmGRYgFo9ZkIlF0nAybIn6ooq%2B4uW6iiKaIjUw7Z8K6qAkKqTG2x7h3EZ8yFa94mEBmsM2XytgJvlQEIt2trshGeKWF4eHTlttN6ZT%2FfD%2F%2BdsP34fT96MbY6DRV9I0rY1VOozjnYy0NIxj6%2Fm6%2Ba%2FPfqsDFKfWcdD9wxF9Ai4OdWOWnGnVd0yelWZcLeYCUoCE3br8O4Kcz9PwAf2rwrq5MC6VxQWoVYCuNhy7zKrNyATWcTCJegJsP0TTkpSzvFSj2q7hnJ8DCP%2FTf5gsRO9LS7XY%2FgF40AOH1hgF4A3EZeJHoX3qjxO8lIhlAhPDmTN4f0N8O5Uw0NAYLK8HdwjirYWP4bjdvk4D%2FUz80awNrFAtwkX2%2FP%2FT8K88fTP1ROBiFQb9zcTEcXAUt3w993%2FFHY%2Fcdbmkv3m4Eb90EejZoba5f5O3zePVzFnSX0XX6qCY%2FpuMRrJ9bX%2BB7PotuJ%2FUHvvsDkYnzj%2BoEAAA%3D) → `www.example.com. CNAME 3600 customers.naulon.app`

No apex test for `route`: it sets `hostRequired: true`, which the template notes as the documented exception.
