### PR TITLE
add Handoff, Client links

### DIFF
--- a/handoff.ai.links.json
+++ b/handoff.ai.links.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "handoff.ai",
+  "providerName": "Handoff",
+  "serviceId": "links",
+  "serviceName": "Client links",
+  "version": 1,
+  "logoUrl": "https://app.handoff.ai/logo512.png",
+  "description": "Serve your Handoff proposals, invoices, documents and client portal from your own subdomain, so the links your clients open show your brand instead of ours.",
+  "hostRequired": true,
+  "syncBlock": false,
+  "syncPubKeyDomain": "go.handoff.ai",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "dhhylw5u6q0sl.cloudfront.net",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds `handoff.ai.links.json` — a new template for Handoff, construction management software for residential contractors.

It lets a contractor point a subdomain of their own domain at Handoff, so the proposal, invoice, document and client-portal links they send to homeowners carry their brand instead of ours. One CNAME, no variables.

`hostRequired` is set because the record is always created at a contractor-chosen label passed as the `host` parameter — which is why `host` is `"@"` rather than a variable in the `host` field.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checklist, since several items are satisfied vacuously rather than by action:

- The template contains **no variables at all** and **no TXT, SPF or MX records** — it is a single CNAME. So the SPF, `txtConflictMatchingMode`, bare-variable and `%host%` items do not arise.
- `syncRedirectDomain` is not set because the template does not use `redirect_uri`.
- `essential` is not set: the CNAME is the whole service. If a contractor removes it their links stop resolving, which is the intended and expected consequence of disconnecting, not a record they need to modify while keeping the service working.
- The subdomain is created via the `host` **parameter** with `hostRequired: true`, which is the mechanism this guideline points at — not via a variable in `host`.

## Online Editor test results

**Editor test link(s):** [Test apply template](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAlJoGoC%2F91TUW%2FTMBD%2BK5ZfadM07bo2EhIbRQLBxsaGBkxV5NiXxsyxPdtpFar%2Bdy5NSwfjhVeeEt99d%2Ffd588bGqCyigWg6YZaZ1ZSgHsnaEpLpoUpiohJ2vuVuWQVIunbLocJD24lOewqlNQP%2FhjbY18rCTqQQ3IFzkujaTrsUWWW5rNT7bAQrE8HA2ZtdBw8aAEnwySyeomlAjx30oZdOb3BKUAaUzuyp0OQpTWeKd8jUq8McsA%2FYXhdIQNPEEV4x8YaF5gihTNV18KsNfF1LkzFpO4Rb0gooSPdAbpCT4wFRJZm3YVz13aV2gdggpiCYNBHSLY0PnyCx1o6QG2CqwGFaTQ%2FV4Y%2F0LRAlvvIVZ2%2Fh2a%2Bm4x7LU30m%2FQOuHHC0%2FR%2BQ0Njd5Jenl282c%2FA46v2goxEdrcGj6IsG7U%2BqSePsVcRV6YWuKcOkYaAyBBQ8NEkjreLbY%2F%2BMBqy44gFqnwgwngFeS0VXruPuKmOA33JHOBx6UxtM3motMyxyrdGOvS4f95kcehyv2%2FTspBLbRxkHr8s1BjcC1bVKsiMrdkxJHiGJlENkvaYxT7PddGd8w40BQvsH3Tp0UzwdgvZmhqK2TiZTU%2F6Aoq8Px4NR%2F0ZTHh%2FPBXsNJ%2FxYT6DJw%2Fk%2BdP52wv5Q0fwHr0lWfsSztSaNZ5ut4seavq%2F7oYu8GwFImMtNomTST%2Be9ePp7fA0HSfpaBSdTibTcfIijtM4bjcAH7pdN%2BiXp06hZ19VaT%2BKuA7T%2Bferq6QYXMw%2FgP%2Bymp%2Br4dJffrj7dnd9ffOoy4uXdPsTLvSTkPIEAAA%3D)

Tested with domain `acmebuilders.com` and host `share`, which produced exactly the intended record and no errors:

| Name | Type | TTL | Data |
|---|---|---|---|
| share.acmebuilders.com. | CNAME | 3600 | dhhylw5u6q0sl.cloudfront.net |

No apex test is included, as the PR template notes is acceptable when `hostRequired: true` — this service is only ever configured at a subdomain.

Linter, using the invocation in `AGENTS.md`, exits 0:

```
dc-template-linter -loglevel error -tolerate info -logos handoff.ai.links.json
```

The Cloudflare profile also exits 0, with two informational notes: `DCTL5006` (`hostRequired` unsupported — harmless here, since the apply-URL always carries a host) and `DCTL5007` (the contractor's own zone needs CNAME flattening).

Also validated against `template.schema` with `jsonschema`.
