### PR TITLE
add Presscloud, Presscloud DNS

### DIFF
--- a/presscloud.ai.delegated-zone.json
+++ b/presscloud.ai.delegated-zone.json
@@ -1,0 +1,28 @@
+{
+    "providerId": "presscloud.ai",
+    "providerName": "Presscloud",
+    "serviceId": "delegated-zone",
+    "serviceName": "Presscloud DNS",
+    "version": 1,
+    "logoUrl": "https://presscloud.ai/images/logo/presscloud_logo.svg",
+    "description": "Delegate a subdomain of your domain to Presscloud nameservers so that Presscloud manages its DNS records automatically.",
+    "syncPubKeyDomain": "presscloud.ai",
+    "syncRedirectDomain": "presscloud.ai",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "NS",
+            "host": "@",
+            "pointsTo": "ns1.presscloud.ai",
+            "ttl": 3600,
+            "essential": "Always"
+        },
+        {
+            "type": "NS",
+            "host": "@",
+            "pointsTo": "ns2.presscloud.ai",
+            "ttl": 3600,
+            "essential": "Always"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a new template for Presscloud (`presscloud.ai`), a press-release distribution and newsroom platform.

The `delegated-zone` service delegates a customer-chosen subdomain to Presscloud's nameservers so that Presscloud can manage the records under that subdomain directly — newsroom hosting, and the associated TLS validation and mail records — without asking the customer to return to their DNS provider for each change.

The two `NS` records are declared on `@` and the template sets `hostRequired: true`, so the delegation can only ever be applied to a subdomain supplied via the protocol's `host` parameter, never to the domain apex. `essential` is left at its default of `Always` on both records: neither is optional, and removing either one breaks the delegation, so there is no record here that an end user should be able to drop independently (checklist item 10).

The template uses no variables at all — the nameserver hostnames are fixed — so the variable-scoping rules are satisfied trivially.

`syncPubKeyDomain` is set to `presscloud.ai`. The signing key is published and live at `_dcpubkeyv1.presscloud.ai`, verified with `dc-debug-pubkey --dns _dcpubkeyv1.presscloud.ai` (reports `record is ok`). The delegation targets `ns1.presscloud.ai` and `ns2.presscloud.ai` resolve dual-stack on separate networks and answer authoritatively.

`dc-template-linter -tolerate warn` and `-loglevel debug -logos` both pass with no findings.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead — the template contains no TXT records
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — not applicable, no TXT records
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — the template uses no variables
- [x] no bare variable is used as the full `host` label — the template uses no variables
- [x] no variable is used in the `host` field to create a subdomain — `hostRequired: true` with the standard `host` parameter is used instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — not applicable; both NS records are load-bearing for the delegation and are left at the default `Always`

## Online Editor test results

**Editor test link(s):**
[Test presscloud.ai/delegated-zone pockies.com/press](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABeQnmoC%2F%2B1Ty27bMBD8FYHXyjapvBABBVo0lzRoarh2ewgMgSK3MhuJVElKiWL437N0%2FIrr9HEMUPhgr2d3dnaWOyceqrrkHkg6J7U1rZJgLyVJMQDnRGka2eeKxBvwmleYTIYbGDEHtlUClnUSSiiQUPYejIYt%2BEtddHH9BeEWrFNGk5TFpDSFmdgS02be1y4dDJ6pGKiKF%2BAGIW0HyULcd22BbBKcsKr2S0ZysdIS8cg1uTQVVzoy36PONDZahd5EO5o0qgyCUVTkTORn3O%2FCFddBQaS8C%2FIjC8JY6SLeeGTzSvCy7Pph6E6LYZNfQXexbHPA0JAyAqmQw7%2BYNDPOj%2BBng1lorrcNxGTVlKQ3c%2BK7Ori6dDLk4u93YVlGae%2FGBkPtWH%2Bf1Xv0%2BOiU0pggANorHkx%2FX97xzpFF%2FHe8yb%2FyThcxCY8i204wxZVtZjfiVoHrC1Ntuy5bYFhY09SZWhfV3PLKhUe7Lr95Vj9dE9ysGEJvVWhjIXP4zX1jYW1o1ZReZfyOb%2F%2BSIuN1XXYo1SGKPHtm66fnvJYnued%2FNjuTIkhW4U4YTRLG8%2FPeEaO8dyyB9XIGokfPJD3LT0QuWL5zdgdv8rd3t2fgoYXsb%2FqloZJXNdQ0xhfyf12vZl14q463IDMechOanPboOWoYM5omLGWsT0%2FwQ99QmlIapgHnn4ad41Xv3jNR98XodnZ8O7katPr8w%2Fhbd912nz9Nmq%2BaPVyeNkNafLx%2F%2BGF1efyWLB4BxU8Gi%2F8GAAA%3D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
