### PR TITLE
Add zahbrandsolutions.com.site template

### DIFF
--- a/zahbrandsolutions.com.site.json
+++ b/zahbrandsolutions.com.site.json
@@ -1,0 +1,29 @@
+{
+  "providerId": "zahbrandsolutions.com",
+  "providerName": "Zah Brand Solutions",
+  "serviceId": "site",
+  "serviceName": "Connect your domain to your Zah Brand Solutions website",
+  "version": 1,
+  "logoUrl": "https://zahbrandsolutions.com/brand/zah-logo-alt.png",
+  "description": "Points a subdomain (for example wellness.example.com) at the website Zah Brand Solutions hosts for you, and adds a verification record so the site can prove it owns the name and issue its certificate. No other DNS records are changed.",
+  "variableDescription": "%target%: the up.railway.app label assigned to the hosting service for your site. %verify%: the per-domain ownership token issued when the domain is added to your site.",
+  "syncPubKeyDomain": "zahbrandsolutions.com",
+  "syncRedirectDomain": "zahbrandsolutions.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_railway-verify",
+      "data": "railway-verify=%verify%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "railway-verify=",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%.up.railway.app",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Zah Brand Solutions (`zahbrandsolutions.com` / `site`). Zah Brand Solutions hosts small-business websites; this template lets a customer point a subdomain at their hosted site and adds the hosting platform's ownership-verification TXT record so the site can prove it owns the name and issue its certificate. Two records, both scoped to the `host` the customer chooses; nothing else on the zone is touched.

`hostRequired` is true because the hosting platform verifies subdomains with a CNAME and cannot express the ALIAS/ANAME an apex would need, so apex is deliberately excluded rather than half-supported.

The TXT record uses `txtConflictMatchingMode: Prefix` on `railway-verify=` so re-applying after a domain is re-attached replaces the old token instead of stacking a second one.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Note on the last item: neither record is one the end user would edit independently (the CNAME is the site itself and the TXT is the platform's ownership token), so `essential` is intentionally not set.

## Online Editor test results

**Editor test link(s):** 
[Test zahbrandsolutions.com/site nvtw.net/wellness](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACAqm2oC%2F%2B1UXW%2FiOBT9K5alSrMqSU0aCCCNtN3pqvuhsu2UGe20QsiJb8C7wc7YDpRW%2Fe97HZJCp6j7sC%2F7MDwguD4%2B9jn3%2BD5SB8uy4A7o6JGWRq%2BkAPOroCP6wBep4UpYXVROamXDTC9p5xk05kvcRG%2F5gvzkceSmBSLIglnJDGoiK5H9udRs%2B6CVgsyRja4MEXrJpSJOb%2F8eoCRrSBueFRiLJTrqdmih5%2FqTKZBv4VxpRycnB299Upf8WuB3BLxwYanmSCbAZkaWriakV1oqZwkntkqbO73LtSFwz9EkwEsUhQJrw6bguX8g3BG3gPaGB2%2B%2F0BZ5PRUK7BC%2FyIXwJ6EamcuMexwxkGkjiNU1Yc2WcUW840CkI3qNXH5JoYk1i7S28kuWZGDclglCMtZEI86Q8%2FFNw4qHGaRbcDUHEXofuZE8LeD8hQVHjps5uKNRfU5VhobLYs03IS9LUvAUCsKtlXMFwvfLg7w4qeakaXAr09QCQnJUS9w0jCWYoLEW1WArF7JEor9BbbUIsl7gbw9tYNJ6r7bH7Wh9oDYqu6rS32FzXiPfyKyHfgQh0Qr3r2Cv5yN8rRCN8XWmgg5tPKSju0fqNqVP8OTPSQPGP7PGpmAr1ieLO44LL%2BvvWzMQ4O4dPoK8kJm75C5boIWXWnjmKwO5vD8MadZeEXu0w4dw2mfsqfN8yQ%2Fjs8ufd9f80b%2FfOuQTvdfs8GWfX3BNnzr0QSuY7SyYorrWRLVy61CB253RPhKszI2uyplsN5Xc8KX1g6bdfrfbP20J7nYM0%2Fq1ez%2Bx2u%2F2uwNIUjYcsCjmvSQ9zcWp6J%2BCYFHaG6TRsJfETKQi4WmaJjmLunncSwbxgJ3yrOfZtno92%2F3gr43SbEm9PoyzNjDzseauMtB2fVkVTs74mu9KIpuhQ8UG7bC4ilTfJkJtB9w3iQj3bDkcjf%2Bsb69rHToTmTda%2BgGcQgSRiHtBhJ8gznMWpN2kH3TZIBrGkCe9GPYG%2B5vT%2F8Bgf913%2FAblJPeD%2BcxrtPTpQCgbp1470zbnjVz%2BHxVOO5jy73H4HocmDjhwLF%2BBmHEPj1jUD9gwYPEkYqNoOIpYyIZJ1IuOGRsx5uWAdVvNjziV9ucRvb08PoOHLxfFdf%2BqvBh%2F%2BTy5Oe5fq3ijblMn3PVvSfkHfF26Xy4%2BvadP%2FwB%2BKZyV1wkAAA%3D%3D)

(`hostRequired` is true, so no apex test per the template note.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
