### PR TITLE
add SparkOS, SparkOS email sending (sparkos.email.json)

### DIFF
--- a/sparkos.email.json
+++ b/sparkos.email.json
@@ -1,0 +1,61 @@
+{
+  "providerId": "sparkos",
+  "providerName": "SparkOS",
+  "serviceId": "email",
+  "serviceName": "SparkOS email sending",
+  "version": 1,
+  "hostRequired": true,
+  "syncPubKeyDomain": "thesparkos.io",
+  "syncRedirectDomain": "sparkhostapp.com",
+  "logoUrl": "https://sparkhostapp.com/logo.png",
+  "description": "Authorise SparkOS to send marketing e-mail from a subdomain of your domain (for example news.yourdomain.com): three DKIM CNAMEs so the mail is signed in your name, plus the MX and SPF for the bounce address under mail.<subdomain>. Optional DMARC policy on the subdomain. Nothing is added at the apex and no existing record is changed.",
+  "variableDescription": "%dkim1%, %dkim2%, %dkim3% - the three DKIM selectors Amazon SES assigns to the domain (32 lowercase alphanumerics each); each CNAME points to the same selector under dkim.amazonses.com.",
+  "records": [
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dkim",
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "MX",
+      "host": "mail",
+      "pointsTo": "feedback-smtp.sa-east-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "mailfrom",
+      "type": "SPFM",
+      "host": "mail",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "dmarc",
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none;",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=DMARC1",
+      "essential": "OnApply",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for SparkOS (`sparkos.email.json`): authorises SparkOS to send marketing e-mail from a subdomain of the customer's domain (`hostRequired: true`, we always apply with `host=news` or a similar label chosen by the customer). Records, all under the `host`:

- three DKIM CNAMEs (`%dkim1%._domainkey` → `%dkim1%.dkim.amazonses.com`, etc.) — the selectors Amazon SES assigns to the identity;
- MX + SPFM under `mail` (the MAIL FROM / bounce subdomain, `feedback-smtp.sa-east-1.amazonses.com`, `include:amazonses.com`);
- optional DMARC on the subdomain (`_dmarc`, group `dmarc`, `essential: OnApply`, `txtConflictMatchingMode: Prefix`).

Nothing is written at the apex and no existing record is changed. Sync flow signed with `syncPubKeyDomain: thesparkos.io`; `syncRedirectDomain: sparkhostapp.com` for the return.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test sparkos/email thekendallcollective.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALlen2oC%2F%2B1XbWvjRhD%2BK4sg0KOWIkt%2BT1NwnRSOq5OQ5GhKCGYtja09S1pld%2BXEF9zf3tmV5Je8%2BQKF3pV8srX77DzzzOzMSA%2BWgiSLqQKr92Blgs9ZCOJjaPUsmVEx49KqrZZPaIIw60JvnF7ghgQxZwEYOCSUxeu1bSwxu0RCGrJ0iqg5CMl4avXqNSviUp3Dbc4EoCElckArizQ4y8efYHHE8SgCLRVB6ZLDuFVAziHEU4FagQxCG6RZ5gQ8QVzMp%2FyziHEzUiqTvf39x6B9DXEy41gIMhAsU8Y5q5%2BriAsmgVRCFDcqSIKPoFAMAdtomwieEEpkPg6NM4RPyILngpSPP024IHBPMdpAUriTjt4tNrUTH3pERQKAHH36OCSDk%2F7wWBLJcRGIIWD4yKYphAStGcspxrhGsjiXBjW8IhQ9uzj7nWguvTTmeRoAoWEoQEqSp5hFY835ZeXorw45NXppTI6G%2FfMByXjMggXhqbGxAjrkhKtIS0ZX0CR6QpWB0AzuDXfKUSKTJi6YFy5CjQ0imk4hdHTeqWB0HMPRVpj3whlL6ns1Yv541R9%2Fj9jG%2FkZgJMSYby4k6Sf0K7p4cXxBqNSRkTo5Gl5F3PdIzO9ABBQTSOMM3cgTECyQBGgQfTgwP0WsUTRL1cqExNCuuMq4aZccalglSJ0zraiQKa3e9YM1FTzPTDVoLG6qRaarwDBYxU1fy3VGhaMzWOgiM%2FyXfGP%2FKaE2qfAq%2By3XXdbeRujtIPT%2BbUJ%2FB6H%2FNkJ9bXWRrUmHV2vGsvtscEwAwjENZrZMVOZIagOVyq4%2FocsEwxJXC%2BxF7hvIscyGT%2BhlNjnPY8DbYLE0iPMQet8aTmwowdr65dXl2vio2gypovg8PzR1Wj8g2WHKUzjQ5%2B7VgKcTLFw1pCrQZTrkoTZ1JmDC7p%2BHlHtrkwjDRgGpYlR3zNO0n2XxYsvtm2XNQkUwWt%2F8G3Rto03PsEHSOA54rOuHzaGUXsrRzQ%2BfjPYRMwaq27QR5kIzWsbGSxOpx1PFcf0yyU3Fcl3Q3JQ8OzhMwWkMrY%2B9wA8b0Jy0pu2ow7pf3Fk99hI%2FbfBm1qrAnga%2FDr1tV2Bfg1%2BHio6l44pdjAsY6W5GVS6gGodJHis2ond0vRQGI6pzg2mQuIsU2IAeVWNaDOFdojbK1CmTU960nSdfL%2BAaXt1AZ47pK97wwR%2B3x649adOO3WhCw6Ztv243x9CFTqMZhC7deNt49BLy3LvG9oXavLj9%2BI4upLXURfZ8UHYl7%2BWg7Dz54wZl1yV9OSg7T%2F5AQTFzpYyIeVnalvqtg2VD3PaM%2BY6kFnPmZa3zQxxpdfLsMCN%2FY%2F%2F9bpO4payYoE%2B0PTNG%2F3st1cxdLm9qOFnfu%2Fp7V3%2Fv6u9d%2Fb2r%2F1%2B6On4VSDqHcEQ11nO9lu12bbdz6dZ7rtdrdB231cXln12357rafZCqUPeA3wibXwfW7cA9HTc7g3rX%2B7rfbQ3mjYVKsuNp0onE5R%2B%2Fiejzl%2BmforVP%2F5oeWst%2FAJeQWEPuEwAA)

(`hostRequired: true`, so the template is always applied with a `host`; no apex test.)
