### PR TITLE
linker by aquarela, 2 templates

### DIFF
--- a/linker.aquarela.app.route.json
+++ b/linker.aquarela.app.route.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "linker.aquarela.app",
+  "providerName": "linker by aquarela",
+  "serviceId": "route",
+  "serviceName": "Connect subdomain to Linker",
+  "version": 1,
+  "description": "Routes subdomain traffic to the origin prepared for linker by aquarela.",
+  "variableDescription": "target: public hostname of the origin configured by the service operator.",
+  "syncPubKeyDomain": "domainconnect.linker.aquarela.app",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 300,
+      "essential": "OnApply"
+    }
+  ],
+  "syncRedirectDomain": "linker.aquarela.app",
+  "hostRequired": true
+}

--- a/linker.aquarela.app.verify.json
+++ b/linker.aquarela.app.verify.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "linker.aquarela.app",
+  "providerName": "linker by aquarela",
+  "serviceId": "verify",
+  "serviceName": "Verify domain ownership",
+  "version": 1,
+  "description": "Verifies domain ownership with a TXT record without changing traffic routing.",
+  "variableDescription": "txt: complete Linker-issued ownership token in the format linker-verification=<token>.",
+  "syncPubKeyDomain": "domainconnect.linker.aquarela.app",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_linker",
+      "data": "%txt%",
+      "ttl": 300,
+      "essential": "OnApply",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "linker-verification="
+    }
+  ],
+  "syncRedirectDomain": "linker.aquarela.app"
+}


### PR DESCRIPTION
# Description

Adds two synchronous Domain Connect templates for linker by aquarela at https://linker.aquarela.app:

- `verify`: proves domain ownership using one TXT record at `_linker`, without changing traffic routing. Supports domain apex and subdomains through the standard `host` parameter.
- `route`: creates one CNAME for a subdomain after ownership verification and explicit cutover confirmation. `hostRequired: true`; apex routing remains manual. The service enforces this restriction even when a DNS provider ignores `hostRequired`.

Both templates require signed requests, use `domainconnect.linker.aquarela.app` for signing keys, and restrict the synchronous return domain to `linker.aquarela.app`. Cloudflare onboarding, signing-key publication and production validation remain separate operational steps; this PR does not claim they are complete. The intended CNAME proxy status for Cloudflare onboarding is DNS-only.

Bare-value rationale: `%txt%` preserves the existing ownership-verification contract: the service supplies the complete persisted `linker-verification=<token>` string, never arbitrary browser input. Its dedicated `_linker` label and `Prefix` conflict matching isolate the record. `%target%` must be a complete hostname because the service supports independently configured deployment origins; it comes only from validated server configuration, not the browser. Requests are signed in both cases.

`logoUrl` is intentionally omitted (optional field) until the production brand asset is publicly available. No broken resource URL is submitted. A logo will be supplied separately for Cloudflare onboarding.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
  Not applicable: `logoUrl` is omitted; no external logo resource is referenced.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

[Test linker.aquarela.app/verify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPfSnmoC%2F%2B1UUU%2FbMBD%2BK5YlntZ2SUvTNtomMZjYYGyIlQkJoehqX1qL1A62W1oq%2FvvOCaVlVNvLHvcU3%2Fk%2B333f3WXFPU7LAjzydMVLa%2BZKov0iecoLpW%2FRtuBuBhYLaEFZ8sZzyDeY4nMQGy3ZOo5iHNq5Eli9Mker8uXG%2BYT7WbmZNFNQmpl7jdZNVEhAAKeM5mnc4BKdsKr0lV1jFLpXKHav%2FIQBG14NmUVhrKw8ZuaZmIAeKz1m3kKeK8EsecluhUxgFYwKPHqRxS98yoQhUdAj%2B1rxayrnZii3Mnpzi5pREX6CLDd2Cp7VWjQrxkpAeO%2F9uyrwQ0jnllqcz0anuDyq6qdcNRFhtEbhW7sFrwk5nl6vuF%2BWQTziSRcT4zwZWQ0jhwQP5NgjBntkel%2FwtBNFDY7OofYKyObf9UFZFqEhFHZodF4o4c%2FAiwmpcmZkeP%2FcYq4Wu0Oe7tadf8mWP97UPC9QKircPzPdxe2xwR%2BMxmzDkNByjcAFhB60qBUbsnQaUwfLTK3jS7AwdWF418jrF9CbNfaahzMxCsddxUdxu7PfTXr9AYyExPxvNr8hAmqsjcXM0Rf8zJJ63s6wwaezwqsM7mHjkiKDID3xdXRLZfzeUV3vxquO%2FpNqtwcikyIopsKC9nvtbgwQN%2FMkGjT3RwKb%2Ff1Ov4lxMuj24qQ36sRbe%2F%2BHX8POtd80btcUPtLAUBf%2FC0FChNWBOcoMQlw7aidNqiPqDeNuGiVpJ2512%2B1u1H4TRWkUBRrofC3MiiZxewZ5fPkj0Up%2Flubh4uT45LI8HvTKwcDOD8Xbg%2F7ik%2FkYn3WTO7wa3tLS%2FgLH3N%2FoBQYAAA%3D%3D)

[Test linker.aquarela.app/verify example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPzSnmoC%2F%2B1UUU%2FbMBD%2BK5YlntZ0KSEtibZJAyZtgzKGGJuEUHR1rq0hsYPtFErFf985aWnZqu1lj3tq73yfz9%2F33WXBHZZVAQ55uuCV0TOZo%2FmU85QXUt2i6cJdDQYL6EJV8c5zySmU%2BFzERnO2qqMai2YmBTa3zNDI8XydXOIumzTLdQlSMX2v0Nip9A0IYKVWPO11eI5WGFm5Jm4xEu1vKHYv3ZQBu%2FhxwQwKbfImo2vHxBTURKoJcwbGYymYoSzFXd8JjIRRgUcvurgHlzKhSRR0yE4afoG0tsZ8o6PTt6gYPcJNkY21KcGxVougYSwF%2BPvevmkK3%2Fl2dq7EWT06xvlR837q1RIRWikUrrtd8JaQ5enVgrt55cUjnnQw1dZRkLUwSuTggBI7xGCHQucKnkZh2OFoLSongWL%2BRb2vqsIbQmWHWo0LKdwQnJiSKkOd%2B%2FvPDI7lw%2FaS5dnK%2BZds%2BdN1y%2FMcc0kPd89Mt3F76vBHrTBbMyR0vkLgA3gPumTFmuxE0%2F8JeVhlcoWowEBp%2FfiusFcvwNcr9JWHXzesfLCNQNjbjfbi%2FmA%2FgZHIcfy3mF8TCTlR2mBm6RdcbUhBZ2rs8LIunMzgHtapXGTg5SfOlk7pGb%2B6qtr9WLrabQgvjf0nD96ciywXXjbp9zQZRYNe3O8FI0ww2BslcZAkURhESV%2FEg34E8QA21v8PX4it27%2Fp37ZxfKLJITP%2Fq7FSwy8SzDDPwFfuhrv9IEyCcHDRi9Own0b9bhKH8f7gVRimYeiJoHWtNAuayc1p5Ad9ezf4Vt6W8vjm8ySSw5thUZ%2Fsv378unf6vTzoJedF8fFwfnN2%2BYFW%2BCdY%2FmH%2FEwYAAA%3D%3D)

[Test linker.aquarela.app/route example.com/go](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH3UnmoC%2F91T227bMAz9FUNAn5oYyj0xMGBds2HZ1q7o%2BlYUBiPRrjZbUiU5XRb030fFTZqiwT5gTxIp8vCQPNqwgLWtICDLNsw6s1IS3UKyjFVK%2F0KXwkMDDitIwVrW2YdcQo37oGS5TnZxFOPRrZTALYozDWHvfc9p50ZrFCHxzVKaGpROgkm%2BbbEodoXOK6NZ1uswiV44ZcPWZtcRzR%2BmOSgKJWJ6uMfEOFWS1zq0REYmhXHJW4pprAFOwbLC%2BSv8AK7EkCW2WVaEem980MQ4McUhvDC6UGUTCxBqfHjuLjEWHQTjYgW%2F1uKqWX7F9XzLleBb0qJtPj0%2BYIfCOOlZdrthYW2307o8u%2FhIT5EOme%2FjGozSwd8YMk9a0ifkDaFi2YDzDkPvUQcFZLPv%2Bszaas2e7lpS1ygVVQl7WseJxGrX%2BNBQLC0yuAafOuyP0Zi%2FUCREuUPB30BKwlSY%2BoVraehekghsrnYZtBqofdTbLvf2VfLdLvs2ppPVNhjtdgHpLlqT945YqVIbh7mnEwLtpaXbYXVTBZXDI7y4pMghToOa8PRKoG%2FnrFuRbrlLCED3I4UPx51LEftRUfFLlGMc8kFXAg67w9Fw1p2NRNGdihGXOC1gMpsdfKR%2F%2FLVj%2F%2BhwrkeXTFumIf93TUXtwgplDjGyz%2FvjLp91%2BeSmN8p6g4z30ulkMp6MTjnPOI99oA9tnxtSyKE22Png2%2FzDxfn8U69ZlIsvp%2F6hz%2B8%2FTy7cj2YcVrL82a%2B5uJraRfX4jj39BSgX0gwjBQAA)

`route` does not include an apex test because `hostRequired: true`; the TXT template includes both apex and subdomain tests. These are Online Editor simulation results, not live DNS changes.

Local validation: official `dc-template-linter` revision `e91773489dfd7aae37afe3fc4e2bba7e3e8d27b8` passed both `-loglevel error -tolerate info -logos` and `-cloudflare`. Cloudflare-specific informational messages identify unsupported optional metadata; the service enforces the subdomain restriction itself and does not rely on those fields for safety.
 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
