### PR TITLE
Add xeoai.com.byod template

### DIFF
--- a/xeoai.com.byod.json
+++ b/xeoai.com.byod.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "xeoai.com",
+  "providerName": "XEO",
+  "serviceId": "byod",
+  "serviceName": "XEO Website Hosting",
+  "version": 1,
+  "logoUrl": "https://app.xeoai.com/xeo-logo-dark.png",
+  "description": "Point your domain at your XEO website.",
+  "syncPubKeyDomain": "xeoai.com",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip%",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a Domain Connect template for XEO (`xeoai.com`), an AI website builder.

Our users connect a custom domain to a site they have published with us by pointing the apex `A` record at our managed TLS edge, which terminates certificates on demand and proxies to the site. Today that is a manual record edit we walk the user through; this template automates that single change.

One record, synchronous flow only, signed.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**Notes on the unchecked item, and on two that are checked as not-applicable:**

**Bare variable in `pointsTo` (rule 6) — not fulfilled, justification below.** The record is `A @ -> %ip%`. The value is the bare IPv4 address of our TLS edge, so there is no fixed prefix it could carry; an `A` record's RDATA is an address and nothing else. This is the exception the rule allows ("the full record value is prescribed by an external standard and cannot carry a prefix"). The already-merged [`approximated.app.arecord.json`](https://github.com/Domain-Connect/Templates/blob/master/approximated.app.arecord.json) has the identical shape (`"type": "A", "host": "@", "pointsTo": "%ipAddress%", "ttl": 3600`) for the same reason. `dc-template-linter -merge-or-fail` reports DCTL1040 on this record; that is expected and is the only finding.

**`syncRedirectDomain` (rule 3)** — not applicable. The template does not use `redirect_uri`; this is a plain synchronous flow with `syncBlock: false`.

**TXT rules (rules 4 and 5)** — not applicable. The template contains no TXT records.

**`essential` (rule 10)** — deliberately omitted so the effective value is `Always`. The single `A` record *is* the service: if the user repoints their apex elsewhere they have disconnected from us, and a provider treating that as a template conflict is the correct outcome. Setting `OnApply` here would tell providers to ignore changes to the one record the service depends on. The Online Editor confirms the effective value as `"essential": "Always"`.

## Online Editor test results

**Editor test link(s):**

- Apex (`host` empty): [Test xeoai.com/byod example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOIkoGoC%2F9VSf2%2FaMBD9KshS%2F1oSbEogRJq0VpvUqRJru3agVShy4hv1SGLLdqAp4rvvzI9Cu32B%2FZXL%2Bd299%2B5uTRxUuuQOSLom2qilFGC%2BCpKSZ1BcRoWqSPD6MOYVAsn0yzdMWjBLWcAWnLdKHFNHWGcCuZUOOlfKOlnPEbMEY6WqScoCUqq5ejAlYp%2Bc0zbtdrnW0StzF6PQY0LBzSLS23oBtjBSu20PcqNk7TqtakxHqIrLusP3v559tWOPvLS2Lm6a%2FBraz1vcO4f%2B%2BbJUxYKkv3hpISAGCmWEJenjmrhWe0MXCHxCIxh%2B8lPx3PZe4e%2BZ1GeYcQ69nA8o3cw2AXlRNWTHNjPUfqCGZ45jhz35vidGc6ManckDXnPDK%2BtXc6h8fFM6O9Q%2BEh9L7SMWxxE7TyLWH0T9hHglcl4rA5nFL3eNQS%2FONOixakonM77ix5QoMtxB2aJwi6%2FY8K3%2Ferdb719wxzF8x3cyhYBkovDqpb8RRoc5Z0yErMcGYb83gDAfURoOE6DxQOSU5eLk1v46wn%2Fc23FwYC3UTnJ%2FSxflireWbDazAIf4H8vHlVq%2BBJFxD%2BvR3iCko5Am9yxOaZKyJIpj1qPDD5SmlHrpYN3O1hq3frpv0v5oFvwhfkna8W9zd%2BViebcQSWIur4f15Od4Mr11RkyL9vuIfiSbP%2FMhOF4YBAAA)
- Subdomain (`host` set): [Test xeoai.com/byod example.com/host](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMkooGoC%2F9VSbW%2FaMBD%2BK8hSPzUJSQgBIk0aUyd1qsbaqd2qIhQZ%2BwCPJM5sh5Ai%2FvvOvBTo9gf2yb675%2B655%2B42xEBeZtQASTakVHIlOKgvnCRkDZIKj8mcOG%2BBEc0RSJ4%2Ff0OnBrUSDHbgaSP5yXWCtX7CVAsDrVupjSjmiFmB0kIWJAkcksm5fFIZYhfGlDppt2lZem%2FMbfy5FuNyqpZeucvnoJkSpdnVIPdSFKbVyEq1uMypKFr0YFr2es%2Fu2daagt1X0ztobna4dwpt%2BFMm2ZIkM5ppcIgCJhXXJBlviGlKK2iIwAUKwe9HOxXLrR8lmleivEKPMailE%2Fv%2BdrJ1yKssID2VmWDvR2pYUxw7HMgPNXePQ%2BZKVmUqjjklVTTXdj3H7PFF%2BuSYP96%2FaIvSWkG36wWdvhdEsRf1ie1IzAupINX4UlMp1GRUhVrzKjMipTU9uThLcRdZgwI0RrHg5RyK%2FY4PPXNqKFrvKM8G4pCUMytC2HOJGQ37venADWLgbsSjmUsHDFyIuoOQdvpxj8VnZ%2FfXPf7j9C5nCFpDYQS1pzXMatpost1OHJzn%2F68CF6zpCnhKLTT0w9j1B67ffwy6SRgl3Z4X%2BMEgCK99P%2FF92z5os5e2wRs43z4x3%2Bsfi3r9PHsIl78hql4yPhrW8R1rv%2F56GIrRtfpqbvP45UY8fSDbPw7aF1guBAAA)

Both were run against the exact file submitted in this PR. The subdomain test produces a single label (`host.example.com`), confirming no `%host%` doubling.
