### PR TITLE
Add mailermine.com.email-sending template (MailerMine email sending)

### DIFF
--- a/mailermine.com.email-sending.json
+++ b/mailermine.com.email-sending.json
@@ -1,0 +1,40 @@
+{
+    "providerId": "mailermine.com",
+    "providerName": "MailerMine",
+    "serviceId": "email-sending",
+    "serviceName": "MailerMine Email Sending",
+    "version": 1,
+    "logoUrl": "https://www.mailermine.com/images/brand/logo-black.png",
+    "description": "Authenticates your domain so MailerMine can send email on your behalf.",
+    "variableDescription": "Adds the MailerMine domain verification record and DKIM signing records for your domain.",
+    "syncPubKeyDomain": "mailermine.com",
+    "syncBlock": false,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_amazonses",
+            "data": "%verificationToken%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "All"
+        },
+        {
+            "type": "CNAME",
+            "host": "%dkim1%._domainkey",
+            "pointsTo": "%dkim1%.dkim.amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "%dkim2%._domainkey",
+            "pointsTo": "%dkim2%.dkim.amazonses.com",
+            "ttl": 3600
+        },
+        {
+            "type": "CNAME",
+            "host": "%dkim3%._domainkey",
+            "pointsTo": "%dkim3%.dkim.amazonses.com",
+            "ttl": 3600
+        }
+    ],
+    "syncRedirectDomain": "mailermine.com"
+}


### PR DESCRIPTION
# Description

<!-- short description of the template(s) and/or reason for update -->

New template for **MailerMine**, an email sending platform built on Amazon SES.

The template authenticates a customer's domain so MailerMine can send email on their behalf. It contains exactly four records:

| Type | Host | Value |
| ---- | ---- | ----- |
| TXT | `_amazonses` | `%verificationToken%` |
| CNAME | `%dkim1%._domainkey` | `%dkim1%.dkim.amazonses.com` |
| CNAME | `%dkim2%._domainkey` | `%dkim2%.dkim.amazonses.com` |
| CNAME | `%dkim3%._domainkey` | `%dkim3%.dkim.amazonses.com` |

The TXT record is the SES domain identity verification token. The three CNAMEs are the standard Amazon SES Easy DKIM records, where each `%dkimN%` is one of the three SES-generated DKIM selector tokens.

### Bare `%verificationToken%` — rule 6 justification

The TXT record on `_amazonses` uses a bare variable as the complete record value rather than a prefixed form such as `mailermine-verification=%verificationToken%`.

Amazon SES prescribes the complete verification token value and matches on it exactly. A MailerMine-specific prefix cannot be added, because SES expects its own token as the entire TXT value and verification fails if anything else is present.

This is the documented exception to quality rule 6: the full record value is prescribed by an external standard and cannot carry a service-specific prefix.

### `txtConflictMatchingMode: "All"` — scope disclosure

`txtConflictMatchingMode` is set to `All` on the `_amazonses` TXT record.

- `Prefix` cannot be used, because the SES verification token is a bare value with no stable prefix to match on.
- `None` could allow stale SES tokens to accumulate on the label when SES rotates the verification token, leaving multiple conflicting tokens behind.

`All` is therefore intentional. To be explicit about the scope: **this applies to the entire `_amazonses.<domain>` TXT RRset**, so applying the template replaces any existing TXT records at that label. This label is SES-specific and is not used for other purposes, so the blast radius is limited to SES verification tokens.

### Intentionally absent records

The template deliberately contains no SPF, no custom MAIL FROM, no tracking CNAME and no DMARC records, because MailerMine's current SES implementation does not provision any of them:

- **SPF** — MailerMine does not publish an SPF include mechanism for customer domains.
- **Custom MAIL FROM** — not configured; the Return-Path remains the default `amazonses.com`.
- **Tracking CNAME** — tracking is served from MailerMine's own hostname, not a customer subdomain.
- **DMARC** — advisory only, and left to the domain owner.

No records were added beyond what the running implementation actually provisions.

### Validation

- `template.schema` — passes with 0 errors
- `dc-template-linter -loglevel error -tolerate info -logos` — passes, exit 0
- `dc-template-linter -tolerate warn` — passes, exit 0
- `dc-template-linter -cloudflare` — passes, exit 0
- `logoUrl` — returns HTTP 200 `image/png`

Only expected informational messages remain:

- `DCTL1021` — `_amazonses` is missing from IANA definitions (an Amazon SES underscore label, expected)
- `DCTL5003` — Cloudflare ignores `syncRedirectDomain`
- `DCTL5008` — Cloudflare ignores `txtConflictMatchingMode`

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checks above:

- `syncPubKeyDomain` is set to `mailermine.com`; `warnPhishing` is not used.
- `syncRedirectDomain` is set to `mailermine.com`, which is the host that serves the synchronous `redirect_uri` callback.
- Rule 6: the `_amazonses` TXT value is a bare variable by necessity, justified in the Description above.
- Rule 7: the DKIM host labels fix the non-variable part as `%dkimN%._domainkey`, matching the recommended form; no bare host variable is used.
- Rule 8: the variables in `host` supply DKIM selector labels, which is the standard DKIM layout, not a mechanism for targeting a subdomain. The `host` parameter is still used for subdomain placement, as shown by the subdomain editor test below.
- `essential` is intentionally not set on any record. All four records are mandatory for the email-sending service and are not intended for end-user modification; removing or changing any of them breaks sending or DKIM signing. There is no record in this template that a user may need to change independently, so there is nothing to mark `OnApply`.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->

Apex (`example.com`, no host):

[Test mailermine.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPIsoWoC%2F%2B1WW2%2FaMBT%2BK5GlPo1ASFoGkfbASidVHdUuVFtVVZFjO%2BCR2KntQCniv%2B843MJK4WEv61QJCedcvnM%2Bn0syR4ZleYoNQ%2BEc5UpOOGXqkqIQZZinTGVcsDqRGapttNc4A2vUL%2FV90INOMzXhhJWOzHq6mgnKxXCre%2BbmXFhD5%2FvGcMKU5lKgsFlDqRzKG5WCw8iYXIeNxnQ6re%2Fm1OAZHjLdiBUWtGE93DjFZFzPSzjKNFE8NyUk6hZmxIThBLhqZyYL5VAJeMLR0qkkRTBIICWnpOFIsbSN2QinSd1miRXHccp6u%2FCUagciVKFW%2BECLJzYuWDqKEamoAwk7vavLvqP5UAD7lVw7iVTV5GxAPRPkSxFfsVmvlO2rjbX5mEoyRmGCU81qaAWIwrs5MrPcXv3g5wBMR1IbeIhwhp%2Bk0Ezbq8IGg%2BykmupAjpk4AaUxUIag5XlwfDTnUiQpJ6aPDRlB5n1JLXY3TdGitgl1ft3tX2yDndAxz5on9WjJasxmtp8kF0YPZEVv%2F%2BqbxFbcNvGP4PtH8P2%2FxA%2BO4AdH8e%2BXhfrGKIfymJfKuaghAGDRtoTgSNfG7BHDxK4Lv0oQTkMlizzia%2FscK5xpO9Vrz7sd1%2Fu17x2y52eVtwqYFONWNa4pVTYdW7C1zfJhJfWrUn8tDarSAN0DR%2Bh8qVhkJwCbQsG1G1VA52ZFaniEp3groiTCeZ7O4Eo0aAHrz64Wy%2B2yr6tfYrHT2REl9q64XWDUT9rMS4gbNzvv3dM2pW6n7QVuM4lpi1DSCnBc2Yf7t%2BWhjbgtGtPaLiWcliM0xTONFnvacMVuc9e7jVjhudQebsNXRtY%2FSNb%2Fv8gGB8kGr4rsfQ320Nucvs3p25z%2B23NqP0vwhNEIWzPf81uu14HfwOuEZ6fhWbt%2B1uz4nvfO80LPs0Qsz5LyHN7j1Tc4ego%2B%2FSi%2Bfva65oZcjlr08TQejofJ7aT38DA66%2F66fbgoxK2U7d70A1r8BvqI2tN%2FDAAA)

Subdomain (`example.com`, host `mail`):

[Test mailermine.com/email-sending example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC4toWoC%2F%2B1WW2%2FaMBT%2BK5ElnkYgJA2XSHugpdpQl2pbmdapQpETG7BI4sx2uAzx33ccAoSNloc9daqEFHwun893bvIGKZpkMVYUeRuUCb5ghIohQR5KMIupSFhKGxFPUP2gvccJWCO%2F0PugB52kYsEiWjhS7WlKmhKWTo%2B6v9yMW21oPBwMF1RIxlPkteoo5lP%2BTcTgMFMqk16zuVwuG6cxNVmCp1Q2Q4FT0tQeZhjjaN7ICjhCZSRYpgpI1M%2FVjKaKRcBVGmueC4NwwEsNyY1KUBEGCYRkFDQMnu5sQzrD8aSho8SC4TCmg1N4QqQBN1ShSnygxSb6XrA0BI24IAYEbAzuhr4h2TQF9qVcGhMuqsHpC%2BU6jT7n4R1dDwrZudpom%2BuYR3PkTXAsaR2VgMh72iC1znTqR48jMJ1xqeAQ4AT%2F4qmkUqcKKwyyWjXUEZ%2FTtAZKpaAMTtuy4O9K3fB0ErNI%2BVhFM4jc50Rj9%2BMYbeuHq27u%2B%2F7t8bIambOkVWsEO1Zzutb9xFmq5IhX9PrTOARWcjvcfwHfvoBv%2FyO%2BcwHfuYg%2F3hXqKyUMyqOeK%2Be2jgCABscSgiPZG9MVhondF74MUCPAaSp4ngVs75NhgROpJ3vv%2FXTiPt77P%2B0AxsUMnnaAVsLEKLOqMVWh0mHpwu1tdodSalel9l7qVKUOGgNXmAAuaKAnAatcQPqVyKGDkzxWLMBLfBSRKMBZFq8hNRK0gPVnd6e7LXPs7kaZmrLFn6Ny0uYBiXTSmN5m3ahH3YnTNqPIvTKvWsQyexi7JmmHnR7BHZt2w8pyPL86X1qPpxWkUuotheNippZ4LdH2TF%2BWNA9Jr3TmGcI7k5eb8xWyti%2Bztv8%2F1s5l1s6rYz2uw756m%2BW3WX6b5dc%2Fy%2FqZgxeUBFib2pbdNq0e%2FEZWz3Ndz%2B02XLvb6jjvLMuzLE1Gcy1ob%2BA9UH0JoOHgU8dZ%2BR%2B%2F5136RbjLnw93o4Hbl75vL1jYXdEP12z445F8uvbfo%2B1v4gD72M8MAAA%3D)

<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
