### PR TITLE
Add crowd7digital.us tickets template

### DIFF
--- a/crowd7digital.us.tickets.json
+++ b/crowd7digital.us.tickets.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "crowd7digital.us",
+  "providerName": "Crowd7",
+  "serviceId": "tickets",
+  "serviceName": "Crowd7 Ticket Page",
+  "version": 1,
+  "logoUrl": "",
+  "description": "Points a subdomain, for example tickets.yourfarm.com, at your Crowd7 ticket page.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "crowd7digital.us",
+  "syncRedirectDomain": "crowd7digital.us",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%host%",
+      "pointsTo": "cname.vercel-dns.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Adds a template for Crowd7, which hosts ticket/landing pages for events and farms.

**What it does:** points a customer-chosen subdomain (e.g. `tickets.theirfarm.com`) at their Crowd7-hosted page with a single CNAME.

- One CNAME record, on a subdomain the customer picks. No apex records, no MX, no TXT.
- **No custom variables** — the CNAME target is identical for every customer, so nothing is substituted at apply time.
- Signed: `syncPubKeyDomain` is `crowd7digital.us`, public key published at `_dck1.crowd7digital.us` (RS256).
- `syncRedirectDomain` is `crowd7digital.us`; the redirect lands on a public confirmation page.

Filename follows `<providerId>.<serviceId>.json`.