### PR TITLE
add Aim Assist, Aim Assist Blog

### DIFF
--- a/aimassisttechnology.com.blog.json
+++ b/aimassisttechnology.com.blog.json
@@ -1,0 +1,18 @@
+{
+  "providerId": "aimassisttechnology.com",
+  "providerName": "Aim Assist",
+  "serviceId": "blog",
+  "serviceName": "Aim Assist Blog",
+  "version": 1,
+  "description": "Connects blog.<yourdomain> to your Aim Assist hosted blog.",
+  "syncPubKeyDomain": "aimassisttechnology.com",
+  "syncRedirectDomain": "portal.aimassisttechnology.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "blog",
+      "pointsTo": "aim-assist-blog.fly.dev",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Aim Assist Blog's signed synchronous connection template. The only record is `blog` CNAME `aim-assist-blog.fly.dev`, TTL 3600. It connects a hosted blog without modifying apex website, email, nameservers, or registrar ownership. Aim Assist signs requests using its dedicated RSA key and returns clients to `https://portal.aimassisttechnology.com/portal/setup/domain/callback`.

Provider authorization stays disabled in the application until the public signing key is published, the relevant DNS provider reports template support, and a consent/DNS/HTTPS pilot passes. Upstream acceptance is not being represented as individual-provider approval.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)
# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Logo-resource check completed: not applicable because `logoUrl` is omitted; no external logo resource is referenced. Official `dc-template-linter -loglevel error -tolerate info -logos aimassisttechnology.com.blog.json` passed (exit 0, 2026-09-05).

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.
- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

There are no TXT/SPF records or template variables. The sole CNAME is essential to the service, so it intentionally retains the default essential behavior. The application's signed production flow omits `host`; the nonempty-host test below checks the protocol's standard prefix handling, not an additional DNS scope requested by our application.

## Online Editor test results

<!--
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->
**Editor test link(s):**

[Test aimassisttechnology.com/blog example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIhLnGoC%2F91SXW%2FaMBT9K5FfSZj5JtE2iXZsmrZW64Q2qQhFxr4Fo8Q2thOaIf577QQKU%2Ff1vKfEvufce8712SMLucqIBZTskdKy5Az0R4YSRHhOjOHGWqBrITO5qtpU5ih8ht2S3NHQhOfBpEa6mgFdcgp1h6XjnK9eoIOrpl6CNlwKlHRCxMBQzZWtz%2BhaCgHUmsB3ar%2BuZKGZzAkXbwMrA38MLtqtpbHAGqwfWwn6pVh%2BgupdzfmjJQ%2F%2BCoxrN%2B4ZrqS2JGv%2FnuXQUjODkvke2Up5e9e3k5upK3kx5xUoyYU1M9loiJp2Ua30IavaDEoHsjZDSW%2BI8WFxCNEPKSA9D1i43Zx0wSNxbwZHEcdJ7m%2BlZaFSfsIroklu%2FLuemPOfqIsTd46Qn8hXQmpIjfsSW2jnxuoCQpQXmeUp2ZHzFaMpUSqrnEDjqq7Fyw2I5r2PG2DEkn9zH6KUUa%2Ba%2BwzReIDjMetHfVgOov4D7UWkF7NoxMZxf4R74xjji0j%2BJbm%2FSOd5fWAMCMtJ5lOa7Uhl0OGwCN0q%2F1tzLgKGlMBS4mFd3B1GOI7wYNYZJbif4HF7OO5gjFsYJ7UUC8Y2bvcuMZdZQavph8dyuzWbb%2Fjz%2B6sZH67VNDfL3W5y%2F73VuVu3iu1msuner1%2FRN%2BjwBE0RhSB5BAAA)

[Test aimassisttechnology.com/blog example.com/preview](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK9LnGoC%2F%2BVSXWvbMBT9K0avtYOcJk5tukGSdSyMdmXrQyEEo1i3rpgsCUl26ob890l28zGyr%2Fc9Cemee%2B45V2eLLFSKEwso2yKlZcMo6AVFGSKsIsYwYy0Uz0JyWbaDQlYoPMDuSOXa0JRVwbRDupoB3bACOoa16zk%2BnaGDWV9vQBsmBcriEFEwhWbKdnc0l0JAYU3gmQbXraw1lRVh4n1gZeCvwQndszQWaI%2F1Y1tR3Nfrz9B%2B6Hr%2BaMmDvwJl2o07wJXUlvDB77scWmpqULbcItsqb29%2BN729cSUv5rgCJZmw5kH2GqKeLuqUPvF2QKFxIGs5yi4TjHerXYhepYD8OGDldrPXBS%2FE%2FRm8iXibpDQ0DDbuodSyVjnbtymiSWX89%2B4Jlj8xrPYUywOHn89KITXkxp3E1tp5s7qGEFU1tywnG3J8okVOlOKtk2tc1TGd70P0v99ZPkqlxJJ%2F20mIclp4E8wnKxnFCQAdRTSGOBrF6SRKcQIRSfATxuk6obA%2BCepf8vyLzJ4tFYwBYRnhPsJ8Q1qDdrtV6Bb8v3h1OTGkAZoTjx7iYRLhNMLjh3iS4VE2mgzGl%2BOryeQC4wxj7weM7U1vXZ5Ok4ToRTm8%2FS7H6mM6jNev5c2X2cv8%2FhH49BNUw2%2BLNuaVnpYzsrh6h3Y%2FADEfcrulBAAA)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required. -->
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
