### PR TITLE
Add three DoDomain templates (dodomain.io): custom-subdomain-cname-with-verification, apex-a-with-verification, email-authentication

### DIFF
--- a/dodomain.io.apex-a-with-verification.json
+++ b/dodomain.io.apex-a-with-verification.json
@@ -1,0 +1,38 @@
+{
+  "providerId": "dodomain.io",
+  "providerName": "DoDomain",
+  "serviceId": "apex-a-with-verification",
+  "serviceName": "Root domain (A/AAAA) with ownership verification",
+  "version": 1,
+  "description": "Points a zone's root (apex) at a SaaS product's published addresses via one A record and, optionally, one AAAA record, and proves ownership with one constrained TXT record at a fixed host. Never a CNAME at the apex. Used by DoDomain (domain-connect-as-a-service) on behalf of its integrator applications; the addresses and the verification token are the only variables. Apply with groupId=apex-a,verify to omit the AAAA record.",
+  "variableDescription": "ipv4 = the IPv4 address the integrator application publishes for the root domain; ipv6 = the IPv6 address (group apex-aaaa, optional); token = the opaque verification token minted by DoDomain for this connect session.",
+  "syncBlock": false,
+  "hostRequired": false,
+  "syncPubKeyDomain": "dckeys.dodomain.io",
+  "syncRedirectDomain": "app.dodomain.io",
+  "records": [
+    {
+      "type": "A",
+      "groupId": "apex-a",
+      "host": "@",
+      "pointsTo": "%ipv4%",
+      "ttl": 3600
+    },
+    {
+      "type": "AAAA",
+      "groupId": "apex-aaaa",
+      "host": "@",
+      "pointsTo": "%ipv6%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_dodomain-challenge",
+      "data": "dodomain-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "dodomain-verify="
+    }
+  ]
+}

--- a/dodomain.io.custom-subdomain-cname-with-verification.json
+++ b/dodomain.io.custom-subdomain-cname-with-verification.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "dodomain.io",
+  "providerName": "DoDomain",
+  "serviceId": "custom-subdomain-cname-with-verification",
+  "serviceName": "Custom domain (CNAME) with ownership verification",
+  "version": 1,
+  "description": "Points one subdomain at a SaaS product via a single CNAME and proves ownership of that subdomain with one constrained TXT record beneath it (the A/CNAME + TXT pattern). Used by DoDomain (domain-connect-as-a-service) on behalf of its integrator applications; the CNAME target and the verification token are the only variables.",
+  "variableDescription": "target = the CNAME destination host provided by the integrator application (e.g. cname.integrator-app.com); token = the opaque verification token minted by DoDomain for this connect session.",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "dckeys.dodomain.io",
+  "syncRedirectDomain": "app.dodomain.io",
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "connect",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "verify",
+      "host": "_dodomain-challenge",
+      "data": "dodomain-verify=%token%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "dodomain-verify="
+    }
+  ]
+}

--- a/dodomain.io.email-authentication.json
+++ b/dodomain.io.email-authentication.json
@@ -38,7 +38,8 @@
       "host": "_dmarc",
       "data": "v=DMARC1; %dmarcTxt%",
       "ttl": 3600,
-      "txtConflictMatchingMode": "All"
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
     }
   ]
 }

--- a/dodomain.io.email-authentication.json
+++ b/dodomain.io.email-authentication.json
@@ -1,0 +1,44 @@
+{
+  "providerId": "dodomain.io",
+  "providerName": "DoDomain",
+  "serviceId": "email-authentication",
+  "serviceName": "Email authentication (SPF, DKIM, DMARC)",
+  "version": 1,
+  "description": "Authorises a SaaS product to send mail for the domain: merges one SPF include mechanism into the zone's SPF record (SPFM), publishes one DKIM selector (as a CNAME to the product's key host, or as the key itself in a TXT), and sets the DMARC policy. Each group is applied independently via groupId; no MX record is ever written by this template. Used by DoDomain (domain-connect-as-a-service) on behalf of its integrator applications.",
+  "variableDescription": "spfInclude = the host of the single SPF include mechanism to merge (e.g. _spf.integrator-app.com); dkimSelector = the DKIM selector label; dkimTarget = the CNAME destination of the selector's key host (group dkim-cname); dkimTxt = the DKIM key record body after the fixed 'v=DKIM1; ' prefix (group dkim-txt); dmarcTxt = the DMARC policy tags after the fixed 'v=DMARC1; ' prefix (group dmarc).",
+  "syncBlock": false,
+  "hostRequired": false,
+  "syncPubKeyDomain": "dckeys.dodomain.io",
+  "syncRedirectDomain": "app.dodomain.io",
+  "records": [
+    {
+      "type": "SPFM",
+      "groupId": "spf",
+      "host": "@",
+      "spfRules": "include:%spfInclude%"
+    },
+    {
+      "type": "CNAME",
+      "groupId": "dkim-cname",
+      "host": "%dkimSelector%._domainkey",
+      "pointsTo": "%dkimTarget%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "dkim-txt",
+      "host": "%dkimSelector%._domainkey",
+      "data": "v=DKIM1; %dkimTxt%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    },
+    {
+      "type": "TXT",
+      "groupId": "dmarc",
+      "host": "_dmarc",
+      "data": "v=DMARC1; %dmarcTxt%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Follow-up to #1436 (merged 2026-07-24), which added the first two `dodomain.io` templates — `custom-subdomain-cname` and `domain-verification`. Both are now served by three providers (Domain Chief, Glauca HexDNS, Cloudflare), and both have round-tripped a real signed apply on a zone we control.

This PR adds three multi-record templates. Nothing in #1436 is modified.

| serviceId | Writes | Variables |
| --- | --- | --- |
| `custom-subdomain-cname-with-verification` | ONE CNAME at the apply `host`, plus the ownership TXT at `_dodomain-challenge.<host>`. `hostRequired: true` — both records hang off the supplied host, never the zone apex. The standard "A/CNAME + TXT" onboarding pattern in one apply. | `%target%`, `%token%` |
| `apex-a-with-verification` | ONE A at `@` (group `apex-a`), an OPTIONAL AAAA at `@` (group `apex-aaaa`), and the ownership TXT at `_dodomain-challenge` (group `verify`). Never a CNAME at the apex. | `%ipv4%`, `%ipv6%`, `%token%` |
| `email-authentication` | Up to four independent groups: `spf` (an `SPFM` merge of ONE `include:` mechanism into the zone's existing `v=spf1` record), `dkim-cname` (CNAME at `<selector>._domainkey`) OR `dkim-txt` (the key TXT at the same name), and `dmarc` (TXT at `_dmarc`). **No MX record, ever.** | `%spfInclude%`, `%dkimSelector%`, `%dkimTarget%`, `%dkimTxt%`, `%dmarcTxt%` |

**Design notes**

- **No MX, deliberately.** A wrong MX write black-holes a domain's mail the moment it propagates, and a connect session knows nothing about the domain's existing mail routing. `email-authentication` writes authentication records only; MX stays a manual record.
- **Variables sit inside fixed prefixes**, not as bare whole values: the DKIM TXT is `v=DKIM1; %dkimTxt%` and the DMARC TXT is `v=DMARC1; %dmarcTxt%`, so a reviewer can see the bounded effect of every variable. The SPF group merges exactly one `include:` mechanism.
- **Groups are applied independently** via the apply's `groupId` parameter. `dkim-cname` and `dkim-txt` are mutually exclusive by construction — both write the same host, and a caller picks one. A session whose record set does not fill one of these templates falls back to manual records rather than being coerced into a template.
- All three set `syncPubKeyDomain: dckeys.dodomain.io`, so every synchronous apply is signed. The chunked public key TXT is live at `_dck1.dckeys.dodomain.io` (`dc-debug-pubkey --dns _dck1.dckeys.dodomain.io` returns `record is ok`; independently confirmed by Cloudflare during the #1436 onboarding review).
- No `logoUrl` yet, as with #1436. The asset is now hosted and we intend to add it to all five `dodomain.io` templates together in a later version bump, rather than leaving the set inconsistent.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — "Check template" passes for all three, and "Test apply template" produces exactly the intended record set for each group configuration (links below)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — vacuously true: these templates intentionally set no `logoUrl` (see the design note above)

Additionally, `dc-template-linter -cloudflare` (Cloudflare profile, the strictest baseline), version 120, built from `Domain-Connect/dc-template-linter@e91773489dfd7aae37afe3fc4e2bba7e3e8d27b8`:

- **Zero errors, zero warnings on all five `dodomain.io` templates. Exit code 0.**
- The only output is informational: `DCTL5003` (`syncRedirectDomain` unsupported on Cloudflare), `DCTL5006` (`hostRequired` unsupported), `DCTL5007` (CNAME flattening), `DCTL5008` (TXT conflict matching ignored), `DCTL1021` (`_dodomain-challenge` is not an IANA underscore name), `DCTL1031` (single-group templates). The same notes are already raised by the two merged templates.
- `-loglevel warn` over all five prints nothing. A negative control (one record type changed to `BOGUS`, non-conforming filename) errors and exits 8, confirming the exit-0 verdict is a real pass and not a silent skip.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — all three set `dckeys.dodomain.io`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — none of the three sets `warnPhishing` at all
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — all three set `app.dodomain.io`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — `email-authentication` uses the `SPFM` record type with `spfRules: "include:%spfInclude%"`; no template writes an SPF TXT
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — DMARC and the DKIM TXT use `All` (exactly one record may exist at `_dmarc` and at a given selector, so any other TXT there is a conflict); the ownership TXT uses `Prefix` with `txtConflictMatchingPrefix: "dodomain-verify="`, so it replaces only our own previous challenge and leaves other verification TXTs at that label untouched
- [x] no variable is used as a bare full record value — every TXT value is prefixed (`dodomain-verify=%token%`, `v=DKIM1; %dkimTxt%`, `v=DMARC1; %dmarcTxt%`). The CNAME/A/AAAA values are necessarily bare, as those record types cannot carry a prefix
- [x] no bare variable is used as the full `host` label — hosts are `@`, the fixed literal `_dodomain-challenge`, the fixed literal `_dmarc`, and `%dkimSelector%._domainkey`, which is the exact form this guideline gives as the correct one
- [x] no variable is used in the `host` field to create a subdomain — subdomain selection is done via the `host` apply parameter only; the single variable label above selects a DKIM selector, not a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — **this check changed the PR.** The DMARC record in `email-authentication` originally carried no `essential` and so took the default `Always`. DMARC policy is exactly the record a domain owner re-tunes afterwards (`p=none` → `p=quarantine` → `p=reject`, `rua=`, `pct=`) while SPF and DKIM keep authorising mail without it, so it is now `essential: "OnApply"`. Every other record in these three templates IS the service — removing the CNAME, the apex A, the DKIM key or the ownership TXT is disconnecting the service, not tuning it — so the default `Always` is intentional there and left implicit

## Online Editor test results

**Editor test link(s):**

1. **`custom-subdomain-cname-with-verification`** — subdomain (`host=app`), groups `connect,verify`. Applies exactly two records: `app.example.com. CNAME cname.integrator-app.com` and `_dodomain-challenge.app.example.com. TXT "dodomain-verify=…"`. `hostRequired: true`, so per the template's note an apex test is not applicable.

   [Test dodomain.io/custom-subdomain-cname-with-verification example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJsUoGoC%2F%2B1VbWvbSBD%2BK8tCIKGWTn6NrVI4J%2BnBtZcQUpcWgjGj1cheLGuV3ZUTXch%2F76wkx1aT3MF9O%2BgnSTszz8w8%2B8zokVvc5ClY5OEjz7Xayhj1nzEPeaxitQGZ%2BVLxzrPpCjbkyi%2FURWUki0G9lQKrGFEYqzaeKaI61hMZ%2BXv30q68LWqZSAFWqoOwBu%2B8CmR1FDs%2Bv5pefjxhLo6p%2Bwy1Wcmc%2FYRAn8a9hd0Oj9EILfPKEvJrJTNrmMqQPZfCwDJgXwC%2BMOolLoRlWwl0ZGS2TJFVKRlksTNv0RzkVQmzKwrfY9WFEbxQmbGajjBms%2B8zplEoHbMIMwRykZYd2xWy6W81%2FLvKKQdrUWcnPvtqKC4q2Y5OdrzjTWUZCuuB8cBrqDqhjIS8gjRxJUnqkNrEpQarNIM8TxtuzHvmktYpLegl2qoxd3jIIbNqjUSMxsqksrRkW9ASohSN7xhuPi5a7DaIHw6SEP1WZjXoShnLGrlUzTm31wtlx%2BgvfVaJxN%2B7eOTiC7U5ed9UWKdSOdwVr3awcbFtIhPKZFfSsIZJZtA4tbi2TJmJs1SJNQ8TSA12uKv5Bu8KqZFkbHWBtdd1EX3GspE6jYRYY2n89mQ4vxuMKVTYZ0%2FXQdutVobh4e0jt2Veid5xR6alVkVez09dLK8rooPf3ehVap4p%2BjyquT%2BiU2tTHvZHQfDUeQYkcbXgKqrKPdpiV5InSEUpZkskYwwWDua9HtTyw1HFbSsVvT7Yc5UldIH2EqxY0excqtjlvtaYyAf%2Bqktje5mDP82fOvxvmqTFnp85lbTjER%2BA1hM6NezbIHJ3bS5kFXJAXNMzgeSgYWPcXtvB3bbw5jvA2wpx3kC%2BBVdTX1nf0Gvl5UhzToNkAj1xGnfH2B9EwQiGSVdM4h6eRuM%2BDIbcdS6XmdK4MPQEW2jcaW9TpFYu4B72R7FYuMkpiShDVkrxUkhZvUxrfpprfbPY1r0uYuGIkk41%2FUkfgmgovEicCm%2BA4743Hk0m9NaNesk4wS4NSeeffhb%2F8ZfQul4aV8ysBCqRT9N7KA1%2FeiH1puFXdO23SPhZd%2F96Of9HcuYdGp1fovglipYoaCcZ2GK8AOfZC3ojL5h4wXjW7YfDcTjs%2Br1xf9jvvQuCMAhcj%2FQvrxl6pA11uJv4t68jO0r%2Buss%2Ff4Lx5Oyb7V8Nko83Z9Pr6PIqmY6KP%2Bw6HSyX5WxNq%2F0H2qdDX1wKAAA%3D)

2. **`apex-a-with-verification`** — apex (no host), all groups. Applies A and AAAA at `example.com.` plus the ownership TXT at `_dodomain-challenge.example.com.` Never a CNAME at the apex.

   [Test dodomain.io/apex-a-with-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABUYoGoC%2F%2B1VbW%2FbNhD%2BKwSBYAkqqZItK46CAHWbvWSrMyN20QBBYJxF2uYiiypJ21GC%2FPceJdmyW2%2FrvnVA%2BcXy3fHh3fPckc%2FU8EWeguE0fqa5kivBuLpiNKZMMrkAkXlCUmfruoYFhtJLeVk60aO5WomEl3sg548uuGth5u6KKzEVCRghd8Lq%2FTdSGlLhk%2BPe6x6uE2K3EbnOuNJzkZMvAPCvtl9x4FDGdaJEXnpiOpAiM5oAeZIZ%2F0kTZcGPbS4nBAzahwBDghWwZWLQny8nqdBzzggwprjWXJOVAIK7SY8onkiFrow5RJZHQJoWTuXFVQc4NsKCrnB3k3RVA4YmMtNGYX14zOh2tIW1%2BUzFI1rnUhuPXHMsDG3vrnv9n63bzDmxuXvkg8aoSUE2ZJPjijEXsTOeGBc0kl0Te4KnkgmfQzolckoEEoKs8JkCIxE%2Fz9OaSn1eHbEt3dZhLbt8EyMfeEZA8dIls7QgK1ACJinXHukhXFHVOlNymV%2Bxi0p6pwQpcDuRC1EVs0OaZ3WsYS73NBT5KiQXZfzVAD%2Fr9ErD4Tq2MmoyRY8NVE1XnRNEjBrEaIt4XGZMqnxxNSqfnNdlV7tkDp%2BWB2lZ2Iz2palSEJrU2hBk1rarrVgXWfI2lckDjaeQau5QK%2F0N%2F7QUirOt0YYNlpM%2FeFHPFs5g8sAL7e2Poo274Qz3JmYbicR8EVYxrml890xNkdup66G51ms7rLTKBv%2B%2FsWNejtJI4t8jK8kR2oxJadyOfP%2FFaZBwHQDD9Y940d%2Fh4YTswVVt1GCNN7W5CXZ4yrMZRycDAzs3VXXlFBdHpUp7R%2BHno3knsyl2j%2BmDSeYim%2FUls2cPFMeBpAdDat%2FXZ9CX%2BxeH2gtn3BB9jyltBOGPgBcr9xK5aMrY1DgWZXwjwS59de0IloOChbY38wb2bg%2F3fgN8R%2B13Cf0NsFZYG9by257vBUHbC%2FzaHlV2P4jZpBvHlb2k0zrC6Rm0klMWdHk7nPgRdKZBcsZa%2FHTSbUPYoZYTMcuk4mONv2CWChk2aontvVimRoxhDY2JJWM70AVSqNGLR%2Bz3alY9Fm8aqfdS3tN3zBJLlLDdE%2FAoiELouonfYW4I4cTtdv2WG0zDNrRaEXT905037cBz942PWiOrvUozIyC1qadrKDR9%2BXpeDhW0w%2FX%2FqKBqYOt6%2FtN0%2FmsTffcs3Ds46T869Uenfv%2Bdire3hhVnYzClhK3I9c9cvzsKwjhox2HgBVHQabdf%2BX7sl7JybSo6nvEu373F6Yent%2B%2FZx%2BHTL7w1%2FPgw7P7V8kfr17f9%2FvWqczOQv0evjP%2Frb73bP09DfB4%2FA%2BkdD2paDAAA)

3. **`apex-a-with-verification`** — apex, group subset `apex-a,verify` — the IPv6-less case the template's `description` documents. Applies A + TXT only, no AAAA. The editor hides the `%ipv6%` prompt entirely once `apex-aaaa` is unchecked, so no value is requested for a group that will not be applied.

   [Test dodomain.io/apex-a-with-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGAYoGoC%2F%2B1Vf2%2FbNhD9KgSBYAkqaXIsK7aDAHWTFcgCB0maYSuCwKDIk81FFhWStqMG%2Be47SrJlt%2B5%2B%2FDcMIwxY4h0f7967O71SC%2FMiYxbo8JUWWi2lAH0p6JAKJdScyTyQinob0zWboyu9UBeVES0G9FJyqM6wAl585q%2BknflL0DKVnFmpttya83dKWVLjk8PRjyNcR8QdI2qVgzYzWZCvAPDVuKdhx6MCDNeyqCxDeqNkbg1h5IvK4QdDtAM%2FdLEcEWZx%2FxNjnwhmIBbcor1YJJk0MxCECaHBGDBkKRnB02RENHCl0ZQLj6jqCpZlpVdbcTUOnvNwoEs83QZd54CuXOXGaswPr7n%2F7X4D6%2BJJ5QvuzpSxAbkGTAz3zq9H45%2Bc2c6AuNgD8otBr6Qka7LJYc2Yj9g5cOszg2Q3xB7hrSSBGctSolIikRBkBaaaWYX4RZE1VJrT%2BopN6i4Pt7PNN7HqCXLCNFQmlWclWTItWZKBCcgI4co616lWi%2BJSnNXSexVIiceJmss6mS3SAqdjA3Oxo6EslhE5q%2Fwvb%2FCxCa%2Fa2J%2FHRkZDUrQ4R91W1SlBxLhFjDeIh1XEpI4XV6vy0WmTdn1KFex5sZeWuYtoV5o6BGlIow1BZl25uoxNmfMPmeJPdJiyzIBHnfR38LyQGsRm07ndLJIrKJvewh7kT1CaYLcVnd8dCDzL7cYTifnKrWbc0OHDK7Vl4bpuhNuNXptmpXU0%2BP7etXnVSvcKXw%2BcJAe4Z21Gh904DN%2B8FgnXHjBcf4oXfw8PO2QHri6jFmuyzs3nWOEZ5FNAo2CWbU2qeuSUZweVSjtX4eOLPVd5itVjx8zymcynYyXc3TcasCHpXpfG9u0d9O3xzaNu4Exaoh8xpLUg8MJwsELA1bxNY53jRFb%2BrQRNvghQMM3mxk3jNdTDDtbjGuyBuucK7jtQTkBnOg67QRh0Ot2gEzb78fp8RZV7idIBO%2BYnotOHbpSEMeulHT4Qx3CS9Lss6lGXr5zmSsPE4D%2BzC43sWb3A0p0vMisnbMXaLcEnrllLpMegFa%2FYrcO8%2FhC8b2XcCXNHu4ngjhDpKoOnqQAedfwQ%2Bh0%2FiuLET3px5PeiJA3TZNBPTzpb36s9n7K%2F%2BcFqJXNjMreSZS70bMVKQ9%2B%2Bqd0mn39UqH%2FJ%2Bb%2BehUcPi%2F5%2FYf%2BDwuJsMGwJYsJsJeFx7IcDP%2Bzfd6Ih%2FnpxEA8G3e7xuzAchpWsYGxNxytOiu0ZQcfvbvUVv5rdPnfF7WfFPsqrD%2BrnX4s7NefJKvky%2Fn15%2BVScf%2BTmMw7WPwANuCy%2BlAoAAA%3D%3D)

4. **`apex-a-with-verification`** — subdomain (`host=app`), all groups. Every record rebases under `app.example.com.`

   [Test dodomain.io/apex-a-with-verification example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAEVoGoC%2F%2B1VbU%2FjOBD%2BK5al1YG2CWlTsiUI6brASewKVLGs9u4Qqlx7Si3SONhOaRbx328cpy9he3f7FWn9pc3M%2BPHM88zYz9TCvMiYBZo%2B00KrhRSgLwRNqVBCzZnMQ6loZ%2B26YnMMpWfqrHaix4BeSA71HlbAMmDBk7SzYAFaTiVnVqqtsGb%2FtVKWeHyyNzwY4tonbhtRTzloM5MFeQWAn8b9S7sdKsBwLYvak9KRkrk1hJHvKoffDNEOfM%2Flsk%2BYRfsXxr4QrECU3KK%2FKCeZNDMQhAmhwRgwZCEZwd1kSDRwpdGViw5R9REsy6qO9%2BJqAjouwoEucPcmaV8DhnKVG6uxPjzm5s%2BbNazLZyqXaJ0pY0NyBVgY2k6vhpfnzm1nQFzuIflqMGpSkRXZZM8zFiB2DtwGzCDZDbH7eCqZwIxlU6KmRCIhyArca2YV4hdF1lBpjv0R69JdHc6yzTex6gFywjTULpVnFVkwLdkkAxOSIcJVvtZ7rcriQpx46Ts1SIXbiZpLX8wWaaHTsYE5a2koi0WfnNTxFyP826RXG3bXsZbRkCl6XKDedNUxQcRkg5isEffqjInPF9dG5f3jpmy%2FSxXssdxJy9xl1JbGpyANabQhyKxrV1exqXL%2BMVP8gaZTlhnoUCf9NTyWUoNYG13YqJx8hqqZLZxB%2FgCVCduj6OKuQeBebteRSMyrMM%2B4oentM7VV4aZuiOZGr%2FWwUp8Nfv%2FuxrwepRuFn%2B%2BcJO%2FQZm1G0ziJopfOBgnXDjBc%2F4mX%2FBseTkgLzrfRBmu8qi3g2OEZ5PeATsEs27qp%2FJVTnbyrVWodhX%2BX9lTlU%2Bwee8ksn8n8%2FlIJd%2FZIAw4k3RnS%2BH48g77cvXSou3DGG6LvMKWVILBkeLFCyNV8UwaqtCpzLOstGxW2GWzKR7yCaTY37nJeId%2B2oO9W2Lc1%2BF2D%2FhPITl4X1oviMAq73TjsRo098faom4rJIE29vSbVOfrTI9bjH0R3AHF%2FEiXscNrlR6IHHyaDmPUPqWNG3udKw9jgL7OlRp6tLrHJ52Vm5Zg9sY1J8LEb6wqJNOjFI9odm%2Fsnw3PXSN5KuqXzWHDHlnRdFEXQncSHUZAksQj6U%2BgHbMD7QS%2FmnB8OkgQm8dbbtuPZ%2B8nHrSWvu1VzK1nm8s%2BeWGXoy4%2Bjs7uqLcrfVlV%2BgJuidkxr2Cr09TT9b0u9BTLuOngB%2FGrdX637BlsX73fDFiDGzNZi9pIgOgqiwU23n0ZRGsdh%2FyhJDnvv8SOqBQZjPSPPeNtv3%2FN0NPiYjLrfhgf68%2Fz8jEXxKS%2FL5XVv8eng%2FI%2FH5dx%2B%2Ffv7%2B5nii29%2F4TP6DyX0c8aCDAAA)

5. **`email-authentication`** — apex, groups `spf,dkim-cname,dmarc`. SPFM yields ONE well-formed `v=spf1 include:_spf.integrator-app.com ~all`; the DKIM selector is a CNAME at `dodomain1._domainkey.example.com.`; DMARC at `_dmarc.example.com.`

   [Test dodomain.io/email-authentication example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACoVoGoC%2F%2B1Wa0%2FjRhT9K6ORIkCNLRtSHkZIpIRt0TawgrSiQigaeybJ7Doed2Yc4kXpb%2B%2B9fsR2C7v026raL5DMnHvu4xxf55lasUxjZgUNnmmq1Upyoa84DShXXC2ZTFypaH97dc2WAKUjNSou4cYIvZKRKGIEnMUOy%2BxCJFZGzErVglSxlwgiXRDZvfvwrk9G76%2FG8Hc8vL3Yg7iV0AYZAr9PuTCRlmnBGNAhRCstjTCEkTvG7ggUyLPIEquIEQknRZKZ0gTSkLKTgCyFnkOISgSBfEQmUZxxAcfRgiXSLOEE4jHiM2B2TIHSIlKaFxWO9%2FokzcJYmkVFgxVDwlhEFnLtMqzn4no4viQVUVUXcH0SOVkoY%2FsEkADEWzyTFuJnkBpCJ%2FcTSMGgfiNsCSmmQVIVyyh3ySWLFmSuVZYSCbnSNJaCQywXKXQNA41zspKshFzxU5IoMr6ve4AQAUMlT1paKxIS5pACDmsTuOQ3A3RwXAtMdsvZOZFKEmjSYcZhTiXoHoyAhGLBoHw1w0ZwgGKuGQ6jKK6U17ioJtOShbEYdZQ06eyqkuGs6BdHhGz42chkHr%2BmFQy40JPsCnfukikwuU16B9K7kVrunRL%2BSS7vaonKJF3ZYhaKuMRNGDDaClUKCc6zMiltWtdVRbZUJbulKkjiRAlYvco8Wdt2UsRXaoSK54TNrChNOpNrmP3O6gxx%2FinZAe8IOOww27VF3iXTUYu4ZRFi2dy8yIqgl2iRaw8FMnkS%2FRSr6BMNZiw2ok%2BxsVvxZya14NtDhH3Iwvcir3YA7IoI2jJud2Ug7lZwiI3sFomqdGHlMAwNHp6pzVPcEPikwU3l4dIktKwGvpwjdzq7zWIBUbQyRtBrnNSjm%2F6WrBCxw9ZI1JD22ibpudOyQugKd58CW5mJqmGlR3pwY21Mg4NDz2vlg0f439lAtrfl4swygGxN0Kss1MkGH9f2QiUzENyOmY0W8JyMFcf0wzimX6oG1W5Kmdbfm7yVTXq1x%2F5T5j4VxuBaZxBAb5Ih7ICcbh43fYobddqI%2FQg5a1OINYP9I%2FBxbUqry57KAl95oKNdWTwwpUyzpcFXWM350CF9rFkfKH4ueL%2FG2dgJka9sFwS21URobW%2B%2Fviz90rly8fwLfDD3uthaB%2FyeniUwxVOiM3aGLzirguL6vNMsDFvOE6XF1MB%2FZjMNLVidwbO7zGIrp%2ByJNUc8muKmzkEbA7eQ5uEf7knK9%2FZ52yYwDr%2FeycErwyF%2FscIShXvAPOCeKY9QJYlWPGH8QBxxzwkPhO8MwiPmHB%2BHwuGzcOD5A37iDVjrl8cLP0re8NOjMVPbmMP4ieWGbl5YE1WzjVIvPZ5f17HzzHy7XXcEfn0ZvMl332LL2w20eezDyvnu7O%2FO%2Fv85G19WbCX4lCFu39s%2FdLwTxzue%2BIPA8wN%2F4J74%2FtHx%2Fg%2BeF3gedgO%2FaMtJPMO7ov2WoL%2F%2F8XF8MrzwP4cfr3%2F59YYfre%2F10b1SN4f7o5urm59HP8Z6HvuLd%2BvxGd38DYpu%2B3U%2FDgAA)

6. **`email-authentication`** — apex, groups `spf,dkim-txt,dmarc` — the mutually-exclusive DKIM alternative. `dkim-cname` and `dkim-txt` write the same host and are never applied together. The fixed `v=DKIM1; ` prefix is applied exactly once, ahead of the supplied key body.

   [Test dodomain.io/email-authentication example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKIYoGoC%2F%2B1WbU%2FrNhT%2BK5alCtCaLn0ZdEGVSGlv1aHChfZKSAhVjuO0HmmcazulHep%2B%2B47z0ia7gNiHSZvEF2jsc57z8jznJC9Ys1UcEs2w84JjKdbcZ3LsYwf7whcrwqMGF7i%2Bv7omKzDFAzFIL%2BFGMbnmlKU%2BDM5CiyR6ySLNKdFclExy36ExQlUjdDz9%2BqWOBlfjCfyduHeXJ%2BC3ZlIZBKdZxz5TVPI4RXSwC95CcsUUImhKyBRBgn5CNdICKRb5KA0SCIkgDMoqcdCKyQW4iIghiId4RMPEZ3BMlyTiagUn4G88%2FgCbI5VaSUaF9NMMJyd1FCdeyNUyhzEZQ8CQUQ2xjonJ5%2FLanQxRDpTnBVhPbIuWQuk6AkswNLfmjGvwDyA0uM7uZxCCQP6K6cwk7QaKRcjptoGGhC7RQookRhxixXHImQ%2B%2BPouhamhouEVrTjKTsX%2BOIoEm90UN4MKgqehZcq1ZhLwthIDDQgQN9E0BHBwXBKPjrHcWFVEERVpEWcTKCT2BFiCPLQmkLwJTiGkgW0himpEml9GrGoZNIjnxQjaoMKniYJzT0EvrNS0yaOa34tEifIsraHDKJzpmjUUDzQGpcQhvQfgGFauTc%2BQ%2F8dW0oCgLUqUtJB4LM7sZAUSdW2VEgvI0jzKZFnnlniVW0XHGigGxaARSzyPPNroc1NjnbHjC3yISaJaJNOAb6P3RumfsmufoCLTD4LCCrDfa4K6IpCXgkkSQJgv1Kqoxeg3WYJ0YgtQ2ov1Q0CfsBCRUrI5NYXfse8Il8%2FeHxuxr4l2xbb4DYFdQKEs1qivD2N0xH3yp3lsaVqpmWTMUdh5esN7GZkOYSYObXMOZSHCWDTxcGOw4uEtCBl44F4ZTOyiphnf1PVhKYgXtQNEBtFYWSa0xzzKEqszuEyArNROFWaaRGtxoHWKnfWrbpXgwwj9GA9o%2BFssnmoDJXgS1XEKVaPBzoy9FFADhekI0XcKcTIRvwrthiN%2FLxrB9SGVePB%2Fi5jKpFRr7R5HrmCll1joBB3wTubADtnj3uKtjs1HnB7IfIWYhCrYhsH%2BYGddDakXac57a5xoodTNLHXBiIslKmRdYgfhQgXwsMB%2Bw%2BZ2ivo94kJKxe2OzGMMyk8a0kHazuMy0UoTOyTSPTz2pyDmKe5PxKJi49uhy%2Bn00HXvtwe2w795%2Bc93O6NodXPb57VV%2FcTsYZgXB1EHbGWzS8IuQs3xvz9IVtbiJoNmPeR15nLgXQePPkUxIz7wTtXDS64tKh4AfvoiEZHMF%2F4lOJFSuZQLjvkpCzefkmRyOfDo3y30LdCq4hTAPfxNclL3qL8rKgi42izXuvNFT9CdJVZQKDvQGgpv71FDLjXrb3TPbbpKOFVDmW50zQiyPeMTqdjqtwKOkS71W6WPlle%2BYD3ytHPRX1rIbPpOtwrsfZisvdc%2F8%2B%2FP8r9FeGdL%2FSc%2Fe3j4fUu1%2FseT9yts91mHHfc7F51x8zkV1Lsz7layZPyfGrmW3Ti37V8vuzpodp3nq2K3GL91m227%2BZNuObZtqgM6sEy%2Fwniq%2FofBZS4wTtxtOhv5IBk%2F38vegfdNfs41QUX90Rb%2FciHY8%2Fe3noRY9vPsLM%2BcsoO4OAAA%3D)

7. **`email-authentication`** — subdomain (`host=app`), groups `spf,dkim-cname,dmarc`. Confirms the composed host `%dkimSelector%._domainkey` and the fixed `_dmarc` both rebase correctly, to `dodomain1._domainkey.app.example.com.` and `_dmarc.app.example.com.`

   [Test dodomain.io/email-authentication example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEkVoGoC%2F%2B1WbU%2FbSBD%2BK6uVIkCNLQdSAkZITQknoV6ggnDqHULRZnedrGp7Xe864KLcb78Zv8R2D1ruW6XrF4h3Zp55eZ4d%2B4laGSUhs5L6TzRJ9VoJmV4I6lOhhY6Yil2laX9rumQRuNKJnhRGsBiZrhWXRYyEs9BhmV3J2CrOrNItlyr2HJ1I14ns3nz8rU8mHy6m8Hc6vj7bg7i1TA0i%2BIM%2BFdLwVCUFok%2FHEK1TZaQhjNwwdkOgQJFxS6wmRsaCFEkCnRJIQ8pOfBLJdAkhOpYE8hEV8zATEo75isXKRHAC8RjxFXx2TOGVSq5TUVQ43euTJFuEyqwqGKwYEoaSW8i1y7Ces8vx9JxUQFVdgPVZ5mSlje0T8ARHtOKZshAfQGoInX2aQQoG9RtpS5diGiTRoeK5S84ZX5FlqrOEKMiVJKGSAmKFTKBrGGiYk7VipcuFOCGxJtNPdQ8QImGo5CFV1sqYLHJIAYe1CFxyawAOjmuCyW45O4frOIYmHWYc5lSE7sEIyEKuGJSvA2wEByiXKcNhFMWV9BoX2WSpYotQTjpMmiS4qGg4LfrFESEa%2FjYqXoYvcQUDLvgku9JdumQOSG6T3oH0LtfR3gkRn1V0U1NUJunSFrKFDEu%2FGQNEW3mVRILyrIpLmdZ1VZEtVsluyQqCODwGqVeZZ4%2B2nRT9KzYWWuSEBVaWIg3UI8x%2BZ32KfoMTsgPakXDYQbaPFnEjlvIWcEsixLKleRYVnZ6DRaw9JMjkMX8fav6Z%2BgELjexTbOxafslUKsX2EN0%2BZosPMq92AOwKDm0Zt7sy0O9aCojlduuJrHTdymEY6t89UZsnuCHwpoGl0nApElpWAw%2FvEDsJrrNQQhSthOH3GiX16Ka%2FBStI7KA1FDWgvbZIeu68rBC6wt2nQVZmpmu3UiM9sFgbUv%2Fg0PNa%2BeAK%2Fzsb0Pa6XIJZBi5bEfQqCXWywc9He6bjAAi3U2b5Cu7JVAtMPw5D%2Br1qkO2mlHn93OStZNKrNfafMvepNAbXOoMAehWPYQfkdHO%2F6VPcqPOG7HvIWYtCPjLYPxKva1MaKKWufK6KkEoGHfrK%2BgEsYSmLDL7Fati7Du59DXxXIN9X0D%2BCbUSFni%2FsGHRsc4qutcgHtbFUTcfk4vl38GD66F88Vmzgc3IawyxPSJqxU3zNWe0X5nedfmHkahnrVM4N%2FGc2S6EFm2Zwg6MstGrOHlhzJPgc93UODBmwQpq7bzQUl2%2FvkpatXGAgg3o3%2By%2BMh%2FzNCmkUKgIRgYrmgiNVCiV5MJKCjY4OHBmMAmfoDd86jB0uHL443j9ko4OjQCxaXyDPfJy84hOkI6q2RsfhA8sN3TyzMaqOG7qam%2Bp2xvBjQjtX6KduvkN2uR7cbzivV8SrdPiTdr5dTZv7PuyiX2L%2FJfb%2FhdjxlcbWUswZuu57%2B4eOd%2Bx4R7PB0PcG%2FvCtezTaH44O33ie73nYEHz9lsN4gjdK%2B11CD26D29Hl%2BddMTd78vtbxxXEEpveDydXkT%2FVHlOfLv67EcHgtBsNTuvkHzLecb2sOAAA%3D)

All three templates pass **"Check template"** with zero errors and zero warnings, including the tool's AJV validation against the published Domain Connect template schema.

One open item, stated plainly rather than glossed: the free editor cannot seed pre-existing zone records, so the **merge half** of `SPFM` — an existing `v=spf1` gaining our `include:` rather than a second SPF TXT appearing — could not be exercised there; the page directs signed-in users to the full apply flow for that. Against the implicit empty zone, SPFM synthesised a single complete `v=spf1 include:_spf.integrator-app.com ~all`, which is the correct create-half. Our template contributes exactly one `include:` mechanism and writes no SPF record directly, so it cannot itself produce a second SPF TXT; the merge is the DNS provider's to perform. Happy to re-test against a provider that implements `SPFM` if a reviewer prefers.

### Files added

- `dodomain.io.custom-subdomain-cname-with-verification.json`
- `dodomain.io.apex-a-with-verification.json`
- `dodomain.io.email-authentication.json`
