### PR TITLE
update KonvoAI Custom email domain return path (v3)

### DIFF
--- a/konvoai.com.email.json
+++ b/konvoai.com.email.json
@@ -3,12 +3,12 @@
 	"providerName": "KonvoAI",
 	"serviceId": "email",
 	"serviceName": "Custom email domain",
-	"version": 2,
+	"version": 3,
 	"syncPubKeyDomain": "konvo.to",
 	"syncRedirectDomain": "konvoai.com",
 	"description": "DNS records for sending email from your domain with KonvoAI (Resend / Amazon SES).",
 	"logoUrl": "https://k2.konvoai.com/favicon.svg",
-	"variableDescription": "dkimKey: Resend DKIM public key (the base64 value after p= in the resend._domainkey TXT record); region: SES region parsed from the send MX record.",
+	"variableDescription": "dkimKey: Resend DKIM public key (the base64 value after p= in the resend._domainkey TXT record); region: SES region parsed from the konvo MX record.",
 	"records": [
 		{
 			"groupId": "dkim",
@@ -20,7 +20,7 @@
 		{
 			"groupId": "outbound-mx",
 			"type": "MX",
-			"host": "send",
+			"host": "konvo",
 			"pointsTo": "feedback-smtp.%region%.amazonses.com",
 			"priority": 10,
 			"ttl": 3600
@@ -28,7 +28,7 @@
 		{
 			"groupId": "outbound-spf",
 			"type": "SPFM",
-			"host": "send",
+			"host": "konvo",
 			"spfRules": "include:amazonses.com",
 			"ttl": 3600
 		}


### PR DESCRIPTION
## Description

Resubmission of #1553, whose sub-domain editor link had a truncated token so the PR description check could not verify host coverage. Template content is identical; both editor links are regenerated.

Updates `konvoai.com.email` (v2 → v3): the return-path record host moves from `send` to `konvo`.

We now create every Resend domain with a [custom return path](https://resend.com/docs/dashboard/domains/custom-return-path) of `konvo`, because Resend's default `send` subdomain collides for customers who already delegated `send.<domain>` to another nameserver or service. Only the two return-path record hosts change; the DKIM record and all variables are identical to v2.

Records created on apply (v3):

- DKIM `resend._domainkey` **TXT** → `p=%dkimKey%` (per-domain key from the Resend API)
- `konvo` MX → `feedback-smtp.%region%.amazonses.com` (priority 10)
- `konvo` SPFM → `include:amazonses.com` (renders `v=spf1 include:amazonses.com ~all`)

All record hosts stay relative, so the template applies correctly to an apex domain (`example.com`) and to a sub-domain via the `host` parameter (`example.com` + `host=mail` → `resend._domainkey.mail`, `konvo.mail`).

Synchronous flow only. Apply URLs are RSA-SHA256 signed; public key published on `konvo.to`.

## Type of change

- [x] Update to an existing template (version bump 2 → 3)

## How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) for both apex and sub-domain
- [x] Template file name follows the pattern `providerId.serviceId.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://k2.konvoai.com/favicon.svg`)

## Checklist of common problems

- [x] `syncPubKeyDomain` is set (`konvo.to`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`konvoai.com`) — synchronous `redirect_uri` is signed by the service
- [x] no TXT record contains SPF content — uses `SPFM`
- [x] N/A — no DMARC/TXT uniqueness records in this template
- [x] variables are not bare full record values — the DKIM TXT fixes the `p=` prefix (`p=%dkimKey%`)
- [x] `%host%` does not appear in any `host` attribute
- [x] no variable used to create arbitrary subdomains
- [x] N/A — no DMARC `essential` records

## Online Editor test results

Validated in the [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) with the documented Resend sample variables (`dkimKey` from a live `resend._domainkey` TXT, `region` `us-east-1`). Template check passed with no warnings; apply preview shows the expected `resend._domainkey` TXT, `konvo` MX, and `konvo` SPF (`v=spf1 include:amazonses.com ~all`) for both the apex and the sub-domain case.

**Editor test link(s):**

[Test konvoai.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANhMnGoC%2F%2B1VW2%2FiOBT%2BK5alSjMql0AChaz6EBqWoQwMFJi2VBVyEgcMSRxsBwpV57evDaFApzP7tNJo1ac4Puf4fN%2B5PkOBwzhAAkPzGcaMLomHWdODJpzTaEkRybk0hJlXUQeFUhW2lNBqSgHHbElcvDXBISLB4S7VvUq4oCHYCoFH5SeSOkvMOKERNHWpv47cbuK08NreiVPvOUHhTnqDPcKwK07lr%2Bg8zF1GYrF9ENqdPpDKlHkc%2BJQBjiOPRJMUgc8kmDVNWIoFrIiYgpQQ%2BHSDlTrIAytEGxqBfr3%2FOSddBHRChyyQz0%2BFiLmZz8%2BLuSMUeR9JzjTK8eVE0UOMICfA9gkyb05CydIEqRe71WyDOHEC4oI5XoNPYoqBgzguG2CJggQD5AvMQHwJJFAlZFvD3HiHXdkM7gYp289%2FycNEejIV6vQMYsQ49na01QtbzKB9lxopbmmwoPnwDCeMJvE2mwqsFIp1rLIo3cifKeVC%2FvyEQuUACSRF8eVZyvJMGQsZMb2saS%2BZ46dpIhyaRF42fDp4aN8dHGxBqrKjJBJ8QOWVj7HnIHee5aGIc2c7dmc5tE0Tx%2Fy1UAllRKyhWdD%2B3T%2BP%2FQOAfvfv9s8QpMpNEmAZHUgiN0g8bL71efDy%2BJKBUoTHh5A%2BytDsqxY%2FIdltODVLHcnTFtmY7PVlylDIVUfuLR9OTB%2F3tg9QndN4q992s%2BG3La1x1V80%2Bk1Ht3v1mtUbWpbR6Fj2VY30WrVJ7ypyip3RZjbqF56G3WAUr1q1BVpM50%2BTi%2Fvhd0T1a%2F0pL0a9bu3Lxh31hvW2bjkXxnxdbk2Nb%2Beb%2Bvlc65RW85hbs6rlag19ZIcGwbNKpXkf35XubkT%2BevR1sSxXxKpqdaqD7%2B376a0z6zVWX289VnYXt91rPbEt1y9804b3I%2FuLPvCMgDNfm7eHvpUv0DK6jTe9pm31rJqiucu4YpnwLEZcZAtQxZtMIsrwmMsvEgmTmRQswRkYJoEgY7RChyvPHaM4DtYyPVxK5Vuy4k8KPNrNrN8W%2BP82yEeVnIFjz1UVSLajQPMMo1IsZREq61nD0Lxs1XOcrGMgXHIcjAyncrQk3tkf762JQ%2F1jLsMtCFLj1QpWaM3hi%2BrY48mQZmbflmk2TqfCa2HkftmibyfEH0TzpALf8FxeyjlUAO9OIPADBcEflrzHjBxkH8310VwfzfUfNJfchhwtsTdGSq2oFctZrZrVSoPChalVTcPIXZSNsl441zRT0xR6zMWO7LPcmMe7ElqSbGvljsS0cjvIF88vsLZa%2B4Zft8PYCmcibjSLXW017Lv8Er78AxocIysxDAAA)

[Test konvoai.com/email example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC9NnGoC%2F%2B1VW2%2FiOBT%2BK1akSjMCQkKAQlZ9CKXDUCa0FJhSqgo5iQMuSRxsh1vV%2Be1rk5TLtKt9W41WlSIl8TnH5%2FvO9UXhKIwDyJFivigxJUvsIdr2FFOZk2hJIFZdEir5vagLQ6GqdKTQagsBQ3SJXbQzQSHEweEs071MGCch2AmBR8QrEjpLRBkmkWIaQn8TubeJ00GbZirOvKucKKn0DnmYIpefyvfoPMRcimO%2Bu1BpdvtAKBPqMeATChiKPBxNMwQ%2BFWA2JKEZFrDCfAYyQuDLHZLqoAisEG5JBPpX%2Fa%2BqcBGQKRnSQFw%2F4zxmZrE4L6lHKIo%2BFJxJpLLlVNKDFEMnQM0TZN4ch4KlCTIvzU7bBnHiBNgFc7QBX%2FgMAQcyVC2DJQwSBKDPEQXxBRBApZDuDNVJil3aDEaDjO3Xv8THVHgyJersG8SQMuSltOUNO8zAHmVGklsWLMV8fFGmlCTxLpsSrBDyTSyzKNyInxlhXPy8QyFzADkUovjiLGN5Jo25iJhR1bTX%2FPHVJOEOSSKvEK4PHuzRwcEOpCw7giPOBkQc%2BQh5DnTnBRbyWD1L2Z2pcJcmhti%2BUDGhmG8UU9f%2B3T%2BL%2FQOA%2Fu03%2Bz0EoXKXBEhER8GRGyQeMn%2F3efDy9JpXhAhNDiF9EqF5q1q0hqLbUGaWOcqaZodugt9sRNpgyGRXvlk%2Fnpg%2Fvdk%2FphdIN2nc5ZHdbvm2pbUu%2B4tWv%2B0Yzd5Vw%2BoNLavc6lrNywbudRrT3mXklLrj7fO4r6%2BHt8E4XnUaC7iYzdfT84fhT0iMa2Nd5OPebeP71h33hle2YTnn5fmm2pmVb3Lbq9xc61ZW85hZz3XL1VrGuBmWMXqu1doP8agyuuPF6%2FGPxbJa46u61a0PftoPs3vnudda%2Fbj3aNVd3N9eG0nTcn39Rhs%2BjJvfjYFXDhj1tbk99K2iTqrwPt722k2rZzUkzTTzkmXCCggyXtAVGXc8jQhFEybekCdUZJTTBOWVMAk4nsAVPBx57gTGcbARaWJCKu4SlX9S6FE6u94Vuppla1%2Ft%2F9tIH5V1Xpl4rixFLJun5lQqdcPXC3UEUaGMXFSon%2Fu1QlUv1X3fq0Dkekcb44Nl8tHOOG0GxETcOYZy3lrBCm6Y8ipb%2BHhUZClKN8VpWk5nxb5M1H9s3N%2Fnxh%2FG96QmPyK8vBBjSgcfDijwCwbBH5jOp7yYc59999l3n3333%2Fad2KEMLpE3gVK1pJWqBa1e0CoD%2FdzUdfGomlHTS9WcppmaJhkgxlPCL2LPHm9YZauXEzy68eE3X6%2FfbFdLL1mXcsPgfBAPrwl%2FrjX68Ti8yrVt%2B0J5%2FRuNX5sibwwAAA%3D%3D)

## Service provider contact

- Website: https://konvoai.com
- App: https://k2.konvoai.com
- Signing key DNS: `_dcsig.konvo.to` (TXT on `syncPubKeyDomain`)

