### PR TITLE
Add gnapex.com web-routing template

### DIFF
--- a/gnapex.com.mail-routing.json
+++ b/gnapex.com.mail-routing.json
@@ -1,0 +1,40 @@
+{
+  "providerId": "gnapex.com",
+  "providerName": "GN-Apex",
+  "serviceId": "mail-routing",
+  "serviceName": "GN-Apex Business Mail",
+  "version": 1,
+  "logoUrl": "https://www.gnapex.com/logo.png",
+  "description": "Configures MX, SPF, DKIM, and DMARC for GN-Apex mailboxes.",
+  "variableDescription": "dkimSelector: DKIM selector name; dkimKey: Base64 public DKIM key.",
+  "syncPubKeyDomain": "gnapex.com",
+  "syncRedirectDomain": "gnapex.com",
+  "records": [
+    {
+      "type": "MX",
+      "host": "@",
+      "pointsTo": "mx.gnapex.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.gnapex.com"
+    },
+    {
+      "type": "TXT",
+      "host": "%dkimSelector%._domainkey",
+      "data": "v=DKIM1; k=rsa; p=%dkimKey%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; pct=100; rua=mailto:dmarc-reports@gnapex.com",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "ttl": 3600
+    }
+  ]
+}

--- a/gnapex.com.web-routing.json
+++ b/gnapex.com.web-routing.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "gnapex.com",
+  "providerName": "GN-Apex",
+  "serviceId": "web-routing",
+  "serviceName": "GN-Apex Edge Ingress",
+  "version": 1,
+  "logoUrl": "https://www.gnapex.com/logo.png",
+  "description": "Configures DNS records to route traffic to GN-Apex Edge Network.",
+  "syncPubKeyDomain": "gnapex.com",
+  "syncRedirectDomain": "gnapex.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cnameTarget%",
+      "ttl": 3600
+    }
+  ]
+}

--- a/gnapex.com.web-routing.json
+++ b/gnapex.com.web-routing.json
@@ -6,8 +6,10 @@
   "version": 1,
   "logoUrl": "https://www.gnapex.com/logo.png",
   "description": "Configures DNS records to route traffic to GN-Apex Edge Network.",
+  "variableDescription": "cnameTarget: The target edge hostname for ingress routing.",
   "syncPubKeyDomain": "gnapex.com",
   "syncRedirectDomain": "gnapex.com",
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",


### PR DESCRIPTION
This PR adds the web-routing and mail-routing templates for GN-Apex edge ingress and business email configuration.

- **Provider ID:** `gnapex.com`
- **Service IDs:** `web-routing`, `mail-routing`

This PR provides:
1. `gnapex.com.web-routing.json`: CNAME records to route custom domain traffic to the GN-Apex Edge Network.
2. `gnapex.com.mail-routing.json`: MX, SPF (using SPFM merge), DKIM (dynamic selector), and DMARC (with p=none monitoring) for GN-Apex business mailboxes.

# Description

Template submission for GN-Apex edge ingress and business email hosting. Allows users with domains on Cloudflare, GoDaddy, and other Domain Connect-enabled providers to configure both web and mail routing with 1-click authorization.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
- [Test gnapex.com/web-routing example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPNxnmoC%2F91T7W7aMBR9lchSf5VACIGUSJPGCtuqdmyiVOqEUOTEl2At2JltSDPEu%2B%2BajxHW7gX2K7kf5%2Fqc4%2BstMbAqcmqARFtSKLnhDNQdIxHJBC3gpZnKFWn8qYzpCjvJp7E7wCIWNKgNT2GPKCFxlVwbLrJz5RLhjFgGzp3IFGiNTRtQmktBonaD5DKTTyrH5qUxhY5arbIsm2caLdvQLPbDGehU8cLsseRWigXP1jjTGY4fHQWpVEw7RjqWDjhG0cWCpzZxwWMMppTqR9MSoYrTJIfhxeBUIPspVRmYyJkucdL%2B3wGLXkptbN1ZSOXwgyTnqN%2BO1JVIv62Te6iGckW5%2BNtTW58A40jXvN1hT5jAzzW2oL9GraFBjuJINNsSUxXW29vx4Mvo2I7he3tfkgujpxLDq5qIKywZgxZ3ep63m%2B8a5JcUEJ9nztHaExV4obgaUOOCSVoUGGQos4j5CVJQRVfabtAJPLtAz0%2Fw2R6PYY2TzR7dq102seR4JqSCWOOXGrzekwerdW54TEt6TrE0xtF5hVo0VnHoa3%2FEYRUPEhg1FIM3Tq5Z1CAxS60ubvcbwmBx0w99Nw0T3w36fs9N%2BknX7SZBO%2BzQhLVZu%2FZWXr%2Bifz%2BWC3eRDwjDqX0Kg7yklSa73byBTv9vmnATNN0Ai6nt9D083eu7Xjj1bqK2H3W6zbYfBqF37XmR51kVoM1B5Rb3o74ZpCfvRt%2B98efnDzp4GFTssfd1saFDuun4TwF9nvJ%2BdX%2F9MIGP0%2BAd2f0GOUwVgPkEAAA%3D)
- [Test gnapex.com/mail-routing example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMuQnmoC%2F%2B1WS3PiOBD%2BKy5X5WQeNhAITlE1NhCGhx1eSchMpSjZlo3AthxJNiap7G9fiYQhZGa39rCHHHJCqB%2Fq%2Frr7az%2FLDEZJCBiU9Wc5IThDHiR9T9blIAYJzEsujuTCL4kNIq4p9%2ByiwYVcQCHJkAv3FhFAYZHglKE4OIpOTSQzpSiGlEoW1%2BZaGSQU4VjWtYIc4gDfkJBrrxhLqF4ub7fb0jGQslAoJXvvHqQuQQnb28ptHPsoSAnkfhcFaTa%2BKkidYd8qSCD2pI5lTNuSj4l0iEKE6uAc0pIIARAEnBB2Tlx6GxTNYAhdhom%2BdybRt79SzHO6lITGEO50yQQU1mtSkjohcl9VN3AnXNNd7I5Th2t1MH8z%2FoirkE%2Bhhwj3%2B2cNLsHEo7L%2B81lmu0RAaS34%2FQpTxs%2FfRHEwihmdY1GCvPShbggTxHYcXrUgM8axrdZV9aXwyxmHyjp1RxN%2FmoaQPymj2A1TD%2BpLfvfe8Tv7%2BWJ%2BND97D9pZaentU%2BJYiIIBBrhK1hL4aJfSpkUouJSS1tkbjmfynyM8eWHpRYC4J%2B5EcTXhKMYxr0rispamqpcSSUFL1JlhfW9UJDDBhNFvJwixnInm4YVjFmDuiveuhT3x7phAH%2BV%2FVnmTHd8%2Fif3hpSA%2F8WCWx%2BI98IgP9YU54DMH3wJ4S4yfAj47yRId9BNAQETFXB4sf56YPhxsf8ri%2FB56cRfDPKUHAYdX3Fn9vtlfG7YZbB5XG9RrblXTmHSvDOO6bUwuDCFvB0N%2B7hrptlHfRmnbdlQwsKdq3GxPJeSO8I3ZAwF0vaCPhw0c4akSX0NvXX6677Zvx9VsfFNRiBsSc0iV9dg1PAdo7XXkZbPbjTSPh4NgUM7Sbd1XSBBs8uqU7vKweh6p1%2Br5TXvaWNg7PFQaSjBzrNthwga9QcWwjJGysf1MyrpGb9Txazfzi2nHD9wQ3SEEtPy71rvmxNLfeXeDXm1kj6%2FGd2amnP%2B4GtVH3YXZ7ZiV%2FvpqI239SnUE8mQS2rUsGCn2LVRzBZr9tpXaWkedg97dBJg8yN79fKY8OvXaD%2FV6Wl9E6eN5p6tKbTxwupZ1H6ye4nyWNMNVz0qnDVCJGu53BTiP28nKqoRli%2BajteetFkHT7d9vL0yvNt9U7rFEJ%2F2OMTFMWfQJCmJM4JLyX8A4gck6IyksyFEaMrQEW3C88twlSJJwx9uKcikv6AdOiF%2Bp9ttxPD7ywa8e%2FUgNS88VnYYEj1%2FUXd%2BHdVBsOj4s1qqOW3SaNafo%2BZrbOPf8%2BrkG3%2B2E37fFvyyFY7fzHQBjhoCgeyPcgh2VX36b%2Bt8zylqcizTpH5hJ%2BguE4SFPnuanz2w%2Fpf%2BRKL%2Bm91NN78k0fe4u%2B%2F%2B35qfL%2FKHAd%2BYXH37x4RcffvHhFx%2B%2BPPAvfwoy6C2BUKuolXpRbRbVxlxT9UpN17TShdaoNiqKquqqKnKAlL3i8cy%2FS99%2FkcowZc3JJIwze7rwOlfd2Bnjm3WUpvd3KnX82eoxq46ctn17q7bkl78BYylOYFUQAAA%3D)
- [Test gnapex.com/mail-routing example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA6anmoC%2F%2B1WW0%2FjOBT%2BK5YlnkiK03Y7EFRp0nbpViiIS5EYIRS5sVssEjvYTi8g5rfvcS%2B0KexqpX2ZkXii%2BNy%2F73xHecWW50VGLcfhKy60mgrG9YDhEE8kLfi8lqoce%2B%2BWC5qDJ%2B5f%2BBEYwWC4noqULyNyKjJfq9IKOdmaqiGoUxohuTEoBm%2FwmnJthJI4DDycqYm61Rl4P1pbmPDoaDab1baNHDmHWrHMzrhJtSjsMhZ3lRyLSak55L3z0M3lmYd654PYQ1Qy1Iuj6y4aK402XbhWR2rOTc21QLWgo4z3KinZk8hveMZTq3S4TIbM%2Bl8kYaZT5DzO%2BSJEHWp4q4mKcpSJdOX6xBcutVnI9LIcgVdPQU25j6uzX3MmNOT93AMsSjODw%2FtXbBeFgzK%2Bg%2FdHZSz8%2Fu7IUUJaM1SOgnltjzehtLALgJd42FrAttEi5M17TwZQxdV0phhflxmHkljINCsZDxN42028Ez%2B8G27DD3ZBO6glbDkSYOEIo5aCy7Tt8AlO0VNbG3qKivbBGscD%2FHmHlQoJy6lOK%2BkcuYFLJJUEVorUtgNCTpEuadvxbFW4DPI1L5S25nsFITu3bnmAOBtTmz7C7saKubqXmo%2FF%2FHOXtW1bv9L7w5uHX6CZZEveA3S84ZfPKWiOrxtYD5av5DAB%2FRSJ2MQUVNPcOG1uou8r4Q%2Bb%2BPtVAldmhwL3Lvm8NBsDwOze4kF%2FHEek37157t8MRo3e1Z%2Bd6Oo2ipr9i6jX7Yir887kCrs5xEQqzRMDf6kFgeHQ6pJ7OC8zKxI6o9snlia0KLIFjG3ACoX2dlauTsF61DWD%2Byv7DuP%2B9iYsdUAId2rIcYN9%2B6Me%2BK16Ovab42Pmn5AR8Ulw3Dwh9GRMCN05Wx8P2r%2FcrSohcKq4tIK6qxRlM7ow%2BO3Dcn462LQNqgnQP2gI%2FaRZthkXpv0tBlzu0o6sa%2FsT72v7Py5ahfVfH4bVEfo4%2FP%2B8RL8kBA8e3KEvHX%2Fp%2BEvHv7eO4QvA0ClnCXWudVJv%2BeTEJ9%2BGQRCSRtis1%2Br1xjFpHhISEuLm4MauMHmF74DdLwD8cvTXYNAakDi%2F7f7gZ2zYOry%2BM3HK4%2FTwuXF59qNTxlH3efD48tTGb38DjPYYlGUMAAA%3D)