### PR TITLE
Add DMARC CNAME configuration for dmarcify.top

### DIFF
--- a/dmarcify.top.dmarc-cname.json
+++ b/dmarcify.top.dmarc-cname.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "dmarcify.top",
+  "providerName": "DMARCify",
+  "serviceId": "dmarc-cname",
+  "serviceName": "Managed DMARC CNAME Delegation",
+  "version": 1,
+  "logoUrl": "https://dmarcify.top/assets/logo.svg",
+  "description": "Configures a managed CNAME delegation record for DMARC aggregate report ingestion and real-time policy enforcement.",
+  "variableDescription": "%token%: DMARCify ingestion token identifier",
+  "syncBlock": false,
+  "syncPubKeyDomain": "dmarcify.top",
+  "syncRedirectDomain": "dmarcify.top",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "_dmarc",
+      "pointsTo": "%token%._dmarc.dmarcify.top",
+      "ttl": 3600
+    }
+  ]
+}

--- a/dmarcify.top.dmarc-cname.json
+++ b/dmarcify.top.dmarc-cname.json
@@ -15,7 +15,8 @@
       "type": "CNAME",
       "host": "_dmarc",
       "pointsTo": "%token%._dmarc.dmarcify.top",
-      "ttl": 3600
+      "ttl": 3600,
+      "essential": "OnApply"
     }
   ]
 }


### PR DESCRIPTION
# Description

Adds the service provider template for DMARCify (`dmarcify.top`) to enable 1-click Managed CNAME delegation for automated DMARC aggregate reporting and real-time policy enforcement.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`dmarcify.top.dmarc-cname.json`)
- [x] Resource URL provided with `logoUrl` is actually served by a webserver (`https://dmarcify.top/assets/logo.svg` returns HTTP 200)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — set to `dmarcify.top` with live TXT public key records at `_dck1.dmarcify.top`
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — set to `dmarcify.top`
- [x] No TXT record contains SPF content (`"v=spf1 ..."`)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — N/A (template specifies a CNAME record)
- [x] No variable is used as a bare full record value — value is prefixed with `%token%._dmarc.dmarcify.top`
- [x] No bare variable is used as the full `host` label — fixed to `_dmarc`
- [x] No variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):** 
[Test dmarcify.top/dmarc-cname example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADFBn2oC%2F91UXU%2FbMBT9K5GlPdGkIetXIu2hUIQ2VgYIhBCqIte%2BSS0SO7LdQlv1v%2B86%2FR6g7XlPsX3vse8599wsiYWyKqgFkixJpdVMcNDfOUkIL6lmIpsHVlWksYtd0xJzyWDYvzvHKEYM6JlgsAf5TLqkXWQDGVJJc%2BBeDfXOr%2FvDC28ABeTUCiUxfQbauFVy2iCFytWDLhA2sbYySbN5WE%2BTGgPWNF1WYGY5gjkYpkVVX5WQcyUzkU81GI965ebh9ZN896SngSnNvUzpTVE0z7ULAoYqpa0nZA6mzqWS4yEtfCtK8CpVCDb3QCKWQQnSBo4A1YKOCxgc1fLFqheQXxJvq9nBrXXIQ12lFZkA7USbS3ZWKPZCkowWBtYnN9PxFcwHqqRCvm%2BOy7gDLpCQ%2FSxnTdaQ5HlJ7LxyHakFwdBEGYvbtEa4XishrblX%2B%2BKDdSz4405rsUNfO2HYIIAdQRLUteyX7FdVMSer0apBFkpCun98hK3aVghvFM0HAVPlvgpc5VpNq1Rs8yuqaWmcQbfI5yPoaIt9Jm5dV%2Bw2FkX21ztXiMil0pAa%2FFKL1iCJ1VOUt5wWVqT0le6POEupY4B1G4ziZe9Fk2tX70Tj1FLc7x%2F9u2YpZ46VcJMDPYijuNvye22W%2Ba1xl%2FoxhJHP%2BTg77bXjXtZuH4zhRyP6%2BSDupf2wTatRA3X%2BzymiMwydAU%2Bpy4vCqOOHsR9276MoaXeSVhyEnU63FZ6EYRKGjgXSXDNe1uvagf0K3tx3O%2Br14cZxh4b71OW1t52vV24knbs%2BHMkj6YODK4Jjff%2BtJTiIKydegf8HVMBlI6jmgueHI0GehpcL8xg%2FqcnTj9uznxePi9gwung9UdnD5E1ezq5u7uOIRfL19htZ%2FQYPjlnLQAYAAA%3D%3D)
[Test dmarcify.top/dmarc-cname example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOBAn2oC%2F%2BVUUW%2FaMBD%2BK5GlPpWEECiUSHtgMGnTRltB13arUGTsS%2Bo1sSPbsDLEf985gQJrq%2B19T4nv7jvfffed18RCUebUAonXpNRqKTjoT5zEhBdUM5GuAqtK0nj2XdACY8loPJgM0YseA3opGOxBPpMu6NmzhYyppBlwr4J6w4vB%2BIM3ghwyaoWSGL4Ebdxf3GqQXGXqq84R9mBtaeJm87CeJjUGrGm6qMAsMwRzMEyLskoVk6GSqcgWGoxHvWJ7cX0lf77S08CU5l6q9LYommXaOQFdpdLWEzIDU8VSydFIc9%2BKArxS5YKtPJCIZVCAtIFrgGpB5zmMjmo5seoR5Ens7Tg7yFq5PORVWpEK0I60lWTvc8UeSZzS3EBtuVrMP8NqpAoq5MvhuIgJcIEN2bdi6mYNie%2FXxK5KN5GKEHQ9KGPxmFQIN2slpDXXal98UPuCP3JaixNqd8OwQQAngk1QN7JLOSjLfEU2s02D%2FFISkv3lMxzVrkJ4oig%2BCJgq9lWgL8dTptWiTMQOU1JNC%2BNEukPfH8FnO%2Fx9nQDPVeXOYJFsvz65gkQmlYbE4JdalAiJrV4gzcUityKhP%2BnexFlCXSdYv0EvJntJnqzVvSVoWz2nlqJxf%2FPfCUw4c%2B0Jt0bQY7w3bzO%2F32ctv9Olc5%2F2044fhZ3zVq8P%2FXbUOdjJ1%2Fb17a085vnVuW1mDST9f%2BkVtWLoEnhCXWwURl0%2F7Pth7zqK4rOzODoPWu1O1I1OwzAOQ9cJtlp3va7%2BK10OSnhy390jUBm3GjyU4Jv6rxTv1L5xy%2Br09uqyHs%2FgIEVwzPG%2FjQVXdOMIzPHlQAZcNIKqXtB%2BuCSk6OhRr5h%2Bu%2FrSmww5vem0Pv64TW%2Bmd9n3aTpZXjZPV7fyLrO95vgd2fwGGu9c6VoGAAA%3D)