### PR TITLE
add Coffer, Send mail from your own domain

### DIFF
--- a/coffer.email.sending.json
+++ b/coffer.email.sending.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "coffer.email",
+  "providerName": "Coffer",
+  "serviceId": "sending",
+  "serviceName": "Send mail from your own domain",
+  "version": 1,
+  "logoUrl": "https://coffer.email/icon.svg",
+  "description": "Lets Coffer send replies from addresses on this domain, signed so they are not treated as forgeries.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "coffer.email",
+  "syncRedirectDomain": "coffer.email",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 1800
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 1800
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 1800
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Coffer (https://coffer.email), a shared inbox for small teams.
The template lets a customer authorise Coffer to send replies from addresses on
their own domain: three DKIM CNAME records pointing at our sending provider
(Amazon SES). Nothing else is touched on the domain.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set - the public key is published as TXT records at `_dcpubkeyv1.coffer.email`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content - the template has no TXT records at all
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique - not applicable, no TXT records
- [x] no variable is used as a bare full record value - `pointsTo` is `%dkimN%.dkim.amazonses.com`, with the target zone fixed
- [x] no bare variable is used as the full `host` label - hosts are `%dkimN%._domainkey`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify - not applicable: all three records are DKIM selectors that must stay exactly as applied, otherwise signing breaks

## Online Editor test results

**Editor test link(s):**
- apex: [Test coffer.email/sending acme.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKTfnmoC%2F%2B1UW0%2FbMBT%2BK5alPS0tubQljbQH2BUYCAa7oipy7ZNiNbEj222VVf3vO%2B5l7UQHD3sZEk%2Fxufv78h3PqYOqLpkDms1pbfRUCjAngmaU66IA04aKyZIGv2MXrMJc%2BnoZRb8FM5UcliUWlJBqtPWuk6%2FRT3wfUhhdkUZPDNEzRYRGp8L0KRgrtaJZFNBSj%2FRnU2LZnXO1zQ4Odm9yILlWbTv1QwRYbmTtlpX0IzhLVtci%2FiLEQF1KsKuZTAgD1qKpFXF30q6HB8TKkQJBrEY3NIQZIEo74gwgK4IwbKDNCAy2antkjeLHpeZjmhWstLDyXE6GZ9C8WeG5x53P%2BARCGuDubzkY00ZYmt3OqWvqJccXR%2BdvMXSnrUPzhRjLKnrRzlc3H0Pjf4uWytkbvRP3nzar2E%2BtEG%2Bb6wrznENGozQMF8GD%2FeNH%2Bsf%2F2D95pH%2FyaP%2FBIqAYgnzL2AC1sKGV8QrWNeu5eBoZPalzuUmumWGV9YrflN1u6wabwlvqz0tSlwmMbezY28PhcGMn3uacU383lJM2kHtZMTcxSIQzE5RJNSmdzNmMbV2C56yuywahWIxil%2Fs%2FX61WCKf%2FSZxgjq39DxMW0Fxwj1X6FYUoFHBYdFpR0U9bnajTa6X9OG11037CEghZUaQ7277vJdi%2F8Vuy%2FZopJ5lf4aNyxhpLF3tUsQaGNO4F5v1PGhjqYS8w738KwAYBrsqzHp%2F1%2BL%2FoER9by6YgcubT4jDutcJ%2BKzy8iXpZGGZJr92Pu51O9yUaYegBgHUrkHN8l3dfZArJ9BRm8dnJzYeSd79fXzK4Ov56OVGn36Jx2u2%2Fk1%2F0%2BXv%2BI%2BpcvaKLX3CH4TwmCQAA)
- subdomain: [Test coffer.email/sending acme.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABrgnmoC%2F%2B1Uy27bMBD8FYJATrUVWVJcW0APbvoK2gapm6BtAkOgxLXDWCIVklKgGv73Li07dpHXoZcGyEnYnd0lZzTLBbVQlDmzQOMFLbWqBQd9xGlMMzWdgvagYCKnnVvsmBVYSw9XKOYN6FpksGoxILmQs212Xfwd88TNIVOtCtKoShN1IwlXmJRYXoM2Qkka9zo0VzN1pnNsu7S2NPH%2B%2Fu5N9kWmpGdqdwgHk2lR2lUn%2FQLWkPZaxF2EaChzAaY9k3GuwRgMlST2Upj14R1ixEwCJ0ZhGhrCNBCpLLEaUBVOGA5QegYaR3mOWSOzt7nK5jSestxAmzmp0s%2FQvGv53NHOVYyBCw2ZfagGMaW5ofHFgtqmXGl8PPr6HqFLZSyGe3wuit6el7Q3n0PjfosS0ppTtYO7j8cK9ltJ5OtlqsA6a1HR3sD3l51H5wdPzA%2F%2BcX74xPzwyfmTZYciBMlWsQl6YSMrywpY96zPNVWKwUyrqkzEpr5kmhXGmX7TebFtnWx6L1bNbryTdlXD2CYOXJymt3jo4izLqLshmkppSJy5mK00ymF1hWYpqtyKhN2wbYpnCSvLvEFCBlGcctcCsl0kPH1HPq9lxplla%2Bxx6To04ZmjLNyyDlnkD4e9qBuGg0E3GkZpl6Vh1A2mMGUhOwiDMNjZ%2B%2FvehPt3%2Fy%2FZ3c5JK5jb51F%2BwxpDl%2FdYZM0P1XyQn8OeOz90x4P8HPZM%2BE06uEIvJn0x6X9tUnyWDauBJ8xVBn7Q7%2FrDrv%2F6tNeP%2FSAOI2%2FYD6IofOX7se87DmBsy3OBL%2Fju202bT1ba85Eaf5wfXMPhVX98fVhfnfcGP2uff6hTc%2FJjfPbry%2Bjo%2FNsbuvwDJH2%2FDVYJAAA%3D)
