### PR TITLE
add Guzli, Guzli Inbound Email Domain

### DIFF
--- a/guzli.com.postal-inbound-domain.json
+++ b/guzli.com.postal-inbound-domain.json
@@ -15,7 +15,9 @@
       "type": "TXT",
       "host": "@",
       "data": "guzli-verification %verifytoken%",
-      "ttl": 3600
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "guzli-verification"
     },
     {
       "type": "MX",

--- a/guzli.com.postal-inbound-domain.json
+++ b/guzli.com.postal-inbound-domain.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "guzli.com",
+  "providerName": "Guzli",
+  "serviceId": "postal-inbound-domain",
+  "serviceName": "Guzli Inbound Email Domain",
+  "version": 1,
+  "logoUrl": "https://guzli.com/favicon.svg",
+  "description": "Verifies your domain with Guzli and routes its inbound email to Guzli's mail receiver so replies to your Guzli-sent messages reach your workspace.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.guzli.com",
+  "syncRedirectDomain": "app.guzli.com",
+  "variableDescription": "%verifytoken%: the domain verification token issued by Guzli for this domain; %mxhost%: the Guzli inbound mail exchanger host; %mxpriority%: the MX priority for that host",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "@",
+      "data": "guzli-verification %verifytoken%",
+      "ttl": 3600
+    },
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "%mxhost%",
+      "priority": "%mxpriority%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a second Domain Connect template for Guzli (guzli.com), service id `postal-inbound-domain`: an apex verification TXT and an apex MX, applied together through the synchronous signed flow (same `syncPubKeyDomain` and key as #1676).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — `Prefix` on the verification TXT
- [x] no variable is used as a bare full record value — the TXT is prefixed; the MX `pointsTo` is a variable because the value is set server-side and signed into the apply URL, never user input
- [x] no bare variable is used as the full `host` label
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not applicable, both records are required

## Online Editor test results

**Editor test link(s):**

[Test guzli.com/postal-inbound-domain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB%2BHnWoC%2F%2B1U72%2FbNhD9VwQCQT%2FEciQ5dmINA7YuQxsU6YrCXdMFgXEiTzIRSRRIyrYS%2BH%2FfUZJ%2FqC22fRyGfTBM8d473ns83guzWFQ5WGTxC6u0WkuB%2BlawmGX1cy7HXBVsdAi8h4KA7I0L0bZBvZYcW3iljIXcl2Wi6lL4QhUgyyPmlOnddiDvV8Lk3s0eukZtpCpZHI5YrjL1SedEWVlbmfji4lDPRQqUUZVjs86IJdBwLSvbMtnvqGUq0XiNqrXXVeFtpF153dFAx2pVW0JIS7%2B%2BEmwrsapDvTJe%2B62Ro6SqPKNoXeUuL2Ha1C3QN1har0BjIKOYRuCrLrxR%2BslUwHHsPGhK%2FjpX%2FInFKeQGu50PdfIOm159zLpaSVeJ3I5P3XfgjygklWMPcKiqAWgNWkKS483AjrO186Ox6gnLs9izK9x70gYkBwf02rgnjalReEnTe5UqTQxpesoP3lmxXdE194k60N7B1jDc8hWUGTnmcC2h0lJpaZuedHfv7Xf6%2FGBbMEkgfUoLw%2BKHF2abyvXL4n5BgTYes5%2FcbYOFfXP6Aw0DqYS0lrpnMgsCWm7tL6pMc8ntHVi%2BkmV2p4TL%2F0FjKrfsu5A%2B9r3D2G50KPHuflhhpWRpzUI593u%2F2hfUie52D6ac1rl73I3YsypxeTTicdT3BfFwC%2FRUsb%2Fv%2FkRaZdTP1VLu8RVoKIx7znvmw4D6uOc%2BMLc%2Bcc1tQZhEfCIucZrO4Cq55nMRYJhGMEku%2BVTMHKVT5dDFNjxpwjZ0FPrAwoA5TTIrlcaloX%2BwtSbTrK7pERR1buUSNnDcEnxJjZ03ZIGhKCX5uhfKbpD8dS%2F8rYpBeywFd3ZJN8ZmSSSmUTr1r3l66V%2FiTPiAydxP5uH1nEd4JaLoZCB%2BMyn%2FyUg8Xh0NDhogEtyc%2BznfQGPY7uvW%2Blbw0PWBlKP74b9P2OOI%2BvP%2F%2B%2Fzv3Cc9eANrFEtwsCiIZn4w94PZIpzGkyCezMfRdB4Fk%2FMgiIPAKUNjO9EvNBdOJwKbA%2BdfnjeRCs%2Br1%2B8%2BN%2Bu39ce3Jvvjc57epBXeLm7eZL%2Bdf0mer8yPbPcn912phrgIAAA%3D)

[Test guzli.com/postal-inbound-domain example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADuHnWoC%2F%2B1U247bNhD9FYHAog%2B1bMm39Soo0KROgyBxsGidYNOFYVDkSCZWIhWS8lpZ%2BN8z1MW20i3ax6Log2GJc85ozpnhPBELeZFRCyR6IoVWe8FBv%2BUkImn5NRNDpnIyOAU%2B0ByB5I0L4bEBvRcManihjKWZL2SsSsl9rnIq5BlzyfTeNiDvNWIyb9lB96CNUJJE4YBkKlUfdYaUnbWFiUajUz2jhGJGJYdmnyKLg2FaFLZmkk%2BgRSLAeJUqtddU4T0Ku%2FOaT1P8rFalRYSw%2BGsrgboSqxrUD8ar3zUwEFiVZxQ%2BF5nLi5g6dQ30DUjr5WAMTTGmgbJdE35U%2BsEUlMHQeVBJ9ipT7IFECc0MNCe3ZfwOqlZ9RJpaUZcEZoeX7jvwb8AFlmNPcFoUPdCeakHjDJY9O672zo%2FKqgeQV5Fnd9B5UgcEow7o1XFPGFMC9%2BKq9SpRGhnCtJQX3lV%2B2GGb20QNqHOwNgwObEdlio45XE0otFBa2Kolre687qTNT20NRgmoT2luSHT%2FRGxVuHlZ360xUMcj8rPrNrW0G06%2Fp6EnFZHW4vRM5kGAjwf7i5JJJphdUct2QqYrxV3%2BWw2JOJBnIW3suY%2BR4%2BBU4uquX2GhhLRmrZz7rV%2F1DWpEN6cnUy7rPG6OA%2FJVSdiejdgM2rlAHhwoXlVo%2B91%2B0dmObynOdLEVHaegmubGXemOfd%2Bjbzr%2BfZNgU1%2B%2Bzj13TMN4zCZ8CrNkTq%2FjBbvhAYTJmE7iKZvxuaM06uokh%2FBiGOvQWfA9CQPitIlUKg1bg%2F%2FUlhrNs7rEy5CXmRVb%2BkjPR5xtccCzCq0wGMUk38%2BEbBZKq%2F%2Bvx%2BJvhfQmZcuZc024jRbTBSQ3EPiLZM786XUc%2B4s5n%2FkLmnCeTCfhdXxzsRv%2FtDT%2FyXbsdxH3CO4TQd3ae5k90sqQ4%2FeT9qzuvv89Rec%2BhP9OfZsBTuz%2F3f2vdheXgaF74FvqoONgPPeDGz%2BYr8NZNAmj4Ho4DcfhePxjEERB4NSBsY3wJ9wZl9uCvGRVeju%2BfX1Hp%2Bvdhy%2FLTx9%2FHeXvfl9%2Bfr%2BesNGbJQ9nX%2F54tV%2B8l6ufyPEbfvXPy9wIAAA%3D)
