### PR TITLE
Presscloud, 3 templates

### DIFF
--- a/presscloud.ai.email-eu.json
+++ b/presscloud.ai.email-eu.json
@@ -1,0 +1,55 @@
+{
+    "providerId": "presscloud.ai",
+    "providerName": "Presscloud",
+    "serviceId": "email-eu",
+    "serviceName": "Presscloud Sending Domain (EU)",
+    "version": 1,
+    "logoUrl": "https://presscloud.ai/images/logo/presscloud_logo.svg",
+    "description": "Publish the records that let Presscloud send press releases from your own domain, through Mailgun's EU region.",
+    "variableDescription": "%dkimSelector%: the DKIM selector Mailgun generated for this sending domain (e.g. email, krs); %dkim%: the base64 RSA public key for that selector, the p= value of the DKIM record",
+    "syncPubKeyDomain": "presscloud.ai",
+    "syncRedirectDomain": "presscloud.ai",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:mailgun.org"
+        },
+        {
+            "type": "TXT",
+            "host": "%dkimSelector%._domainkey",
+            "data": "k=rsa; p=%dkim%",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "email",
+            "pointsTo": "eu.mailgun.org",
+            "ttl": 3600
+        },
+        {
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mxa.eu.mailgun.org",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mxb.eu.mailgun.org",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=reject; pct=100; fo=1; ri=3600; rua=mailto:140210b3@dmarc.mailgun.org,mailto:5d0582fc@inbox.ondmarc.com; ruf=mailto:140210b3@dmarc.mailgun.org,mailto:5d0582fc@inbox.ondmarc.com;",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/presscloud.ai.email-us.json
+++ b/presscloud.ai.email-us.json
@@ -1,0 +1,55 @@
+{
+    "providerId": "presscloud.ai",
+    "providerName": "Presscloud",
+    "serviceId": "email-us",
+    "serviceName": "Presscloud Sending Domain (US)",
+    "version": 1,
+    "logoUrl": "https://presscloud.ai/images/logo/presscloud_logo.svg",
+    "description": "Publish the records that let Presscloud send press releases from your own domain, through Mailgun's US region.",
+    "variableDescription": "%dkimSelector%: the DKIM selector Mailgun generated for this sending domain (e.g. email, krs); %dkim%: the base64 RSA public key for that selector, the p= value of the DKIM record",
+    "syncPubKeyDomain": "presscloud.ai",
+    "syncRedirectDomain": "presscloud.ai",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:mailgun.org"
+        },
+        {
+            "type": "TXT",
+            "host": "%dkimSelector%._domainkey",
+            "data": "k=rsa; p=%dkim%",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "email",
+            "pointsTo": "mailgun.org",
+            "ttl": 3600
+        },
+        {
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mxa.mailgun.org",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "type": "MX",
+            "host": "@",
+            "pointsTo": "mxb.mailgun.org",
+            "priority": 10,
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=reject; pct=100; fo=1; ri=3600; rua=mailto:140210b3@dmarc.mailgun.org,mailto:5d0582fc@inbox.ondmarc.com; ruf=mailto:140210b3@dmarc.mailgun.org,mailto:5d0582fc@inbox.ondmarc.com;",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
+            "essential": "OnApply"
+        }
+    ]
+}

--- a/presscloud.ai.newsroom.json
+++ b/presscloud.ai.newsroom.json
@@ -1,0 +1,21 @@
+{
+    "providerId": "presscloud.ai",
+    "providerName": "Presscloud",
+    "serviceId": "newsroom",
+    "serviceName": "Presscloud Newsroom",
+    "version": 1,
+    "logoUrl": "https://presscloud.ai/images/logo/presscloud_logo.svg",
+    "description": "Point a subdomain of your domain at your Presscloud newsroom.",
+    "syncPubKeyDomain": "presscloud.ai",
+    "syncRedirectDomain": "presscloud.ai",
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "newsroom.presscloud.ai",
+            "ttl": 3600,
+            "essential": "Always"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds three Domain Connect templates for Presscloud (`presscloud.ai`), alongside the delegation template merged in #1763. These cover customers who keep DNS at their own provider rather than delegating a zone to us.

- **`presscloud.ai.newsroom.json`** — one CNAME pointing a subdomain at the customer's Presscloud newsroom.
- **`presscloud.ai.email-us.json`** / **`presscloud.ai.email-eu.json`** — the Mailgun record set for a sending domain (SPF as `SPFM`, DKIM TXT, tracking CNAME, two MX) plus the DMARC policy Presscloud requires. Split by region because the tracking CNAME and MX hosts differ; everything else is identical.

The DKIM selector is minted per domain by Mailgun (`email`, `krs`, …), so it is a variable. The `._domainkey` suffix and the `k=rsa; p=` prefix are fixed, so neither the host label nor the record value is a bare variable (rules 6 and 7).

`syncPubKeyDomain` is `presscloud.ai` for all three, sharing the signing key published at `_dcpubkeyv1.presscloud.ai` and already in use by the merged delegation template.

## `hostRequired` on the email templates, and DCTL1037

Both email templates set `hostRequired: true`, which raises **DCTL1037** ("hostRequired template should be combined with NS or CNAME record that uses host @ or empty"). This is deliberate, and we would ask that it be accepted rather than removed.

Presscloud sends only from a dedicated sending subdomain, never from a customer's apex. Without `hostRequired`, a DNS provider will apply these templates at the apex, where two records do real damage: the `MX` pair takes over inbound mail for the customer's entire organizational domain, and `_dmarc` publishes `p=reject` for that whole domain — replacing any existing `v=DMARC1` record via the prefix conflict rule, which can immediately start bouncing mail from the customer's unrelated senders.

Nothing else prevents this. The spec notes `hostRequired` is "largely informational, as most DNS Providers already enforce such rules", but that enforcement concerns CNAME-at-apex, which is invalid DNS. `MX` at an apex is perfectly valid, so no provider will refuse the apply.

We read the spec's definition as covering this case: "the template has been authored to work only when both domain and host are provided", with CNAME-at-FQDN offered as *an example* rather than as the sole qualifying shape. The record-type section makes the converse binding — CNAME or NS at `@` requires `hostRequired` — but not the reverse.

`dc-template-linter -tolerate warn` exits 0 on all three files. DCTL1037 is info-level, so only `--merge-or-fail` rejects it, meaning these two will not carry `automerge-possible` and need a maintainer merge.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead — SPF is published via `SPFM` on the apex in both email templates
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — set to `Prefix` with `v=DMARC1` on the DMARC record
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — the DKIM value is `k=rsa; p=%dkim%`
- [x] no bare variable is used as the full `host` label — the DKIM host is `%dkimSelector%._domainkey`
- [x] no variable is used in the `host` field to create a subdomain — `hostRequired: true` with the standard `host` parameter is used on all three
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — set on the DMARC record in both email templates

## Online Editor test results

**Editor test link(s):**

- [Test presscloud.ai/newsroom example.com/press](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKqGn2oC%2F91TUW%2FaMBD%2BK5FflwQDSYBIldZuXdV1ixBifShCkRMfYCmJPduBZoj%2FPhtIoS2V9rwn63zf3X33%2BfMWaShFQTSgeIuE5GtGQd5TFJsAlMoLXlOfMOS%2BJBNSGjAav6RNToFcsxz2dRVslOS8PF2%2Fq3CSE2YNUjFeobjrooIv%2BS9ZGOxKa6HiTucViQ4ryRJUx8LOMqmNfbVemm4UVC6Z0PuOaMxZpR3iqDqjvCSscvjCaXgtnWNI9CE8o9bS9y3%2FpsrHdfYAzdc9%2FoIqFjIByiTk%2BkPQiis9gd%2B1QRmFtKzBRaaAS6pQPNsi3Qgr0Jfk%2BuftEW7Cz1Z0u4Ga8jNd%2FbfdtTaK9SOMXWQSUGlGrITXxYY0Cu3mOxf94RWkp4lzI1TLFZ6JMQD4%2Bf41jqP3I0y4lLwWKWuLBJGkVNYpbfnsVf28bTA7drCz2bLiElJlTqJrCa0AZV1olpINOV3RPCVCFI2hqkzW9HkvTnUwU8uQEk3%2BUZyU5pY6syalwyCjsBh44TAMvCAMMm80wgOP9gaLKMfdkIbZmecvfogPTP9GwktPspu7Rs7%2FdTfjAkXWQFNisT3cizw88vBwivtx2I%2B7gR%2BFgyiMPmEcY2z3AKUPu26NX86dgnoJy56%2B957ru%2BrH6pbcgCzgPviWJ48PDXu8SwQX0xsY0u4kuEK7v53ZD9zOBAAA)
- [Test presscloud.ai/email-us example.com/press](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJGGn2oC%2F%2B1Xf2%2FiOBD9Kpal1d3qIE2AUkiFVApsVVX0Wmh1q60qZGIn%2BJrEWdvhx1XcZ79xCJC0VLo7nXS7q%2F6VxJ55nnkz86w8Y82iJCSaYfcZJ1LMOWXykmIXPphSXihSahGOK7vNaxKBMb7ZbcOeYnLOPZb5sYjwsJqq%2FfIrDzRmMeVxgPoCjGP08%2F34I5jPmVRcxNh1KjgUgbiXIbjNtE6Ue3RUiueIRyRg6siYFXYm5ttS8wDQKFOe5InOEPFNOg25miE9Y0gyT0iq4J1oFDKNCpEpiAxlgGAWMqKYQr4UEVqJVCKxiBHNYq6AtxRpMENDSDdI458Uuh%2BDTwDnWSYZIjmZhqxfCuMDfeLRGIA9LeQHNwunf3U5hHM3a1s4FLCYSagLRT6s6hlXWWyGNZqzxqzAQhndFfQk1cdTlMHnsFOIvdlAo3EXJSZ5Dz2xVQ4GeW8PrGTGSQfNSZgyJPx9TBueTB1XsQcEXrHVpmAHusOYjBjl4KPfNJoJpUfsawpW0ClapqyC82Jg9%2BEZ61ViGmV882mYW8PXmUFP%2FFEaMrDCPPbClDI32vBkCRngdWXne%2Ff5bu9aZtuabIgDGkx7EE3A5KkjFTmF%2FDfUwYbW0HX1pm0XUHvX3eFgj5txbkZC8FirOwFLxXAOYww%2Fl3MqOi%2BJVQZIJBeS6xXMgv0v4Kb%2FGK7E24RGRHp7kuad%2FrA76jmGJ8l%2BBzrhzdMdx7ZPoaM6sCF5xyDCS0o65nAtXKdh1xx7Wj%2FL4IohVXKLY2oft2q%2Bd8bjqVhaIt5YeiIyQP5%2FAlQsB7wudU%2FEPoyDHhLtzWCehoLm8uTzJT5oku%2FtmQAzaG0Wa06MRv0ad5MkXOH147qC%2FxAxm%2Bzb%2BhFo3A4EWxJQW2bi2rOdTQl8BqAnyYRvnRIiSaSMLG%2FdH0r%2Bj1uAhxzBHFTo98w%2Ba9R8wywMLy%2F8Yde%2B6I2%2FXowvp%2FX%2B7eC8e3vf7TYurrv93jm%2FvToPbnsn2CTCg1hINlHwJDqVbDuyURpqPiELsl%2Bi3oQYBiBvBbtw1MOL1oo3l8A22V1nwWg76MBQoz9JGG5rB6WD2k2oZ%2Bjg5pbxGr7jt%2Brtart23Kw2fL9ebXm0VvVrzROfOTXPbnmFS%2BvgjfbGrfWiLMU6d8MFWSm8fjU4eXYZSkFnrBfp7tTmb9eh1LzfJAFbbSxR8CLvN9TxG80ok9bD%2FfpaqQvJlFX2%2B0tt%2Bl2nVhrEzQ1mvVKbH%2BYe%2B%2F9LsLvz1o8VuK%2Fe9f5d79%2F1%2Fl3v3%2FX%2Bx9d7%2BKFQZM7ohBjjml1rVu121W7d2XX3uOY22tZJo10%2FcX6xbde2TSJM6U1NnuG%2FovhHgad0%2BuVEttVvR2Sw%2BBIlS%2Bfq1unRm6bvn5N4kA7Oe71oIOrBp0UHr%2F8CyRHPFbASAAA%3D)
- [Test presscloud.ai/email-eu example.com/press](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGKGn2oC%2F%2B1XYU%2FjOBD9K5al1d2KNqQtLRBUidKyqIJwQGFvTwhVbjJJvSRxsJ1CD%2FV%2B%2B47TtE2hSKfVSbd7x6ck9szzzJuZZ%2BWZaojTiGmgzjNNpZhwH2Tfpw5%2BgFJeJDLfYpxWlpvnLEZjerHcxj0FcsI9yP0gZjyqQrZafuVBBpD4PAlJT6BxQn49vvmI5hOQiouEOrUKjUQobmSEbmOtU%2BVsb6%2FFs81jFoLaNmalnaH5ttQkRDQflCd5qnNEepGNIq7GRI%2BBSPCE9BW%2BM00i0KQUmcLISA6IZhEwBYoEUsRkKjJJxGNC%2FDzmCnpLkYVj4mK6YZb8osjxDfqEeJ5lkmGSs1EEvbUwPvj3PB4gsKeF%2FODk4fRO%2By6eO19bwJEQEpBYF58EuKrHXOWxGdb8gjWwQovkdFfIvVQfD0gOX8COMPbWDrkadEhqkvfIPUwLMMx7cWAlN07bZMKiDIgIVjHNeTJ1nCYeEngK03nBNnSHMbkCn6OPftNoLJS%2BgocMrbBTtMygQotiUOf2meppahplcPHJLazx69Cgp8FVFgFaUZ54UeaDE895soQM6ayy9L3%2Bcr1yXWfbGs6JQxpMezDN0OS%2BLRU7wPzn1OGG1th1jZZtl1C75x33eIWbc25GQvBEq2thljKrHNFmGPfLelol%2F%2FiJWa8wUsmF5HqKE2F%2FB%2BLoexDXCBz6MZPeiq1Ju%2Bd2rro1Q5iEr8grvnm6XbPtA2ytNm5I3jaI%2BJKxtjlcC6e2Y9dr9qhxmMOVQ6oUFk3fbu7VA%2B%2BQJyPxZIlkbumJ2AAF%2FwhQuSj4%2BqS7IglwLrTLtDfGwXKFX%2BhUwJ%2FoRpNib8UEmmGPQ6I5M2L1W9JJ02hKZ3ezCv1TJDBc9fcd0riYDHhiKLtg4lqxnY8LfoYoLOmQL5xSJlmsjD4v3G%2FX%2FO8WALcFgjmo1Pi5fd6xxYZZcPsngduxT7qDh5NBf9ToXR4fdS5vOp2dk%2FNOr3vEL0%2BPwsvuLjWJ8DAREoYKn0xnEhazG2eR5kP2yFZLvjdkhgHMW%2BEuHnX7orWS%2BW2wSHbZWTjjNbJhuslfLIoWtcPSYe2Gvmfo4Oa6adSbMPK8RnW%2F0WpUd3zYr44arFaFfWjVWIs1d8Eu3V4br7Y3rq8XZSnXuRM9sqmis1eDU2SXo5QEx3qR7lJ2%2FnYd1pr3hyRgIZJrFLzI%2B22Z%2FEGTygV2c8tulOxSPuta%2B%2FNlN%2FrZs1ubyPlVZr2Snf%2FMhfbvl2B5%2Bc3uKnhxvQv%2Fu%2FC%2FC%2F%2B78L8L%2F%2F9I%2BPEXQ7EJ%2BENmjOt2vVW196v23rXdcJp1x65brd29Xbu5ZduObULRoPS8Js%2F4p1H%2Bx6Dn2yf%2BZ56dbYUX7I%2BHiZr8%2Fmm%2FvxWcPWxtfXUFDMYsvXg460Gw22%2FT2Ter6L4LyxIAAA%3D%3D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
