### PR TITLE
Shopiyz, 2 templates

### DIFF
--- a/shopiyz.com.storefront-routing.json
+++ b/shopiyz.com.storefront-routing.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "shopiyz.com",
+  "providerName": "Shopiyz",
+  "version": 1,
+  "logoUrl": "https://superadmin.shopiyz.com/brand/shopiyz-logo-black.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "shopiyz.com",
+  "syncRedirectDomain": "superadmin.shopiyz.com",
+  "serviceId": "storefront-routing",
+  "serviceName": "Website traffic connection",
+  "description": "Connect the selected customer website hostname to Shopiyz after ownership and TLS verification. Cloudflare also supports the zone apex through its CNAME flattening extension.",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.myshopiyz.com",
+      "ttl": 600
+    }
+  ]
+}

--- a/shopiyz.com.storefront-verification.json
+++ b/shopiyz.com.storefront-verification.json
@@ -1,0 +1,33 @@
+{
+  "providerId": "shopiyz.com",
+  "providerName": "Shopiyz",
+  "version": 1,
+  "logoUrl": "https://superadmin.shopiyz.com/brand/shopiyz-logo-black.svg",
+  "syncBlock": false,
+  "syncPubKeyDomain": "shopiyz.com",
+  "syncRedirectDomain": "superadmin.shopiyz.com",
+  "serviceId": "storefront-verification",
+  "serviceName": "Website ownership and TLS verification",
+  "description": "Verify a customer-owned website hostname and prepare its TLS certificate before moving website traffic to Shopiyz.",
+  "variableDescription": "ownership and certificate are exact per-hostname opaque tokens returned by Cloudflare for SaaS. Their prescribed values cannot contain a service prefix. They are restricted to fixed verification labels in signed requests.",
+  "records": [
+    {
+      "groupId": "ownership",
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "ttl": 600,
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "certificate",
+      "type": "TXT",
+      "host": "_acme-challenge",
+      "data": "%certificate%",
+      "ttl": 600,
+      "txtConflictMatchingMode": "None",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add two signed, synchronous templates for customers connecting their own website domains to Shopiyz, a multi-tenant storefront platform. This is separate from Sendvoya and the existing shopiyz.com/mail-sending template.

* storefront-verification: per-hostname Cloudflare for SaaS ownership and certificate TXT tokens at fixed _cf-custom-hostname and _acme-challenge labels. Groups allow either challenge or both to be applied. Bare token values are required by Cloudflare/ACME and cannot carry an added prefix. The signing service obtains them from the exact tenant's registered custom hostname, not from arbitrary client input.
* storefront-routing: one CNAME to the fixed customers.myshopiyz.com target, after separate ownership, hostname, TLS and existing storefront-target readiness checks. No MX, SPF, DKIM or DMARC records are requested.

The standard domain/host parameters identify each customer's selected hostname. The provider domain shopiyz.com is the shared service identity, not the domain being connected. Apex and www are separately registered and authorized.

The routing template uses hostRequired=true to satisfy the portable schema for CNAME at @. The first integration is Cloudflare-only: Cloudflare explicitly ignores hostRequired and supports ordinary CNAME at the zone apex via flattening (https://developers.cloudflare.com/dns/reference/domain-connect/#custom-record-types). The generic editor test is therefore on www; Cloudflare apex behavior still requires an account-scoped live pilot after onboarding.

TXT conflict mode None preserves coexisting challenge values on providers that implement it. Cloudflare ignores this setting, so its actual conflict display and retention behavior must be checked in the pilot; no guarantee is made about unrelated pre-existing challenge records. Challenge records are OnApply because they may need rotation/removal. Existing certificates and DNS remain authoritative; the callback does not mark a hostname ready.

Both files pass dc-template-linter -loglevel error -tolerate info -logos and the Cloudflare-specific -cloudflare check. Production application is disabled pending onboarding and pilot validation.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):**

[Test shopiyz.com/storefront-verification example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALQUoWoC%2F%2B1VUW%2FbRgz%2BK4cD%2BjTLlu3EjQXsIU2xbuiaZonXDQ0CgzpR9iHSnXp3cqwG%2Be8jZceW13RLgT0M2A5%2BkETy4%2FeRPPpeBiyrAgLK5F5Wzq50hu6nTCbSL22lm899ZUvZ25nOoSRXebUxkmGFzmtrZDLsycIu7K%2BuIPsyhMong4GvK3SQldr0O3iD1IHJBtsvEYdFaQHqtu9XC8L0jVGvCqtuZZJD4XHz5aJO32Lz2pagzRf82OESM%2B1Qhb3Lk9nZG91KK9zoDNZh7qwJEWnRuVYQWNDOayv5N0y9DijsnSHJS10J0iBmP1%2BJP4Vl6JXTVfuWyA9sbAQIVVOmEl3EAJm428ItrQ%2BGMrRolcMKHAodfIus0IUNNIoUcyIqSuqDWezCg4OcHESwYtuTPjcFnIa0wNcHVA6Zd7E5J65BBUEFi3aUbAWfasphb9F44TDUjqmnjTgrbJ3lBccRK3EFcNUXsyVqxxo4aUqOKyhq9EKBMTYIRSWmvlAptoVl11yv28Cm5UChwWkVKJYEkY1BOtUVBaRYeEEoXi%2BYi0Ni6INn1dR76zIvk%2Bt7uXC2rtr%2B7lSTR2gqbuXs9xm9sEx6mas82vRmJ5ybCAHI%2BGIX%2FYLDA832JI7paR3OrMkL4voOglpSS97ZjLHPreF49B5N0MCX4b05raqikQ%2B9Lq9O%2Fb%2FGDFSJkVpCUaBZdFl1Yv8JXjcPPfmZ7PN9BW8o2eM1osmgHYHbu7MlR0%2Btlrlu%2FQ%2FK3JVGQDTSUHpeMI%2BQ1weYN4%2Bg15KfW9i%2FgdybyG%2B4PdGITjSmEx3RiY47h4O6GBR2%2BvwjuUI0cHQB5zx4QDeBMIKraTeVdRH0HO5g%2FylTc%2BDSUkE9WSkbjeRBi81mqfzl8D1LV7f780xxlTWP18l4nB2nx6NoOJ5m0VH8UkUwTCcRTPAExup4hEfDzl5%2FYuU%2Fb0nux%2BHJ0eKZf1L412b7W7ryb9d%2B06N79H%2Fn%2F4udp3XjYYXZHNhvFI8mUTyl3yw%2BSYbDZDzqD2Nq8PS7OE7imPXQv9imEPe0a7pbRl581BfTxctpbU6XZ5fNJfy4Pn%2FrapioT%2FYNrPTJevrDLx8Gb87Wp9%2FLhz8ALkLHKtMJAAA%3D)

[Test shopiyz.com/storefront-verification example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANAUoWoC%2F%2B1V227bOBD9FYJAn2o5slPHiYA%2BOAmw2O32gtptkwaGMaJGNhGKVEnKlwT59w5lxZFbF5sF9mWBEnkINTNnzpkZju%2B5x6JU4JEn97y0ZikztH9mPOFuYUq5uesKU%2FDOzvQOCnLl462RDEu0ThrNk16HKzM3n6wi%2B8L70iVHR64q0UJWSN1t4R2lFnR21HyJQliUKhC3XbecE6bbaHGujLjlSQ7K4fbLhyp9g5tLU4DUP%2FELDh8xkxaFf3I5mD14o11KgVud3ljMrdE%2BIi0ylwJ8ELTzaiR%2FwdRJj8ysNEleyJKRBjb5e8x%2BCMvQCSvL%2Bpbwz8G4YcBERZkKtFEAyNiqgVsY5zVlqNFKiyVYZNK7Glmg9VtoZCnmRJQV1Ac934V7Czk5MG9Y05NuaApYCanCyz0q%2B8zb2CEnrkF4RgWLdpRMCd8qymFuUTtm0Vc2UE837EKZKstViCNWbAww7rLJAqUNGkLSlByXoCp0TIDWxjNBJaa%2BUCmawgbXXK7rwE3NgUK9lcJTLAkiWwBpVZcpSFE5RihOzgMXi8TQeRdUU%2B%2BNzRxPbu753JqqrPu7U00eflOGVk6uJnQJMukyE3m07c1OeGgieCDji130ixDuabZP4pj%2BW%2FsLo3NFXN%2BCFwtqyVuTBex3Rod4dA61lxAew3s9Kku14Q%2BdNq9W%2FX%2FFDESBkViAUqjnbVat2P%2BC1%2FShw%2B%2FIPnuq4JSSPT4jmgzaEdi8nYbcarWiSy1nJuuQvUq31REWTTUULuyYR9SbPdjpI%2B5NDTxtkP8B9clEfr3mRH060TGd6BWdaNA6IaiNQWGj5x8e6kRjR89wFsYP6D0QhrcVbaiiUl7OYAVPnzIxg1BgKqsjK2WjwdxrtN6ulgMj2N3Wt2n4s7S152CWiVBsGQbteJinp%2FGQUgzjYfRK5HmUDrM8OsaTszzGrDfA49aGP7D8n7cu9wbj4JyFB3BQ%2F%2F6g72v%2FNw36H5Rg2qG39XsOfs8BrSIHS8xmEFz7cf8kis%2FobxKfJr1%2BEsfds9PB4KT%2FMo7pEiTR79y2Fve0h9obiF%2BM7taD4nL54a%2FeaLWO30%2BGf6zfjPDTy3N1vTzXyn4df5tfpYO7y%2BvX%2FOE7mngt7%2FUJAAA%3D)

[Test shopiyz.com/storefront-verification example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAUVoWoC%2F%2BVUTW%2FbOBD9KwSBntayFeXDsYA9tM0WaNOmbez9DAxjRI1sIhSpkpRtJch%2F71BWHHmbBXLobQkfTM3MmzdvhnPPPZaVAo88veeVNWuZo32f85S7lalkczcUpuSDvekKSnLl052RDGu0ThrN06MBV2ZpfreK7CvvK5eORq6u0EJeSj3s4Y0yCzofdV%2BiEBZlCsTt0K2XhOkaLd4oI255WoByuPvypc4usbkwJUj9A7%2FgcI25tCj8k8uz2YM32rUUuKvTG4uFNdpHVIsspAAfCtp7dSX%2FiZmTHpnZaCp5JStGNbDZxyn7V1iOTlhZtbeU%2FxGMDQMmaspUoo0CQM42HdzKOK8pQ4tWWazAIpPetcgCrd9BI8uwIKKspD7o5T7cWyjIgXnDup4MQ1PASsgUXhxQOWTexw45cQvCMxIs2lMyFXyrKYe5Re2YRV%2FbQD1r2Ftl6rxQIY5YsSnAdMhmK5Q21BCSZuS4BlWjYwK0Np4Jkpj6QlJ0wgbXQm7bwKblQKHeSuEplgoiWwDpqcsUZKgcIxQnl4GLRWLovAtVU%2B%2BNzR1Pb%2B750pq6avu7r5o8fFOFVs7%2BmtEllEmXhSiiXW%2F2hYcmggcyvtpHvwrhnmb7LI7p39a%2FNbpQxPUTeLGilnwyecC%2BMjrEo3OovYTwGD7r11WlGv4w6PPq6f9fzECUGIkVKIV62WfVi%2F0ZvOYPA35H9sWTgnNK9viMaDJoR2D3djpym82GLm05C9mG9JSmaJpjKF3YKo84NwdA80ekmxZq3mH9gPN0IctRd6KETnRMJzqhE532Tgjqa0thr19%2BeNCCRoue2iKMGNDME4a3NW2hslZeLmADT59ysYAgIknnyErZaPgOmql36%2BOZMRvuNOya%2BqLa%2Br1e5CLIK8MwnU3GJ1kSj6NTkeXRyfFkHE3iCUYYJyiScVwUcNTb4s8s%2BJetxIPmPztLD%2FMBDc%2F%2FXgQaQgdrzBcQXJM4OYviCf1m8Xl6lKSnx8Pz8cnZePJLHKdxHEqiLbYT4Z4msD97fP31%2BIP9dnlZ1AjvEvX52m23bnpxDdX5%2Bd36AySj4p%2Ftu%2Fi3Jvv7V%2F7wHTytRqXTBwAA)

[Test shopiyz.com/storefront-verification example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABgVoWoC%2F%2B1U227bOBD9FYJAn2o58i2xBfSht4dut01QO7tFA8MYUSObG4pUScqOEvjfO5QVR%2B5mgS6wj0v4wdTMOXPmwnngHotSgUeePPDSmq3M0H7IeMLdxpSyvu8LU%2FDe0fQZCnLl84ORDFu0ThrNk0GPK7M211aRfeN96ZKzM1eVaCErpO53%2BM5SCzo7a79EARalCsRt323XxOlqLd4oI255koNyePhyVaUfsX5nCpD6b%2FqCwxfMpEXhn1yejR680W6lwEOe3ljMrdE%2BolxkLgX4kNDRq035T0yd9MjMTlPKG1kyyoEtfp%2Bzn2AZOmFl2dwS%2Fkcw1gyYqChSgTYKBBnbtXQb47ymCA1babEEi0x61zALtP5AjSzFnISygvqg10e4t5CTA%2FOGtT3ph6aAlZAqfHci5VR5lzvExDsQnlHBoqMkU8L3imKYW9SOWfSVDdLTmr1VpspyFXCkis0B5n222KC0IYcQNCXHLagKHROgtfFMUImpL1SKtrDBNZd3DbBuNBDUWyk8YSkhsgWSTnWZghSVY8Ti5DposUgKnXcha%2Bq9sZnjyc0DX1tTlU1%2Fj1mTh6%2FL0MrF1wVdQpp0WYk8OvTmmHhoIngg44sj%2BkWAe5rt8zimf3f%2BrdG5Iq2fwIsNteSTyQL3Z6MDHp1D7SWEx3CpX5elqvm%2B19XVqf8%2FKQNRYCQ2oBTqdVdVB%2Ftf6Frue%2Fye7KunCi4p2OMzosmgHYHt22nF7XY7ujTprGQDOcmI8DTJULiwVx6Zbk6olo9cNw3ZsmV7humphWQbtCca0olGdKIxnWjSOQHU5SDY618%2FPNSDxoue2yqMGdDcE4e3FW2iolJermAHT58ysYJQSCqfIytFowE8aag%2BrJCfGto%2F1LBt6r8R2G35KhOhxjLM1HgmcDwRo2g6HQ6i8YUQ0XSCSFcxwiwWYgTQWebP7Plf24wnM%2FDsSO2XPZqh%2F%2BuwX9IoOthitoLgOoyH51E8o98iniaDUTIY9mezi%2FPh7GUcJ3EcUqJ9dqjFA81hdwL57vv7v2big3NX918KcVnP17n7NhbjC3m9%2Fe1q%2BnFyKSbX5ebNt5fvX%2FH9D0DRidLdBwAA)

[Test shopiyz.com/storefront-routing example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJcVoWoC%2F91Ta2vbMBT9K0JfFztOlqSJYbCuD7Z17ba262AlBFm6jkVtSZXkuG7If99VHktLC9vngcG673uOjpbUQ2VK5oGmS2qsXkgB9pOgKXWFNrJ9jLmuaOdP6IJVmEqvNkEMLMA6qRVNex1a6rn%2BYUuMF94bl3a7rjZgmaikip%2F062aWKdHdeqJQFmUl43exW8yxp2sV%2F1BqfkfTnJUONp5vdXYG7bGumFQv9gsJlyCkBe73Ka9OD9lgF5LDBqfXFnKrlY%2Bsrr1U833CFu1PyJz0QLxleS454VopnBNgd6gAx600ayulR5sQ8QUQByUeQRBe45AKLGm2jQrtvMLexGuypZKw3GOGbhQSWkhDkCFy%2FeWKIMESh7IwICZHpa5FXjILBJnRBCEabb1bD3zUCt0GHtBCLPOCSIwcXRyenxCs8R4UwiPwgIdwaTGuH1a5hPsamUM2vK2RbSRRW%2BFoerukvjWBgnWTbTqa74MktFTeXWs0dwBdXLXPmfYe5TBKktV01aFhv9m%2B%2BRTJ210VPDDUIWyrtlOapkFjjlDMTO5KDLOsckGuu%2BLbZ9XTXfntuj7MlXOFdzxz%2BGe%2BtrDDWdWllzPWsL1L8BkzpmxxTYdR7PKSA7VRxWY7wTz7JwY6dCZ4WFsG1XFg44NxlkVcvJ1Eg4PhMMomSRIdZKLXSzgb5EN48uxeeZF%2F1fAzEsE5UF6y8DgPy4a1jq5W0w4S%2Bj%2FjQy04tgAxYyGzn%2FRHUTLB7zoZp71h2pvEg95olPTeJEmaJAEMOL9BvETdPFUM1YuPbX9ycqP9%2BNAsTvlp%2Fr2A%2Fn3z9XJ%2BBt38c6V%2Fnd8cZ93TavCOrn4DjX9CIFkFAAA%3D)
 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
