### PR TITLE
add AgentMail, AgentMail Email

### DIFF
--- a/agentmail.to.email.json
+++ b/agentmail.to.email.json
@@ -1,0 +1,90 @@
+{
+    "providerId": "agentmail.to",
+    "providerName": "AgentMail",
+    "serviceId": "email",
+    "serviceName": "AgentMail Email",
+    "version": 1,
+    "description": "Configure DNS records for AgentMail custom-domain email: inbound routing, sending authentication (DKIM), SPF, and DMARC.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "agentmail.to",
+    "syncRedirectDomain": "console.agentmail.to",
+    "records": [
+        {
+            "groupId": "inbound",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "inbound-smtp.%region%.amazonaws.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "core",
+            "type": "MX",
+            "host": "mail",
+            "pointsTo": "feedback-smtp.%region%.amazonses.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "core",
+            "type": "SPFM",
+            "host": "mail",
+            "spfRules": "include:amazonses.com"
+        },
+        {
+            "groupId": "core",
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=reject; rua=mailto:%dmarcrua%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
+            "essential": "OnApply"
+        },
+        {
+            "groupId": "byodkim",
+            "type": "TXT",
+            "host": "%selector%._domainkey",
+            "data": "v=DKIM1; k=rsa; p=%dkimkey%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DKIM1"
+        },
+        {
+            "groupId": "subdomains",
+            "type": "MX",
+            "host": "*",
+            "pointsTo": "inbound-smtp.%region%.amazonaws.com",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "groupId": "tracking",
+            "type": "CNAME",
+            "host": "link",
+            "pointsTo": "%trackingtarget%",
+            "ttl": 3600
+        },
+        {
+            "groupId": "easydkim",
+            "type": "CNAME",
+            "host": "%dkim1%._domainkey",
+            "pointsTo": "%dkim1%.dkim.amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "easydkim",
+            "type": "CNAME",
+            "host": "%dkim2%._domainkey",
+            "pointsTo": "%dkim2%.dkim.amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "easydkim",
+            "type": "CNAME",
+            "host": "%dkim3%._domainkey",
+            "pointsTo": "%dkim3%.dkim.amazonses.com",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **AgentMail** (https://agentmail.to), an email API that gives AI agents their own inboxes. Customers bring a custom domain; this template applies the DNS records that domain needs for inbound routing and authenticated sending, replacing a manual copy-paste of 5-8 records.

Sending is backed by Amazon SES, so the records are the usual SES set plus our own inbound routing:

| Group | Records | Applied when |
| --- | --- | --- |
| `inbound` | apex MX for receiving mail | customer enables inbound |
| `core` | MX + SPFM on the MAIL FROM subdomain (`mail`), and DMARC | always |
| `byodkim` | one DKIM TXT at `%selector%._domainkey` | default for all new domains |
| `easydkim` | three DKIM CNAMEs | legacy identities provisioned before we moved to BYODKIM |
| `subdomains` | wildcard MX | customer enables subdomain inboxes |
| `tracking` | CNAME at `link` | customer enables open/click tracking |

`byodkim` and `easydkim` are mutually exclusive - our service selects exactly one per domain based on how that identity was provisioned, and never requests both.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

> On the third box: this template sets no `logoUrl`, so there is no resource URL to serve - the check passes vacuously rather than because a logo was verified. Flagging it explicitly rather than leaving the box silently ticked. We do not currently publish a square logo asset suitable for a provider consent dialog; happy to add one and update the template if you would rather every template carry a logo.

Also validated with the official linter, clean at every log level:

```
$ dc-template-linter -loglevel error -tolerate info -logos agentmail.to.email.json
$ echo $?
0
```

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Justification: bare variable as a full record value (rule 6)

The `tracking` group's CNAME uses `%trackingtarget%` as its full value. A CNAME's value is a hostname, so it cannot carry a service-specific text prefix the way rule 6's TXT example can. The target is the CloudFront distribution serving that customer's tracking links, which differs per environment and per tenant, so it cannot be a fixed string either.

The exposure rule 6 guards against is bounded here: the host label is fixed (`link`, not a variable), so the record can only ever be created at one predictable place in the zone, and the whole query string is RSA-signed against `syncPubKeyDomain` — a caller cannot substitute their own value without our private key.

### Note on SPFM placement (rule 4)

Our `SPFM` record sits on the MAIL FROM subdomain (`mail`) rather than the apex, because that is the domain SES authenticates against for bounce handling — the apex SPF is not what governs our sending. This follows existing accepted practice in the registry rather than departing from it: 139 templates here use non-apex SPFM, 14 of them on exactly `host: "mail"`, several also SES-backed (e.g. `xmit.sh.email.json`, `agentsmail.io.sending-domain.json`).

## Online Editor test results

**Editor test link(s):**

- Apex (no `host`), BYODKIM: [example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEETm2oC%2F%2B1ZbW%2FiOBD%2BK5ElpLs9iBLoG1khlbb01EW03ba627u2QiYxkBJiznZouar322%2FsJCSh4aW3sNs98anGY%2FuZsWeemUmfkSDDkYcFQdYzGjE6dh3CzhxkIdwjvhhi19MFRcWp7BwPYS2qS2kLpCDihI1dm6hdZJiZm12tNSL5mDDuUh9ZZhE5hNvMHQn1Gx1Tv%2Bv2Aka0k%2FNrjRGbModrXcq05BQ74IIOSw6F03xNYVqa63do4Dsao4Fw%2FV5R48R3YKDhQPRhp2tjCaH9dNI8a%2F1c1K4vT4sahg0nrfrVsS6Vnvj2kUftAbK62OMknLkMOk0yOVFYr%2B9FrrgijguKiukam%2FqcekSfWRsZg6zbZ9QDNUfqyiK9QS4mI3lbrS8w7lMuYHwor566vuA3NFlb4kMx0guM9MCggo6H%2BG%2Fq40eu23So3sqlzBUTuF0DThUesip7hvFSTMOCKiQfM3qiFGyXEKeD7UEuLidfgQuP0HqFzEfdq8AjXBlse4FDrCzUohNvvtwkB7adIWY2%2FHawwPB7XFOPbX7URjVGHuDNPmoswDUJLKhVUMthooBS%2BsPwSUi39Fwb%2FE%2FYffCqFnUk2iUjXfcJ5S6JZAkqLCOcS1fEcDS68OujkTeZsaYzoc7AHc4xqMCJB1pTVtDbofsPyCRjHzg3mDeoMY6llQV5GKxZu0USZ0Z1HnRCnXi%2BY33YmDMLBt4JCia4x%2Bf1ViOB9uCisuiFeI%2FArEdE5n6yhxPMJ9knmTlc3bE58yJpqEgu%2F7wKmq8CLS8BLW8CtLIEtLIU9P6liEBE2gkj3oMPx%2FRJnjAkJRJti6BhpBRtu2p9ijaj%2BE8CJ%2BuHsWsAwggzPOQy1cVYtxmw%2BxjtFsmxwvuvWKE%2Fy90BL8HFipIpp2OGkQI1PswkiXuZOsMIlyumMrU1jGQ53zo7Ozp7qJ8f9QZ%2F9Qfur9VH46j%2BuXFar18c1z8f1KX8uNeEcaMeGQg5DMKYMOCeU8puCBeRotk4UHqZ5coO7tiObns0cLqM%2BkL3QRYpYSrVOjYsE3RAfDMWlNVu0t3Z3VOCciyoSEGv7%2B4fVJWggqQLuD0frrPN4S8WkPGRJVgAWXcYeMJt40ecTDl2G0uyBI%2FhIIXjIIemKcYPK43DhAsz9DJ9g1f8kiLFLNW0HVt6iisDwyHYcTqmXTIq5b3SjoGdUtUk1dIexk6ng%2Fe7lSpJFUl5BVRelZS4djov1L1HPOHoRcZmjonR3sjKbGqeNTMn%2BN6zmWGqy7VzXIOqwNRy6wHtH%2Bx5sY1g4nu26o0VSQ5FZN7yu9k5LV7mGZqcvFqhsjZKex%2F3sySIP%2Fw%2FeSouFyIro6orMnRuWnlnL3ZfhGpkm1626WWbXrbpZZtetullzelF9nh4TJw2lsvKBmAb1ZKxc2MeWLumtbOrH%2BzsVqr7vxiGZRhSfXC90MhnNVYdLB6Rp9K0YYeJMQZP7ajPZs%2FT7jPVfKZ7T5Qb%2BEnnmWo8U30nWmcQzXSdi54v6jmzLee048w2nNN%2BM9tuzv26ML%2FHz%2B%2Fsi8lHEtnChu1o%2BEk3Jw5TWHrWDyOnNQ1tpQBdkKz1VUBWy%2BOLcmUuTJgNI5i75Vn0DqHFmWu5MXdvz2lZ1AxP6pt4oRyaWo4z1%2F%2FnH5yOh1QaXI6V2ZjzrW4%2BZDrW3gSZ2fgmyHQcvwkyszEPUgawotH4c96WRdfOoku%2FlG5J9Eck0aW1%2BIo6bKhK%2F8EZXwbFNFy27PS17BQV5EQptVmq8nv6t6GrFYHWQVlzoDZAW6sY9S2oa2U9vgd9bcjFcilsFaxFNPYSEw50u7JzlTeeLrhAnv73H3qgf7D%2B753x7vWR27fH1eb4z%2Bbg6vK35qArzCq7cPvsdO9To%2Ff40Kihl38BpZu2Jb4kAAA%3D)
- Subdomain (`host=eng`), BYODKIM: [example.com/eng](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAL8Tm2oC%2F%2B1abW%2FbNhD%2BKwIBA1tnC5Jf0kRFgCpva1Y4TdNs7dAGBi1RjmpJ9EjKiRdkv31HSrZER46dJW7TwZ8s60g%2Bd%2BTdc3e0b5Ag8SjCgiDnBo0YHYc%2BYcc%2BchAekETEOIxMQVF9JjvBMYxFrpR2QQoiTtg49IiaRWLt3fxo4zCXjwnjIU2QY9eRT7jHwpFQ39E%2BTYJwkDJiHJx8MBjxKPO5EVBmFKt4KRc0bvgUVksMhekYYdKnaeIbjKYiTAZ1g5PEhwcDp%2BISZoYelhDGTwdvj7s%2F140Pp0d1A8OEg657tm9KpSeJtxdRb4icAEecZG9O0%2F5bMjlQWHf3RY44I34IiorZGI8mnEbEnBubG4OczzdoAGqO1JbleoNcTEZyt7qf4PmScgHPr%2BXW0zAR%2FJwWYxs8FiOzxsgADKqZOMZ%2F0wRfcdOjsTqrkLJQTGB3LVhVRMhpbVnWbb0MC6qQasz8iEqwASF%2BH3vDSlxOHoELh9C9g8xHwVkaEa4M9qLUJ44Odd%2BK55%2FOiwV7foyZB999LDB8H%2B%2Bqw7ZfGaNdRr7Cmb0yWIp3JbCgTk0Nhxc1VNIfHq%2BFdMso9MD%2FhHcJXtWlvkQ7ZSQIr1HlkFxWoMIwwrl0RQxLo3eJOxpFkzlr%2BhPqD8N4gUE1TiLQmrKa2cvcf0gmmn3g3GDecJdxLK2sycVgzJNbJHHmVOdpP9OJVzvWi7U5s2DgnaBggbt%2F4nYPC%2BgINkpHr03nCMwGRGj7oy9OMJ%2FoRzK3uNpje%2B5EylC5XH7cCZpHgTaXgDbXAdpaAtpaCnpxW0cgIr2CES%2FAh6f0Sa4xJCWST8uhiTpdpWsvVFNKzJlTQBE7uitOvQNARpjhmMtsN4X7rOFdTAE%2FK8SLHPK%2FwmVeLWenvAHbKxq2fD3lGSlQz6%2B1VHEhE2gW53LETKamZvEs33ePj%2FeOv7one4PhX5fD8NedK2vPfX945Lrv9t33266U7w%2FewvOhm9sImQyCmTBgoCPKzgkXuaJ6NCi97Garjfueb3oRTf2A0USYCchyJWylWt%2BDYYIOSWJPBU01mwTtzpYSNKeClhQMLsOX2ztK0ELSEcJBAtvZ4%2FCJBeR95AiWQu6N00iEPXyFi1e%2B18OSMsFvOEhhOcikZaJJsnoj85WcEzWamZ3CHZ4pkaNOOT3fk%2B4SqqJoy2v5gUUa21vtfqONW%2F3GdmCTho3tznaHBFst72WpWKoqpKqqJc3FyynCja7whKNbGaYVdqpVNWP1TD1vbUUsPnNrs%2BS30NzxLtQKtlFZJRj%2F4CiamgqWPnPjslJl3rx7y5UK5tBO9nuaOytuFtlbLF4kkzvWzxUzT0Z4z2ablgT4C%2FP%2FTGXT4iI3VtZour0LU9DzO7%2BLOpQwm2y0yUabbLTJRptstMlG3zcbyQ4Sj4nfw3Jk02puNaydhtU%2Bt7edTsvp2OaOZVvtzi%2BW5ViWtAB8MbPzRj2rFhmPyHVjdikAL8YYXLevruZuZr1tqbUtd7aokhCKvrbU1pa6WvSUUTXX0953gnlHqze0s35Wb2dn3azezC68wVh8g1B9b1AvLmJkg5w1u9m1cVV5UWCZuivmfmtbxkqhem9aXwFktWx%2FfzqtgMmSZQ7zZXmS%2FYLQsqy2zJgvD891Ouoca67hhCrZahnOQv9fvHA5HrTcuAxLm1hxH7gYshxrD4LUJj4IshzHD4LUJlZBygBWNDq9LNyw6JOz6NJ72A2J%2FogkukKBvpIOayrbf3DGl0ExC5cNOz2Wne7%2BSrU2qkoG5rehqxWBnoKyFkCtgbZWMepbUNfKenwP%2BlqTiy1osR9HY7dTwoFuV3au5T8izHgNBpV%2FYUS4%2BZt9GrePzt4wTFzotcYfmwH9dLLzNQg%2B%2FvFh3KGDw3e%2FX%2F75BtNddPsvM4cfEiclAAA%3D)

Each link opens on the named test; both carry all three saved tests, so the Easy-DKIM variant can be selected from the dropdown in either one.

| Saved test | Domain / host | Groups | Records produced |
| --- | --- | --- | --- |
| `apex-byodkim` | `example.com`, no host | inbound, core, byodkim, subdomains, tracking | apex MX; MAIL FROM MX + SPFM at `mail`; DMARC at `_dmarc`; DKIM TXT at `agentmail._domainkey`; wildcard MX; tracking CNAME |
| `subdomain-byodkim` | `example.com`, `host=eng` | same as above | the same seven records, every one under `eng.example.com` — nothing escapes the requested host |
| `apex-easydkim` | `example.com`, no host | inbound, core, subdomains, tracking, easydkim | the three Easy-DKIM CNAMEs in place of the DKIM TXT |
