### PR TITLE
add Nubes, Website and application hosting

### DIFF
--- a/usenubes.app.ingress.json
+++ b/usenubes.app.ingress.json
@@ -1,0 +1,26 @@
+{
+  "providerId": "usenubes.app",
+  "providerName": "Nubes",
+  "serviceId": "ingress",
+  "serviceName": "Website and application hosting",
+  "version": 1,
+  "syncPubKeyDomain": "domainconnect.usenubes.app",
+  "description": "Connect an apex domain or subdomain to Nubes and verify ownership for automatic HTTPS.",
+  "variableDescription": "IP is the Nubes ingress IPv4 address. TOKEN is the ownership token assigned to this hostname by Nubes.",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%IP%",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_nubes-verification",
+      "data": "nubes-verification=%TOKEN%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "nubes-verification="
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add signed Domain Connect setup for Nubes static websites and server applications. The same template supports apex domains and subdomains through the standard host parameter. It installs an ingress A record and a prefixed ownership TXT record.

Public signing key: `_dcpubkeyv1.domainconnect.usenubes.app` (published and verified). The application signs requests with RSA/SHA-256 and independently verifies DNS ownership before enabling automatic HTTPS.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — not applicable: optional logoUrl omitted.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

[Test usenubes.app/ingress example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGDjnmoC%2F%2B1WUWvbMBD%2BK0bQp8aem7hJaxi0tIVmo1nYDCtrg5GtSyLmWEaSk3gh%2F30n22mcJWPNQ2GDQSCn0326u%2B9OJ6%2BIhlmWUA3EX5FMijlnIPuM%2BCRXkOYRKIdmGWm97A3oDG3JwGyhWoGc8xhKBE8nElRDW9t%2BhUhxDRZNmYWHJTymmovUmgqlEYP2c5AKNcQ%2FQ2yRxsM8%2BgjFrZhRjkrCSiEWaQqxdn4JjIGKJc90iSc3lRH6QlewtCqoJaSl8qheaGGV4ZcBoWs%2BLiyxSDGGKc%2BsMdrSXKOp5rF1HwTDL44JkUpOowRud9z1hxZXlp5CfWJNgdUfzj2LMmYWjhV8%2Bng32BhuPWnxHTBMpfgkBWbC0lM0MrSkyJwVFdWpxr2EWEimiP%2B0IrrIDK3XqDa2KF6ZAgmeahUIXJ70hyeo0Tohfsd1160XTPAYbFFhSaNdMlDXxPBJNcXN%2Fb33J2UezZNRWmqkfIw11Q9Ux1Mk4EEw42ooYcyX5KBJvXfQC1mP1i3yQ6QQbpMeteomQAwsKbYsOLGYbXNBaSJFnoV8Y59RSWfKtPUG%2BbQDHW2wT8TI%2FaGROp7TcZ2zC%2Bfc6Mp8jboKExjXQtoaEGVixLIJCaEpH9W5xKS1zKFFZnmieUgXdKticWg6v8CUFO7imbt1TKubcrXlvxFJk%2B%2BQxSYlbu4buF43YrRr9%2Bh51%2FZo59KOwAObur2oN%2B5Be9y5aNzcQ7f68PXdcoprSDWniYkzWdBCkfVeO9XBH9tO%2B6T%2BbYmOWthI%2Fwv1DxQKL6uic2AhNWZtt9213Uvb7QVnXR9%2FnbbT7V60O96p6%2Fqua%2BLHNKqMV6VcDoprfDHM%2F2bWl0ozGHaLXI8FcoiX30ypcjaZubQ2o9yMgL1RXhengXN2eN5vtyPq6%2Fzp2OdXFf6ZVNN5gDK%2BWC9P6tuQVhedZtxRmk6qT4XXM9nAOW%2FE6jEujmF4be5Bgt8x2NElR%2F4%2B5WjTfHrIuzEb8P7nbhxM548F%2FdD2ira3HFx%2FC9hNIrO7dHB%2FmuSMLh4UvrE%2FAdZDSKX5CQAA)

[Test usenubes.app/ingress example.com/api.staging](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGzjnmoC%2F%2B1W7WvaQBj%2FV8JBP9WkUaO2gcFKK5srdZY6WmglXJJHvTXmsruLLxP%2F9z2XxBpnytoPhTEGhV6e9%2Bf3vLkmCmZJRBUQd00SwecsBNELiUtSCXHqg7RokpDaM69PZyhL%2BpqFZAlizgLINFg8ESBL1EL2DnzJFBg0Dg00FrGAKsZjY8qlQh2Un4OQSCFuHXVXcTBI%2FStYXfIZZUgkYfYIeBxDoKzfAgtBBoIlKtMnF7kQ%2BkJXsDRyVYMLQ6Z%2B8aG4kYWfBYSu2Xhl8EWMMUxZYoxRlqYKRRULjM%2FD4eDW0iFSwagfweWeu97AYNJQUygsFhAYvcHcMWgY6g%2FLGH696va3gjtPij8Bhiklm8QQ6rDUFIU0LDEiZ%2Fir3Kp2LyDgIpTEfVgTtUo0rOdI1rL4%2FKgLxFms5JDj51FvcIQUpSLiNm17U3vWGd4Pd1peBqOZIVDURONJFUXmIe%2FDUZZH2TK%2BlgohH2NN1TVVwRQBuOahdjUQMGZLUilS8Cq9kM1oUyM%2FeQzeLulRrWgC1IElxZYFK%2BCzXS40YZZUdJL300TwNPHYVjWhgs6k7vCtkYc9K6OtmYc9O0juDTSx6VhN26qfWi1Ny1DQ5Dx4CJniwlSABnTkWEwuwNNFpSoVCIUSKdTILI0U8%2BiC7khh4Ol5WGGiErloc7%2B6cT4%2F%2B7kV9SnFVK6HFwY6T6bncdyot%2BxOu2GeBfXAdADAPPPbodm0fbDDNjgd3ylNdtXUV493JebIglgxGungowVdSbI56Lwio4rOsyqzrOiPQ9T%2F4vxHNey%2F%2F0X9x4qKS0DSOYQe1RoNu9E27TPT7gzrbRf%2FHMdyWq2G0zy2bde2dSqYUZ78Ontnu%2Bgc75P%2Bv70sGVEvnP02KNYNqYLohZ2YrT%2B9%2Bjb6cOjVcnA4ipqV9Kw9yA8b8i1l%2F5PZx1f1wCPJb0Ef33gfnw%2F4%2B4D28iF5FZIlPeudUH2Li7cgvNEjEeGvJuzoDCP3EHKUKZ80cup8sedP598XN53jBbu99rud9Obk%2FvTuot790bu86HY%2BNU7q13P1jeNF%2FwVhdJ4XZwoAAA%3D%3D)


Both links were generated by the Online Editor and decoded locally to verify that their template content exactly matches this PR. Both rendered the expected A/TXT records. Official linter and Cloudflare-specific lint pass without errors.

Notes: No redirect_uri is used, so syncRedirectDomain is not needed. IP is a full A-record value because the ingress address comes from the service configuration; its value is protected by the signed request. Both DNS records are required for routing/ownership verification and must remain with the template, so the default essential=Always applies. TXT conflict matching is scoped to nubes-verification=. Cloudflare ignores TXT conflict hints; DNS verification still checks the current token. 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
