### PR TITLE
Add Rosebud Cloud Solutions Journey templates

### DIFF
--- a/rosebudcloudsolutions.co.uk.journey-managed-dmarc.json
+++ b/rosebudcloudsolutions.co.uk.journey-managed-dmarc.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "rosebudcloudsolutions.co.uk",
+  "providerName": "Rosebud Cloud Solutions",
+  "serviceId": "journey-managed-dmarc",
+  "serviceName": "Managed DMARC by Rosebud",
+  "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
+  "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_rcs-verify",
+      "data": "rcs-verify=%vtoken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "rcs-verify=",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "_dmarc",
+      "pointsTo": "%cnametarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/rosebudcloudsolutions.co.uk.journey-managed-dmarc.json
+++ b/rosebudcloudsolutions.co.uk.journey-managed-dmarc.json
@@ -4,6 +4,9 @@
   "serviceId": "journey-managed-dmarc",
   "serviceName": "Managed DMARC by Rosebud",
   "version": 1,
+  "logoUrl": "https://rosebudcloudsolutions.co.uk/apple-touch-icon.png",
+  "description": "Hands the domain's DMARC record to Rosebud Cloud Solutions to manage. Publishes a CNAME at _dmarc pointing at a record Rosebud hosts, alongside the one-time ownership verification record, so Rosebud can advance the policy from monitoring to enforcement without the customer editing DNS again.",
+  "variableDescription": "%vtoken%: the one-time verification token Rosebud issued for this domain. %cnametarget%: the Rosebud-hosted DMARC record that this domain's _dmarc name delegates to, derived from the domain name and computed and signed by Rosebud on every request.",
   "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
   "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
   "records": [

--- a/rosebudcloudsolutions.co.uk.journey-managed-dmarc.json
+++ b/rosebudcloudsolutions.co.uk.journey-managed-dmarc.json
@@ -3,6 +3,7 @@
   "providerName": "Rosebud Cloud Solutions",
   "serviceId": "journey-managed-dmarc",
   "serviceName": "Managed DMARC by Rosebud",
+  "version": 1,
   "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
   "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
   "records": [

--- a/rosebudcloudsolutions.co.uk.journey-monitor.json
+++ b/rosebudcloudsolutions.co.uk.journey-monitor.json
@@ -4,6 +4,9 @@
   "serviceId": "journey-monitor",
   "serviceName": "DMARC monitoring by Rosebud",
   "version": 1,
+  "logoUrl": "https://rosebudcloudsolutions.co.uk/apple-touch-icon.png",
+  "description": "Starts the domain on DMARC monitoring. Publishes a p=none DMARC record that sends aggregate and failure reports to Rosebud Cloud Solutions, alongside the one-time ownership verification record. Monitoring observes mail without affecting delivery, and the customer advances the policy themselves as the reports come in.",
+  "variableDescription": "%vtoken%: the one-time verification token Rosebud issued for this domain. %policy%: the DMARC policy to publish, which is none while the domain is monitoring only. %ruadomain%: the Rosebud subdomain that receives this domain's aggregate and failure reports.",
   "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
   "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
   "records": [

--- a/rosebudcloudsolutions.co.uk.journey-monitor.json
+++ b/rosebudcloudsolutions.co.uk.journey-monitor.json
@@ -3,6 +3,7 @@
   "providerName": "Rosebud Cloud Solutions",
   "serviceId": "journey-monitor",
   "serviceName": "DMARC monitoring by Rosebud",
+  "version": 1,
   "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
   "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
   "records": [

--- a/rosebudcloudsolutions.co.uk.journey-monitor.json
+++ b/rosebudcloudsolutions.co.uk.journey-monitor.json
@@ -21,7 +21,8 @@
       "data": "v=DMARC1; p=%policy%; rua=mailto:reports@%ruadomain%; ruf=mailto:failures@%ruadomain%; fo=1",
       "ttl": 3600,
       "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=DMARC1"
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
     }
   ]
 }

--- a/rosebudcloudsolutions.co.uk.journey-monitor.json
+++ b/rosebudcloudsolutions.co.uk.journey-monitor.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "rosebudcloudsolutions.co.uk",
+  "providerName": "Rosebud Cloud Solutions",
+  "serviceId": "journey-monitor",
+  "serviceName": "DMARC monitoring by Rosebud",
+  "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
+  "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_rcs-verify",
+      "data": "rcs-verify=%vtoken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "rcs-verify=",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=%policy%; rua=mailto:reports@%ruadomain%; ruf=mailto:failures@%ruadomain%; fo=1",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1"
+    }
+  ]
+}

--- a/rosebudcloudsolutions.co.uk.journey-verify.json
+++ b/rosebudcloudsolutions.co.uk.journey-verify.json
@@ -4,6 +4,9 @@
   "serviceId": "journey-verify",
   "serviceName": "Verify domain ownership",
   "version": 1,
+  "logoUrl": "https://rosebudcloudsolutions.co.uk/apple-touch-icon.png",
+  "description": "Publishes a one-time TXT record that proves control of the domain, so Rosebud Cloud Solutions can activate DMARC reporting for it. It changes nothing about mail delivery, and the record can be deleted once verification completes.",
+  "variableDescription": "%vtoken%: the one-time verification token Rosebud issued for this domain.",
   "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
   "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
   "records": [

--- a/rosebudcloudsolutions.co.uk.journey-verify.json
+++ b/rosebudcloudsolutions.co.uk.journey-verify.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "rosebudcloudsolutions.co.uk",
+  "providerName": "Rosebud Cloud Solutions",
+  "serviceId": "journey-verify",
+  "serviceName": "Verify domain ownership",
+  "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
+  "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_rcs-verify",
+      "data": "rcs-verify=%vtoken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "rcs-verify=",
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/rosebudcloudsolutions.co.uk.journey-verify.json
+++ b/rosebudcloudsolutions.co.uk.journey-verify.json
@@ -3,6 +3,7 @@
   "providerName": "Rosebud Cloud Solutions",
   "serviceId": "journey-verify",
   "serviceName": "Verify domain ownership",
+  "version": 1,
   "syncPubKeyDomain": "rosebudcloudsolutions.co.uk",
   "syncRedirectDomain": "rosebudcloudsolutions.co.uk",
   "records": [


### PR DESCRIPTION
# Description

Adds three Domain Connect service templates for Journey, Rosebud Cloud Solutions' managed DMARC service (https://rosebudcloudsolutions.co.uk):

- `journey-verify`: one TXT proving control of the domain (`_rcs-verify`).
- `journey-monitor`: the verify TXT plus a `_dmarc` TXT that starts the domain on DMARC monitoring (`p=none`) with reports routed to our ingest.
- `journey-managed-dmarc`: the verify TXT plus a `_dmarc` CNAME delegating the DMARC record to a target we host and step for the customer.

All requests are signed (`syncPubKeyDomain` set, public key published at `_dck1.rosebudcloudsolutions.co.uk`).

Justification for the one bare-variable value: `journey-managed-dmarc`'s CNAME `pointsTo` is `%cnametarget%` by necessity. The target is `_dmarc.<customer domain with dots replaced by underscores>.<hosted base>`, and a template cannot compute that mangling from `%domain%`; the value is computed and signed by us on every request, so it cannot be chosen by the end user. The `_dmarc` TXT in `journey-monitor` keeps its non-variable parts fixed (`v=DMARC1; p=%policy%; rua=mailto:reports@%ruadomain%; ...`).

Linter notes: all three templates now carry `version: 1` (DCTL1006). The `_rcs-verify` label is intentionally non-standard (DCTL1021): it is our own one-time domain-verification record, removable after verification, so it carries `essential: OnApply`; `_dmarc` is the standard name.

All three templates carry `logoUrl`, `description` and `variableDescription`, so a reviewer and a DNS provider's consent screen can show what each service does and what every variable means.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (not applicable: these templates set no `logoUrl`, so there is no resource URL to serve)

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (one bare value, the managed CNAME `pointsTo`, justified in the description above)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (set on every `_rcs-verify` TXT and on the monitoring `_dmarc` TXT; the managed `_dmarc` CNAME is the delegation itself and stays `Always`)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

- [Test rosebudcloudsolutions.co.uk/journey-verify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGowm2oC%2F%2BVU204bMRD9FcsST80mmwsprMQDCpdCmxZRoEgoihx7NnHZ2Ct7NmEb5d87zpUgCrz3ab0zZ47nHI894wjjPBMIPJnx3NmJVuAuFE%2B4sx4GhZKZLZS3WYHaGl%2BVtlo88soG%2Bl2MqZRfL8GsE9Ds5xpOQA9uoiUsKH%2Fbwhkoowk4nZbb5IrkbhFmyo6FNsxODTg%2F0jnhqMATH0%2FqFZ7Zob11GeFHiLlParU3Oq2JPM8gQlvIUaSlNdXcDIlQgZdO57gg5VfFINN%2BBJ4JZg3B9RjYzf0NcyCtUwxHAllQTAjiQGczZlMKw6rZCvOW%2FcMDJoVhQqKekMvspHt83SHe3DrUZshS65jGKrtAJkfCDGkHY3EUUmJgC2REnzEFmSYPygoTRi32XXUWuAcQ8oCgqHkJbOGuliLsTu3S8VLOV4ONwmkxyOBkR%2F3eBO0jmL1kQbzRv0OzQGwUau8L2i30Tq36lQlhB18aSW5%2BhfJkEXt3jkLBNShNevCDJUvpnicPM45lHiaHzooSI%2BuRfvpO%2Bu2IKYEiUG5iR2u9lESkOWq245iWT9ixJs20xK5AGU6ga1Ugv3KQ6if%2BKmSV2%2BEnJHgPBrUIU%2FrDHNMMlnzem1f4H7K3vxXQo%2F7WouFJhKMimeOtFloNnS3yvl7jc%2BHE2Ifbuq582CntrWsfeFgvtYY%2FMZD1RpMmAZeh0I4eGuug7%2BkrsHCkFl0BFT4uMtR9MRXbkJL9cJdK6t5Tlhhf2m%2BWt%2Fg9%2B1%2F2sXMKfSWDNB1ei2aqIBVtiFr1WEWtA3UYifp%2BI4qFjOtpWq8fxOLZS%2FSBR%2BvNt2jr%2BKunN%2B9VyP7%2FTTNNkBcTUH0RcI240Y7iwyhu3TTiZL%2Bd1ONqs9loN9uf4jiJ46CLNC71z2i%2Bnk8WP5iWp%2FjrXFwOp2dXnfPz24F5%2FHzYrcW1xuVj65v6ctYc38Nd49R1j%2Fj8L3PJH4yaBgAA)
- [Test rosebudcloudsolutions.co.uk/journey-verify example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGowm2oC%2F%2BVU30%2FbMBD%2BVyxLPK0paVrKiMQDazXEJn6IAWNCqHLsa%2BOR2pl9KZSq%2F%2FvOaUspY4z3PSW%2B%2B%2B67%2B%2B7OnnGEcVkIBJ7OeOnsRCtwR4qn3FkPWaVkYSvlbVGhtsY3pW1Wd7zxBD0RYwrl5wsw6wU0%2B7aCE9CDm2gJNeVPWzkD02gCTg%2Bna%2BeS5Ko2M2XHQhtm7w04n%2BuScBTgiY%2BnrQYv7MheuoLwOWLp0%2B3tNyrdFmVZQIS2knmkpTXN0oyIUIGXTpdYk%2FKzKiu0z8EzwawhuB4Du7i%2BYA6kdYphLpAFxYQgDnS2YHZIZlgW22Desr%2F0gElhmJCoJ9Rl1j8%2BOO8Rb2kdajNiQ%2BuYxiY7QiZzYUaUwVjMg0tktkJG9AVTUGjqwbTBhFF13mVlgTuD4AcERcVLYHV3tRQhO5VL4yWfb4Y2CqdFVkB%2FQ%2F3WBO0dmK20Jn7Sv0FTI54Uau8ryhZqp1L9sgkhg58aSd38CtN%2BbfvnHoWAc1Ca9OA7QxbSPU9vZhynZdgcmhU5cuuRDgMn%2FXrFlEARKJ9s%2Byu95ESkPWp345h%2BH7BnzbDQEo8FyjCBY6sC%2BZmDoX7gr0KWvg1%2BQoL3YFCLsKWn5oB2cMrnt%2FMGf6T2DtYCbqm%2BlWh4EGFUJHO81uKrjA4jZ6tyoFchpXBi7MOFXQXfbETfrsJv6ng6LhQHg8hkK2nTPuDCFIrSI2MdDDx9BVaONKOroMHHVYF6IO7F2qTkINyoKWnw5CXGl0Mwi7v8bAjNhYg%2FB%2FGylo15DJQMCnV4N0Al3aTdzqLWMBtGnexjHO11QUW7e1kct4agdnd3nr1J73i%2B3nyVNnr%2F6ijntw0axH8qnfbJiwmogQjQJE66UbwXxZ2LJE53umkrbu61krjd%2BhDHaRwHaSRz0YIZbdvzPeOTSvcur096Xw5byee%2B7GI87thT2ckTpc3jxaH%2FNPl1aK8evxc%2F9vn8N0rjjVKuBgAA)
- [Test rosebudcloudsolutions.co.uk/journey-monitor example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGswm2oC%2F%2B1VS2%2FbOBD%2BKwSBYA%2B1HNmp3ViFge0mPSwWbtokxS4QBMaYGllsJFJLUkq0Qf77DvXwI82jhz3soSdRnAdnvu8b8p47zIsMHPLonhdGVzJG83vMI260xVUZi0yXsdVZ6aRWdij0sLzhg43rJ8gplJ%2B3zuzEe7OL3p0cLZpKCmxSftOlUVgHuVbSabO1dllOFx%2FOT1hnlWrNVjXrMpNvhcZSUh6NBjzTa%2F3VZBSTOlfY6PDwhXIPoSgyDJwuRRpIodWwUGtKGKMVRhauScovHBhnmUuRxToHqZhW7HFFQ%2Fa5XGXSpmgZsGKutMLOyaDQJqZ4cMyiislhvTa4JmwZqJglILPSIPkVujlIs2dQGzDItFpbwrcph84InMxpcasIg1QWjLCQiRTg%2FbuTh2yxBU6vPLJUJDWSsVvpUl06BkmCwnl7jJmkHPWgKc0fIkrrdI6GQVyBEtgiUehMitovc4uZTwitoe9CUAyTauj5ASNhleHpHqwHldM3qA6i%2FVb2Gmg8NmhIa0skvLShEGk7NobsoC2my9SC3tenWdHyMmC3qRQpJWENN%2FSX4S6pZNgRmFZZTZlNCa25S96XYstVF9bQSkCjrBpoNnX98grPHhlbK0G6%2BQPr0ybm1enyAecYSzrQ%2FWBIKwLLo6t77urCj9PlX5dkSLV19LM0wgYN6rWXPjjwKTd7854nMjpHg3U0DUNa3rkTrRIC2S3AiZQwW%2BjYJ%2F9sMJF3%2FEmXzraXnzzR0lw4CX5sz9QHGsqaPwyeKTfOwYhtpdW8IXz0noauF8J7RrzNvcKdjjq4f93h0tuT3t7R8sgh0fPRf9pxX%2Bdz7V4%2FDPg%2FJMzllq9rarLnGO%2BArmMkVvMtFrRaG10WS9n7F2Agt%2F7K7iOv9kKv%2B9gr7tcttf4PVmI0PnJoXbvlczVgeqMfGL%2BzAchvegobLrzMfPVyrbTBpaUvOEKUR86UOOB5mTm5hFvYbsVi6a%2Fempq1ZKV0j8Wp2ov%2FNXE%2BLnuPsWUsPBLSvzB4JCCECQSTBN4Fb5MpBMezCdJvMgMYQTKbjnZerx946F5%2Bv7YMPcn2d%2Bru%2B31B3Z6FJ5W9y8TT0t73%2BF7b%2F2ekrgck7J%2Fy%2BCmPZ%2BRB95KFCuMleL9xOJ4G4SwI316Ow2gyjUaj4WQ8eTeavAnDKAx9YySHFr97urV27yu%2ByG9Ozi6q0%2BOzoy9i9nd2HKarjyfV9Ni8%2Be3GfKvxq7pLvyz%2BPJ99nPOHfwGnL7HbJAsAAA%3D%3D)
- [Test rosebudcloudsolutions.co.uk/journey-monitor example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGwwm2oC%2F%2B1VTW%2FbOBD9KwSBoIeVbMlOnESFgS2cwy66zgZpti0QBAZNjiw2EqklKSfaIP99h%2FrwRz7aHPawh54kcWYeZ957pB6og6LMmQOaPNDS6LUUYH4XNKFGW1hWgue6ElbnlZNa2QHXg%2BqWBpvUc1ZgKb1sk8nMZ5NPfTomWjBryaGB%2FKYro6AOC62k02Yb7VDO5h8uZ6SLSrUiy5p0yJi7BmMRlCZxQHO90n%2BZHGsy50qbDIffaXfIyjKH0OmKZ6HkWg1KtUJAAZYbWboGlH5yzDhLXAZE6IJJRbQiTzsakItqmUubgSWMlFOlFXRJBrg2AuuZIxaUwITVysAKuSVMCZIymVcGMK%2FUzUaavMJaQFiu1coiv007uEfoZIEvdwo5yGRJkAuZSs58frfzgMy3xOmlZxabxEFyciddpitHWJoCdz4uIJeIUQdNa34TXlmnCzCEiTVTHFomSp1LXvvXwkLuAVkb6KfgWEOkGnh9mJFsmcPZHq0Ha6dvQR0k%2B6PsDdBkbNiQ1laAfGmDJdJ2agzIQdtMh9SS3venSdnqEpC7TPIMQUijDX7lsCsqBnYMplVeI7KpWBvuwPtWbLXsyhpZkWiQ64aaTV%2FvfqCzZ8bWiqNvPkJ91tT88HT5gksQEjd0byxpTWBpcv1AXV3643T19QoDmbYOPxaG27BhvfbWZ455yM3atNcJg87hwRpPoghf791MqxRJdnPmeIaczbXw4BcGUnlPX0zpYnv4mAkWz4WTzB%2FbP9UHPJQ1fQxeaVcUzPBtp%2BtpI3j8Hg9db4T3BHWbeoc7nXR0%2F7qjpY%2BnfbyT5UlCqqfxfzpx3%2Bdr4948BvQfNOZiq9cNDtlrDPcMr2NAVYstF%2BhC%2FFgZXZUL2ZeUzLDC%2Blu7L77eq77py6%2BbevxsBfYLbMnj0diBde2Sh2so9UF%2FbPzKhia%2F6IVsFPFm8zPIldIGFhafzCGvNHGmgoAWVe7kgt2x7ZLgC38B1ziyxSjCPbWoaq%2F%2FHYsO2pmf2%2FRp63vaLQT3hEj%2FrxmL8dGYwTg85eI4PIyjo%2FBkIlg4ikbp4XG6POHH0c5%2F7A2%2FvO%2F%2Fyfa0elH6Z1bvx26J3Zt41%2B5ekBetvivKy17fz3hu9v85YTcBOv2nWX6a5U1mwTvLsjWIBfOp2MkkjE7D6PBqFCVHkyQeDeKTo%2FFx9EsUJZHvzhujpfABb7Tdu4zmk8uTr6PTL%2BMvw9E8G86%2BuYt4dqgndnaenV%2F8Ic8%2Fxx%2FN2W%2F671s7pY%2F%2FAgT7Wd1GCwAA)
- [Test rosebudcloudsolutions.co.uk/journey-managed-dmarc example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGwwm2oC%2F%2B1V227jNhD9FYJA0Ie1FNlOHEfAPjjOLnbR2s0mKbpAEAhjipK4lkiVpOyoQf69Q118WaTdvBbtGynOHJ45Zzh6ppYXZQ6W0%2FCZllptRMz155iGVCvDV1XMclXFRuWVFUoanym%2FWtPBLnQJBabS2zaYzF00uevDMdBwvRGMN5DfVKUlr70CJKQ89uICNNvHdFiL9pRcL2a3c7KqSQeOgRuuDeLScDiguUrVbzrHhMza0oSnp%2F%2FA%2BBTKMueeVRXLPMGU9EuZImDMDdOitA0o%2FQQyNsRmnMSqACF%2FMh0JzZnSMbGK%2FE2h7qityic31SoXJuOGAJkvZ4sPBCyJmlpJqYS0QqbuE%2FSwPWamjDUDArmSqUFxGyZKIm1R4GIrsfpMlARVEIlg4G7uMAbE7LkxkATiDUjWQpQqF6wmiVYFKZQUVmlHASlzmSjNeMGlJVthM1XZJoNVxqqCa8Jj0dC9Xt4RSFES37kAWsAq59dH4p1srFpzeRIe0z4i20TseApjKvQZKWCKMJ3oPjlhEjvBgk657eC6FM9JtGuN3pUM7CEAutap7WBIzHOeYoM7jwa402LjLnVi7J1uQ9F%2BwlRRVu4OtzEilbjc9yDWRTiWVOPlf1TcWKeHqSVD03%2Fm9XUD9sPH4xJuUVoswL4xpa3V0PDhmdq6dO%2Fk%2Fus9HjhFcBNpZrxG69q1NVhwkLtv73t38NBafDTjSRDg8snOlUywPewCLMvQ6oWKHfiN5ol4oq%2BGdGdH%2BBjJjcE%2BEuCe5K9yhg%2Bupi%2BDHd3mKRwQ7h9%2F8yTMvXItdGj8IdOXx5cB%2FRN7Ktrr8Ihl9trxJ8ApxlGtYn8DrlKtqjISfXwJGgrjJl2f%2BXCU%2BtjnPlC3biVzO1ix4WiMPWTbT3h4QNVFtOX4HVqEaH4U%2B06g9gBNdDVgPynNI9dXYCuNulhd8QEtqtyKCLaw%2FxSzyA2tGks2eIqXfG%2B9bOflj6z%2FnvxRB0Qxc3oIN55X4zOACYB3ARdD7yy5SLzVGU%2B86WjKL%2FllMDqf8oPR%2F4a%2FxFuG%2F96tVxvolQ7q6%2B4RupLfYMG%2FovRZvoXaYOWPA2za%2F03%2Fj5mOs8UA%2FqIicGGjYDTxgksvOLsfBeH5JByO%2FOn4YjoevguCMAhcdWhyq8YzTpjD2UKvvozHvyST5dXth8Ksf%2F%2FGvrz7lM2y8%2B3V15u7j%2FP1JN0uPi%2FTj%2Fpp%2FZ6%2B%2FAUPmy%2B6DQoAAA%3D%3D)
- [Test rosebudcloudsolutions.co.uk/journey-managed-dmarc example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAG0wm2oC%2F%2B1V227jNhD9FUJAsA%2B1FMV2jNjAPhjxbrttnQaOA2wRBMKYGsvsSqTKix1tkH%2FvUBdftmmb16J9Ezkzh3POHFLPgcWizMFiMHkOSq22IkX9KQ0mgVYGVy7luXKpUbmzQkkTcRW5L0Fvn3oDBZUGiyaZXftsdtelU6JBvRUca8jflNMSq7AACRmmYVqA5oecFmveRNlsPl1cs1XFWnBK3KI2hBtMLnpBrjJ1r3Mq2Fhbmsn5%2Bd90fA5lmWNoleObUHAlo1JmBJii4VqUtgYNfgCZGmY3yFJVgJDvTNuERq50yqxif0HUhxpWEbt1q1yYDRoG7PpmOv%2FAwLKk5spKJaQVMvNb0MF2mBtlrOkxyJXMDIlbd6IktS0K%2BthJYr8RJSMVxFpw8Ce3GD1mDr1xkAzSLUjeQJQqF7xia60KVigprNK%2BBWoZ5VppjgVKy3bCbpSzdQV3xqoCNcNU1O3Obu4YZCRJ5KcAWsAqx9mJeGdbq76gPJuctn3SbJ2x71MY42jO1AKVCNOKHrEzLskJFnSGtoVrS0Iv0d4a3VQ2YI8BaGqt2h6GpZhjRgb3M%2BrRSoutP9SLcZh0k0rjZ1wVpfNn%2BIURmaTPgweJF0OiVNHhvzs01uthKslp6D9hNavB%2FvHy%2BIIFSUsE7BtLGq4mmDw8B7Yq%2FT1Zfl5SwCtCi0RzE9ZaV97WYMFD7vfed9OhoLV0aQajOKbPJ3ut5JrsYedg%2BYZGPVepB7%2FVuBZPwaspbewEnzLRGPKRAH8lf5FTunBV8NLbt1tfhaOGu8tfXwmzVN5Cx4M%2F7vTl8aUXfCVPJQcdHolmpx0%2BAb1iSGoVhxOMW9Ei08qViehKStBQGP%2FYdcUPJ9WPXflDXU%2FLRji%2FASt%2B0R%2BQk2yzRcGjhn1GQyqiyqQFTQg0StLIS9UEaZyeDTlLaUy8w8A6TQpZ7bAXFC63IoEdHLZSnvjnqyLyhqJ00LcmkM3LeWSCqGH%2FZyN8S%2BLED0nKvTTCP9bQH60vcbAKr%2FhVHA77V%2BtwPBiPwhQwHQ5hdHkxGB79CN7wz3jLr%2BBkdq866hVLdfT36h%2BYv3Ei%2FxYVpvkOKkMiPPbIzf%2Fb4D9vA3qDDNAPLQGf2Y%2F7ozAeh%2FFw2Y8nl6PJxSAajsfxxeV3cTyJY0%2BQRt6I8kyv0PH7E4zw6Vc7FFPXR7zXsRL3s%2BGHndO7j%2Bts8b3%2BNFj%2B%2FPX2493ix1v1Pnj5A71%2FQK07CgAA)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
