### PR TITLE
Add astrae.us verification template

### DIFF
--- a/astrae.us.verification.json
+++ b/astrae.us.verification.json
@@ -1,0 +1,22 @@
+{
+    "providerId": "astrae.us",
+    "providerName": "Astraeus",
+    "serviceId": "verification",
+    "serviceName": "Astraeus Domain Verification",
+    "version": 1,
+    "description": "Creates the TXT ownership record Astraeus needs to verify you control this domain before monitoring its external attack surface.",
+    "logoUrl": "https://astrae.us/icon.svg",
+    "syncPubKeyDomain": "domain-connect.astrae.us",
+    "syncRedirectDomain": "astrae.us",
+    "syncBlock": false,
+    "variableDescription": "txtValue is the full TXT record value (astraeus-verification=<token>) that Astraeus issues per domain.",
+    "records": [
+        {
+            "groupId": "verification",
+            "type": "TXT",
+            "host": "_astraeus",
+            "ttl": "300",
+            "data": "%txtValue%"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds the Astraeus (`astrae.us`) Domain Connect service template **`verification`**. It creates a single TXT record at `_astraeus` holding the ownership-verification value Astraeus issues per domain, so a user can one-click-apply it at their DNS provider instead of hand-entering a TXT record. Astraeus is an external attack-surface monitoring service and verifies domain ownership via this record before scanning.

Synchronous signed flow — `syncPubKeyDomain` = `domain-connect.astrae.us` (public key published at `_dcpubkeyv1.domain-connect.astrae.us`), `syncRedirectDomain` = `astrae.us`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`astrae.us.verification.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://astrae.us/icon.svg`)

Also validated with the official `dc-template-linter -loglevel error -tolerate info -logos` → exit 0 (no errors).

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (the template uses `redirect_uri` in the synchronous flow)
- [x] no TXT record contains SPF content
- [x] no bare variable is used as the full `host` label (host is the fixed `_astraeus`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute

Notes: the single TXT record uses a bare value variable (`data: "%txtValue%"`) intentionally — Astraeus issues the complete value (`astraeus-verification=<token>`) and the apply is signed via `syncPubKeyDomain`, so the value is not user-controllable. `txtConflictMatchingMode`/`essential=OnApply` are N/A (one-shot token at a dedicated `_astraeus` host; duplicates harmless).

## Online Editor test results

**Editor test link(s):**
- [Test astrae.us/verification — subdomain (host=www)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIGjmmoC%2F92UbWvbQAzHv8pxUNhYnLqJ29RmHaTtRsdglDYpLSUY5awkt9h35u6ch4V898l2HruyD7BX9lnSX9JPOq%2B4wyxPwSGPVjw3eiYTNN8THnGwzgA2C8sbO8NPyMiRdytTZbFoZlJgFTFDI0dSgJNa7U1vYtitzkAq9nTsTLG2fIvOGjxBK4zMK0vEbwxSeZa5CbLec4%2FpuSLficyZQaFNwnbKCjEhP82qQpZsqQsmtHJGpxQtLUvq1EMcaYMs00o6baQaM%2Bksw4VDoyBl4ByIKbOFGYHAJhWX6rHum5SKmTiX2%2Bj0dAfnVFKGpp2Ny4aXStwXwx%2B4rHsk%2FzqjRz4KhWseMi29HzCR1IXb%2Bb91uE61mPJoBKlFggRGwjDF2yNAbuGeIC2QyRrSqEjTitSGz6wyfoANJu9wTFefnZ6i%2BvKRIsHtUUprC2Keo9lAKzHUepZHrys%2BNrrI35u6W%2BbluCk%2FHSbaOjrEsF8Y50qObd%2Bn9wQc0OFk28EJXw%2FWDf5bK4z3yQaNDcY3fDbi8%2FmcDlU9sawCjkui8BwMZLbc8K3Q64HSYCv1WmkNNmLvCW0LLW28LFWOFa1SbOkJrjBkcKagSWVF6mQMc9h%2FSkQMeZ4uqTNLVpIgjEe0VH1TdrSadWsbSlt2hK7B40SU7cjqonZ8CMJW4g3Pz0ZeMATwIIDEC0a%2BaA3DsB2K9sEd%2Futy%2F%2BMKHyFGa1E5CeX8uukclpav14MGzee%2FaITGa2GGSQylZ8tvXXh%2B6PlB78yPzoPovNMMLjuhH3zy%2FajaXvopubqlFW3C4Q7w8KHfu368e765aXXvso4NuotvX00gfl1OF317P2v3X8Lr%2BVP2ePFyxdd%2FABAAH3WFBQAA)
- [Test astrae.us/verification — apex (host=@)](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANKjmmoC%2F9WUbW%2FTMBDHv4plaRKIps2aPkYMaWwIGGKwsU2MqYqu8aW1ltqR7bQLVb87l6SPY%2BI9r3ru%2Fe%2Fpd3aW3OEsS8EhD5c8M3ouBZrPgoccrDOAzdzyxtZxCTMS8tPKVXksmrmMsYqYo5GJjMFJrXauZzHsXM9AKnZ3KKZYW1rhcYMLtLGRWeUJ%2BZlBas8yN0V28%2FOG6YUi7VRmzGCsjWDbzApRkE6zqpGCFTpnsVbO6JSipWWiLj3GRBtkM62k00aqCZPOMnxyaBSkDJyD%2BJHZ3CQQY5OaS%2FVE35qUmpk6l9mw1drCaUmq0LTzSTlwoeLv%2BfgLFvWMpK8reqRRGLvmPtNSfY1C0hRuq38ueJ%2Fq%2BJGHCaQWCRIYCeMUzw8AuSd3B2mOTNaQkjxNK1JrPvPK%2BQrWmLz9NZ28dfoR1bvXFAluh1JamxPzDM0aWomhzmd5%2BLDkE6Pz7KWtuyIr10316TDV1tEhgt2Fca7kGPg%2B2QIc0OFoM8ERX41WDf5bK4x2xUaNNcZnfNbJyaqaiWSlPuyHYjMwMLPl9d5kedhLM9rkeeClXWV6KcumxVpITcqJoksUWfoFlxtyOJPTjmZ56mQEC9j9JeIIsiwtaCZLXkpBAA84qfqN7HNas9kQI2ANHom4nEOW2P1uN%2BkEKLxu3O56nSBJvGEiOl486Lch6fR6%2FYG%2F93L%2FetL%2FeLg7sGgtKiehXNlpuoDC8tVq1KCV%2FN8T0EItzFFEUMrafrvn%2BUPP79wc%2B2G3Fx4Pmu2h3%2B37b3w%2FrG4qfYBcPc%2BSdr%2B%2FdT789O16shir29ZATsdf%2B7%2BKq%2BDqLLiXeedCQGB%2BfLwsAv9DdpHfn%2FDVH1EsPAdxBQAA)
