### PR TITLE
Add cite-met.com.site template

### DIFF
--- a/cite-met.com.site.json
+++ b/cite-met.com.site.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "cite-met.com",
+  "providerName": "CiteMET",
+  "serviceId": "site",
+  "serviceName": "CiteMET Site",
+  "version": 1,
+  "logoUrl": "https://platform.cite-met.com/logo.png",
+  "description": "Point this domain at your CiteMET site and issue its HTTPS certificate.",
+  "syncPubKeyDomain": "cite-met.com",
+  "syncRedirectDomain": "cite-met.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%project%.cite-met.dev",
+      "ttl": 3600,
+      "groupId": "site",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%fqdn%.693d7acb2bcecfe5.dcv.cloudflare.com",
+      "ttl": 3600,
+      "groupId": "site"
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "ttl": 3600,
+      "groupId": "ownership",
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

CiteMET points a customer's domain at their hosted site and issues its HTTPS certificate. Three records in two groups:

- `@` CNAME → `%project%.cite-met.dev` (the site) and `_acme-challenge` CNAME → `%fqdn%.<uuid>.dcv.cloudflare.com` (Cloudflare DCV delegation) in group `site`
- `_cf-custom-hostname` TXT → `%ownership%` in group `ownership`, so a domain that needs no ownership record never has an empty TXT written

The ownership record is split into its own group because the value is nullable upstream: the apply URL sends `groupId=site` when Cloudflare asks for no ownership token, and `groupId=site,ownership` when it does.

**Only two variables, both behind fixed text.** `%project%` can only ever produce a `cite-met.dev` subdomain, and the Cloudflare DCV delegation identifier is hardcoded rather than a variable — a forged apply URL therefore cannot steer certificate validation anywhere. (Comparable accepted templates make one half or the other a variable; this one hardcodes the uuid and uses the `%fqdn%` built-in, so neither is caller-controlled.)

**`hostRequired: true`** because the template carries a record at host `@`. Our service refuses apex-connected domains rather than sending an apply request that could not be honoured.

Signed: `syncPubKeyDomain` is `cite-met.com`, with the RS256 public key published as `p=1`/`p=2` TXT records at `_dck1.cite-met.com`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

### Note on "no variable is used as a bare full record value"

The `_cf-custom-hostname` TXT uses a bare `%ownership%` rather than a prefixed `citemet-verification=%ownership%`. This is the rule's "unless necessary" case: the value is Cloudflare's own custom-hostname ownership token and Cloudflare verifies the TXT content by **exact match**, so any prefix makes verification fail.

The collision risk the rule guards against is covered two other ways: the record sits at `_cf-custom-hostname`, a Cloudflare-specific label no other service writes to, and it sets `txtConflictMatchingMode: "All"` so re-applying replaces our previous value instead of accumulating duplicates.

### Note on `logoUrl`

Confirmed live: `https://platform.cite-met.com/logo.png` returns HTTP 200 with `content-type: image/png` (505x512 PNG).

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

[Test cite-met.com/site example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJo8g2oC%2F%2B1UXW%2FaMBT9K5ElnkpCwkcKSJOG2m6tNrqK0mlThSJj34DXxE5tB5oh%2FvtsPkpoYdKe1oc%2Bge89ucfn3uO7QBrSLMEaUHeBMilmjIK8oqiLCNPgpqA9IlJUfc5d49Rg0ZnJ9i%2BGJqFAzhiB1TfKRHehfahzu07OQComOOoGVZSIibiTiQFNtc5Ut1azd4mFTL0yfc3ivIxPzOcUFJEs06sS6EYwrh09ZcqhIsWMO1g7hcils2W1V3Iwpw5TKgeHaeVcDoc3tw4BqVnMiNHu2TsXnNzk4y9QnK8Kve6ARQyAMglEH8NMhdIDeMwNyPRDyxyqyOCFpAp17xdIF9mqJde9%2FsUGbo4fbX%2BtEjUU5lgxvf5lSCq7JlCYGYzWplWN0PeraCJFnpV7DkoB1wzbZn7jvSxLCrSsHmOMMEnBJVOcJMAn8II%2FfqS84oWdBj3FZFwfEyAxtDxKZh5JRE7jBEvYKD5%2BpxL78MewxE1il%2BRKi9S1EW5dYuaKNbbcYs6NQaYsqxwr%2FoywgCd9JnicMKL7WJMp45O%2BoJaylyRoOVpW0W%2FBIdrNYGSotsODJ2zMD6XZmeB8PkcbuoitPtm2eEdsimRY4lTZV7Mtd79Xb7QteL%2BqONqUPFpuPXKbtn%2FdwAZ3CBM2B1eLB%2BAuHhNklbEJFxIiZX6xziVsDZfmiWYRnuNdiJIIW0uYRiiTNfVem5Gvn%2Bta%2F2Yc67v8xYcRJbYHzA4m7oSdlh%2BHLm2F4DaDMXEx8QOXNhpBp92uk5BAaZMc2jIHlsneWA66%2FIDNN1pe2Nzb02YOXmli%2F%2B73%2F6i9l8xxofakr9%2FYVvjrN7Yvft9Nb07WqGoe6rtF3y36hi1qFrTCM6ARtsi6Xw9dv%2B0Gp8Mg7LYa3Wbo1cOwHbRPfL%2Fr%2B1YAKL3WtjDbu7y3USe%2F%2B16Lx5c%2FPzVbnfEgII2mfvIVCT53BufspPh6VdwR%2BVCvw%2BQDWv4BP64I6bYJAAA%3D)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->



