### PR TITLE
Add cowliss.com.sending-domain template

### DIFF
--- a/cowliss.com.sending-domain.json
+++ b/cowliss.com.sending-domain.json
@@ -1,0 +1,48 @@
+{
+  "providerId": "cowliss.com",
+  "providerName": "Cowliss",
+  "serviceId": "sending-domain",
+  "serviceName": "Cowliss sending domain",
+  "version": 1,
+  "logoUrl": "https://cowliss.com/favicon.svg",
+  "description": "Lets Cowliss send email from this domain: the three Amazon SES DKIM keys and the MAIL FROM subdomain that carries bounces.",
+  "variableDescription": "%dkim1%, %dkim2%, %dkim3%: the three DKIM tokens Amazon SES issued for this domain. %region%: the AWS region the SES identity lives in.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "cowliss.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 3600,
+      "essential": "Always"
+    },
+    {
+      "type": "MX",
+      "host": "mail",
+      "pointsTo": "feedback-smtp.%region%.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "mail",
+      "spfRules": "include:amazonses.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Cowliss (https://cowliss.com), a customer data platform that sends email on behalf of its customers' domains through Amazon SES. The template publishes what SES needs to sign and bounce-handle mail for a sending domain: the three Easy DKIM CNAMEs, and the MX plus SPF pair for the custom MAIL FROM subdomain (`mail`).

Variables are the three DKIM tokens SES issues per domain (`%dkim1%`, `%dkim2%`, `%dkim3%`) and the AWS region the identity lives in (`%region%`), which only varies the fixed `feedback-smtp.<region>.amazonses.com` MX target.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set to `cowliss.com`. Our apply URLs are signed RSA-SHA256, with `key=_dcpubkeyv1` and `sig` as the final parameter.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow. Not applicable: the template does not use `redirect_uri`.
- [x] no TXT record contains SPF content. SPF is an `SPFM` record on the `mail` label.
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique. Not applicable: the template has no TXT records. DMARC is deliberately left out, so a customer's existing policy is never touched.
- [x] no variable is used as a bare full record value
- [x] no bare variable is used as the full `host` label. Each DKIM selector sits in a fixed `._domainkey` label.
- [x] no variable is used in the `host` field to create a subdomain. Subdomain claims go through the protocol's `host` parameter.
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove. The DKIM CNAMEs are `Always`: mail stops being signed without them. There is no DMARC record to mark.

## Online Editor test results

**Editor test link(s):**

Apex (`acme.com`, no host): [Test cowliss.com/sending-domain acme.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANGioGoC%2F%2B1WbU%2FbMBD%2BK5YlPtGUkFDaRuJDN9iEWGGCTkMgVLnxpVhN4sh2igJiv33nvNB0vH2YNrEJqVXsO5%2Bfe3znR76jBpIsZgZocEczJZeCgzrkNKChvImF1t1QJrTz4DpmCS6lHysnOjSopQihDNGQcpHOHS4TJtKVcz2I1MvIw7IlKC1kSoPtDo3lXH5TMS6%2FNibTwdZWK5GtiOF%2BMu3q5RzjOOhQicyUsfQLGE3aGARw%2F5hESibEXAtdAwY4AfwrADJK2K1MydnBGdk%2FOhyTBRSaMAy1S8ajwy%2Fk0%2BnJmOh8VsWinRkSMqUEaDKTeRqC7loKTAk2i2F%2FLaUNvhDJ9kaHlAOvGfgb7RxKYCMXkOp2PsgiB04iqdrJd8mGgjnuXm8x%2Bn5GKkM5LQM5pEaYgsRiiUlijK1EkYYfYhkuaBCxWENl%2BZrPjqDYr%2Brwa8kVhFJxTYPLO2qKrKzg8Wh8gK5rqc2KXnda5YaHZztFitToiWz57afLSmoamu2NwSL7u67boaC1TZnZqo%2FiG1Zoet95EdR7BdT7E6D%2BK6D%2B74KOz1eItnXXMSIAPmPhwtGJybpNGzxCy5SQCsuPt8ltYbdgzr5%2BGj8C0ll0mseA5aYiDeOcQ%2FAsj%2Fur%2Bw5FF0xXPXKF17HpIxYmUMfUIDiaK5lnU9Eszphiibaq04RdruKumsBLasdlG9kJ3pLtxuDVBq8x%2BLXBt4bqdKwFcucGtHEwELMW81QqmGr8MpMrPA6jcrwNSR4bMWU3bGXi4ZRlWVwgSY1e3OvxRUgrZbN5rfcGZ4Y1jteaYspDew7CSmjEWTgYDvvOoO%2F3nZ2doesMdmbMGbg8GvZYb%2BAOdlty%2FIRSvyjIq3I81YlP9P%2BKoPccQe8%2FIeg%2FR9D%2FJwmWYlKzq%2B94TWldSB7ux0sE10XlLdKdnE%2Be47vcQ3HbJk%2FKGvnB4vitFvOqg0r5LjrvovMuOu%2Bi89dEB19Pmi2BT5ld5rneruMO8Tdx3cDtBX6%2F2%2Bv3Bt5w085dSwMrWbG%2BwxdW%2B21FT8OTY3%2Fr%2FHZzln%2B%2BgHl6PR4LXUzcPhQXO%2FvJea84%2BPztaBC5%2FmiP3v8Ex0yGko4OAAA%3D)

Subdomain (`acme.com`, `host=mail`): [Test cowliss.com/sending-domain acme.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEujoGoC%2F%2B1W70%2FbMBD9VyxLfFqT5geUEmkfOhgDjTIEbENDqHKda7GaxJHtlAXE%2Fvadk4amg5UP0yQ2IbVKcufndy93fsodNZDmCTNAozuaKzkXMajDmEaUy5tEaO1ymdLOQ%2BqYpbiU7tZJTGhQc8GhgmjIYpFNnVimTGTL5CqILJaRh2VzUFrIjEZ%2BhyZyKj%2BrBJdfG5PrqNttFdKdMNxPZq6eTxEXg%2BZK5KbC0iMwmrQ5COD%2BCZkomRJzLfSCMMIHwL8CIIOU3cqMnL0%2FI3sfD4dkBqUmDKF2yXBweET2Tz8NiS7GNRbjzBDOlBKgyVgWGQftWglMCTZOYG%2BlpI14JlJ%2Fo0Oqm6C5CTfaNVTERs4g0%2B16UEUBMZlI1S7eJRsKprj7YovB1zNSB6rHChhDZoQpSSLmWCRibCfKjL9LJJ%2FRaMISDXXkpBh%2FhHKv7sOvLVfApYo1jS7vqCnzqoPHg%2BF7TF1LbZby3FFdG748OylSZEafy1beXlxWSdPQbG8MNjnseV6Hgta2ZGa7PkhuWKnpfWctafAMafA3SMNnSMM%2FJR1eLBnt6K5yTADiMeMzR6cmd5sxeMSWKyEVth9Pk9fibtGcnewPHxHpfHJaJIDtpiLjSRFD9Fsd91f3HYopGC1n5AqPYzNHjKewwKySTJUs8pFoADlTLNXWeRro5RJ71YAva7QlsONkA3ha%2FCYQLAJBEwgXgdAG6rdkI1A4N6CNg0CsXkwzqWCk8cpMofC1GFXgqUiLxIgRu2HLUMxHLM%2BTEsVqzOJejw9EVjucras1I%2B5CdswMa7LPTcgo5vaFCOun0O8HzNucOMGk13M2%2FS3PGff7vuN7O%2F1t3g92%2FF7Q8uYnbHutO6%2F25qnRfOJALJUGa5UG%2F5HScK3S8J9VWvnNQqZF%2FKJt1XAezs86pavm81J1n1%2BcrxU%2Bf4tu6JMnfZD8YEnyktt71UFrfXWoV4d6dahXh3qZDoXfZZrNIR4xuzTwgp7j7eDv3PMibzsKd9ygt%2Bn722%2Fss2elYFtr5Xf47db%2BaqO9NCj5xYG%2FdXDQy73bb8GX7nc5y3YP%2BKY6PQpDNt7teh%2FUfFZ%2BfkvvfwJZtlpc8A4AAA%3D%3D)

In the subdomain test the MX and SPFM land on `mail.mail.acme.com`, which is intended: the claimed sending domain there is `mail.acme.com`, and Amazon SES puts its custom MAIL FROM subdomain one label below the claimed domain. The `mail` label in the template is that MAIL FROM subdomain, not the applied host.
