### PR TITLE
add VacayOps, VacayOps website

### DIFF
--- a/vacayops.com.website.json
+++ b/vacayops.com.website.json
@@ -1,0 +1,37 @@
+{
+    "providerId": "vacayops.com",
+    "providerName": "VacayOps",
+    "serviceId": "website",
+    "serviceName": "VacayOps website",
+    "version": 1,
+    "logoUrl": "https://www.vacayops.com/assets/VacayOps-Logoicon.png",
+    "description": "Connects a domain to a VacayOps booking website hosted on Firebase App Hosting: the hosting A record, the App Hosting ownership TXT record, and the certificate-validation CNAME.",
+    "variableDescription": "hostingOctet: the last octet of the 35.219.200.x address Firebase App Hosting assigned to this domain. txtverification: the App Hosting ownership token (the part after fah-claim=). acmetoken: the random label App Hosting appended to _acme-challenge_ for this domain. acmeid: the certificate-validation id assigned to this domain. acmeshard: the numeric shard in the certificatemanager.goog validation target.",
+    "syncPubKeyDomain": "vacayops.com",
+    "syncRedirectDomain": "vacayops.com",
+    "records": [
+        {
+            "type": "A",
+            "essential": "Always",
+            "host": "@",
+            "pointsTo": "35.219.200.%hostingOctet%",
+            "ttl": "3600"
+        },
+        {
+            "type": "TXT",
+            "essential": "Always",
+            "host": "@",
+            "ttl": "3600",
+            "data": "fah-claim=%txtverification%",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "fah-claim="
+        },
+        {
+            "type": "CNAME",
+            "essential": "Always",
+            "host": "_acme-challenge_%acmetoken%",
+            "pointsTo": "%acmeid%.%acmeshard%.authorize.certificatemanager.goog",
+            "ttl": "3600"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **VacayOps** (`vacayops.com`), a vacation-rental operations platform. Tenants host their booking website on VacayOps (Firebase App Hosting); this template lets them point their own domain at it in one click. It creates the three records App Hosting requires for a custom domain: the hosting A record, the ownership TXT record (`fah-claim=…`) and the certificate-validation CNAME (`_acme-challenge_…`).

Notes on the quality rules:

- `syncPubKeyDomain` is set to `vacayops.com`; apply requests are signed (RS256, `key=_dck1`) and the public key is published at `_dck1.vacayops.com`.
- Every variable is embedded in fixed text: the A record fixes the `35.219.200.` prefix App Hosting uses for custom domains and passes only the last octet; the TXT record fixes the `fah-claim=` prefix; the CNAME fixes the `_acme-challenge_` host prefix and the `.authorize.certificatemanager.goog` target suffix.
- The CNAME host label is App Hosting's own ACME naming (`_acme-challenge_<token>`); the linter reports the informational DCTL1021 for it because the token suffix is not in the IANA underscore registry. It cannot be renamed on our side.
- All three records are required for the site to work, so `essential` is `Always` on each; none is meaningful to keep independently.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — not applicable: all three records are required for the service, so they are `Always`

## Online Editor test results

**Editor test link(s):**
- Apex (`example.com`, no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIlSoWoC%2F%2B1WbW%2FbNhD%2BK4QAAxtqyZIsy7aAATXSpku7tFmRdR2CwKDIk81FFgWSfkuQ%2F76jbNmy43TZtw4ooA%2FS8bnjvTwPqQfHwKzMqQEneXBKJReCg7rgTuIsKKNrWWqPyZnT3q19pDPEOl%2Fs6qdS44oGtRAMKqclpFpgsJ31CE72gAUoLWThJEHbyeVE%2FqFyBE6NKXXS6SyXS6%2BZQYdqDUZ36kDub%2BgimCy8sphgNA6aKVGaKqJzJosCmNGEEi5nVBTESHzfZZFKeSeKSZ0NmUptgBNZkHOhIKUayKgsya9oRlhCzHSDsT4jooBJxduVtQEjcllgTVNRkuuv1zsULXiFZKCMyATDXrsLmgtObbLk7OPo8q1n%2B0GVoGkObw4q2e76iRkwmzxyqg2R9pvIrLJ0e14YDL3Q970VoZwr0PpkIQSbKCYFVortMFOht93xiFkZnMcmPdw4%2BUZtRt5BQX6ygJIqQ2hmQJGMTl2WUzH75WePUDaDCraJo7AFcoaJp5AfplOWUPBNOmPr5LIpzXMoJjAmmVSHOVqA4Mm3min48yVadz2lahuhmM%2BwYEYqE7EMOQw7owWdgPImUk5IYwtD1QSMHZheF%2Bxqnn6A9Ztqi6easYjPwHESzDyH2dBEO8nNg2PWpRXLCM04QiiMoFYTo3xJ11Zplgz4%2FdrKUYrC6GuJn43xt5p0aSHMGBugG%2Fu%2B89jebYD0fMEWDV%2FUFzUUv%2FZjbh1RptptZVB5WS6YuaSGTTGTS8ntjlcKMrE6DdmuNYM3k60E8i%2FpHpOntWNg67BXrQ2JWl5rR4eWR%2BdmKpW4B%2B%2BZ%2BR818vax7dzLAsb72d1ih%2BoBw4rikQrb%2BW4zxLeJkvNyLGo8iofOtD12a8%2BbA9fb2vfGqd%2FryVrb0BqPZmDtvh%2B6%2BERRNuiHw8Dt8zBzoy7jbsqjgRtGWS%2FkPOoFcWoj7Bplfe9WCwyz6lGZxaynVA0Q3K72eyFAAJEbUYjdqJcN3TTOUpdlfJh1s26fDuLao%2BqsdQrQhO1CSUoFYytNauYK52rUHNrObJ4bMaZLujdxNsZzIV9jdzWuYpBDZRSbG%2BX1npQNAQzrUdlJtZ0xZ7bBNn%2BnG4RxHLOhywZ97kYs8910GPfdro%2Bl9AYxo7TXuOdO3YGnb7r9hE9Q9PGJ7J7mv%2Bf9fxned1xoLdltqcfqfEKzXSdeQjEviF%2Bu2O%2BnO7dtFP0PJv9g8v%2BfyXjGa7oAPqYWFvph7PpDfK6DMOn2kjDw4tiPB9Er30%2BqnwcD2mz68oB3QfMWcFYQyIvf%2F%2BwMO%2Bev%2FPzL9P27r59zGp5dvI3uz%2F7%2BK1BX52YUvWfvpMa%2Fgn8APylAK68MAAA%3D
- Subdomain (`stay.example.com`, host `stay`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALFSoWoC%2F%2B1WbW%2FbNhD%2BK4QAAx1mKZJiJ7aBAfOSZSu2vKxzt2FBYJxISmIrkQJJ23GC%2FPcdJdmRXafLvhVDaX0wyeeOd8%2FdI%2BrRs7ysCrDcmzx6lVZLwbh%2By7yJtwQKa1WZgKrS62%2F3rqBErPeH272uDO4YrpeC8tpoxRMj0Nl2dQ9OngFLro1Q0ptEfa9QmXqvCwTm1lZmcnS0Wq2CbgRHYAy35mjjyP8VTQRVMqhkht4YN1SLytYevTMlJafWECBMlSAksQr%2Fb6NIlPooZLaJhuTKWM6IkuRCaJ6A4WRaVeRnXEbYhNi8wTibKdGcKs369WoHRtRKYk65qMjsr9kWBZLVSMq1FamgyLW%2FhEIwcMGSs6vp5Y%2BB4wO0gKTg5zuZtKdeU8ttE0cBxhLl5kSl9crxMIijcRCHYXBPgDHNjTmYCEESRSYxU6TD5sK07ATE3lusRxMeHjz5TG5WfeSSvHGACrQlkFquSQq5TwsQ5XffBARoyWtY40cjBarEwBNe7IZTVVyyJpy5M%2FJpDkXBZcbnJFV6N0YHEGzyOTIFezlFZ25y0K0HuSgxYUrqJeI6ZNdtCRIyroNMqYx0jrCgM25dwcxa0ptF8gtfn9dHfKoZh3jHGVaC2pcwTZsYb3L76Nl15cQyxWUsIZdWgNPEtFjB2inNNQPOv3dyVEJaM1M47ZS%2F122XHsKsdQ6OT8LQe%2BpvD8D2fMURHVvUF1jA2XOZe3stU592b1F5aSGovQRLc4zkUjF34o3mqbg%2FDGn3us67wdYC%2BZdw95unt%2B3A3i5XvaaJekFv2w69ABY2V1o88OCF%2Bu8ReffU9x6U5PPn2t0hQ5sC83vAVypv69tGaCyscZZptajmYmODAoLSuFfvxvp2x%2FxuY3%2FbOGjnmwq79WjoVveK4TbCMPbxidrhxzj8Yxz%2BAIc%2F7AznYcuYs4WEMp5mufgQRvHxYAsQrPacNj%2F%2FgN%2FN2FjUFNdxnniON9Sm0nzuNAp2obHAVi943ysXhRVzWMHzEqNzfEEUa6TZ4C462ZWIbK6Wltm2QTtiQGbaurmy9b05o45pl4MXpywdRlHis1E48gej48QfJwx8np4O4tHpMIli1rn0Dl2Ih6%2B93XIf6NmnT3R4MI9nLfyXOn7h%2BW6k3Ga8r9r9rgt2KXlN2wXRyevl%2FGXRdNfHN8LXDv%2Fa4f%2FfDsc7wcCSszk4aBzGJ344xmcWxRjqJIyCcDAYj06%2FDcNJ%2FdVhubENN494d3RvDe%2FDw8nFlby0UyR0cfZ%2Blf95%2Fnf0O9yMf7v4KXrQMLuB8fB69gM7HeHnxD95N3x%2B6AwAAA%3D%3D
