### PR TITLE
feat(groceryio): publish ownership TXT with storefront routing

### DIFF
--- a/groceryio.com.storefront.json
+++ b/groceryio.com.storefront.json
@@ -3,9 +3,9 @@
   "providerName": "GroceryIO",
   "serviceId": "storefront",
   "serviceName": "GroceryIO Storefront",
-  "version": 1,
+  "version": 2,
   "description": "Connects a custom domain or subdomain to a GroceryIO storefront.",
-  "variableDescription": "",
+  "variableDescription": "%txt_value%: claim-specific Cloudflare hostname-ownership token for the requested custom hostname.",
   "syncBlock": false,
   "syncPubKeyDomain": "groceryio.com",
   "syncRedirectDomain": "groceryio.com",
@@ -15,7 +15,16 @@
       "type": "CNAME",
       "host": "@",
       "pointsTo": "store.groceryio.com",
-      "ttl": 3600
+      "ttl": 3600,
+      "groupId": "routing"
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%txt_value%",
+      "ttl": 300,
+      "groupId": "ownership",
+      "txtConflictMatchingMode": "All"
     }
   ]
 }


### PR DESCRIPTION
## Description

The GroceryIO storefront template previously published only the routing CNAME. That proves that a hostname points at GroceryIO, but it does not prove that the current claimant controls the domain.

If one store removes an active binding while the customer leaves the DNS records in place, another store could otherwise inherit the existing CNAME. This update publishes the claim-specific Cloudflare hostname-ownership TXT record as part of the same authorization flow.

The TXT host is fixed to `_cf-custom-hostname`; Domain Connect combines it with the requested `host` parameter, so apex and subdomain applications produce the correct record name. The token remains an exact Cloudflare-provided value and is intentionally a bare TXT value because Cloudflare requires the exact token.

## Type of change

- [x] Update to an existing template (version bump 1 → 2)
- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A because `logoUrl` is omitted
- [x] Domain Connect linter and JSON schema validation pass in CI

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`groceryio.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (`groceryio.com`)
- [x] no TXT record contains SPF content — this TXT record is Cloudflare ownership proof, not SPF
- [x] `txtConflictMatchingMode` is set on the unique ownership TXT record (`All`)
- [x] no variable is used as a bare full record value unless necessary — `%txt_value%` must remain exact because Cloudflare requires the full token
- [x] no bare variable is used as the full `host` label — the host is fixed to `_cf-custom-hostname`
- [x] no variable is used in the `host` field to create a subdomain — the standard Domain Connect `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] N/A — no record is intended for independent manual modification, so `essential` is not required

## Online Editor test results

Validated with both routing and ownership groups enabled, `host=shop`, and a representative claim token. The preview produced `shop.example.com CNAME store.groceryio.com` and `_cf-custom-hostname.shop.example.com TXT <token>`.

**Editor test link(s):**

[Test groceryio.com/storefront example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOlPnGoC%2F%2B1VbW%2FaMBD%2BK5GlfhpBIVAKkSata6ep2vpO1WoVihz7Am4TO7MdCkP8950D4aUv2z5O0%2FIh4Nzdc3fPc7nMiYW8yKgFEs1JodVEcNAnnERkpBUDPROqyVROGmvjGc3RmXxemk%2FO0WRATwSDKsxYpSHVStqN4XmId73tNAFthJIkChuEg2FaFLY6kyMlJTBrPOqxEoFzj6ucCukp7ZkyWR2sQvsGe1NA04FTLWiSwfEO8J6d2nhCsxL2Io9lVOS%2BKYCJVDDvKFMlTzOqwRsrYyXW7qsniUWORYHJHkF6KRZgx%2BBp%2BF6CscDr%2BuoIl9rMJPuYKfZIopRmBpZPLsrkC8yOq9JfYdm5XAEXGvt%2B08llucLU6IWUW10iNgYozQ2J7ufEzgrH99HZ4emnlTsePzgRlZDWDFQtVPM5tLUZidrdIGi4rGVRaYp%2FrJAjsmissQd3gw1yzFJ%2FSYBfE4BGTi3d5XqNvwu%2FZtfZpxZVTzPB7Cm1bIxpTxV3GQ%2BzjCyGiwb5oSTEm3aHmKkmCqYUpxm2aHKNjpVDrvLFoopZd9TYSo5ABdU0N%2B5VqCHvdzCHNej9EnW4gv0F5Lp75xOsLr%2B6ddytVx%2Fri7gexUiiOrHBX2pLDbXKeZlZEdMnunnEWUyLIpshJQatmOblBMjlC7hiYiXMbwcg5sxRIZxGPZpAO%2Bl2%2FU6rf%2BB3eLrv9yBN%2FaQTdHrQD9rdMNhaEq9ukDfXxK5QYAxIK2hWif5EZ4YsXkzeqqNXJq%2B52%2BUfUb49l39T18MGjvd%2FOf8ZOXEfGDoBHlPnGgZh1w%2F6frA%2FaB1EYRh1%2Bs12K%2BwG%2B%2B%2BCIFr2gV%2BXZedz3Arb%2B4B8TXq3l4O7b6Pk4vLGTFv89jo8fBjf9JPzSY9yZW%2FhYTDtXYtT854sfgLQhvXo6QcAAA%3D%3D)
