### PR TITLE
Add Maxioos AgentPort Domain Connect template

### DIFF
--- a/maxioos.com.agentport.json
+++ b/maxioos.com.agentport.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "maxioos.com",
+  "providerName": "Maxioos",
+  "serviceId": "agentport",
+  "serviceName": "AgentPort Domain Identity",
+  "version": 1,
+  "description": "Connects a business-owned AgentPort subdomain to the AgentPort gateway with one CNAME record.",
+  "hostRequired": true,
+  "syncPubKeyDomain": "maxioos.com",
+  "syncRedirectDomain": "agentport.maxioos.com,agentport-staging.maxioos.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "gateway.agentport.maxioos.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Maxioos AgentPort Domain Identity template.

This template connects a business-owned AgentPort subdomain to the Maxioos AgentPort gateway using a single CNAME record.

Example:

`agent.example.com` → `gateway.agentport.maxioos.com`

The template uses the synchronous Domain Connect flow with signed requests and supports redirects back to AgentPort production and staging.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to not be backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A, this template does not define `logoUrl`

The exact template also passed the current official Domain Connect `dc-template-linter` with network checks enabled.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set because AgentPort uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` requirement is N/A because this template contains no TXT records
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential: OnApply` is N/A — the single CNAME is required for AgentPort routing and is not an optional user-modifiable record

## Online Editor test results

`hostRequired` is `true`, so the required subdomain test was performed with:

- domain: `example.com`
- host: `agent`

Expected and verified result:

`agent.example.com` → `gateway.agentport.maxioos.com`

[Online Editor test: maxioos.com/agentport example.com/agent](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACdTnGoC%2F91T207bQBD9FWtfG0eODQmxVKkpFIooCEWARKPImngHs8HeNbvrXIjy751N7CQt9KGvfbJn5szsOXNZMYtFmYNFFq9YqdVMcNSXnMWsgIVQyrRTVbDWLnQDBUHZ9TZIAYN6JlLcpECG0pZK272%2Fxg9c5JYi3pkqQEjvkpND2CUhZ6iNUJLFnRbjaFItSrux2amSElNrPPAmlRESjfHVXCL39vVMNeHbklZ59hkPQhnJmsPSmwv77CmJ3unN4PqbpzFVmrfp5Wdl7BBfK6GR6FtdIfFeyvS2mlzhcsv0XSccYIicclK7g%2ByUtw%2FArZ3XNxYyIbP2%2B1Jfc5W%2BsPgJckOvb7kZFo9WzC5L17oN6ZosmV%2FcMJSQ1twpMmuN7Q8JENTanMVRNwjW43WLvVEXkv0bY2p4owAXQIuAdVr92KYqmZlWVZmIJqkEDYVxG9Okj37LHzcFRnUFcoCz3A8NrPlNJW1Hg3QOu9j9FoudE3SGtZ80iEwqjYmhL9hKYzO4osqtSGAOexdPEyjLfEmSDUWpxPu2yu2CNko5WPiXtrZYwlPXCeEO4KmPAYSdns8nEfhH%2FSfuQ68b%2BTyKjiedE4QowINj%2BuDO%2FnZOfwyELsHdD%2BTutnJiath6PW7RcP5vhW5%2FYIY8AYcNg7DrB30%2FOL7r9IhsHPXb4VHYC7ufgiAOAicDjd0qXtHuHG4Nuzo%2Fefxe6OlwMVjMxdHw%2FuLiYfpwP33RP8%2FD80H5OpkGnbPHH9Nq%2FpmtfwFAB7n%2BKgUAAA%3D%3D)