### PR TITLE
add Domain0, Domain verification

### DIFF
--- a/domain0.dev.verification.json
+++ b/domain0.dev.verification.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "domain0.dev",
+  "providerName": "Domain0",
+  "serviceId": "verification",
+  "serviceName": "Domain verification",
+  "version": 1,
+  "description": "Verify a domain connection with a Domain0-specific TXT record.",
+  "syncPubKeyDomain": "domain0.dev",
+  "syncRedirectDomain": "domain0.dev",
+  "records": [
+    {
+      "type": "TXT",
+      "host": "_domain0-sdk-test",
+      "data": "domain0-verification=%verification%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "domain0-verification=",
+      "essential": "OnApply",
+      "ttl": 3600
+    }
+  ]
+}

--- a/domain0.dev.verification.json
+++ b/domain0.dev.verification.json
@@ -4,6 +4,7 @@
   "serviceId": "verification",
   "serviceName": "Domain verification",
   "version": 1,
+  "logoUrl": "https://www.domain0.dev/brand/domain0-logo-white.svg",
   "description": "Verify a domain connection with a Domain0-specific TXT record.",
   "syncPubKeyDomain": "domain0.dev",
   "syncRedirectDomain": "domain0.dev",


### PR DESCRIPTION
# Description

Add Domain0's scoped domain-verification template (https://domain0.dev).

It writes one TXT record at `_domain0-sdk-test` under the applied domain/host, with value `domain0-verification=%verification%` and TTL 3600. Prefix conflict matching limits replacement to prior Domain0 verification values at that label. No arbitrary host or website destination variables are accepted. `OnApply` permits independent removal after verification.

Requests require Domain0 signing (`syncPubKeyDomain: domain0.dev`) and allow a Domain0-hosted callback (`syncRedirectDomain: domain0.dev`). Signing-key publication and provider onboarding are separate rollout steps; this submission does not claim live provider acceptance or end-to-end conformance.

Both editor tests below were generated using the exact submitted template, including its redirect-domain field and hosted logo. The official linter passes with upstream-required flags and Cloudflare-specific checks. Offline tests with the official `domainconnectzone==4.0.0` engine cover rendered scope, prefix replacement, unrelated records, repeated application and destructive CNAME/delegation conflicts. No live DNS writes were performed.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Verified `https://www.domain0.dev/brand/domain0-logo-white.svg` returns HTTP 200 with `Content-Type: image/svg+xml` on 2026-09-08.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Test domain0.dev/verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEcLoGoC%2F%2BVUW2%2FaMBT%2BK5GlPjUBN9wj9WFbu2qXdm0H1bQKRcY%2BgLdgp7ZJoIj%2FvuMCI%2B3opD3vKT7%2BvnN8vnPJijiY5RlzQJIVyY0upADzQZCECD1jUtGagIKEv6ErNkMqOduACFgwheTw5FKAkWPJmZNa7aFnLsELDprWn5KTkGR6ogcmQ%2B7Uudwm9XpZlrVKHvWRYUrUtzeR50flVDqo2WKCwQRYbmT%2BFDohd%2F6lZcCCDT%2FgWingHgxK6aYIbFVENgfukwr63%2FqBAa6NqPn8l4pfz0efYLkh%2FlEUT7gFIdHFvULZRLMkuV8Rt8x9IfARBKbaOjTSnRgrfkYO8A5lMMf2gaJqxU6PqtYRkt3CvdNqnEnuLpnjU6kml1r4d64NjOXiMGWLvfII%2BoC1oJxkvhtf1Js8z5Y%2BkkO70aZ0PVyH5FErSPcCh%2BE2GrrAguFYQY3r2V4rniZGz%2FNU7vg5M2xm%2FejtPO%2BfuQ53vvfEn5%2FNDt7tkvd1i2Iat2mPdolPTU6UNpBa%2FDI3N1gOZ%2BYQktk8czJlJdtfCZ4yLw%2BVWEQx7stWqc0A%2F2urDmdXKWKIIbkXL%2F3ydFgLGOMs4t2WiJpIjkatURw126O4zbqNJqWtyiIe2NG%2FrOK%2BA4cau14PQ2zH%2F6gbp8qyAkTKPM9nG9FeRLv9k0Zy0ktoo9bs0DjuHVOaUP%2B%2F86o26lc4Z9UJI8ub94PxxwsQ54%2Fx2wv59bxz8919PrvtPtw1570f2bUrHkQXbo8H5SlZ%2FwJDyQEkewUAAA%3D%3D)

[Test domain0.dev/verification example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAF8LoGoC%2F%2BVUXW%2FaMBT9K5GlPi0JhgCFSH3ovrRuo60YmzpVKDK2E6wS27NNKEX8910TGNDS%2FoE9wfU55%2Fqee6%2BzQo6XekYcR%2BkKaaMqwbi5YihFTJVESBwzXqHwH3RNSqCijzUIgOWmEpRvJBU3IheUOKHkHjqSBM84EFr%2FL22GaKYK9dPMgDt1Ttu00VgsFvFBHY2JIZI1tieR50eLqXA8tlUByRi31Ai9SZ2iX%2F6mZUCCmh9QJSWnHgwWwk0B2LqIrObUFxWM7kaB4VQZFvv6l5Leziff%2BLImvmiKJww5EyBxr1DqbBal9yvklto3Ai4BYKqsgyDbmbHsIXIczsAGcWSfKDrs2MXZYXQGZPfoPiiZzwR1A%2BLoVMhioJi%2F59bwXDyepmyxVy4BDbeWSyeIn8aNvNR6tvSZHMRJF%2BP1eB2iJyV5tjc4DrfZQMIfCawVj6kq916J1hAURs11JnYSTQwprd%2B%2Bnfj%2BSD3eye83%2BnF4vGVwvLPguxe1cKuL%2B7iHfIGikMrwzMIvcXMDTXFmzkNUzmdOZGRB9keMZsSbBD8WUMj7fGCyXuMXA4trW28N7XSFB%2B0MIS31PRD%2BGdF%2Bwiasm0cTltOo3e71I5J3ulGLNSedNkk6uM0OnuSJ1%2FrGozyaxakpr9fjEAbzH9uHHbOk4iwjnuoLjnA%2Fwr1RM0mb%2FbR1HndwL8G9dxin2H8DvbG6ASvYusN9Qz%2Fc9d13fZWwYZUs30%2B%2B8OrTIOdP5dXX5Hf7z%2BdeMby8KYaN6%2FnD4AKt%2FwJhllM9jwUAAA%3D%3D)
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
