### PR TITLE
add Relay, Relay help center

### DIFF
--- a/superrelay.ai.helpcenter.json
+++ b/superrelay.ai.helpcenter.json
@@ -1,0 +1,29 @@
+{
+	"providerId": "superrelay.ai",
+	"providerName": "Relay",
+	"serviceId": "helpcenter",
+	"serviceName": "Relay help center",
+	"version": 1,
+	"logoUrl": "https://superrelay.ai/favicon.svg",
+	"description": "Serves a Relay help center on your own domain and verifies that you control it.",
+	"variableDescription": "%token%: the verification value shown in the Relay dashboard for this domain (hex, without the relay-verify- prefix).",
+	"syncBlock": false,
+	"syncPubKeyDomain": "domainconnect.superrelay.ai",
+	"syncRedirectDomain": "app.superrelay.ai",
+	"hostRequired": true,
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "@",
+			"pointsTo": "docs-cname.rldocs.com",
+			"ttl": 3600
+		},
+		{
+			"type": "TXT",
+			"host": "_relay-verify",
+			"data": "relay-verify-%token%",
+			"ttl": 3600,
+			"txtConflictMatchingMode": "All"
+		}
+	]
+}


### PR DESCRIPTION
# Description

New template for Relay (superrelay.ai): serves a customer's help center on their own host (CNAME to `docs-cname.rldocs.com`) and proves control with a prefixed verification TXT (`relay-verify-%token%`) under `_relay-verify`. Signed synchronous flow only.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the sync flow uses `redirect_uri`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the verification TXT (`All`)
- [x] no variable is used as a bare full record value (`relay-verify-%token%`)
- [x] no bare variable is used as the full `host` label (hosts are fixed: `@`, `_relay-verify`)
- [x] no variable is used in the `host` field to create a subdomain (the `host` parameter is used; `hostRequired: true` because the CNAME sits on `@`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` not needed: both records are owned by the service and must stay as applied

## Online Editor test results

**Editor test link(s):**

- [Test: domain example.com, host help](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE%2BXmmoC%2F%2B1UbWvbMBD%2BK0Yw2FjsOq9rDIN1bSmltOu6dC0rwcjyORFRJE%2BS89KQ%2F76T46TxsrGvG%2ByTrbt7nnt5dFoRC9NcUAskWpFcqxlPQV%2BmJCKmyEFrEHQZUE4aO%2BcNnWIwuXMeNBvQM86ghIxB5AykBf3i2A%2F3XIC3i5iBNlxJEjUbRKiRutfCkVibm%2BjoqJb%2FKKNIpmRgZiNEpmCY5rkt0eQLZgLjUe8giaekt1QFfufSS9WUculRmXqYmWccMXZMrYvwkNtqJTxuA1cZ1ZwmAs5qeV5ZNQH5KkIUVBSMOp83o6IAz4xdGkzh%2FJtaUmrGiaI69TKl0c7NtozXY1g0vDm3Y1XYElH26pe8S9%2FLNWR88cZVY5aSfRSKTUiUUWFgY7ktkitYnpVsWNyGFtuQwGzws3gOcAcp1%2BjcQWieHwSOlbF38L3ASFTU6gKzIUjp1JDoaUXsMndynt6cXJ9X4Xj84O6H4tKagSprYcZnEpUPtHCHgKkphliLArd7Ybhu7JgGj4MXnnh%2FBk5naimaa5OpVNinw9%2BFPVUyE5zZa2rZmMvRtUod%2F4kQZD1cN8izkhC%2FtDJsVCPDGFhQXAKoqqxqcdcITyOtijzmW0xONZ0atyxb9FMNPtzinzYEeC7rdQaasGarTVwxfCSVhtjgl9pCw3bU00JYHtM5fTGlLEahxBJrN%2BhFokMZ5GbJqpKrqf1RhQaJU%2BZa4W55m52kn0ES%2BsfdpOl3jrs9P0l6x%2F67Nmv2ADpA%2B529Z%2BCXb8RvH4P6TMEYdHAqSn3mdGnI%2BuBKVD3VrkRQ77B2L6rp%2FrX9DRt4f%2F5L909Kh1ts6AzSmLrQVtjq%2BWHfDzuDZhiFrajbDbphp9Pqvg3xHLpGwNhNpyvc9v09J%2FziYaYfLrPzT4P5Tef5nn%2Fujtqno8lUTK4sk4%2Fs4ja974%2FSb18n78n6BzWYkwyhBwAA)
