### PR TITLE
Add slydeonline.com.website template

### DIFF
--- a/slydeonline.com.website.json
+++ b/slydeonline.com.website.json
@@ -10,7 +10,6 @@
   "syncPubKeyDomain": "slydeonline.com",
   "syncRedirectDomain": "slydeonline.com",
   "hostRequired": true,
-  "shared": true,
   "records": [
     {
       "type": "CNAME",

--- a/slydeonline.com.website.json
+++ b/slydeonline.com.website.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "slydeonline.com",
+  "providerName": "Slyde",
+  "serviceId": "website",
+  "serviceName": "Slyde Website",
+  "version": 1,
+  "logoUrl": "https://media.slydeonline.com/sites/cmtlprw9z0001xja0k4xryw3v/logo-dark-1788461145526.png",
+  "description": "Points a hostname at a website built on Slyde (slydeonline.com). Adds a single CNAME to Slyde's origin so the site is served over HTTPS.",
+  "variableDescription": "No variables. The CNAME target is fixed to Slyde's origin; the customer's hostname is supplied through the standard host parameter (www for a bare domain, or the chosen subdomain).",
+  "syncPubKeyDomain": "slydeonline.com",
+  "syncRedirectDomain": "slydeonline.com",
+  "hostRequired": true,
+  "shared": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "origin.slydeonline.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template `slydeonline.com.email.json` for Slyde (slydeonline.com), a website builder for small businesses. It lets a customer send transactional email (booking confirmations, reminders, payment requests) from their own domain via Slyde's email provider: a DKIM key on `resend._domainkey`, and a bounce MX plus SPF on the dedicated `send` subdomain. The domain's existing root MX/SPF are untouched. Companion to `slydeonline.com.website.json` (#1792).

# Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (synchronous flow with `redirect_uri`)
- [x] no TXT record contains SPF content — the SPF is an `SPFM` record on `send`
- [x] `txtConflictMatchingMode` is set on the DKIM TXT (`All` — one key per selector host)
- [x] no variable is used as a bare full record value — DKIM is `p=%dkim%`, MX target is `feedback-smtp.%region%.amazonses.com`
- [x] no bare variable is used as the full `host` label — hosts are fixed (`resend._domainkey`, `send`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear in any `host` attribute (`hostRequired` is false; records apply to the registrable domain)
- [x] `essential` / `OnApply`: not applicable — the template writes no DMARC or other user-editable records

## Online Editor test results

**Editor test link(s):**

`slydeonline.com.email.json`
- Apex test (host = @): [Test slydeonline.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEpwomoC%2F%2B1VXVPjNhT9KxrNMIVp7Mj52iQdHgJhKaXZJQRaOgyTkSUlUSNbXklOMAz97b1yEpJQui992ensk%2BXr%2B3XOPbp%2Bxk4kmaJO4O4zzoxeSC7MBcddbFXBhU6VTEXIdIIrr58%2F0QTc8cg7gNkKs5BMlEEioVJtbbue6Mx%2FQyORcplOwWchjJU6xd2ogpWe6lujwHfmXGa71WoiuKThmyaqVjphqyxxKjPLzhMhJHr8k5J549EUy%2Fqi6vMEnJp5EH1otxutKGo0m7VWmJUVubDMyMyVVfGvwllEUZxbyG4tstAZkmCLtZ5Di4jpdCJNQr2%2FrSAjEpkCfAgCx4wWiUgdWL%2FkwkLUxOikDNfLFHENYFPkZkbn0xlaEXD4Bs1RiHqc%2Bx76lxcDNBdFmZmmaHT1sRrrPGUC6kiDNGQEPhjMiSObx6v09icoINa1frBIPErrfOMl0UYwbSD74eCuTAs5EXVlhNHaHSFqBEo1WHTOZoKHfiTUSBor0d8jis9l0i0Dyz6zPFaSle0eemN2jBZU5eJoDVNam0ObE20gRtp1fyE0NIV8q0S9hD4BqNHZaG1ex%2FoZrKisIBFOQ5TbQFDrgsi3Z4uUXeXxpSj6Zc53VeqdroEswO%2B%2B4jbT1l3D7MAPhDuhyooKXnOGu%2FfP2BWZ1%2B7N3c3aG16M8A2G4xUkYMCLijoKn7LjA8%2FTAVicAyHXW4TA8dGdgoqALzegjs1gOgPNfd6eUvil8lpmcLet4mv466Zl6uyNBstECB5TNg9s4rLwYEXZQUhLFq2wrxdUaiNdAVeK7LSxUwZEMPhHIZtNrnMlADaWKVM5F939zC8PLxUM72K8JegBkG%2FYFY8Ulsgus2CE0xTUn43lxj%2BjhibWL5pN5P1e6MMm9h77s6fTnwcX55NBj5yfjr6cjy7ien94dtIb3vZ6jfNPvf7piRxenkyHp7AYHExk%2FxHV6g2fa8WYz%2FYqKOxByWmqjRhbeFKXG6DImRyEkOTKyTFd0q2JszHNMlUABxa%2BQq63IklX2%2B6rIvnPYPbkNebM0yn96p2wdn3SiTpBjZBJ0GAxDyjpNANRiwhhrSaPo9rOEv%2BXHf%2FeMt8OFNYk7DxJVSngJS0sfnkr4jULa22tge8LeHup3yp4B9u%2BmL8xpHsD34e6OIb7FKF3bxL6iyq1gQkovxVgDxW4n9%2Fl%2FF3O%2FxM5w8a3dCH4mHq3Gqm1AtIJInJD2t1mo1tvhO1Oo%2Fmh9SMhXUI8ApDkCvAz%2FBV2%2Fwd4Pr9a%2FNa%2BSTryY9T6ZTBdzPqf573zp%2Bb18Hd1O%2B%2F8YVrFiWn9zD6zY%2FzyN%2BzNDYxRCwAA)
- Subdomain test (host = shop): [Test slydeonline.com/email example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJpwomoC%2F%2B1W227jNhD9FUJA0AS1ZMmX%2BFLkwbGzQeL1No6dNmgQGJQ4tllLopakfNnA%2B%2B07lK%2Fypn3py6LYJ0ejmTNzDg9HebM0RElINVjNNyuRYs4ZyDtmNS0VrhiIOOQxOIGIrML%2B9ScaYbo1MAkYViDnPICsCCLKw0PsOJPcmHdkADHj8QRz5iAVF7HV9ApWKCbiSYaYO9U6Uc1iMQLGqXMyRFFxDaoYRDpM5KLxxXVdb%2Fk3dWeVpVwtyvOiwbEZlTPbq9XrlUvPq1SrpUsnyToyUIHkic66Wh9BK0KJnypEV4oonIxwjPlCzHBEEoh4zGVETb4qEAkRj5E%2BFmFiQlcRxBqjn1NQWDWWIsrKxSImTCDZmOipFOlkSjYCnJ%2BwuXBIizEzQ6d71yMzWGXINCaDhw9FX6RxANiHSyIQEfUI8JwYUam%2FgVe%2FYQPY9vpFEVhypc3gmdASAiER%2Fbz3nMEiJqE6q5BC6AtCJZBYYESkwRSYY46ESk79EDo5odiMR82sMJszSf2QB9m45yaYXJE5DVO42NLkSqU45lhIrOFqO5%2BDA00QbwPUiugXJDW4GWzD21pzBhspCwSciUNSZQNV2vbMeGoVBw%2Bp34VVJ8N816Um6RHFQv76X9KmQulHPDvMQ%2BOOaaigYG01s5ovb5ZeJca7w%2BfhNhsfJJgBndGGEipgTEU1xVfJ1ZnR6QwjWqORy5eui38udRtdhHrpHtXBFE%2BnJ5jBbYWhtS7s2%2FSeD11MD3PdBI%2B1GgqMjAGYT4OZrSKdOGcbyc4cmqmoQO0vKBeS6xVeKfdojKM2aILed41UMn5MQ0DaFo%2BDMGXQzCOvX9cFC59hdBDoFZnv1IUlxSVyrKwBn4oEnyZ4A5IR39UkVNJImWWzq37Jlb%2Fu6l82AKYNymqee3e3417LvW0PPt8O7vxyp39z3eo%2FtVqV20%2BtTvua97vXk34bF4TGk8n%2FeKVyxWBtlDNoe2NZhhyfxELCSOEv1alEqbRM0RBRGmo%2Bogt6CLFgRJMkXKEWCt8i1qlZ4s3W%2B84szlaSvWP%2BM6Oc10YsMLpys4cpK0G5XKrajdLYsys1VrOpXwtsVvZ8r1oduy5zjzb6Pyz89zZ7%2FnRxb%2BIS5DTMHL2gK2WtT129lSMTI69A3taHq37q6yOSeYv%2FgJRzFniH8%2FwKr5tH3r1o5CsNwx1fpPsjMXwt4PX96fSfTv%2F%2FOx2%2FE4rOgY2oSS25pUvbbdieO3TrzWq1Wa04Da%2FcKFV%2Fdd2ma%2BYwRt2QfsNvyfFXxIqWY%2Fx%2FrfLXU3dWg5L3x30r%2BVBs%2Fynr3vXivhss7%2FuN2TD%2BvV55cK%2Bs9TcZwFz0jwsAAA%3D%3D)

`slydeonline.com.website.json` (carried from #1792; hostRequired=true, so no apex test)
- Subdomain test (host = www): [Test slydeonline.com/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMjqoGoC%2F91UbW%2FaMBD%2BK5a%2FrFUhOJCEkmnSUNtpU1WKCtukVQg5iUncJnFqOwSK%2BO87J4XSl037PClS5Lvn7p57fOcN1iwrUqoZ9je4kGLJIya%2FRdjHKl1HTOQpz5kVigy39u4RzQCOJwYAZsXkkoesDqpYoLg%2BsB5i0c%2B9d8mk4iLHvt3CqYjFd5kCKtG6UH6nk7GIU%2BsVgY4JVZ0w02khq8EjIcRe3VFy76zkuuotOyZPO6Lyvm33T08dz7Yd1%2B16VpHHUDFiKpS80HVVPBY81wpRlAilc%2BCIqIbTE30UlDzVSOSo4X30isqxhYZRZMIVz%2BOUobPR8OoCadHgPygkJI95jpRAOmGozskVMpqwCAnoHn2dTscTy0hBJadBys5fEBwJtHMoC02TfQ0qY6ZNsgVfQa43NT%2FWFcNSaZExCeZ9h4ZAWRQpN2GJFGWcNOw0zUG2qEaigkoAa2B4VFUVWggJbQZUMhSJjPK8BXWaEgBn0GIZNI5j04xa5%2BG4DC7Z%2Brw2vjtHBnQDVyxZqP8CM3Ru2EMJOBgtLUvWwhAiZKSwf7vBel2Y0ap1eYLD8bMZ1Pp2pwKOjSjW2%2Bxaw8T1PEK2s20LP4qczZ%2BTz2BedsTYisKGHJIyc15VcIhBxGLOdyG1dMos0i749kX0bBd%2BW8ebujzOhWRzBX%2BqS8l2fWZlqvmcVvTZFIVzCre3BpoKvJDlrQZ5s20Nu4hq%2Bk8KtPA8Cg1tblZ4sBg4XuBEbS9gpO30erQ9WLinbZe4QRC4zsL2woPH4A9vxfuPwgv1mIL50ZyazR%2BmFV0rvN3OWqDkf9kY3L6isP5zapBd0vXaZADflLi%2B3fUdYvVtz%2B07J4T4hJg2mNJNqxuYlMMZwTejLusngvPL4Y%2F%2B8ld%2BVV3cJSfhmRp8iR%2FsyaK8G18vl73J%2BfW3T3j7G6cfYz3lBQAA)
- Subdomain test (host = shop): [Test slydeonline.com/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANfqoGoC%2F91UbW%2FaMBD%2BK5a%2FrNUgmJdQkmnSUJnUaRpDLWgfKoSc2CQeSZzZDiFF%2FPedk0Lpy6Z9noQUfH7u7rnHd7fHhqd5Qg3H%2Fh7nSm4F4%2BoLwz7WScW4zBKRcSeUKW6drqc0BTi%2BswAwa662IuS1U8kDLcyZ9RyLfpxut1xpITPsd1s4kZFcqARQsTG59judlDNBnRcEOtZVd8LUJLkqvQdCSHf3k5LNYKeqsr%2Ft2DhtRtWm3b0ajQbDbnfgur2hk2cRZGRch0rkps6KZ1JkRiOKYqlNBhwRNXB6pI%2BCQiQGyQw1vC9eULl00Jgx665FFiUcXU%2FH3z4jIxv8O42kEpHIkJbIxBzVMYVGVhPOkITq0c18PrtzrBRUCRokfPKM4FSi44V20Dw%2B5aAq4sYGW4sdxHqV80OdMSy0kSlXYD5VaAkUeZ4I6xYrWURxw87QDGRjNRLlVAHYAMOLsizRWiooM6CKIyZTKrIW5GlSAJxDiUXQXFzaYnSVhbMi%2BMqrSW18s48s6BaeWPHQ%2FAVm6dzyXwXgoLWMKngLg4tUTGP%2Ffo9NldvWqnV5hMPxk23U%2BnXnEo6NKM7r6MZAx%2FWHhByWhxZ%2BkBlfPQVfQr8cifEdhQk5J2XZxjKHUwQq5itx9Km103aSjt73z9yXR%2F%2F7JoDNLKJMKr7S8KWmUPxYaVokRqxoSZ9MLFxReL8KiGq4hTCvVciaeXvkx6ih%2FyRCC69YaIkLO8VXa9fzCHfbwag%2FbA%2BCIfxz1%2Bv2MAi9wbrnDjxGzvbBH9bF23vhuYBcQw8ZQe30j5OSVhofDssWiPmflgYtoCksgRW10B7pDdvEg9%2BcuH6357uuQ8iw73bfE%2BITywR2nmlq3UO3nPcJdjfp6KpIvstqcTN7mF%2BXplThr0k4qQJv7HqLW9qJJ5tpsbgJP%2BLDb7Q%2Buf%2FrBQAA)

Note: the branch also carries `slydeonline.com.website.json` from #1792; this PR reduces to the email template once that merges.