### PR TITLE
Add mail-o-mail.com.momv1 (Mail-o-Mail email sending)

### DIFF
--- a/mail-o-mail.com.momv1.json
+++ b/mail-o-mail.com.momv1.json
@@ -1,0 +1,76 @@
+{
+  "providerId": "mail-o-mail.com",
+  "providerName": "Mail-o-Mail",
+  "serviceId": "momv1",
+  "serviceName": "Mail-o-Mail email sending",
+  "version": 1,
+  "logoUrl": "https://mail-o-mail.com/static/images/logo-inverted.png",
+  "description": "Authorizes Mail-o-Mail (mail-o-mail.com) to send email for the domain: SES domain verification, DKIM (Amazon SES tokens), SPF via the mom-controlled include, DMARC with a hosted report address, plus a pre-provisioned relay DKIM selector CNAME and return-path CNAME (inert until activated; no MX records).",
+  "variableDescription": "%sesverify%: the Amazon SES domain verification token; %dkim1%/%dkim2%/%dkim3%: the three Amazon SES DKIM tokens issued for the domain; %dmarctoken%: the customer's DMARC report inbox token at dmarc.mail-o-mail.com; %relaytoken%: the per-domain relay DKIM key handle under dkim.puma.mail-o-mail.com.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "mail-o-mail.com",
+  "syncRedirectDomain": "mail-o-mail.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_amazonses",
+      "data": "%sesverify%",
+      "ttl": 3600,
+      "groupId": "verify",
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "SPFM",
+      "host": "@",
+      "spfRules": "include:_spf.mail-o-mail.com",
+      "groupId": "spf"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600,
+      "groupId": "dkim"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600,
+      "groupId": "dkim"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600,
+      "groupId": "dkim"
+    },
+    {
+      "type": "TXT",
+      "host": "_dmarc",
+      "data": "v=DMARC1; p=none; rua=mailto:%dmarctoken%@dmarc.mail-o-mail.com",
+      "ttl": 3600,
+      "groupId": "dmarc",
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "mom1._domainkey",
+      "pointsTo": "%relaytoken%.dkim.puma.mail-o-mail.com",
+      "ttl": 3600,
+      "groupId": "relay",
+      "essential": "OnApply"
+    },
+    {
+      "type": "CNAME",
+      "host": "psrp",
+      "pointsTo": "puma.mail-o-mail.com",
+      "ttl": 3600,
+      "groupId": "relay",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template `mail-o-mail.com.momv1.json` for Mail-o-Mail (https://mail-o-mail.com), an email + WhatsApp marketing platform. One approval authorizes a customer's domain for email sending through Amazon SES: the SES domain-verification TXT, the three Amazon Easy-DKIM CNAMEs, SPF via `SPFM` (`include:_spf.mail-o-mail.com`, a provider-controlled include so the customer's SPF never needs editing again), DMARC with a hosted report address (`p=none`; `essential: OnApply`; in its own group `dmarc` so the service provider excludes it via `groupId` when the domain already publishes a policy), and a pre-provisioned `relay` group of two CNAMEs (a fixed-selector DKIM CNAME and a return-path CNAME, both pointing at provider-controlled names, inert until the relay is activated). No MX records. Synchronous flow only. The signing key is published at `_dcpubkeyv1.mail-o-mail.com`.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description — **one justified exception:** `_amazonses TXT "%sesverify%"`. Amazon SES domain verification requires the verification token as the *entire* TXT value at `_amazonses.<domain>`; SES does not accept a prefixed value. The record sits at its own dedicated label and is scoped with `txtConflictMatchingMode: All`, so it cannot collide with other TXT content on the domain.
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

**Editor test link(s):**
<!-- run A: apex, all groups -->
- apex (`example.com`, all groups, 8 records): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFp3n2oC%2F%2B1YaW%2FbNhj%2BK4SAYC1mO7p8KQhQLz1WtG67JO3aFYFBkZTFWBJlkrLjBNlvH0nJV2LHDVZg7eBPSsj34PO8J3xjSZLmCZTECm6snLMJxYS%2FxlZgpZAmdVbXnwZiqVVbXL%2BDqRK3%2BqWA%2FqhLQfiEIlKqsnTiLM%2FuywOizQJBMkyzoZKcEC4oy6zAqVkJG7KPPFEasZS5CA4P7zzlUEgoKTqkKRwScajl6zRTJiTBjdzYw0QgTnNpbFq9QsaM02siwOojntyx%2BxRIZt5UPS9iHMiYAMzUv1kAzl6cVX8D5YxGFEHtoAaev3ndB096KbxmmZGSbEQy8bQGzj68BBMKjRnFSh2xTHKWJAQDmqGkwERp93unJ2BKZQwgiJlQKAAnOeMSQIw5EaIG8qQQ6jbnpG6ioMkyYgmcle4FSQiS6sUn73r9FwBm%2BlYWPKvnUFkuT5%2FQTLEEikwqeBBJOlGRx0cgY6D%2FWckjxrF42tABgZzCMCHP14g8EEQY6LODwGBawbyBmZKHI3CARzR1Dg7N162%2BXmVCxpysGTJwSgYBFaJQONcjoQ2mkCMjU1lBhZAsJfwXUfFZMUizkF2V1gCUwOg17sRd2TNErtrLCa9XiFZIHpEZiBW1CVEcqkoAGkgjL1J416bmUMwy9FvC0MgKIpgIUp58KMI3ZPbc2N5YZlrolGCqwiEfENOZckrGhZLDCwdVCK3g640lZ7kuu%2FPP55W0%2BmcADc8qjLpIoITrQVWHUqrK81q2XbOGnBW5KejyWt9eyROWRQlFsg8lilX19hnWbnpJYt3WFl5V4veXbp9pWHl0WiTKcWBVqR8M1FnjPrKlX3W%2FatQk8dJqlVaNQRkoFRzdpBjNpDhnK%2FcmSAvglZONOLXkLofuDofu93bo7XDo%2FRuH69lhymOZGZNjU0vOEciPM9VwjgAv4LGOlGTBag0%2B21hXW99QeXk4mWqW6nxEdSqoR8H7rJfnyewBrlR7dbYTtVLgja1Fu%2B3BRvnRD8oFz9df8d18XtzWLBVrMljW%2B4WK2rxZkCuohjpZaRTqcF5YA2rklzWti6xWJkZtEZvSvTKaQw5TobeDufmva%2FYv5g6%2BWvpv4%2BIR5he9R%2Bv8MfKuPnXjt6l7nnfEn9j%2FgpxT2HpH7L%2BK9svL5qvQ%2FT3uvhl5b8WxVjb1rRXbE3cmx9Hl%2BMqnl9yXCLl5mA4Rn8aXIp2RubCrhUfNK2%2FcLtDUjZPxtTcdt3nYyrJo7CGfTy%2BzubCnhcPxxM3G6NpFYTH1J63Mi2J4KaScirAVzaQRXhSC1oBO6CIP%2B6QZtey203G7HvTDJmrhNulEXdtxPb%2FZane05jIrtaYXdaGD2qQZurgDfdQidqSMYUuHmw4zxslAqC9UY13lm%2BSF6vhpkUg6gFO4PMJoAHWeqOwQ6laZvjsNsnIj2zQNHhWDtdwdYKTThOrsDTuO53kE1lEUNes%2BCnEdtt1uHbawH%2FltbLt%2BuLJRblk4N%2B2Uy2xerYxeMoUzYd3e62wV0merTU1lpAMemkHgb2gakAGnsP144OatpoK3K%2F%2FX%2B2JFxE6lXVPlx%2BZkV5lv5GSn0s%2FNya5utpGTnUo%2FGSfrLfAxK8%2B3tvZvWYf%2BS1IWe8T2TLm%2FTVUEbRtS37pV%2FeC4q6WtAvuzwLmoqf1vP%2BT3Q34%2F5PdDfj%2Fk90N%2BP%2BT%2Fh0Ne%2F1wCJwQPoJZzbbdVt7t1u3Nuu4HfDpp%2Bo%2B13XLfzq20Htq0hECFLkDe3CsXKbwfW2asvZJiwoT1y%2BMmv4yj%2B4Ew%2Bubg5neQf3xcvZt3OyRhin1I0PbZu%2FwGmAd%2FnJxoAAA%3D%3D
<!-- run B: host=mail, groups verify,dkim,spf,relay (the customer-already-has-DMARC shape) -->
- subdomain (`example.com` + host `mail`, groups verify,dkim,spf,relay — the customer-already-has-DMARC shape, 7 records): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAp3n2oC%2F%2B1Xa2%2FbNhT9K4SAYC1qO7Iky7aCAHWTditaZ12Sdu2KwKAoKqItkTJJ%2BZEg%2B%2B0jKfnZOG6xAmuxfKJN3nsu77kv6taSOMtTKLEV3Fo5ZxMSYf46sgIrgySts7peGohlVm15fAYzJW71SwG9qEOB%2BYQgXKqybNJc7X0pD7CGBQLTiNBrJTnBXBBGraBZs1J2zd7zVGkkUuYiODzcusqhkFASdEgyeI3FoZavE6ogJI4aucGLsECc5NJgWr1CJoyTGyzA%2BiWebOE%2BBZKZO1XXixkHMsEgYuovDcDFy4vqN1DGSEwQ1AZq4PTN6z540svgDaNGSrIRpuJpDVy8ewUmBBoYxUodMSo5S1McAUJRWkRYafd75ydgSmQCIEiYUF4AjnPGJYBRxLEQNZCnhVCnOcd1EwVNlhFL4bw0L3CKkVQ3Pjnr9V8CSPWpLDit51Ahl7tPCFUsgYJK5R5EkkxU5KMjQBnof1TyiPFIPG3ogEBOYJji0w0iDwQWxvX5QWB8WvP5HmZKHo7AQTQiWfPg0KxOtboVhEw43gAy7pQMAiJEofzcjIQGzCBHRqZCQYWQLMP8F1HxWTFIaMhmJRqAEhi9xlbcFZ4hch0vx7xeebRG8gjPQaKoTbHiUFUC0I408iKD25iaQzGn6EXK0MgKYpgKXO68K8I3eH5qsO8tMy10jiOiwiEfENOZco7HhZKLlgaqEFrB51tLznNddpcfLytp9WcADc8qjLpIoISbQVWbUqrKc33brlnXnBW5KejyWJ%2FO5AmjcUqQ7EOJElW9fRZpM700te5qS6sq8fsrs8%2B1W3l8XqTKcGBVqR8M1F7jS89WdtX5OqhJ4hVqlVaNQRkoFRzdpBihUlyytXMTpKXjlZF7%2FdSS%2Bww6eww639ugu8eg%2B28MbmaHKY9VZkyOTS01j0B%2BTFXDOQK8gMc6UpIF6zX4%2FN662nmHysrDyVSzVOfDqlNBPQp%2Bp708T%2BcPcKXaa3M3UWsF3thZtLsubJS%2F%2BUK54PnmLb6bzau7mqVijQerer9SUVs0CzyDaqjjtUZRdZBFcQ2I0VnVtS60Wpkctcq0Aswhh5nQL4MF9OcN7KsF%2BOcS%2FaqC%2FwroZc%2FRsn%2BM3NmHbvI2cy7zjvgz8j6h5jn0z7D9V9F%2BNWz9Gjq%2FJd03I%2FetONbKpq61YnvizOU4Ho5nHhlyTyLk5GF2jfg0GYpsjhfCjhYetWbuuF2gqZOk4xt3Om7z0Kc0HrvI49MhXQi7WjgcTxw6RjcOCoupN%2FGpGydwKKScitCP59IILwtAa8Bm6CA38nAr9u12s%2BN0XeiFLeRHbdyJu3bTcb2W3%2B5ozVU2ak037sImauNW6EQd6CEf27ECiywdZnJNGccDoVaoxrnKM8kL1emzIpVkAKdwtRWhAdT5obJCqFMFvT0FaPkSW02BRpUVVcF%2FUyA2EncQIZ0nRKeu34IuardxPUbIrXttt12HXhzVY6eDsNf1PTtsrT0nd7w273tQbqbyemn00imcC%2Bvui9ZWubzp5%2BRYZWUTPDSHwN%2FQNCHjo3Lxx%2FRx0XIqL%2FfVw1p%2F3Ir8Xs19I%2BbHJ2df%2Fe8mZ6%2Fmz0%2FOvn63m5y9mj8%2FOVtPiy0CdrXvr31n%2FNf%2BL18VuwnQT5ktr38mv65q6nn0OAsfZ%2BHjLHychY%2Bz8HEW%2Fp9nof74hhMcDaCWdWzHr9vdut25tJ3A8wPXa7gd3293n9l2YNvaDSxk6eit%2Bh5d%2FxK1XOGecjYcht4LzlyavvpwNm7NPrXQ24vk%2BsR7f168sHM5fMYvXx9bd%2F8AWR9aKm0YAAA%3D
