### PR TITLE
Add WorkSync templates (custom domain, email sending)

### DIFF
--- a/worksync.works.email.json
+++ b/worksync.works.email.json
@@ -1,0 +1,27 @@
+{
+	"providerId": "worksync.works",
+	"providerName": "WorkSync",
+	"serviceId": "email",
+	"serviceName": "WorkSync email sending",
+	"version": 1,
+	"logoUrl": "https://worksync.works/icon.svg",
+	"description": "Authorises WorkSync to send customer-facing email as the domain: the DKIM public key (a TXT record at the selector the mail provider issued for this domain) and the bounce/Return-Path alignment CNAME. Both records are DNS-only; the CNAME must not be proxied. Applied to the sending domain itself (usually the apex); a sending subdomain rides the host parameter.",
+	"variableDescription": "%dkimselector%: the DKIM selector issued for this domain (the label before ._domainkey); %dkimkey%: the base64 RSA public key from that DKIM record (its p= tag).",
+	"syncPubKeyDomain": "worksync.works",
+	"syncRedirectDomain": "worksync.works",
+	"records": [
+		{
+			"type": "TXT",
+			"host": "%dkimselector%._domainkey",
+			"data": "k=rsa;p=%dkimkey%",
+			"ttl": 3600,
+			"txtConflictMatchingMode": "All"
+		},
+		{
+			"type": "CNAME",
+			"host": "pm-bounces",
+			"pointsTo": "pm.mtasv.net",
+			"ttl": 3600
+		}
+	]
+}

--- a/worksync.works.email.json
+++ b/worksync.works.email.json
@@ -4,7 +4,7 @@
 	"serviceId": "email",
 	"serviceName": "WorkSync email sending",
 	"version": 1,
-	"logoUrl": "https://worksync.works/icon.svg",
+	"logoUrl": "https://fallback.worksync.works/icon.svg",
 	"description": "Authorises WorkSync to send customer-facing email as the domain: the DKIM public key (a TXT record at the selector the mail provider issued for this domain) and the bounce/Return-Path alignment CNAME. Both records are DNS-only; the CNAME must not be proxied. Applied to the sending domain itself (usually the apex); a sending subdomain rides the host parameter.",
 	"variableDescription": "%dkimselector%: the DKIM selector issued for this domain (the label before ._domainkey); %dkimkey%: the base64 RSA public key from that DKIM record (its p= tag).",
 	"syncPubKeyDomain": "worksync.works",

--- a/worksync.works.hostname.json
+++ b/worksync.works.hostname.json
@@ -1,0 +1,27 @@
+{
+	"providerId": "worksync.works",
+	"providerName": "WorkSync",
+	"serviceId": "hostname",
+	"serviceName": "WorkSync custom domain",
+	"version": 1,
+	"logoUrl": "https://worksync.works/icon.svg",
+	"description": "Points a customer's own hostname (for example shop.example.com) at the WorkSync edge and delegates the hostname's certificate validation to it, so the TLS certificate issues and renews with no further action at the DNS provider. Both records are DNS-only (unproxied): the target is itself a Cloudflare-for-SaaS fallback origin, and a proxied CNAME in the customer's zone would break that routing. Applied to a subdomain only (hostRequired): the routing record is a CNAME at the applied name.",
+	"variableDescription": "%dcvuuid%: the certificate-validation delegation id of the WorkSync edge zone (a UUID, read live from the edge when the link is minted; embedded in the fixed .dcv.cloudflare.com suffix).",
+	"syncPubKeyDomain": "worksync.works",
+	"syncRedirectDomain": "worksync.works",
+	"hostRequired": true,
+	"records": [
+		{
+			"type": "CNAME",
+			"host": "@",
+			"pointsTo": "fallback.worksync.works",
+			"ttl": 3600
+		},
+		{
+			"type": "CNAME",
+			"host": "_acme-challenge",
+			"pointsTo": "%fqdn%.%dcvuuid%.dcv.cloudflare.com",
+			"ttl": 3600
+		}
+	]
+}

--- a/worksync.works.hostname.json
+++ b/worksync.works.hostname.json
@@ -4,7 +4,7 @@
 	"serviceId": "hostname",
 	"serviceName": "WorkSync custom domain",
 	"version": 1,
-	"logoUrl": "https://worksync.works/icon.svg",
+	"logoUrl": "https://fallback.worksync.works/icon.svg",
 	"description": "Points a customer's own hostname (for example shop.example.com) at the WorkSync edge and delegates the hostname's certificate validation to it, so the TLS certificate issues and renews with no further action at the DNS provider. Both records are DNS-only (unproxied): the target is itself a Cloudflare-for-SaaS fallback origin, and a proxied CNAME in the customer's zone would break that routing. Applied to a subdomain only (hostRequired): the routing record is a CNAME at the applied name.",
 	"variableDescription": "%dcvuuid%: the certificate-validation delegation id of the WorkSync edge zone (a UUID, read live from the edge when the link is minted; embedded in the fixed .dcv.cloudflare.com suffix).",
 	"syncPubKeyDomain": "worksync.works",


### PR DESCRIPTION
# Description

Two new templates for WorkSync, a field-service platform: one points a customer's
own hostname at our edge and delegates its certificate validation, the other
publishes the DKIM and Return-Path records for sending mail from their domain.
Both replace a table of records we currently ask customers to type by hand.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`logoUrl` is `https://fallback.worksync.works/icon.svg` — served as
`image/svg+xml` on the same registered domain as `providerId` and
`syncPubKeyDomain` (`worksync.works`). It is on that subdomain rather than the
apex because the apex serves only our marketing page; the subdomain is part of
the platform's own routing and is a permanent host.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**
      Set to `worksync.works` in both templates. The RS256 public key is published
      as chunked TXT at `_dcpubkeyv1.worksync.works` (`p=<n>,a=RS256,d=<chunk>`)
      and is live and externally resolvable.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — neither template sets it.
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri`
      Set to `worksync.works` in both.
- [x] no TXT record contains SPF content — neither template writes SPF. The only
      TXT is the DKIM record in the email template.
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique
      The DKIM TXT carries `"txtConflictMatchingMode": "All"`. It is the only TXT
      record in either template.
- [x] no variable is used as a bare full record value
      The DKIM TXT data is `k=rsa;p=%dkimkey%`, not a bare variable.
- [x] no bare variable is used as the full `host` label
      The DKIM host is `%dkimselector%._domainkey` — the `._domainkey` suffix is fixed.
- [x] no variable is used in the `host` field to create a subdomain
      The hostname template sets `hostRequired: true` and writes its routing CNAME
      at the applied name via `host: "@"`, using the `host` parameter as intended.
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify
      No record in either template is one the end user should remove or edit:
      removing any of them breaks the service the template exists to configure.
      Please tell us if you would rather see it set explicitly.

Additional notes for review:

- Every record in both templates is DNS-only (unproxied) by intent. The hostname
  template's CNAME target is itself a Cloudflare-for-SaaS fallback origin, and a
  proxied record in the customer's zone would break that routing; the email
  template's records are a DKIM TXT and a Return-Path CNAME to our mail provider,
  neither of which may be proxied.
- Synchronous flow only (`syncBlock` unset). No `APEXCNAME` in either template.
- The `%dcvuuid%` variable in the hostname template is our edge zone's
  certificate-validation delegation id, read live when the link is minted, and it
  is embedded in the fixed `.dcv.cloudflare.com` suffix rather than used bare.

## Online Editor test results

Three runs, one per required case (`worksync.works.hostname.json` sets
`hostRequired: true`, so its apex run is not required):

**Editor test link(s):**

1. `worksync.works.hostname.json` — subdomain (`host` set):
   <https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOlUnmoC%2F%2B1VbU%2FjOBD%2BK5YldCCSNC3QQlYrLbtd7XJ3y%2B1SENpDqHLsSWqR2MF2WrqI%2F37jNC0tV3T78aQ7f6HOzDx%2B5pkXHqmDsiqYA5o80sroqRRgzgRN6EybOztXPGp%2B0GBlPWcletNr%2FDxCO1osmKnk0IRNtHXKe6w%2Bv%2FAnvLZOl0TokkmFblMwVmpFk25AC53rK1N4HOcqm3Q6GSuKlPG7aJNPR3KtIjvNEUCA5UZWrgGhX7VUzhLWvgPmF0v0TJElMbKbaUPggWHeQOxEV1F7ibgu9whzxE2ArOiCyIEwJYiAAnJUyjb2JRyiczBOZpKjjUxZIQXzVIjTRLqAWN34X%2F4%2B2nCU1tYI5YENKJhZMpNuQpQmWW0wwBDGG5iWz%2FB8RJYViMh7jb4GuDYCMUxjDrUq5mS3Vuj2IEHsJU2gYyYHh%2B8hGwtFhsp8KHQtsgLjQtQiHDE2IkudiTYylypomDHSYpEP56dfPhKpGsg1ZX9oBWSm60KQ1AC7QzsSNrp2UuUROa2qwoejFozYOl0UnSyYegkv4L6WZkW2DWxT86RZ%2B3QrA2sBvfSRbx5mJEsLGG70wI7g07qWYmeBuqZ7uFagtqD%2BpxREZ1vq3qS3y8jV1dkwQFZMkEJOgWQGO9i7N16zCSyEKaS686RLbEEQbwiUKQiBdFvhMvmAlwjZRXxVA992qE2Gxj2fkm%2Fyr3X6G8yHixHZMov%2BcgEClePuda91gWniTA0BbZuGJjeP1M0rP5mNwK07Xt%2F5WW%2BG6FLj9ZUBRCfncFAP%2BnH8FLyGNWa8hJBPEANUDpvIO9m9UDvRqlhbdNl45fYpoL4g4%2BccbnH6l%2BmvTfEzAT%2FfeMuxsaqxXMZUzLDS%2BpW3jL7ZCL9dxt8sAPwzC5L%2BU7c9YQ9PeIAnPMQTHq0d6snKXGkDY4t%2FmasNLGtQ1oWTYzZjz58EH%2FvWnmNuFq34zN%2FroxaLtE0Jm5j9XHkCOhbcJ%2Bvp0yOI026a8nDQPeDhIbZ0eNxnLDxI%2B70%2BxFk6OBmsbfvt%2Fwte2fibooO1oJxkfp2fFjM2t%2FRpS6u0ab1olWgzzZd7OvqZIvxDQ%2F2rdLkNsDH%2Fr%2Fl%2Fq%2Ba4Vyybghgz79qLe%2F0wPgnjwWXcT%2BLj5LAbHfX6%2FaP%2BfhwncezzAOsW6jziflnfLLT8dtm5vs9dR%2Bzvg76%2B4L8Oj%2F9I0%2Fi%2B%2BPPbp%2Fdnn9Mv3%2B3nTydq8OPjW%2Fr0F2Q13Aj5CQAA>

2. `worksync.works.email.json` — domain apex:
   <https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAI1WnmoC%2F%2B1U227iSBD9lZalkRItGEO4JER5MCSzy0SQhDCbiaIIle0CerHdnu42gUT8%2B1Y391lmX%2FZltdoXKHdV1%2BWc0%2FXhaEyyGDQ6zQ8nk2LGI5SdyGk6b0JO1SINXWs4ha23BwlFO090%2FEh%2B8iiUMx6ivYYJ8Hh39kMws26mMI14OqawGUrFReo0ywUnFmPxVcYUPtE6U81SaQRxHEA4dQ%2BbKfFQpK6amQQRqlDyTNskjp%2FriZBcoWLbklrYeizMlRYJyuIIQiq%2BbgUU0xNkkaCvtGnt69tOl2V5EPOQTXHBToANvg2YxFDIiIG2QQpjDLWQ9sNm2uDDuFI5RmxknVytc58yoCZMdCDyNMRSH3Uu0%2BI96AmDmI%2FTBFPN2j2%2Fe%2BOylqDTVUXFQFJTvceiSOPFpU1ho1hCE7FUaBagqT7nGLnMz7KYDDP2qk8L9boJxjU1PmInucoJ24UNgQznp5cMtrEqD9bhkgZaATQRVCsDSXxqlK6hDiSHIMbrAwY%2BRVOebMD5tAfoFrDj8LATExlDgDGNQ05k7nDlIg6oPZuYzHXOABTWq6z%2F6O9TNZIiITdxZGuuKTuhqVl2xTSMT03nRkn3eXCLi2tb4JjazUcfI04p9M%2Bj1gw5zZcPRy8yI3WSCjkMXH9BY28go1zQQCHTK6ngMrvazkcurekVnNU9j8y5bot0RAPqLuhwQvx0RWQK%2BXHsLAvbulYSu8pZUlzpzD5dwVOtBsKeu4kGNXNT1PuVlq%2FLgvMuUhzuZnqlJjej4xxoUaAbimRXhKyxFHk25Jt4qxBllsnm5svB1dfN3RfH2PvwmLOKV6l7Za%2B88Rmk6Ljb6bQ6f%2Fi91nj6fTLlv168eS3%2F4eaz79%2B1%2FYdz3%2Fjb41uyb3zvm%2BjK9%2BfGs%2F9U%2Bfw7PDhmMHpdpKihon%2BgV0d4aZljwUnyWPMhvMHuKAqHQE9oQTgo8lL5H7lNVztt0%2BvfsvqPOj8QwjAKDazcLNla0MAKngXF6GwUFqsNLywCINIP1BEb9Ur1rLK3sY%2Fv82Nbe8crKtoGmkNslfYGC%2BUsj6htjcWB2tYQ%2FExp%2F45RXgsk1%2F%2BZ%2FS8yS7tDwQyjIeg1mUXvoug1Bl69Wa41q2X3%2FLxeLXu%2FeF7T88wAqPRqtA%2FaFftbwnnSvYfga%2BO3i76669%2FfwXnN1%2BkXWanF7ffW8zQvDXr8ezgf1wbdK2f5JwG%2FJVhPCQAA>

3. `worksync.works.email.json` — subdomain (`host` set):
   <https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGlWnmoC%2F%2B1UW2%2FiOBT%2BK5alkVoNSQPtQKHqQ%2BhlxXSh9DKdma0q5CQH4iWJM7YDzVT89z024dZlnvZlpV1ecM45Ppfv%2B3zeqIY0T5gG2nmjuRQzHoHsRbRD50JOVZmFrj3Q2to7YClG069ofkA%2FehTIGQ%2FBXoOU8WRjexdMrJsoyCKeTTBsBlJxkdFOvUYTMRFfZILhsda56hwdjVmSBCycurvNHPFQZK6amQQRqFDyXNsk1C90LCRXoMi6pBa2HgkLpUUK0hmzEItXrTBFdAwkEviVdez58qbXJ3kRJDwkUyjJASOP3x6JhFDIiDBtgxQkEGoh7YfNtMKHcKUKiMjYOrmqch8Shk2Y6EAUWQhH96ALmTlDpmPCEj7JUsg0uRj4%2FSuXdAValxUVYRKbGjw4IkvKM5vCRpEUJyKZ0CQAU%2F2VQ%2BQSP88TPJixl31aqKsmCNfY%2BJgcFKpAbEsbwnJ4PTwjbB2riqAKlzjQEqBYYK2cSeRTg3QNdUxyFiRwucPAh2jK0xU4H7YAXQO2Hx5yYCITFkCC46ATiDtaupADbM8mxmOVM2AKmifk%2FsHfpmosRYpu5MjWrCg7wKlJfk40mxyazo2ShkVwA%2BWlLbBP7ebjHiKOKfSvoyqGaOf5jeoyN1JHqaDDwPU3NLYGMsplmmHI9Fwqdpafr%2BdDl9b4Co6bnofHV30hsjEOqPtMhzHy0xeRKeQnCV3U1nWtJDaV89RZ6sw%2BXcEzrR6FtbupZmrmZqC3Ky1eFjX6U2Qw2sz0gk2uRodXhosC3FCkmyIqFjl%2BTaQo8hFf3bEqUWahrG4%2F71x%2FWd1%2FXiYwZbZgMvaG12h6da%2B%2B8hnE0Nzv9bq9P%2F1BdzL9EU%2F5b%2B251%2FXvrq59%2F%2FbCvzv1jf9icoPnK9%2F7Jvry5%2FfWd%2F9r4%2FqJ3VEzIL4yVNZI4T%2FD14e4aVlAjaZFovmIzdnGFIUjhk%2BpRDwUerH8e46z5W5b9brFrlsB847if9T%2BjipGUWjw5Wbjtr32SQsaLefktB46J8fHoXN6Og4cFniN41bQjBqN9tb63r%2Fc963wXZJB4XrQnCVWenNWKrrYI78KlI383mHxK%2F39e2Z6qaGI%2F%2Bf6v8E17hfFZhCNmK7odby247UevWan%2FqnjfXKb7Tr%2BPnpex%2FPMEKD0crw33Cfbm4TOf7%2Fq9mLxOQ3aTz%2BG9%2Bo6u3mI%2F2hdlOGTmnrD7mTYL%2B8%2B5re3gy%2FndPEXSAVoe3sJAAA%3D>

<!-- How to produce each link, in the Online Editor
     (https://domainconnect.paulonet.eu/dc/free/templateedit):
       1. Load the template, click "Check template" (extended schema + consistency)
       2. Fill domain/host and the variables
       3. Click "Test apply template"
       4. Click "Copy Markdown" and replace the matching PASTE-LINK-n above

     Variable values that work:
       hostname template — %dcvuuid%: any UUID
       email template    — %dkimselector%: e.g. 20260101
                           %dkimkey%:      any base64 blob

     Replace each PASTE-LINK-n token above. Nothing inside these comment
     markers renders in the PR, so no link belongs in here. Delete this whole
     comment block before submitting if you prefer. -->
