### PR TITLE
Add SenPrints storefront templates (senprints.com)

### DIFF
--- a/senprints.com.storefront-proxy.json
+++ b/senprints.com.storefront-proxy.json
@@ -1,0 +1,38 @@
+{
+    "providerId": "senprints.com",
+    "providerName": "SenPrints",
+    "serviceId": "storefront-proxy",
+    "serviceName": "SenPrints Storefront (proxy)",
+    "version": 1,
+    "description": "Point your domain at your SenPrints storefront",
+    "syncBlock": false,
+    "syncPubKeyDomain": "dc.senprints.com",
+    "records": [
+        {
+            "groupId": "storefront",
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "web-v5.storeproxy.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "email",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mail.mystoredns.com",
+            "priority": 10,
+            "ttl": 3600,
+            "essential": "OnApply"
+        },
+        {
+            "groupId": "email",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mail2.mystoredns.com",
+            "priority": 20,
+            "ttl": 3600,
+            "essential": "OnApply"
+        }
+    ],
+    "hostRequired": true
+}

--- a/senprints.com.storefront.json
+++ b/senprints.com.storefront.json
@@ -1,0 +1,38 @@
+{
+    "providerId": "senprints.com",
+    "providerName": "SenPrints",
+    "serviceId": "storefront",
+    "serviceName": "SenPrints Storefront",
+    "version": 1,
+    "description": "Point your domain at your SenPrints storefront",
+    "syncBlock": false,
+    "syncPubKeyDomain": "dc.senprints.com",
+    "records": [
+        {
+            "groupId": "storefront",
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "mystoredns.com",
+            "ttl": 3600
+        },
+        {
+            "groupId": "email",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mail.mystoredns.com",
+            "priority": 10,
+            "ttl": 3600,
+            "essential": "OnApply"
+        },
+        {
+            "groupId": "email",
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mail2.mystoredns.com",
+            "priority": 20,
+            "ttl": 3600,
+            "essential": "OnApply"
+        }
+    ],
+    "hostRequired": true
+}


### PR DESCRIPTION
# Description

New service provider templates for **SenPrints** (senprints.com), a print-on-demand
e-commerce platform. Sellers point their own domain at their SenPrints storefront:
`storefront` covers the default zone, `storefront-proxy` covers proxy /
custom-payment stores. The optional `email` group carries the platform MX records
and is only applied when the seller opts in — the two groups are designed to be
applied separately (`storefront` places a CNAME, so it cannot coexist with the MX
records at the same owner by definition).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: no `logoUrl`; the logo is delivered to DNS providers through their onboarding process.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`dc.senprints.com`; key published at `_dcpubkeyv1.dc.senprints.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — N/A: we do not use `redirect_uri`
- [x] no TXT record contains SPF content — N/A: no TXT records
- [x] `txtConflictMatchingMode` — N/A: no TXT records
- [x] no variable is used as a bare full record value — N/A: no variables
- [x] no bare variable is used as the full `host` label — N/A: no variables
- [x] no variable is used in the `host` field to create a subdomain — N/A: no variables
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove (both MX records)

## Online Editor test results

**Editor test link(s):**

`senprints.com.storefront.json`
- [storefront group (CNAME), host set](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJvfm2oC%2F92TbW%2FaMBDHvwq6t0uQCQ%2BCSJNGH16wqQyNbuqKUGTiS2stiVPboWSI775LAiPQtZq0d3tlne%2Fud%2Ff3nbdgMclibhH8LWRaraVAPRHgg8E00zK1ph2qBJzfzilPKBjmmM4qN7kM6rUMsU6zSmOkVWqPjvOU1rwZtEZtpErB7zgg0IRaZrayYaYoulWoXLeESrhMW3xvHlGn9Yo0vIhV%2BAP8iMcG65tZvvqExVVFIKoI2%2BfaNIZKCwP%2BYgsPWuXZSym2yEoNl9PxzTWZj8pYMj%2BUD1N2aW4VmUlR5Yj0ALY2Br87YGznNMlIrcRH6M3d60QKbL%2FAUvNKS1vQm7FGEQfQkDQrOV3A53ScZXEB%2F1Lae6u29xe1lzX9Cz7lkijgW53jzoGfKsXg%2BOwUJg7zwQ2nlcR9uX1v5lFlZFU6AlnlNOdD%2BRnXPDHlGh9IixPU8sBa1LDlnnZOoubkQ0p2YOjkNtdYd%2B1AksdWBvyZH69EGPBSKWkx5CUYrdDZrqT1%2Bu8lCG75m6viQCDCUocs58XZsMMjZK4YiJHbQyHcVa8XuYOR14v6%2FVVvJXjjd%2F7x6776P08ftznAcfzMCwM7GiAN53%2FTRLM3fI0i4GWox7yBy0Yu69%2Byke91%2Fe6o7TE27HrvGPMZK4WgsbXILe1HczPg63xzgR3Vv4%2FGfDAbK5lcbibXKltt7obTq83H3v0knn%2BfPn3Tk%2Few%2BwWjU0iQcQUAAA%3D%3D)
- [email group (2 MX), host set](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEnim2oC%2F%2B1U227aQBD9FbSvNXQxl4ClSg1pqqZRCAo8UCFkLd5xsqq96%2ByuoQbx7x1jU0wSKqS%2BtFKfrNmZOXPOXLwhFuIkYhaItyGJVkvBQd9w4hEDMtFCWtMIVEycX84hizGYjEGOdm50GdBLEUCRZpWGUCtpD46XKbVxNWgJ2gglidd0CAcTaJHYnU1GCqNrmUp1jauYCVljpXmAOq6XyWAQqeA78UIWGSheRuniFrJPOwRE5UHjpTYNgdLcEG%2B2IY9apclrKTZLcg1Xw8u7azSflLFofswbk7M0E4VmnO1yuNwDWxsRr9WldOtUkQGpRAfQu%2BlpRAxsvIJF8koLm2HPaKWIQ8CgNCsYPpB7eZkkUUb%2BpLT7u9ruGbXnBfoDPKcCUYhndQpbh6yVBP%2FQdgzj%2B%2FnAD4YrCWW5kpt5UglaOx2%2B2OWUUjA1YZrFJt%2FgPcjsCGW%2Bh5kVOPMSqAKClMSjRKG%2BwS%2BzqYaCq0PiNLLCZyt2eOKBz3J9qMCgF3FwcaodlcXGl6w5s%2BzkLCsdPB6rz4NcksintgigB71%2Bt047Iau3e6xZX3Q41NtBi%2FJuCOFFL6zc6JsHfPJKj1v85hjzHTpLn3umQPdvEzh3cAn%2FT%2FFfnyKetmFL4D7LY13qIpc%2B0pnQvtfqeLTTaPYu3G7nHaUepbkuMLZQvsF%2FQPX6ye1Da3o%2FfZaD91ftb4Zma7qeLL58FuMmHURf6SoeXWeL4TBcRTcfyPYnYIpxcEsHAAA%3D)

`senprints.com.storefront-proxy.json`
- [storefront group (CNAME), host set](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPrhm2oC%2F91TbU%2FbMBD%2BK5U%2FbSKpTEpLG2nSOjY0tgIdZRMIoci1r8VbYgfbSQlV%2F%2FsuSUtKtRekfdun5Hx3z3PPvSyJgySNmQMSLklqdC4FmBNBQmJBpUYqZ9tcJ8R7cp6xBIPJBNS4cqPLgsklhzrNaQMzo5XzMeOhaNy7ia3JU2jrVRX7GoNzMFZqRcJ9jwiw3MjUVTYZa8xqFTozLaETJlWLrc0GsmEveQvF38Wa%2FyDhjMUW6pdxNv0MxfsKAVEFb%2B8qNcC1EZaEN0syNzpLd4RhiCvSUsvR2fD0A5p32jo035ZtKqu0lxrNBUz9vNuuEit9a3znYhJ2epSuvG0CwIriBvv06rfAZWA7KSpgoZoBSW2kK7B1dIvEI2BRoZMMH8i5GqZpXJB%2FoQ7%2BxB28gPu2Rr%2BA%2B0wiCgmdyWDlkUetIGq6j2FiMyZ4YLinsKZb12bvdIpWpSOSVc72mDA%2FZYYlttztDdLNM6jbDdZNDXa7RttFwuLkXKEdWfwylxmoq%2FZIksVORmzBmifBI1YqRS0WvQiGm7SzMqq%2BhrUEwRx7ycZ4JBK8lCPLsQmg%2B90%2BP%2FQZ5dQ%2F6Af98g%2F8Wb837QQ0ELPpwdbl%2FvKs%2F3K7zzu9Pc1hvGCFJSucJk7qvxaIW2FZDiJiZSjy9nw68Gn3kg7CTic86LV7g%2BBw0N2jNKS0lAPW1YqXuDnbO0Nme18eHi9G19%2BOj0YnVx9H1%2FeTPL%2Fg380iOJ6PeTzvfRqex4G6k1%2FfkNVPf7TqJKAFAAA%3D)
- [email group (2 MX), host set](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOnfm2oC%2F%2B1U227TQBD9lWifQLWTrZurJSRKoQiitIEGEVRF1sY7aVbYu2Z3ncaN8u%2BML63dqoVKvCDEkzU7M%2BfMmYt3xEKcRMwC8Xck0WojOOgPnPjEgEy0kNa0QxUT5855xmIMJhcgp4UbXQb0RoRQplmlYaWVtC5mbLPa%2FTCxdXEX2npRxL7E4A1oI5Qk%2FqFDOJhQi8QWNpkqzGplKtUtrmImZItVZg1Zs%2Be8mQzfRCr8TvwViwyUL9N0OYbsbYGAqDxsP1SqIVSaG%2BJf7siVVmnyQBiG2CzJtZycHU%2FeoblWxqL5Om9TXqWZKTSvYelueu0isdBX4VsbEf%2BoT%2BneaRIAVhTV2JP5k8B5YDvOCmAu6wEJpYXNsHW0QeIQMKjQCoYP5FweJ0mUkT%2Bh9n7F7T2De1Gif4YfqUAU4ludwt4hN0pCUHcfw%2FjtmGDLcE%2BhoqtqM2uVoFXoCESRU0nB1IRpFpt8rW9BLu%2BhLG5hLkucRQXUAMGSxJVEoYHBL7OphrJWh8RpZEXArln9xMOA5fpQgUEv4uD%2BNDsqywOoqubMsidn2ejg%2FbEGPMwliXxqYb%2B3Wh6OQteD%2FsDt8hFzh6zvuWzYgz5FL%2B8OGof76FX%2F5nTvN%2FrRYeab9CyV3jNlen%2BnzIWDC%2Fl%2Fov%2FSRPHkDdsAD1ge61Gv79KRS3szOvK9rt8btA%2B7g%2BGIHlDqU5qrA2NL%2FTv8NzT%2FCuTrqfk4n8edzrfxfMbS92abWLkNV5PTwZfZ%2BHzdOcmOzcFRNhl9ekX2PwG6XxRSeAcAAA%3D%3D)

(`hostRequired` is `true`, so per the instructions the apex test is not required.)