### PR TITLE
Add sendwax.com email-sending template

### DIFF
--- a/sendwax.com.email-sending.json
+++ b/sendwax.com.email-sending.json
@@ -1,0 +1,53 @@
+{
+  "providerId": "sendwax.com",
+  "providerName": "Sendwax",
+  "serviceId": "email-sending",
+  "serviceName": "Sendwax Email Sending",
+  "version": 1,
+  "logoUrl": "https://sendwax.com/logo.svg",
+  "description": "Authorises Sendwax to send email from your domain. Adds DKIM signing keys so receiving servers can verify your mail is genuine, plus a bounce subdomain so delivery failures come back to us and dead addresses stop being emailed.",
+  "variableDescription": "%dkim1%, %dkim2% and %dkim3% are the three Amazon SES Easy DKIM tokens issued for your domain. %dkimzone% is the SES DKIM signing host for those tokens (region/cell-specific, e.g. dkim.amazonses.com). %region% is the AWS region your mail is sent from, for example us-east-2.",
+  "syncPubKeyDomain": "sendwax.com",
+  "syncRedirectDomain": "sendwax.com",
+  "syncBlock": false,
+  "multiInstance": false,
+  "hostRequired": false,
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.%dkimzone%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.%dkimzone%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.%dkimzone%",
+      "ttl": 3600
+    },
+    {
+      "groupId": "bounce",
+      "type": "MX",
+      "host": "bounce",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "bounce",
+      "type": "SPFM",
+      "host": "bounce",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds the Domain Connect service template for **Sendwax** (sendwax.com), a transactional email platform.

The `email-sending` service configures a domain to send through Amazon SES:

- three Easy-DKIM `CNAME` records (`%dkim1%`…`%dkim3%`),
- a bounce-subdomain `MX` (`feedback-smtp.%region%.amazonses.com`), and
- an `SPFM` record on that `bounce` subdomain (`include:amazonses.com`).

DKIM tokens and the SES signing zone are template variables (`%dkim1%`…`%dkim3%`, `%dkimzone%`, `%region%`). The signing public key is published at `_dcpubkeyv1.sendwax.com`. `syncBlock` is `false`; records are additive and scoped to DKIM selectors and a dedicated `bounce` subdomain, so they don't disturb a domain's existing mail.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`sendwax.com.email-sending.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://sendwax.com/logo.svg`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`sendwax.com`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`sendwax.com`)
- [x] no TXT record contains SPF content — the SPF record uses the `SPFM` record type
- [x] `txtConflictMatchingMode` — n/a: this template contains no TXT records that must be unique per label/content
- [x] no variable is used as a bare full record value — no bare-variable TXT records
- [x] no bare variable is used as the full `host` label — DKIM hosts are `%dkimN%._domainkey` with a fixed `._domainkey` suffix
- [x] no variable is used in the `host` field to create a subdomain — the `bounce` host is fixed
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential`/`OnApply` — n/a: every record (DKIM CNAMEs, bounce MX/SPF) is required for sending; there are no user-modifiable records such as DMARC

## Online Editor test results

**Editor test link(s):**

- [Test sendwax.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHj6nmoC%2F%2B1WW2%2FbNhT%2BKwSBABsmO7r4DvTBS7wh7dIVcdqlCAKDFo8d1pKoipQdNch%2B%2B86RIl9aO%2B2APbRDHgzQPJfvXD%2FqnluI00hY4IN7nmZ6qSRkZ5IPuIFErsRdM9Qxd9ai1yJGVT6uhCgwkC1VCKUJxEJFDTJUyXwj27VhI9Ji47XWEjKjdMIHnsMjPddvswi1b61NzeD4eCuMY5I2zZKMJJgwU6ktDfkwt7c6UwYMq1GsZmTKypjYLNMxK3SeManxImmyoZSGnb46O2dGzROMhC2gMMxolkEIakk3FD8Gx0KRMDyoWVH5KF0qw%2BaQ5CoBh6VRbphgU50nITCTTysU8iYhUmhbsBka5RlGiJkAm4pwQTGSHUYpQUgmpEQ5JWGsTtkUKIYyfpBNKpTIlJhGcLqT%2B5FcqNg7clh58I9Kf%2BU5wHMGzN7SLwNgw1h80gkbj8ZsJExRpW%2F1AhKD6ZgcJJvpbLdOpSe0giPKmHyR%2BU7hbrWxpSE2wUDt8KcM5hjhcQgRzkQKoZqp0GHQnDcZ%2BWyKMhpMl3r7MyJVBmuc4V9jVl3tVh3basuGOiUo3AmcYMBKNkAY2%2FCpVKZIwjf59BUUp2UeX8wzKVyAVNhs%2B4TKr5EOF3wwE5EBh8d5ZNVZYqzANq9vKf0L%2BJijL7m%2BRL86k4YPru%2F5PNN5Wi4I5Y2ebZHSQpy8Hp6PeOVg08jmpCo9jiPtnVaJNZd6S77pCLmyuCxBx3UfnH8H5H8FyP%2BvgIKvAAXfBlTt1gbq%2FGqDs5Zt%2BZ4BSFqyholt2qxna3foSl5TSBy2QPZxvxl7%2FOa38z3oJp1d5BFg07lKwiiXMPgcbgNw8%2BBwSnmymZQbpLV6FB%2Bn%2BtHsEQlPZVATVeunIhOxIe6uLa93TG9q22tO53KC6I%2BYhp4fSJi12p35rer2%2Bh8Wkev5tRJFRnpfLmqt4ZM4TnTQaqcfs063Z2zed73l6s4PWrVSQErFp3ani4C9vouACIuACPuBlKq2kNZ6fTlVBplFZzAhhhEWWZMPbJbXGzgRK7G5kuFEpGlUYCENStEXrtxn85hUL9ChrHcHVAornlLeU5Otxjp8IkNqiKLJCQOv1wtc0ej3u9BoCRE0%2BqIdNqatjhdK0Qe%2FLbZe1z0P71Pv62Ys6NlIrBL0cg6jlSgMf6AZ3l%2BHQ23bW4eDyj9%2BHQ5N5t46HFT%2BAetQkudjEdb09ZjnLnFuXtUnMtwl0e8w38ury8MJL18gcXtsL2Wzv0UUfaftvHHwBXjmumeue%2Ba6Z677v3MdfisasQQ5EaTmu36n4fYbbvfS6w7a7YHbarZc1wu8X1x34LqUBRhbJX2P35PbX5L85agzXYSno1P7Mhqufl%2F96cfDi2FL3f3xtnsy759cvVu%2BO3sv3yvoveAP%2FwBYIo%2F1IxEAAA%3D%3D)
- [Test sendwax.com/email-sending example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJf8nmoC%2F%2B1WXU%2FjRhT9K6ORkFptEmwnxMHSPqRAVbRilxJa0CIUjT3XyRDHYzzjBIPob%2B%2B9NvliCWylPmwrHpDMzD333M8zeeAWplkiLPDggWe5nikJ%2BbHkATeQyrm4a0V6yhvLq89iiqZ8UF%2FihYF8piKoIDAVKmkSUKWj1d0mhh2RFRssrWaQG6VTHrgNnuiR%2FiNP0HpsbWaC3d21MHbptmVmBJJgolxltgLyfmHHOlcGDFuwWM0IyqqYWJzrKSt1kTOp8SBtsb6Uhh1%2BOj5hRo1SjIRNoDTMaJZDBGpGJxQ%2FBscikTL8UHFZ%2B6hcKsNGkBYqhQbLksIwwUJdpBEwU4Q1C3mTkCjElixGUJFjhJgJsFBEE4qRcBilBCGZkBLvKQljdcZCoBiq%2BEG2qFAiVyJM4HAj9x05UVN3p8GqD2%2Bn8ld9t%2FE7B2bH9JcDsP5U3OuUDY4G7EiYsk7f6gmkBtMxBUgW63yzTpUnRMEOZUy%2BCL5RuLE2tgJiEwwsHP6Uwwgj3I0gwZnIIFKxihoMWqMWI58tUUWD6VJvf0amGrDk6V8MWH20WXVsq60a2qhI4U7gBANWsgnC2KZHpTJlGp0W4ScoD6s8vplnMjgDqbDZ9hWTXxIdTXgQi8RAg0%2BLxKrj1FiBbV6eUvpncFugL7k8RL86l4YHVw98lOsiqxaE8kbPtsxoIQ4%2B90%2BOeO1g1cjWsC49jiPtnVapNed67X7VEXJlcVnaXcd5bPwzIu8NIu%2FfImq%2FQdT%2BPqJ6t1ZUJ5crnuXdmu8YQNKSNc3UZq3FbG0OXaVrCoXDlqg%2BzndzD05%2FPXmB3WTxWZEANp2rNEoKCcFzuhXB9WODU8rD1aRco6wtRvFpqp9gT0y0AfhfFdhQLTCZyMXUkH4v0Fcb8OsF%2Fqp2QDQ0SXQgwsj12hLizl53NFZ%2Bb%2F9mkjiutzCiCMnu24VdWHiV31S3O3vZbd71e8YW%2B447m9957c7CqE1G5f1e10fC3r6DhEiLhEh7Q0Z1e8hqucacKoQKo3MYktIIi%2BrJA5sXi00cirlYHcloKLIsKbGgBm%2FRF67es7lM65doW9Zrg9p6qrUUVryGeKEwa11u8KGMqDOKxihy424YQtz0Oz3Z7ISh39zv7cmm7Pqy7bq9bge6a0%2FtC6%2Fwa4%2Ft5ozQO5JaJegp7SdzURr%2BSEP9ckG29W97QbYi%2Fh8F2Tar2wuyFfEfLUilr0%2FVqBXuWcKbArt6fV9JdVNsf9DEzy%2FP38h89hGV3mUvajz7SyTJD9zg6wY%2BGe%2FC%2BC6M78L4LozvwrgmjPgr1IgZyKEgU8%2Fxuk1nv%2Bn4524vcDqB47c833O73gfHCRyHMgFj68Qf8Jfq%2Bm9UfntfxDfj3271rvF%2FH5V%2FfumHvjcvT3X09dIe6IuL8YFrvt59uBxMPvLHvwFkkRF0hREAAA%3D%3D)
