### PR TITLE
Add sitenoar.app website template (apex and subdomain)

### DIFF
--- a/sitenoar.app.website.json
+++ b/sitenoar.app.website.json
@@ -12,19 +12,18 @@
   "syncRedirectDomain": "app.sitenoar.dev",
   "hostRequired": true,
   "records": [
-    { "groupId": "apex", "type": "A", "host": "@", "pointsTo": "%ipv4%", "ttl": 300 },
+    {
+      "groupId": "apex",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 300
+    },
     {
       "groupId": "apex",
       "type": "AAAA",
       "host": "@",
       "pointsTo": "%ipv6%",
-      "ttl": 300
-    },
-    {
-      "groupId": "www",
-      "type": "CNAME",
-      "host": "www",
-      "pointsTo": "customers.sitenoar.app",
       "ttl": 300
     },
     {

--- a/sitenoar.app.website.json
+++ b/sitenoar.app.website.json
@@ -4,19 +4,20 @@
   "serviceId": "website",
   "serviceName": "Website",
   "version": 1,
-  "logoUrl": "https://sitenoar.dev/logo-black.svg",
+  "variableDescription": "%ipv4%: current Site no Ar gateway IPv4 address; %ipv6%: current Site no Ar gateway IPv6 address. Both are supplied by the service backend in signed requests.",
+  "logoUrl": "https://sitenoar.dev/logo-filled.svg",
   "description": "Connect a Site no Ar website using selected DNS record groups.",
   "syncBlock": false,
   "syncPubKeyDomain": "domainconnect.sitenoar.app",
   "syncRedirectDomain": "app.sitenoar.dev",
   "hostRequired": true,
   "records": [
-    { "groupId": "apex", "type": "A", "host": "@", "pointsTo": "204.8.219.40", "ttl": 300 },
+    { "groupId": "apex", "type": "A", "host": "@", "pointsTo": "%ipv4%", "ttl": 300 },
     {
       "groupId": "apex",
       "type": "AAAA",
       "host": "@",
-      "pointsTo": "2a09:8280:57::136:600c:0",
+      "pointsTo": "%ipv6%",
       "ttl": 300
     },
     {

--- a/sitenoar.app.website.json
+++ b/sitenoar.app.website.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "sitenoar.app",
+  "providerName": "Site no Ar",
+  "serviceId": "website",
+  "serviceName": "Website",
+  "version": 1,
+  "logoUrl": "https://sitenoar.dev/logo-black.svg",
+  "description": "Connect a Site no Ar website using selected DNS record groups.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.sitenoar.app",
+  "syncRedirectDomain": "app.sitenoar.dev",
+  "hostRequired": true,
+  "records": [
+    { "groupId": "apex", "type": "A", "host": "@", "pointsTo": "204.8.219.40", "ttl": 300 },
+    {
+      "groupId": "apex",
+      "type": "AAAA",
+      "host": "@",
+      "pointsTo": "2a09:8280:57::136:600c:0",
+      "ttl": 300
+    },
+    {
+      "groupId": "www",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "customers.sitenoar.app",
+      "ttl": 300
+    },
+    {
+      "groupId": "subdomain",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.sitenoar.app",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add Site no Ar website DNS configuration for Cloudflare Domain Connect. One template supports
two groups: `apex` for A/AAAA records and `subdomain` for CNAME records. Each signed request
configures one hostname, using `host=@` for apex or the relative hostname for subdomain.
IP destinations are parameters supplied and validated by the backend; CNAME points to
`customers.sitenoar.app`.

All records require DNS-only proxy status. Cloudflare onboarding must validate live consent,
record application and preservation when configuring/reapplying separate hostnames.

## Type of change

- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?

- [x] Apex and subdomain checked using Online Editor
- [x] Template file name follows `<providerId>.<serviceId>.json`
- [x] logoUrl is served by a webserver

Passed dc-template-linter with -cloudflare -loglevel info -tolerate info -logos.
Only informational Cloudflare compatibility diagnostics were emitted: DCTL5003, DCTL5006,
DCTL5007. Local app tests verify exact selected record names and RSA-SHA256 signatures.
Cloudflare consent/record application tests require onboarding and have not been performed.

# Checklist of common problems

- [x] syncPubKeyDomain is set
- [x] warnPhishing is not set
- [x] syncRedirectDomain is set
- [x] No SPF TXT records
- [x] No TXT uniqueness rules needed: no TXT records in this template
- [x] Bare IP variables are justified: A/AAAA require complete IP address values. The backend validates the address families and signs the current gateway values, allowing gateway changes without template updates. CNAME remains fixed.
- [x] No bare variables as host labels
- [x] Standard host parameter is used for subdomains
- [x] No explicit %host% attribute
- [x] All selected records are essential to serving the requested hostname

## Online Editor test results

Both links below contain the exact final template:
- group apex, host=@, ipv4=192.0.2.10, ipv6=2001:db8::10 creates A/AAAA at example.com.
- group subdomain, with a relative host and without IP parameters, creates a CNAME at the selected subdomain.

These are editor tests using documentation IP addresses, not live DNS changes.
Cloudflare end-to-end tests remain pending onboarding.

[Online Editor: apex](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOPnnmoC%2F%2B1VW0%2FbMBT%2BK5YlntaGpJSUZpq0cplWbSsI2ECgqnLsQ%2FBI49R2AgX1v%2B846ZUBe9we1ifn%2BHzfOd%2B5uE%2FUwjhPmQUaPdFcq1IK0H1BI2qkhUwx7bE8p43l3YCN0Zee4S3JFOlpvDOgS8mhgt1D7JAr6xxwsbSXoI1UGY0CPDMtWZzCIRiuZW4rO92SedneiggvtIbMklUwkmCq92xK%2BidlmzAhNBjznjhA%2BEdAuAB4ZF%2FZW8I0EFPkeSpBkHhK7C1%2B10mTmPE7yASRGTEyydBBw6QAY42HElKVqO86xVRvrc1NtL29rJaActtdN29kmoLwTJkgQGzoO1BZBtwStp7ovHCkMDJLMI8UPTDs4eAMQ3OlBUm0KvIqvplmfD9V%2FI5GNyw1UFtOivgLTA%2FVmEkXRVQHXsfynrXT%2BZ%2BCkEhtlwi88taFoN%2BtMvYUlaMjdtfqAmPV6RgaXT%2FRKqeq8SyHBwTYae7a3Ztj8fjRTY%2BSmTXnatlc52mxgDu%2BP2u8QYO%2FN5nC15lMEdclWNEdDHrfjl7l44WxaozT%2BbxYS%2F7hrEEfVQajVQmGjXmhkQAeGC4TeFyNN4NUSY1kBagVIixnmo2N27sFwfUGw3BBcY0cwznJOoErpPsOui3P91pe4M%2BtobO2fD%2BIRLwXRc6OieMYKw0jN87MFhoW7RwXqZUjds9WJsFHqDydok6Dt0iHrV7rbFbvtJMmmGV4XMthVa8GHQnuBErXj71Opwt77bjZbbWh2b4B0Yx5d7cpQtEOhGgFnMPaQ%2FPSI%2FTyQ7NWaFxu3H%2FJ3Gr2Utx7Q2duKjbH6ff0N4r1zwkYNnDM%2Fnfgb3YAF8uwEsSI2SrZVtj0u02%2Fcx6E0c5u1O54wV4r3Gm%2F8%2F3IrwTgf0Ut7Ql3b33raBB85pOfn44nX7rh5eHl1%2F5DctVPjgbHvcf%2BOM1%2BmMlFEl6Vg5Pz3gc6%2BwWMrmJTowcAAA%3D%3D)

[Online Editor: subdomain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAO3nnmoC%2F91UyW7bMBD9FYJATrUVeVNsFQXqLIckiOBmQQoEhkGRE5uILKokJUcx%2FO8dSt6SJmnP1Wk0M%2B%2FNyllSC%2FMsYRZouKSZVoUUoM8FDamRFlLFtMeyjDa2tojN0ZfeoJWkigw12gzoQnKoYAuIHXKnXQPut%2FoCtJEqpWELZaYlixM4BcO1zGylpwcyK7oHIeG51pBasgtGppjqgpXkfFR0CRNCgzFfiQMEfwUEG4BHjpWdEaaBmDzLEgmCxCWxM%2FyvkyYx40%2BQCiJTYuQ0RQcNv3Iw1nhYQqKm6k4nmOrM2syEh4fbbgkoDp25%2BSiTBIRniikCxKv6TlSaAreE7Se6bhzJjUynmEeCHhj2NLrB0FxpQaZa5VkV35QpP04Uf6LhI0sM1JpRHl9CearmTLooohJ4Hct7M07nfw1CIrXdItDk7ReCfjNl7DVWjo44XatzjFWnY2j4sKRVTtXgWQbPCLBl5sY9XGNR%2FO62R8nUmlu1Ha7ztNjAju%2BvGp%2FQ4PcpU%2FAxk8njugU7upNoeHX2IR%2FPjVVz3M63zdryj1cN%2BqJSmOxaMG6sG40E8MzwMYHH1XwXZLFY4E%2BV1kRWkL3MEJ0xzebGPb8Nz8MrovGG6aGiGq%2B5%2FuBxbXXKtRzUMiaM66s0TNwaM5tr2IxxnidWTtiC7VSCT7DipMT6DFqRAkf8pndp%2FZ7rsgSz7F8616ATwV2N0k0GfOGzHg%2BawFnc7A5ANGMmes2gP%2BgPOu34qD8QeyfnvXP0%2Fsl51XJ86HgLJHPPdJjgDTB0tRo3cGL%2FXVE4csMKEBPmPNt%2BO2j6g6Z%2FdNsKwk4v7B15%2FW6r3Q6%2B%2BH7o%2B64EvGR1mUvckP3doMfZJRdGl5eG3fOZ5Rfq8exF%2FLwro%2BhHq7eIon553bl5GemLq2909RtYZ4iuQQYAAA%3D%3D)

