### PR TITLE
add FunnelLingo, Hosted multilingual pages

### DIFF
--- a/funnellingo.com.custom-domain.json
+++ b/funnellingo.com.custom-domain.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "funnellingo.com",
+  "providerName": "FunnelLingo",
+  "serviceId": "custom-domain",
+  "serviceName": "Hosted multilingual pages",
+  "version": 1,
+  "logoUrl": "https://app.funnellingo.com/funnellingo-mark.svg",
+  "description": "Connects one customer-selected hostname to FunnelLingo hosted multilingual pages.",
+  "syncPubKeyDomain": "taptapdns.com",
+  "syncRedirectDomain": "api.taptapdns.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "seo-fallback.funnellingo.com.",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Enable FunnelLingo to safely direct a user's selected subdomain toward their dedicated multilingual content pages.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**
[Test funnellingo.com/custom-domain example.com/languages](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOkUm2oC%2F%2BVTYU%2FbMBD9K5W%2FrmnTEto00qShDsTGgIl10yZURdf4Wiwc29hOIa3633duKWSMTdrnSZEin989v%2Fd8XjOPpZHgkWVrZqxeCo72A2cZm1dKoZRCLXSn0CVrP21fQElwdrIFfAoA2nRol6LAbWtROa%2FLiOsShHree%2Bw71c4jb5WV9CLQVyBbBhboCLlE64RWLOu1mdQL%2FdVK6rjx3ris2wVjOi9kdRvrqAR723HLBRFxdIUVxm%2FJ2FgTqPCupRW2durQRg4lFUnKDSlSJK7ldavhalt%2FVWknmKpV8bmanWH9fuczYx4MfVy5x8AC5Aq5sHTMEwiM6LwEhoOu8K4iJOXnbYVtRk3acsey6zXztQnJjS%2BOzo8f4bR8F%2B5EC%2BXdRNPSoY7mIOUMituXMQXB3lOWB3G8mW7abEVJ5M9HTCmxvUB8ABoJbEijooRgf3dJC6srk4t9owELpQvzs6e4%2FoVjuie5brAEDWKhtMXc0R98ZXHvfJt3DvfwXOJFTpcva5LsaJe4fk9F7carqZSDh39Ips1yXgQjYjvFw7SYjQaDiKd8ECVJ2otgAElUxPNiOOunI0z7jVfxh0fzt3fxSrboHCovIIz9kbyH2rHNZtqmnP8rwzQzDpbIcwj4ftwfRPEoipNJL80O0ywZdQ56w1E%2FeRPHWRwHR%2Bj8zvyaJqs5U2yVfrnRveFhPRt9r9OT7vnk8kyejL9hUs4vP54eHCd3Y7Ma9uPVj7ds8xMbYndFEgUAAA%3D%3D)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
