### PR TITLE
Add siteinthemail.com website template

### DIFF
--- a/siteinthemail.com.website.json
+++ b/siteinthemail.com.website.json
@@ -5,13 +5,13 @@
   "serviceName": "Website",
   "version": 1,
   "logoUrl": "https://siteinthemail.com/favicon.svg",
-  "description": "Points www at the customer's Site In The Mail website. One CNAME; nothing else in the zone is touched, so existing email keeps working.",
+  "description": "Points the customer's www at their Site In The Mail website. One CNAME on the host they choose (always www in our flow); nothing else in the zone is touched, so existing email keeps working.",
   "syncPubKeyDomain": "siteinthemail.com",
-  "hostRequired": false,
+  "hostRequired": true,
   "records": [
     {
       "type": "CNAME",
-      "host": "www",
+      "host": "@",
       "pointsTo": "fallback.siteinthemail.com",
       "ttl": 3600
     }

--- a/siteinthemail.com.website.json
+++ b/siteinthemail.com.website.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "siteinthemail.com",
+  "providerName": "Site In The Mail",
+  "serviceId": "website",
+  "serviceName": "Website",
+  "version": 1,
+  "logoUrl": "https://siteinthemail.com/favicon.svg",
+  "description": "Points www at the customer's Site In The Mail website. One CNAME; nothing else in the zone is touched, so existing email keeps working.",
+  "syncPubKeyDomain": "siteinthemail.com",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "fallback.siteinthemail.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Site In The Mail** (siteinthemail.com), a hosted-website service for small US businesses. It writes one CNAME on the host the customer chooses (our flow always passes `host=www`) pointing at our Cloudflare for SaaS fallback origin. Nothing else in the zone is touched; MX records are left alone so the customer's existing email keeps working.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow (not used: no redirect_uri)
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) (no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (no variables)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description (no variables)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead (uses the `host` parameter; `hostRequired` is true)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (the single CNAME is the service itself)

## Online Editor test results

**Editor test link(s):**
[Test siteinthemail.com/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAhYoWoC%2F91TXU%2FbMBT9K5ZftmlpG9KmSzNNGgIeEIKxjQk0VEXGuW28pr6Z7TS0Vf%2F7rlPKxwBpz5MiRb4%2B5%2Fjc4%2Bs1dzCvSuGAp2teGVyoHMxxzlNulQOlXQFzocquxDkP7gFnYk4E%2Fp0g7FiziwLYKaEIYcEslIRWoYEbL%2FJQvaNd3tcXYKxCzdO9gJc4xR%2BmpP3Cucqmvd4zB72JIBnUXbuYEjsHK42qXKvAz5GwlhGcydo6nIN5Y1nTNEw4X1WG%2Fe2X3Tnssi8a2MHZ%2FukRQ91KFGhb1pLJAtECeyvKRiy3gkozrA2blNi8%2B8g0ukLpKYOSYGpLXyEJKnKDtSwgD5hFBrfKuhbo%2B2EzgIrk0Myo1vUhLbU8r29OYHmIhNCv3IF39g1%2B18oAhexMDQE3INHklqfXa%2B6WlQ%2B57eYOTsvP%2FvbahC6QlhNRljdCzrovneAc3UJ%2FGIab8SbgvpXs4YAx5b6zB7eChgceGfO33jS0mBqsq0ztKJUwYm79jO3I10%2FY4x39uuX7c9VUo4HM0l%2B42sCu13ldOpWJRjyUcpmJqiqXZNPSLqk8z0FvZ2%2FrLhdO%2FHMKAc9y6a0rP9STvkzCAfQ7kRz2O4MwmnRG0SjpDCAafhD9QZz35aOX8upTevmhPMkQrAXtlPBvYr%2BdPr7ZjAPK8z9ujybBigXkmfDIKIyGnXBE38VelMZJOki6cRLHg%2Bh9GKZh6BsB67YNr2lqHs8LN5isvl72GtxbXSWX0VVcTOIj%2FBWv7Ojk7HY2s7PC%2FVwkh8mB%2FMQ3fwDam2yQDAUAAA%3D%3D)
[Test siteinthemail.com/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAA5YoWoC%2F91TYW%2FaMBT8K5a%2FbNMCdWmgNNOk0bJp7VSKOqZuQigyzoNYTezUdkgZ4r%2FvOUBL11ba50mRIj%2Ffne%2Bdn1fUQV5k3AGNVrQweiETMOcJjaiVDqRyKeRcZk2hcxo8AAY8RwL9jhByrsgoBXKJKERYMAspoFaoYOpFHqtb2s1DfQHGSq1odBjQTM%2F1D5PhfupcYaODg2cODmYcZbRq2sUc2QlYYWThagU61Ii1BOFElNbpHMwbS6qqItz5qjTkb79k67BJrhSQs0Hv8jPRqpZIta1ZSyJSrS2Qtzyr%2BHIjKBXRpSGzTFfvPhClXSrVnECGMLmh%2F9YoKNGNLkUKSUCsJnAvrauBvh9yC1CgnDa3WGv6kJZKDMvpN1j2NSLUK3fgnV3DXSkNYMjOlBBQA0KbxNJovKJuWfiQ6262cFx%2B8rdXJzTSuJzxLJtycdt86QTn8BaOOoytJ%2BuA%2BlbixwMmmPvOHtxzHB7YM%2BY9p7rA1dzosojljlNww3Prh2zHHj%2BhT3b88UbAnyznShuILf65Kw3sus3LzMmYV%2FyxlIiYF0W2RKMWd1HmeRJqM31bfwl3%2FJ%2BDCGicCG9e%2BrlmnWlXsFa7IY6PWo2wk7DGlIXdRtLtMM6mAGHI9x7Lq6%2Fp5bfyNEawFpST3L%2BLXj2BdL2eBBjpf90gjoPlC0hi7qEt1uo02Al%2Bo8NW1O5G7bAZHp%2Bwdvc9YxFjvhOwbtPxCidnf2ZoWFyU5c0vtcgvVEeefTGDYf969jW%2F6g%2BPT4dzc3rpfvby%2B%2FxGhB%2Fp%2Bg%2Bb%2FOw0EgUAAA%3D%3D)

`hostRequired` is true, so the apex test is not applicable; two hosts are tested (www, which our flow always uses, and an arbitrary second host).
