### PR TITLE
Add HomeRecon AI website template (homerecon.ai / website)

### DIFF
--- a/homerecon.ai.website.json
+++ b/homerecon.ai.website.json
@@ -1,0 +1,38 @@
+{
+    "providerId": "homerecon.ai",
+    "providerName": "HomeRecon AI",
+    "serviceId": "website",
+    "serviceName": "HomeRecon website",
+    "version": 1,
+    "logoUrl": "https://homerecon.ai/media/homerecon-logo.png",
+    "description": "Connects a home inspector's own domain to the website HomeRecon AI hosts for them. A TXT record on the bare domain proves the inspector controls it, www points at HomeRecon's site host, and the bare domain forwards to www. Applied at the domain apex only (no host parameter): the inspector's address is always www.<domain>.",
+    "variableDescription": "%token%: the per-domain ownership code HomeRecon issued when the inspector added the domain in the app. HomeRecon reads it back from the _homerecon-challenge TXT record to prove control of the domain before the address goes live.",
+    "syncBlock": false,
+    "sharedProviderName": false,
+    "hostRequired": false,
+    "syncPubKeyDomain": "homerecon.ai",
+    "syncRedirectDomain": "app.homerecon.ai",
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_homerecon-challenge",
+            "data": "homerecon-verify=%token%",
+            "ttl": 600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "homerecon-verify="
+        },
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "sites.homerecon.ai",
+            "ttl": 600,
+            "essential": "OnApply"
+        },
+        {
+            "type": "REDIR301",
+            "host": "@",
+            "target": "https://www.%domain%/",
+            "essential": "OnApply"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **HomeRecon AI** (`homerecon.ai` / `website`). HomeRecon hosts a home inspector's booking website; this template connects the inspector's own domain to it: a TXT record on the bare domain proves control of the domain (`homerecon-verify=%token%`, one variable), `www` CNAMEs to our site host, and the bare domain 301-redirects to `www`. The template is applied at the domain apex only (our application never passes `host`); the subdomain test below is included for completeness.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`homerecon.ai`; public key published at `_dcpubkeyv1.homerecon.ai`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`app.homerecon.ai`) — the sync flow uses `redirect_uri`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on the TXT record (`Prefix`, `homerecon-verify=`) so a re-apply replaces the previous token instead of stacking
- [x] no variable is used as a bare full record value — the TXT is `homerecon-verify=%token%`
- [x] no bare variable is used as the full `host` label — hosts are fixed (`_homerecon-challenge`, `www`, `@`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the CNAME and REDIR301 records the end user may later change

## Online Editor test results

**Editor test link(s):**

- apex (domain only): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADiCoGoC%2F%2B1WbW%2FqNhT%2BK5alapsGNAESINqmS%2BnVLpva21EmXamqkIlPwCLYubaBsqr%2FfccJkBSYrvZpldbyoY59Xp7nvNnP1MIyS5kFGj3TTKu14KCHnEZ0rpagIVaywQStHc5u2RJl6Sc8HblT0h%2FiqQG9FjHkihuYGoEGD7snKqXEGrQRStLIr9FUzdSfOnWurc1MdHlZhXC5BC5YuVV34o1MztAKBxNrkdncEh0oKSG2hjDipImQJsNvpb8zRG0k4WrJhCRWETuHPRZSJYR6BvUTpZ3IskH6ZPxlTJxfzQmKOMUp07C35YIDJt8%2BeCNoy2qVGiJsjWw2G5IpIR0sWzpDSLl357BGmOQnphHEhmluHF40gliyLBXAnRknuxNjGTwhsnRLvpcqN0cypjHwFvQP0Wtk6JRxrsEgNFymG7Y1ue2fCmO%2FNFxmmBZsmsL1q9heWLUAeVEYzEDXd%2B4xrpjJuciQNa8GUxizQrCbOcij8CAE4FUKopBgWdaoGNDAuAshBiVekESrZS41KQshnrM0BTmDapIwWnlS9lkgKqn6mgLGFQp%2Fu1DMFGYwFWtw7M1Wxlepihc0SlhqAHfmmBR%2B96oLdkcu2iP4uhIoUMqjhbvV9HfYXucuTzvKSYywqHHLHmQc%2ByO5gpGh0cMztdvMtRISpYVf%2FDgXCtcUzLKq0zr2mki2P%2B9SiBLWYrOFnoerJ4tdk6QitjfMxnMhZzeYR1S%2F05CIJ3pWZHd2xgd9qR2wDm77Nx9LtFhnbprkrTBWuOHq3xxzLqFhakBawdxc%2BCxd8W%2Br1kcfr4ejlueXDj44daZnYCuTxFX3RZH7i0v6D1YfX2r0LyVhUkb8EeO4T43GctgubbKCtBGrZekRVzOtVtlE7HXy1jNupO61H07UH%2Ff6D9St86y4j16Q9FqJz1rNLpt2un7oQ%2BwH02kn4LHfDgLqYIqZxPqdGPzP7EpjJKxeYdUtV6kVE4YT47DF4wlz%2FJCVwVN0cVxHspjP%2F7KOvomzmsUJj100hLsfQvDDjtfr1SGMvXob2n69F7JWHXjA2t1Wx2u348qFc%2B4yOn%2FdlOmoprefzzf6cqYkd8SLktzx%2FEY5%2FodEDnVaYdIvWXwoOfjNTsPDn%2F%2BmoePfWfRR9KZxVybOKfbqvDlqeDd23gSVxxqOqPcZ8D4D3mfA%2F3cG4IvDsDXwCXNyTa8Z1r1e3euOm37UDqNWsxF0%2FU7Q%2FNHzIs9zuQBjC4LP%2BP6ovjzoH1%2BuvPDau%2F96MxzcfzJXv43ug9tfw97gzhv2FsF4tOjMk8Fi0%2F08xJfh3%2FlI44JzDgAA
- subdomain (host set): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMCCoGoC%2F%2B1WXW%2FiOBT9K5alanY1QJMABaKd0TLTzky1aqdCrTRSVSET34DVxE5tQ2Cr%2Fve5ToAESreP24cCEol9fe459yt5pBbSLGEWaPhIM60WgoM%2B5zSkM5WChkjJFhO0sd27ZCna0h%2B4O3K7ZHiOuwb0QkRQHMxhYgQCblefHaksFqCNUJKGfoMmaqpudOJcW5uZ8Pi4TuE4BS5YtdR05q1MThGFg4m0yGyBRL8qKSGyhjDirImQJsN7pT8YonJJuEqZkMQqYmew4ULqgvCcwfOx0s4kbZEhuf51TZxfzQmauIMTpmGD5YIDpljeeiOIZbVKDBG2QfI8J5kS0tGylTOkVHh3DhuESf4MGknkTHPj%2BCIIcsmyRAB3MM52bcYyWCKzZEX%2BkKqAIxnTGHgL%2Bs9wlxk6ZZxrMEgNL5OcrUyB%2FVcJ9rnlMsO0YJMETndie2TVPcijEjAD3Vy7x7hiJmciQ9W8HkxhzBzJ5jOQe%2BFBCsDrEkRpwbKsVQPQwLgLIQYluiexVmlhNa4KIZqxJAE5hXqSMFpFUjZZICqu%2B5oAxhVKf%2BtQTBVmMBELcOrNSkZfEhXd0zBmiQFcmWFS%2BNVOF6y3XLRH8DAXaFDZI8LVfPIPrE4Ll887ylmMsKhxyW5tnPo9u1KRoeHtI7WrzLUSCqWlX7w5FArXFMyyutMm9pqIV5%2FWKUQLa7HZTjwPr5YWuyZORGQvmI1mQk4vMI94%2FEpDLJb0oMl674AP%2BtTYcv16Obw4q9hinblpUrTCtcIFV%2F9mX3NFDVMD0grm5sJP6Yp%2FVUcfnZ2ej9qeXzn42x1negq2NklcdR%2BVuT86pi%2Bg3j016L9KwriK%2BB3GcZMajeWwSm08h6QVqbTyaGYqw7upVvNsLDbnivYzbqxuEG6fQdxtMG5LELwvsuMWBt140I591g76bNLr%2Byc%2BRH53Mul1eeR3ul3q6IqpxDoeG%2Fxndq4xIlbPsfrSeWLFmOHk2C7xaMycTlRncBdd7NeTLOf0oXpqrTW%2BVFSvkq2ndMwjFxbhHhbAPfzEQZPHA7%2FZGQyg2e94rMk96EOPed24OPxfT6bDz57d3NTzPSwGHn06UKPrCLhq2RX8SpH%2Bz4q2FVyTNKzk7Erxg17Lw6%2F%2F5hXg5yURYfjm6dcm00EJ9dG0NxfchHoziu4aOM3eR8X7qHgfFe%2Bj4pVRge8vhi2Aj5mzDbzgpOkNml7%2FOvDDTh9%2FrSAIBr730fNCz3NpAWNLkY%2F4NlN%2Fj6GDwP%2BSPrQ7w4eg%2FW3V%2Fa7hctaZXnzMv%2BU%2FjL1hvbO%2B11veLIP%2BGb5v%2FgbcAWa%2FyQ4AAA%3D%3D
