### PR TITLE
add Loot OS, Loot OS storefront

### DIFF
--- a/lootos.com.storefront.json
+++ b/lootos.com.storefront.json
@@ -1,0 +1,47 @@
+{
+  "providerId": "lootos.com",
+  "providerName": "Loot OS",
+  "serviceId": "storefront",
+  "serviceName": "Loot OS storefront",
+  "version": 1,
+  "logoUrl": "https://lootos.com/domain-connect/logo.svg",
+  "description": "Points a hostname at your Loot OS hosted storefront and lets its sign-in emails come from no-reply@ that hostname. The certificate is issued and renewed automatically once the records resolve.",
+  "variableDescription": "%target% is the storefront edge hostname the CNAME points at (cdn.lootos.com in production). %endpoint% is the CloudFront routing endpoint behind it, which the _cf-challenge record names so CloudFront can confirm the hostname is meant for this storefront. %dkim1%, %dkim2% and %dkim3% are the Amazon SES Easy DKIM tokens issued for the hostname; the three CNAMEs let sign-in emails be signed as no-reply@ the hostname. Every request is signed; the DNS provider verifies the signature against _dck1.lootos.com.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "lootos.com",
+  "syncRedirectDomain": "lootos.com,lootmonsters.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-challenge",
+      "data": "%endpoint%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `lootos.com.storefront.json`: the template behind the one-step DNS setup of a Loot OS hosted storefront. It points a hostname (always a subdomain, `hostRequired: true`) at the storefront edge with a CNAME, adds the `_cf-challenge` TXT record CloudFront requires to accept the hostname, and adds the three Amazon SES Easy DKIM CNAMEs so the storefront's sign-in emails can be sent as `no-reply@` that hostname. One consent adds the storefront and its branded sender together.

`%target%` and `%endpoint%` are variables rather than fixed values because one template serves two environments (`cdn.lootos.com` / `cdn.dev.lootmonsters.com`). Every request is signed (`syncPubKeyDomain`, key published at `_dck1.lootos.com`), which is the mitigation for variable targets.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Comments:
- Bare variable value: the `_cf-challenge` TXT carries `%endpoint%` on its own because CloudFront prescribes the exact record content (the distribution's routing endpoint) for its hostname ownership check; a prefix would make the check fail. It is scoped by its fixed `_cf-challenge` label and `txtConflictMatchingMode: All`, so a stale value from an earlier attempt is replaced rather than accumulated.
- `essential`: not set on any record on purpose. All five records are required as-is for the storefront and its sender to work; there is none a user would need to edit independently.
- Linter: passes with `-tolerate warn`; the only finding is DCTL1021 (info).

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test lootos.com/storefront example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKNcnGoC%2F%2B1XW0%2FjOBT%2BK1YkpF1NW3JpelutNCywEpqBmQVWi4RQ5dqnqaeJHWynpSD%2B%2BxynTZsWZvqwL4uWB1Qn5%2F6d7xyHJ89ClqfUgjd48nKtZoKDPuPewEuVssq0mMq8xlpyQTPU9D6jjHy5QoEBPRMMSgtjlYaxVtJuBNsGZEtlBtoIJb1B0MBoifpbp6g6sTY3g8PDTfxDrjIqZJMpKYHZQ6fbMrMEXXAwTIvclm68r0pIawglE2WsxMiEWrJQhSZVfCcAXkuDUMlJCmgl8M%2BIRDaFJIDxUkMwNhBUy4hUTQ15uvhI7AR9Vv5b5HoChIG2YiwYokgEOjKmwBjOsQYJc3cuLJZgUSVNF0RJBugHUMyU5gZ%2FjUpn0HKYUC3oKIWTrcIOLNUJ2APn3hnW8geewKZeJzy%2BODo%2FJfkKC0t%2BYVy2NmgSrA%2FbyQvmnP%2FaIgcgeam9dn%2BcqoL%2FWbrXqrBCJqTSISOYCKxM2AaZTwSblAZDNm6yCRYHMqnKIi4hhFTV3TEqEVU5FjorDdeJY%2BQMKGqMlUYJPm5qxBT5VGTBQWN5CA9KcMtzhGe9rPsoo49KkqvTK3JKzYKcfDo7J1ZNQa57snS%2BCftb%2BWQnGlawGceFXRqMoHzj%2Bmi2mAA1IpwimxdY%2Bn0BxrpylibLCCcXV6QaIYKKyBZYdRK1qC2wBJogx9F0yNk0qPXLscIsJPsjVWzqDcY0NbB887UYfYLFSTkcuwPr5JfABfbCvqLRcMdMYTycwZWJq%2BUS80cbnGarCwyzYqg3uH3y7CJ3o1zitFLHx49uO5Rcu1Y1puJba3GcI99%2Fbqxtr2%2BuN5ZbpHGzTC11HtZ0rPnA04M9RuKkgtlzahmSMDlX3Dk9SlOvFmMnvxV1WsPlEpnCYifhldz9tGhJIQMVJK%2BU8Jr7cI%2F78N%2B5j%2Fa4j%2Fa5v3tueCiB4aadd4h3RQt4oHgHQI0GbplPVI5PCS6AfCgqm5xqmhl3V1TWt1vmd5X97dIBPi8J4d5s7yEnq1rtpDyg4ShibR5DZ9xtMbc0luMv0dzl6xrlNGkwClnE2xCPO0l30hP9b%2F40SMMskm0V551KOXTK913dM33rF8EsnEcP7UX82KHdUY%2F1uQ%2FBOKyUI6ecRJO2iL91pt20l%2FWlr4I8vI9028S2U3RnPc8hiROLm2m4ntxqVrIitWJI53TzirMhzXFZIPAGpRji5RzJ5Q25wns1BDtQ1QcB94PDX7gb1%2BcBb3fCuNnp%2BP1mm9N%2BcxTGYTOKe6Mojngnivza7f3yXv%2Fh9b3NAjAGpBU0LcdtThfGe34x1qtCtsa6tV3Wz3v8H69yp2H7WFib2R0U9lr%2BdJrfAjb7hu7H2Oy1fPPY7NsxP8Zmr%2BVbweaugXfJ%2ByZ834Tvm%2FB9E%2F6%2FNyF%2BfRo6Az6kTjX0w04Ts%2FDj66A3CLoDv9sKwiD2%2Bx98f%2BC7PCz%2Be7lE4Qm%2FRetfod75%2FVx%2FuKdd8yjiy7Pkc%2Bdmrq%2Fur8%2BK8c2N%2FSt6KMIv%2Fj%2BjEQLn%2F%2B49fwekayj%2F%2BxEAAA%3D%3D)
