### PR TITLE
Add honestwriter.ai.blog.json — HonestWriter blog subdomain template

### DIFF
--- a/honestwriter.ai.blog.json
+++ b/honestwriter.ai.blog.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "honestwriter.ai",
+  "providerName": "HonestWriter",
+  "serviceId": "blog",
+  "serviceName": "HonestWriter Blog",
+  "version": 1,
+  "logoUrl": "https://honestwriter.ai/og-image.png",
+  "description": "Publish HonestWriter articles on a subdomain of your site, e.g. blog.example.com. Creates one CNAME; your existing site and email are untouched.",
+  "syncPubKeyDomain": "honestwriter.ai",
+  "syncRedirectDomain": "app.honestwriter.ai",
+  "hostRequired": true,
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "blogs.honestwriter.ai",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template: `honestwriter.ai.blog.json` — HonestWriter, an AI-visibility &
blog-publishing service. The template applies one static record on a
user-chosen subdomain via the standard `host` parameter
(`hostRequired: true`): `@ CNAME blogs.honestwriter.ai`, serving the
customer's blog with an automatic HTTPS certificate on our edge (HTTP
validation — no `_acme-challenge` records needed).

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature which would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

<!-- MANUAL STEP (owner, before submitting):
1. https://domainconnect.paulonet.eu/dc/free/templateedit → load
   honestwriter.ai.blog.json → "Check template"
2. Fill domain + host (e.g. blog.example.com) → "Test apply template"
3. "Copy Markdown" → paste below AND tick the first checkbox above.
(hostRequired=true → apex test not required per the template note.)
-->

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`honestwriter.ai`) — all sync applies are
      RS256-signed; the public key TXT (`_dcpubkeyv1.honestwriter.ai`, split
      p=1/p=2 records) is published BEFORE this PR is opened (go-live
      checklist step 1). Signing verified with openssl against the
      reassembled TXT form of the exact key pair being deployed.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.honestwriter.ai`) — the apply URL
      carries `redirect_uri=https://app.honestwriter.ai/settings?tab=blog`
- [x] no TXT record contains SPF content (single CNAME, no TXT at all)
- [x] `txtConflictMatchingMode` n/a — no TXT records
- [x] no variable used as a bare full record value — the template has **no
      variables**; the single record is fully static
- [x] no bare variable in `host` — no variables at all
- [x] no variable in `host` to create a subdomain — subdomain selection uses
      the standard `host` parameter (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` n/a — nothing the end user needs to modify without breaking
      the template

## Online Editor test results

**Editor test link(s):**

[Test honestwriter.ai/blog example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHs2nWoC%2F91TbU%2FbMBD%2BK5a%2FrgmGJqFkmjTGNoGmVQyB2ISq6pJcU4skDrbTF6r%2B953TpoXRSfu8T7bPz3Mvz92tuMWyLsAij1e81momM9RXGY%2F5VFVo7FxLi9oHyXu77yGUBOeXLeC%2BBdCvQT2TKbbcpFD53nQAzz5tEDPURqqKx8c9ThZ1pwsX2traxEdHf6RwpHJPlpCjX1eOnKFJtaxt64BfN0khzZS9CgPayrRAw1TFgJkmyVQJsmJqwpaq0cwQqsfQz33mcvZxASQH%2BqkqfXahkYRxXGQXw%2FPvX95vSLiQxsoqb9kMqowhOS0oGLKmsqpJp5j5rv5llVJa33D5uQ17UFUHusFMakztDgZ17b%2BFTpWxN%2FjUEJZUtrrBDZ3ETB95PIHCkIUcKZ0ZHj%2BsuF3WTvo2%2B60Den50zVSysuZWbbtlDoSzlprRj4RYj9Y9%2Fkz%2F473vEenfZftCtX2Q7QzkWjX1WHacGjSUxg1bx354RR91%2FIeNA3qDe7gLta%2B7phXNVAd0BrvYXcvFzgg6x62dKpB5pTSODZ1gG42dhGVTWDmGOexNWTqmFhRLKtjQL7l4K2a1GettnRlY%2BBcte3ycpa5%2B6RYliEAE%2FVB4IpwEXhAmfS85EeCdRkHiXoMBRC827y%2BLeWD1XjcBjcHKSnDLdV7MYWn4ej3qUUP%2Bw7LcpMAMszE46Ik4iTxx5onoVpzFQRT3Q38wCE%2FDwTshYiFcERR3U%2BeKpuTlfPCn2eQ5Ky5%2F%2FgpyvLl7Suqr5%2Bg4Cr%2FCsRqm18O78x%2B308fZmSnu8w98%2FRstlpDQTgUAAA%3D%3D)

[Test honestwriter.ai/blog example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKI2nWoC%2F91T224TMRD9FcuvJBtn2ybsIiRCqVQUkZa2UFAVRY492bjs2ovtTbJE%2BXfGubY0SDzzZHt8zlzOzCyph6LMuQeaLmlpzUxJsB8lTenUaHB%2BbpUHG3FFG%2FvvAS8QTi%2FXgPs1AH8d2JkSsOaOc5MdTEfw5P0GMQPrlNE0bTcoWswXm4fQ3pcubbX%2BSKFlsqYqeAZRqQNZghNWlX7tgF5X41y5KXkWhluvRA6OGE04cdVYmoIrTcyE1KayxCGqQSDKIhJyjmDBUQ6IhCkicm4BhQlcIOeD3qeLNxsSLJTzSmdrNuFaEkCnOQYDUmlvKjEFGYX6ay0wrT7UH9Zhj6oaQDcglQXh9zBeltFL6NQ4fwM%2FK8Siyt5WsKGjmOIHTSc8d2hBR8ZKR9OHJfV1GaRfZ791gM93oZlGae%2FuzLZb7kg477EZJx3GVsNVg%2F7C%2F9HB9xD132X7RLVDEA1zh6%2FMmqocqR2n5JYXLgzbjv3wjD7c8R82DvDNwyNcsH27q9A4UztgMPjF%2Flos9kZuM9jasQKVaWNh5PDkvrKwk7Cocq9GfM4PJilG2IK8xoId%2FqKLl2LqzVhv65Tc83%2FRskFHUoT6VViUeJK0Y9aVzaTNus3TsWg3X%2FMz0eyAEN0kSU745OzJ5v1lMY%2Bs3vMmgHOgveJhuXr5nNeOrlbDBjbkPywrTAqfgRzxAI1Z3GmypMk6dyxJT7tp%2BzRqxzE7675iLGUsFIFxN3UucUqezgdNbi%2BTZPH9fsouJ9%2F6nwe3V61Bv8qmV4tHOXvsdSXE7mu%2F7On64i1d%2FQb8dyxxTgUAAA%3D%3D)

## Notes

- Precedent templates with the same shape (CNAME `@` + `hostRequired: true`):
  `beeranked.online.content.json`, `cloudcat.me.connect-site.json`,
  `creativo.ai.landingpages.json`.
- `syncBlock: false` — synchronous flow only (Cloudflare supports sync only).
