### PR TITLE
add Trama, Link de ofertas

### DIFF
--- a/trama.so.link.json
+++ b/trama.so.link.json
@@ -1,0 +1,37 @@
+{
+  "providerId": "trama.so",
+  "providerName": "Trama",
+  "serviceId": "link",
+  "serviceName": "Link de ofertas",
+  "hostRequired": true,
+  "version": 1,
+  "logoUrl": "https://assets.trama.so/brand/bimi.svg",
+  "description": "Apunta un subdominio propio al Link de ofertas de Trama: el registro de tráfico y las dos verificaciones que emite Cloudflare for SaaS.",
+  "syncPubKeyDomain": "trama.so",
+  "syncRedirectDomain": "trama.so,trytrama.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "groupId": "routing",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "ownership",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "groupId": "cert",
+      "host": "_acme-challenge",
+      "data": "%dcv%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Trama** (`trama.so`), service `link`.

Trama is a conversational sales platform for travel agencies. The `link` service lets a customer point a subdomain they own (e.g. `link.theiragency.com`) at their Trama offer microsite, which is served through Cloudflare for SaaS.

The template writes the three records that setup needs:

| group | record | why |
| -- | -- | -- |
| `routing` | `CNAME @ → %cname%` | the traffic record, pointing at our Cloudflare for SaaS fallback origin |
| `ownership` | `TXT _cf-custom-hostname` | Cloudflare for SaaS hostname ownership verification |
| `cert` | `TXT _acme-challenge` | DCV token for certificate issuance |

The three are split into groups because Cloudflare issues the certificate token *after* the ownership token: there is a window where only two of the three values exist, and `groupId` lets us apply the records we can actually fill instead of writing an empty TXT.

`hostRequired` is `true`. The service is subdomain-only by design — an apex would need `APEXCNAME`, and our platform explicitly refuses to offer this flow for an apex.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — `trama.so.link.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://assets.trama.so/brand/bimi.svg` returns `200` with `content-type: image/svg+xml`

Also validated with the official linter:

```
$ dc-template-linter -loglevel error -tolerate info -logos trama.so.link.json
$ echo $?
0
```

At `-loglevel info` one note remains, which we cannot resolve: `DCTL1021 missing from iana definitions` for `_cf-custom-hostname`. That underscore label is defined by Cloudflare for SaaS, not by us.

The `syncPubKeyDomain` key is published and validated with the pubkey tester:

```
$ dc-debug-pubkey -dns _dcpubkeyv1.trama.so
{"level":"info","dns":"_dcpubkeyv1.trama.so","message":"record is ok"}
```

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `trama.so`, key at `_dcpubkeyv1`. Every apply URL we generate is signed; the private key never leaves our server.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set — `trama.so,trytrama.com`
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — both TXTs are verification tokens and are set to `All`, so reconnecting a domain replaces the stale token instead of leaving it alongside the new one
- [ ] no variable is used as a bare full record value — **not fulfilled, justification below**
- [x] no bare variable is used as the full `host` label — both TXT hosts are fixed literals
- [x] no variable is used in the `host` field to create a subdomain — the standard `host` parameter is used
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is **not** set — deliberately. None of the three records is user-modifiable: removing or editing any of them breaks routing or certificate issuance outright, so there is nothing the end user should change independently.

## Justification for the bare TXT variables

Both TXT records use a bare variable (`%ownership%`, `%dcv%`) rather than a fixed prefix.

This is not a stylistic choice: the values are opaque tokens minted by Cloudflare for SaaS, and Cloudflare matches them **byte for byte** when verifying hostname ownership and when answering the ACME challenge. Prefixing them (`trama-ownership=%ownership%`) makes verification fail — the record would exist and be silently useless.

The exposure this rule protects against is mitigated three ways:

1. Every apply URL is **digitally signed** (`syncPubKeyDomain` set, no `warnPhishing`), so only we can produce a valid request.
2. Both hosts are **fixed literals** under a host that the template requires, so the blast radius is `_cf-custom-hostname.<host>` and `_acme-challenge.<host>` and nothing else.
3. `hostRequired: true` means the template can never touch the apex.

`%cname%` in `pointsTo` is a variable for a mundane reason: we run two environments with different Cloudflare for SaaS fallback origins. It is signed like everything else.

## Online Editor test results

**Editor test link(s):**

[Test trama.so/link example.com/link](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALCWoGoC%2F%2B1UUW%2FbNhD%2BKwKBPs2yJcuxJQMDmrlbtrXOutQF2qaGcSJPFhFJVEjKqRbkv%2B%2Bo2LGdFGj71gJ9EnV3%2FO7u%2B453yyyWdQEW2fSW1VptpED9l2BTZjWU0DeK9R7s51BSHFs4D5kN6o3k2EUXsrram7aBr8joCfRUhtqCIX%2BujL3A60ZqpFtWN9hjG9RGqopNwx4r1Fq91QXdza2tzXQwAGPQmv6umkGqoRKDVJaybzZrghRouJa17SDYad1UFrym8kyTClXKSiqP6q%2FpA4X3qCJ37LqZelh4GtfSWK2c1eqPTRBgmEmuvNYrXKwyHtUqyQScsqHxrhv0sJQWvVmhGpEVoNHLlPbeALzpOz7air9u0pfYvlAlyOqYV%2Be9QEFkcPvE37O6vT9zVVIwBSktDJte3jLb1o7f2fnp%2FHdyrbVq6k4GOlhZrbdMk%2BG5k0%2FJypqFot9nvCJpnpHRWmI5GgfBXe8Bb%2FFucYSmbirSJpf1Hm%2FFM583xqrSdxaH5jQACw794UKX4ZOdqSorJLdzsDynuuZKuDynRfGVFXCS6SA58BJ9nkNRYLU%2BTCz45ttSLu967D%2FScLWndUlwOxHwE9CzwC312%2FTbGe%2BqW8nuzgHhh2R1ZRNeDSSgcU9rh3x5BL3cYV%2Fegy%2B36F9G7nR0YYamb%2Fc8dhj7CxTAIfKTbMhDMUlHGMMoC3gionQMJzjJQj4Uo9RdIgpdePCnid%2B10dW%2F9cWwPN8sJumr0c0HmI3xRZidJfnf0dX8pHo9ub5gjkO5rpTGlaEv2Ebj7lGXTWHlCm5gbxJ8BXVdtES5IS8lezrJ913tmN6q%2B6TFAyF7bCW4I1i6cUniBMcjyPwIxok%2FwvHQjxMIfDEM4jSKQwAQB%2Fvs8Z77zEI7lh5pGVVWQtFN1A20ht09md5tD595Kf3jvr5KmR%2Bj1%2BOH%2BajPbxip76vbZY%2BWws8h%2FTmk3%2FWQ0u42sEGxAhc6DIZjP0j8IF4Mo2kYTU%2BG%2FSiehKPklyCYBoGrHo297%2FqWNvjh7mZBztvBWzhpP%2BRh%2BH62%2FuflVRjPY%2FtHFOTvT606a%2B3Z5jqxv43Mr%2Bzuf5xzQMI%2BCgAA)

`hostRequired` is `true`, so per the template note the apex test is not required — the link above is the subdomain test (`example.com` / host `link`), with all three groups selected. It renders:

```
link.example.com.                       CNAME  3600  sites.trama.link
_cf-custom-hostname.link.example.com.   TXT    3600  "ca3-9f2c1d7b4e8a4f0c9d3b6a5e7f1c2d4b"
_acme-challenge.link.example.com.       TXT    3600  "0Hs8Xy3kQpR2mNvT7bL4wZaC6eD1fG9hJ3kM5nP7qR"
```

---

🤖 Prepared with [Claude Code](https://claude.com/claude-code). The Online Editor link above was generated by actually running the template through the editor, per this repo's AGENTS.md.
