### PR TITLE
Add Folio email template (folioinbox.com.email)

### DIFF
--- a/folioinbox.com.email.json
+++ b/folioinbox.com.email.json
@@ -1,0 +1,64 @@
+{
+  "providerId": "folioinbox.com",
+  "providerName": "Folio",
+  "serviceId": "email",
+  "serviceName": "Folio email — receive, send, and DMARC",
+  "version": 1,
+  "logoUrl": "https://folioinbox.com/pwa-192.png",
+  "description": "Connects a domain to Folio (folioinbox.com): inbound MX, SPF, a per-domain DKIM key, an enforced DMARC policy, the Amazon SES ownership proof, and the SES custom MAIL FROM pair. Applying this template replaces any MX at the apex, which moves incoming mail to Folio — the user is told so before they reach this screen.",
+  "variableDescription": "dkimselector: the DKIM selector Folio generated for this domain (e.g. k3f9a2). dkimpubkey: the base64 public key for that selector — the template supplies the surrounding v=DKIM1; k=rsa; p= prefix. sestoken: the Amazon SES ownership token for _amazonses.<domain>.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "folioinbox.com",
+  "syncRedirectDomain": "folioinbox.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "inbound.wm.emcognito.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:emcognito.com include:amazonses.com"
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimselector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimpubkey%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DKIM1"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=r; rua=mailto:dmarc-rua@%fqdn%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_amazonses",
+      "data": "%sestoken%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "MX",
+      "host": "mail",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "mail",
+      "spfRules": "include:amazonses.com"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Folio** (https://folioinbox.com), an email service for custom domains. `folioinbox.com.email.json` publishes the seven records a domain needs to receive and send through Folio:

- apex `MX` → Folio's inbound host, and an apex `SPFM` authorising the inbound infrastructure and Amazon SES (our outbound carrier)
- a per-domain DKIM `TXT` at `%dkimselector%._domainkey` — the `v=DKIM1; k=rsa; p=` prefix is fixed in the template and only the key material (`%dkimpubkey%`) is a variable
- an enforced DMARC policy (`p=reject`) with `essential: OnApply`, so a customer who later tunes their own policy does not detach the template
- the Amazon SES ownership proof at `_amazonses` (`%sestoken%`)
- the SES custom MAIL FROM pair at `mail`: an `MX` and an `SPFM`

Applying this template replaces any existing MX at the apex, which moves the domain's incoming mail to Folio. Users are told this explicitly in Folio before they reach the DNS provider's consent screen.

`syncPubKeyDomain` is set to `folioinbox.com`. Folio signs every synchronous apply request (RS256 over the encoded query string, `key=_dcpubkeyv1`); the public key is published at `_dcpubkeyv1.folioinbox.com` through our infrastructure-as-code alongside this template. `syncRedirectDomain` is set because we pass `redirect_uri` back to `folioinbox.com`.

Validated with `dc-template-linter` (only the informational DCTL1021 on `_amazonses` remains — that label is Amazon's, not ours) and against `template.schema` with zero errors.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
  - One bare value, by necessity: `_amazonses TXT "%sestoken%"`. Amazon SES prescribes the exact token as the full record value for domain ownership verification, and the record must be unique at that label, so it carries `txtConflictMatchingMode: All`. The DKIM record is *not* bare — the template fixes the `v=DKIM1; k=rsa; p=` prefix and the variable is only the key material.
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**

Apex (`domain=acme-example.com`, no host): [Test folioinbox.com/email acme-example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIAXnmoC%2F%2B1YeW%2FiRhT%2FKiNLkVoFiHEI15ZqzZWQxNzk2q7QYA%2B242OMZ2wgq%2FSz9425N0m1K7VSWuUvxvPu4%2FfeiG8SJ17gYk6k8jcpCGlsGyRsGVJZmlLXprY%2FoYuMTj0ptaW2sQfcUlPQ4ZqRMLZ1ksgQD9vu7m6fEyU09EekyNkcColO7JikECO%2BkULYN1BdU%2Fs1kI1JyGzqS%2BVsSnKpSUehCzoszgNWPjk59OokmON0tqRkAt8EUYMwPbQDnohLNer7ROcMYWRQMO4jTtHKl18O1fxaRuIcgRfaXQoNuk1wCQUkTK8F61ctDTlkKTxFxJ%2FSUCdrj1EAqnSgcIsg1cNP1EeDxgDRuQ%2BBWHaAIG90uopR8AiiHjFOPaSprWvU7Hc0FGA7zCA1CNyl7ZvAZzO0qQwkC351AoH4S3AQYZ4owgFZpNDcsnULeTQGuu1DMEI%2BSfU22nXOhUwElUFCN3UNxCiaEIiFCNISzGDQlJiGNBLiZ0Q1cGjjiUvqB6k1HNtjxIXs0rCcKE4ytLla2zUJpAACMBAYWSle5%2FMXkjEzyDmdlrDyawYJdUE0gQSvlE0wI%2FkcgitIrcj7WgEEvjWxF9Q2USyCBNqQCHHLojAUJRX5iCvCv%2Bwn5FRChj%2BhoAJVIVN7kQGFUAqH%2BOW3C5jQExfGOKGDTOa3VSi%2FiySxpa9XXao7UnmKXUZWN91ockWW9YTtNTwJnj4xbMACf5vLooz3ySwCNmOrHkRoaDCp%2FOWbxJeBAJl2t2aG82eBVtDC2ZDC57q3M3MvQzydmr7N6RbTNg1tvgS0ySmJc4DaaV6Wn1NbvQAG7VAzC6b9yCUs0ay7kUHKB2rR5naXLGFsT%2BfwbrhTebTfTEeZ8SqvUHQBaMwxsLws39GuZY6kPcfhuOAA%2FCk0Dtcw1y0ov0YNYbWbVFx6lWVN25p609ux4eFQP3BNTIGscCokjxDEJ8R2Ryz8rDA4QNYq4ScURrgi0MlpOdGUhovPR9OZ4f%2FjcSR%2BARthMGS5jcUY7fjJjHk7vG3NdiEebSDywx6qrrtvYb811wtirzunhBgTrDtp5vEgE7E0wYyns5nD7vn5Vt2sopfd%2Bl1ffn1OSfBNxjtUfYXgN4jEukfSZIFhxpA9TAIFTiaMmGBsb4QCHGKPiVW6Ef%2FyUv7rRsEXSZz321%2FcrabihrLqcXGvtVrV1qParprOzHLs89Jcrqq9RlNVOzW1V1QFvWZewbmhnpZm4cXJiU4nVsFqNNs0OPa1ohZ3NWdQKF6c3IexOmoObo9bt1qn%2B1C4657Ojh%2FOR80hqT0RvHRyk8Fo%2FjBrdKtxdfBY8k1n0IyyNH%2FDzju4U%2Bg9DS4ZVh26xDf2ZcN%2B8B6tYr352DHwMFhGOWt502rOlvgiPO61p4XutWHlLp%2BUxa1Sm3tztW32z7rtllHVSlW5f8HDlkX9hkH0xZOjjE5HhVmdGNYsnoVTdl%2Fs3ntdl8r3xoldPD4euc3anWmx2VWjHevKA2X5a%2FemG1shK15Fzb4i31h%2B%2FnyRDy5uBgOW7dwU%2FNthtbfQTEW%2BDO6vzLOe4T76uZPGLdN44V6rV2dXWcbd2wu3Njkd3vdsO5o%2FMNUctPJno9ysV%2BSj0TBa9lp1tadWRWU2iBB1iS%2BLTk%2FxHgpcnej1RjOrnObO8oViScYT3SDT84vW5dW11u50exVJ9Jpt%2BrBzxwx%2BMY9C6FweRjDUvcjl9hjP8e7K0MdY4BVakwEVzH038P3VC%2BvzDq1%2FM%2Bz3sHsIprGhi561k2ffBBdxTsmncwaR0znFmKSLhn4Gn2clXSkVdawX9h6Drz8VX3sT7kCzP5BUd46XTHp%2BMZBeRhZXAMtZ9BM7B%2F2JXXcTOMT9vkNdAf8HF%2BDHNHgn0%2BAAVu%2B4u%2F6Vh8sru%2FF9ZGP7znkzHa88dH5qkr%2Fjuu9vhrXsOsIffWv9FzfFYaTfLYv%2Fwlr4moIn5Md%2B%2F9jvH%2Fv9Y79%2F7PeP%2Ff6x3%2F9f%2B138cYBjYoyxYFNkcEEupeXCUM6Wc%2FlyTs6cFbJKUT6W5bIsiwAI46t4vz1DDHv%2FGEjuHeatJ1zqX5yaTrMdOxP9fDCLODEeajKOl61etqA419TtzSvS81%2Fil5Z05xkAAA%3D%3D)

Subdomain (`domain=acme-example.com`, `host=mail`): [Test folioinbox.com/email acme-example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJsXnmoC%2F%2B1YWW%2FiSBD%2BKy1LkWYUcIwhXLNZrQmQEMbhzjU7Qo3d4A6227jbgDPK%2Fvat5ibHaEe7D1mJpzhd1V9VfXV0iR%2BKIF7gYkGU4g8lCNmU2iSs2UpRGTKXMuoP2Fy1mKckNtJr7IG2UpVyOOYknFKLLO4QD1N3e7ariRYy9Geka6kMColF6JQkECe%2BnUDYt1HZNNrncHdKQk6ZrxRTCcVlI9YLXcBwhAh48eRk36uTYIaTqYKuBv4IrtqEWyENxOK6cs58n1iCI4xsBsZ9JBha%2BvJpH%2BZzEcnvCLww7xKo06yCSyggYXJ1sVyvmWhMYukpIv6QhRZZeYwCgLJAIhyCDA8%2FMR91Kh3EZj4E4tAAAW9suIxR6kihFXHBPGQata%2Bo2m6YKMA0VJERBG5M%2FRHoUY7WmQGy4K9FIBA%2FBgcRFgsgHJB5As0cajnIY1OQUx%2BCkfcXVG%2BiXXEu70SQGSSxmWsjztCAQCxEimIwgwFpYRpoJMRXZTZwSPHAJeU9au0x9ThxgV0WFhfAC4bWRyu7IwIUQAA2AiNL4BWfn4g6UtE4PSxg%2FbOKJFwQDYDgJdgAc5LNIDgCaiXvKwAIfGNiJ6gNUTwCAikQIU95FIYypZKP6Zn0L%2FUFjc9Cjr%2Bg4AyyQoZ0rgIgpGJM%2FOL7CVzIFy708UIOd9TflqH8LknisW%2BVXGaNleIQu5wsT5rRoE7i8kLtrX6SOm1iU%2BgF8b6Ww7hok0kEavYGHq6w0OZK8dsPRcSBbDLzbqUM33%2FIbgUUwbsM%2Fl3VtjrzVOJZbORTwTY9TVlIRQzdpiUUIaDV0llNe05scKEZzH1kHgzbkUv4AtlyI5sU92DR%2BnRLljS2g9m9624hj3aL6UjtL3mFpMuGxgKDyuv0HW1L5kjZcRw%2B5wIafwiFI0wsLAfSbzJbWm0uMq68qbKSbUy9623f9nBo7bkmp0BKOhWSRwjiC%2BLbTyz9POPwAaydhV9QGOEz2Z2CFRdISTj442g4sf3%2FPI6FX6BGOAxZQbEcow1%2FMWPeD2%2BTs22IR%2BsW%2BcceGq67a2G3NFcPxE51DgmxB9gaJ7knAjXiSYK5SKbU%2Fer59VJdP0Wvq%2FVFXX5%2FTijwP%2Blvu%2Bo7BL%2FuSGx5JEnmGGYM2enJrYURjJmgT9cXAxxij8vndA3x7TXG9zXItyWKNLjTBvJ8OR3XkmWty3OzVivVHo3r0mg8ccb0ojDTSkarUjWMxrnRyhtSfj6qw3fFSBcm4eXJicUGTs6pVK9ZcOybeXPaNMedXP7y5D6cGr1q5%2Fa4dms2mg%2B5u2Z6cvxw0at2yfkTwfE4M%2Bj0Zg%2BTSrM0LXUeC%2F5o3KlGKZa94RcN3Mi1njpXHBtjFuMbelWhD96jky9XHxs27gZxlHHim1p1EuPL8Lh1Pcw1v9pO5upJn9%2Fq5zNvZlyP2qfN65pdMgslrX0pwprD%2FIpNrPnTWO%2Ble7lJmdjOZDoJh%2Fw%2B37z3mi7T7u0Tmj8%2B7rnV87uRwyf1yvXU0h8Yz351b5pTJ%2BT5elRt69qN42cv5tng8qbT4anGTc6%2F7ZZac3Oka1fBfX102rLdRz9zUrnlpsjdm%2BXSpJ7iwr29dM8H6e59i9Jo9sCNUaeWPe1lJq286PW6UdyqlY2WUZKZWXeGzMv0Kj9u6d5DThgDq1yppvR05jSbyxc0PLBsMry4rF3Vv5rXjWbrTJE1R0c%2BvL19Dn%2BxiEKoYBFGMNy9yBW0j2d4e2RbfSz7FkqUgxTMvRj8%2FnLTWlXkqnF%2FMvd32ni%2Fr%2Fq2JUuXym0urduFjI3TybSdySczA91KFrS0lsxgkrdzWZLDWX1nL3x7a3xrPdzvn935ZLgzHHPl%2BdV8ejPA6Rl0dwr9wiuE%2FsKuu44fwv%2F4ES%2FHwM6zqL7k4OXbeBgQH2RA7LXZBy%2Bz5V7zurb%2B%2FXIjD9Q3HtGPw81mKXqXnO0MeUHQr8z8D14OL9%2BRF6H%2B0zXt%2F%2FyyqD99Xv4vD8n3BKyhh%2F3gsB8c9oPDfnDYDw77wWE%2FOOwHu%2FuB%2FOECT4ndx1JV1%2FRsUisktVxXSxUzuaKWU%2FOZ09NC9ljTipomgyBcLGP%2B8Qxx7PxiodwdZ58e4yuq1aqM5cZxUJqXJ51MvV26vcv6Jf3%2BEUfz22oJz6DCn%2F8GwEHBQ28aAAA%3D)

Both runs render all seven records with no errors; the two `SPFM` records merge to `v=spf1 … ~all` as expected and `%fqdn%` resolves in the DMARC `rua`.
