### PR TITLE
Palisade: allow apex domains in both DMARC templates

### DIFF
--- a/palisade.email.managed-dmarc.json
+++ b/palisade.email.managed-dmarc.json
@@ -3,13 +3,12 @@
   "providerName": "Palisade",
   "serviceId": "managed-dmarc",
   "serviceName": "Managed DMARC monitoring",
-  "version": 1,
+  "version": 2,
   "syncRedirectDomain": "app.palisade.email,palisade.email",
   "logoUrl": "https://app.palisade.email/logo.png",
   "syncPubKeyDomain": "domainconnect.palisade.email",
-  "warnPhishing": true,
   "syncBlock": false,
-  "hostRequired": true,
+  "hostRequired": false,
   "description": "Save time, stop email spoofing and get your customers DMARC compliant 10x faster.",
   "variableDescription": "mappingSubdomain is the Palisade DMARC CNAME value for your domain",
   "records": [
@@ -18,7 +17,8 @@
       "type": "CNAME",
       "host": "_dmarc",
       "pointsTo": "%mappingSubdomain%.palisade.email",
-      "ttl": 43200
+      "ttl": 43200,
+      "essential": "OnApply"
     }
   ]
 }

--- a/palisade.email.unmanaged-dmarc.json
+++ b/palisade.email.unmanaged-dmarc.json
@@ -3,13 +3,12 @@
   "providerName": "Palisade",
   "serviceId": "unmanaged-dmarc",
   "serviceName": "Unmanaged DMARC monitoring",
-  "version": 1,
+  "version": 2,
   "syncRedirectDomain": "app.palisade.email,palisade.email",
   "logoUrl": "https://app.palisade.email/logo.png",
   "syncPubKeyDomain": "domainconnect.palisade.email",
-  "warnPhishing": true,
   "syncBlock": false,
-  "hostRequired": true,
+  "hostRequired": false,
   "description": "Save time, stop email spoofing and get your customers DMARC compliant 10x faster.",
   "variableDescription": "dmarcValue is the Palisade DMARC TXT value for your domain",
   "records": [
@@ -19,7 +18,8 @@
       "host": "_dmarc",
       "data": "%dmarcValue%",
       "ttl": 3600,
-      "txtConflictMatchingMode": "All"
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
     }
   ]
 }


### PR DESCRIPTION
# Description

Both DMARC templates reject apex-domain apply requests because `hostRequired` is true, although their record host is already `_dmarc`. The Online Editor reproduced “Template requires a host name” for `domain=palisade.tools` with no host. Set `hostRequired` to false so the same templates support apex domains and subdomains, and bump both versions to 2.

Preserve the existing record names, values, TTLs, group, signing key domain, redirect allowlist, and TXT conflict behavior. To meet the current template guidelines, remove `warnPhishing` while retaining mandatory signature verification through `syncPubKeyDomain`, and set `essential: OnApply` on the DMARC records so users can edit them independently.

The unmanaged record retains its full-value `dmarcValue` variable because DMARC syntax and each domain's existing policy/report destinations must be preserved; adding a service-specific prefix would make the TXT record invalid. The existing `txtConflictMatchingMode: All` remains necessary to prevent duplicate DMARC records at `_dmarc`.

These are template simulations only: no production DNS records were changed. The separate Palisade request-signing fix is tracked in https://github.com/palisadeemail/dns-auditor/pull/3255.


## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
- [managedApex](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHxToGoC%2F%2BVUbU%2FbMBD%2BK5YlPpEG05a0RNqHQpnGUAEV0DShKrrGbvGW2MZ2Orqq%2F32XpG%2B0iD%2BwT3V999zd8zznLKgXucnACxovqLF6Jrmw15zG1EAmHXARihxkRoNN9BZyzKb3qzhGnLAzmYoKloOCqeANnoNNt7EVaFBHSX%2FQG16SXCvptZVqiokzYZ3UisZNBM1VOhRcWpH6vsb%2BeE3BmPD9UMHBjJme6iebYfaL98bFJyeHqJMyKTRV07LRfTG%2BEfNNG14dUq0UNg8POpSIi0ynv2k8gcyJgL5o54fitcBp%2BeaSC5daaXzFiD7ATBAvcxEQ57UhVTHijNYTJE9AcTIVnsx1YUlaYEqOYqxESjUaJEF5csreyAScFzYs9QIrYZyJ%2FrtOOfLFkg%2FFuOZBpCP%2BRZC1W6uil7e9wRWZQVYIMtG27lwjsDTKri13NH5e0KnVhamcXTvq56a0sipBa%2Fr4N1mHjZbKu0eNd0f70xwd6uk9utVuNRkLqHBOKC%2Bh9O9O9YzJ5nQ5Wgb0r1Yi2U41ClYu7a6p1zpz23nwVI2eyDXEgIXclXu%2BBj%2Fvo0dr%2BDMtz%2FvjHyLCmnbIFYJxUDlV2orE4S%2F4wqJO3ha4DnmReZnAH9he8TSBkiHychjF2qj2nraqfjUbbTl4OOC8M8Pn8iY8LdnL0swxXkVRc9KIGOeN9lmLNSAC3ugwOI%2Fa58BaE7Hz5j%2F%2BInz27rc2fOjqchSgJ%2F8XY9wohx8CnkCZ12TNqMHOG6z7eNqNm52YdcNW1O6etY8ZixkrqQjnawEWuFu7W0Vff3a%2FRXfFcceo%2Fq%2FeY1%2BpZnp1odvtzhv%2F8eSzm2s9zN6%2B3nxXgy90%2BQ8QK0O35wUAAA%3D%3D)
- [managedSubdomain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAINToGoC%2F%2B1U207jMBD9FcsSTyQhDaWXSPvQLaxYIS4L5WVRFU1iN3hJ7GA7ZUvVf9%2FJpZS2wBfsU9u5nDNzztRLanleZGA5DZe00GouGNc%2FGQ1pAZkwwLjHcxAZdd6yV5BjNb1p85gxXM9Fwuu2HCSknLksB51scm3TZZMlp5ej2zHJlRRWaSFTLJxzbYSSNAywaSGTW86E5ok9VciPYQpF4W0P5ezNmKlU3esMqx%2BtLUx4dLTfdVQVeUVNWhHdlPEFX7zRsPpLoqREcm%2BPoer4nqnkiYYzyAx36KMy9pY%2FlzgtewsybhItCltvRO9gzokVOXeIsaogNRgxhVIzXJ6AZCTllixUqUlSYkmOYrQiJQoNEiAt6fh%2FyQyM5dqr9AItIM746RZTjvsi5F0ZN3sQYYh95GTtVgs6vhpdnpE5ZCUnM6Ub5qYDoVF2pZmh4cOSplqVRe3s2lG7KCorawjarI8%2Fo3W6UEJaM1EYO9id5mBfT2vRre5x4PsO5cZwaQVU%2Fl3LUVFkC7qarhz6qiSPNlNNndal92dqlcrMZh5IrJhDpYr7DBiu94hE3d%2BugjAFaMhNdftrwIddxOka8mEHc9qCbgHubrzX5m3De41uHpPIhJuKVCrNI4OfYEuNQltd4j3lZWZFBC%2BwCbEkgkoiFMZgFpnQrh1zZPO3a0l2NWFgYVeqz%2Bf72ruIJZWMor6UIRz7SS9249kwdrtBv%2B%2FG3XjgDvos9oe9OPD5ybsH5ePn5qtH5ROPP7yf1dTBg%2FkvzYfS4MUafJtYBFVT4Ac91x%2B6%2FmDSGYRBP%2ByceMcdvzcMDn0%2F9P1qL25so80Sr%2FX9ndL4vHN4cmd%2FX%2F2asDI%2Bfzm8n7CL0eufJHtKn%2BQ4%2FTG%2BOOtacT2zZ9%2Fo6h99hx8gegYAAA%3D%3D)
- [unmanagedApex](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMpToGoC%2F%2BVU224aMRD9FctSn8rFyy2wEVJzUaWqTYJS0kSN0GpYG3C7a7u2l7KJ%2BPeOFwghiSr1uRISxjNn5sw5gx%2BpF7nJwAsaP1Jj9VJyYT9xGlMDmXTARUPkIDNae4peQo7ZdLSNY8QJu5SpqGCFykHBXPA6z8Gm%2B%2BgWdrOLk%2FOLk%2BszkmslvbZSzTF1KayTWtG4hbBSpdeCSytSf66RA15TMKZxSKz2imem5%2FrGZpi98N64uNl8jWqGpIapmoZGo2L6WZRPbXh1SLVS2LzxqkNAnGY6%2FUnjGWRO1OhCO38tfhXIlj9dcuFSK42vJqJfYSmIl7moEee1IVUx4ozWMxyegOJkLjwpdWFJWmBKjmJsRUo1miRBeRKxFZmB88I2gl5gJUwzcX7QqRL%2BG2SFINIRvxBk59W23PhuTJZVfKbtpuNmYiyJcmvLHY3vH%2Bnc6sJUru689KUJJmIBuhkafyS7IAcP%2BPvdvv%2B7APFoRbvHGB5X%2FkyrWSZTfwE%2BXeDcF5qHgidZ0FU4J5SXELy7UifGZCVdT9Y1%2BqCVSPbMJrWtQ8%2FX1GuduT0rPFX0E7mDGLCQu7DnO%2FD9S%2FRkB7%2Bn4bwfJNwsh5V60TExQ4WEjoktYBhc9Dq2wmjr3QexArRKNNAxGpjLudJWJA6%2FwRcWC3lb4G7kReZlAr9hf8XTBMLIOKjDKLZECw4EV5u%2F0EvB%2F5nYgSkJT4MmMtg87XbZtNU9qne6fVHvRL1Bvd%2BeQb3LgB8NOox32eDZS%2FD2O%2FH312Bvz5turyc19Oq%2FHBwXzuEbwRMIeS3W6tXZoM7646gft%2FDTa7TaEfJ4z1jMWJhFOL9R4hE37fmO0auHH%2BXoaNVkp53b2%2FLyS1Sq1fTh42I8k%2Bbu%2B%2BmqbSGNRsvpKHJDuv4D%2Bzl3TQYGAAA%3D)
- [unmanagedSubdomain](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMJToGoC%2F%2B1U204bMRD9FcsST%2BSySbgki5CaggSohXIXAkXRxJ4El13b2N6UgPLvHW8SQoBW6nufdnfGc2bOObN%2B4QFzm0FAnr5w68xYSXRHkqfcQqY8SKxhDirjldfsCeR0mp%2FO85Tx6MZKYFlW6Bw0jFBWZQ5OLLPzsqtFnu0fd8%2F3WG60CsYpPaKjY3ReGc3TJpVNtDhHqRyKsG9oBgpzsLa2Oljlw5yZGZkrl9Hp%2BxCsT%2Bv1j1X1eKhmy6ax0Wkx%2BIaT1zayfBFGa2pe%2B9AhVnzNjHjg6RAyjxV%2Bb3w4x8eCppWvQYleOGVDyYhfwBhZUDlWmA%2FGshKMeWvMkMgz0JKNMLCJKRwTBR3JSYy5SMKQSQp0YI3kiQ3BB3S1qBc4BYMM91c6lcJfQ1YgU56Fe2QLr%2BZwlzeXbFzmh8bNOs4YEyTJbZz0PL174SNnClu6uvAyTGw0kQD4jDR99BdJCQHoe23Zfy2WBLKitZUk9PoU9oweZkqEYwjinngfGxkBu1nUFb1HHRRE737orrXZhE970wp%2FNhr7y8l6lblDb9c0GJP55VQgghpDVKT6CBQuufRVWT%2BnQzAWHOQ%2B7v4C8O49Ym8BefcOszcHXQFcco%2Fh8W4peGOH2V1NHHaYK2A3Gh9M6tAaF%2FwXfAJyF2tkMo9k1Ugbh31PTwiFI6DgClqnvMiC6sMvWIak6ENUibTxlKWW5NqKR3r21808qr0XZe7YP4%2B54mpfiiigKvckwcFgKGW102qL6oZoYHUgoFVtYFs0N7bbzcFg881V8vlF8%2Ffr5A%2F%2Bfro7016FluW%2FJqua0Jp6uoxkH2JRM2luVZNONWlfNtpps5022rVWs9na3lxPkjRJIjH0YSbLC%2B3n283k9afhwc%2BAt4fDg6OT52t7nXXG69n3VivpyLPuzenDYdAX6ui28%2F1sl09%2FA1fscSNvBgAA)
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->


Official `dc-template-linter -loglevel error -tolerate info -logos` passed with exit 0 for both files. The logo URL returned HTTP 200 (image/png). Both templates were checked and applied in the Online Editor: apex with no group filter, subdomain with `dmarc` selected. The four editor test payloads match the submitted templates exactly.
