### PR TITLE
Add Feedvote custom feedback portal templates

### DIFF
--- a/feedvote.app.custom-domain-ownership.json
+++ b/feedvote.app.custom-domain-ownership.json
@@ -1,0 +1,27 @@
+{
+  "providerId": "feedvote.app",
+  "providerName": "Feedvote",
+  "serviceId": "custom-domain-ownership",
+  "serviceName": "Customer feedback portal with ownership verification",
+  "version": 1,
+  "logoUrl": "https://feedvote.app/images/logo/logo.svg",
+  "description": "Connect your chosen subdomain to your Feedvote feedback portal and verify ownership.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect-keys.feedvote.app",
+  "syncRedirectDomain": "feedvote.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.feedvote.app",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "ttl": 300
+    }
+  ]
+}

--- a/feedvote.app.custom-domain.json
+++ b/feedvote.app.custom-domain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "feedvote.app",
+  "providerName": "Feedvote",
+  "serviceId": "custom-domain",
+  "serviceName": "Customer feedback portal",
+  "version": 1,
+  "logoUrl": "https://feedvote.app/images/logo/logo.svg",
+  "description": "Connect your chosen subdomain to your Feedvote feedback portal.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect-keys.feedvote.app",
+  "syncRedirectDomain": "feedvote.app",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.feedvote.app",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add two Feedvote custom feedback-portal templates. Both set the selected subdomain CNAME to customers.feedvote.app; the ownership template also sets Cloudflare for SaaS verification TXT.

The bare ownership value is required by Cloudflare and cannot be prefixed. TXT conflicts use the default None mode intentionally: independent verification tokens can coexist at this dedicated label. All host labels and the CNAME destination are fixed. These records remain required while the portal is connected, so essential OnApply is not applicable. Public signing key: v1.domainconnect-keys.feedvote.app. Cloudflare onboarding and live approval testing remain pending.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
[Template 1: example.com, host feedback](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAApeoWoC%2F91Ta4%2BbMBD8K8hfDwiQ5yFVau5Rqa9rdb2qraIIOfaGWAFMbcMdF%2BW%2Fd4EQ0lxV9XMlBLJ3djw7jHfEQJon1AAJdyRXshQc1FtOQrIG4KU04NI8J%2FaxdkdTxJI3hypWNKhSMGiaWKGNTB0uUyqyvnZoum6qoKyae0XZ1sqlMjRBYAlKC5mR0LdJImP5VSXYsDEm1%2BFgcKplIFIagx7UqObl6jJGBg6aKZGbhoVcyywDZqxKFspiG6khs3SxaoVZRraFbopzQW4tvcrYVSLZloRrmmhodz4Xq%2FdQ3bTzhaTlY%2B1hzhYq7Z75VjfdAxcKAce2MwzKM%2Ffws0AQmmhUgYchXiquSbjYEVPljX1384%2B3BzguX9d%2FRYrM6Ad5tB5tPFdgDFo59Lz9cm%2BTZ5lB1HMv7cMISABPFKMALpNpf0hnDO7EShZ5JLq%2BnCqa6jo2HcPiN4plx7HoSWoFIs6kgkjjl5pCQTdwWiRGRPSR9lucRThCUqFgjVWkemlG1kbrRCenhv6LHzaJOKv1iybufDiCwJ84wZQHzmgIY2cGwaXDYUq9KRvPmM9OrsGfrsjfLsJLO0FjJo2gdc7nySOtNNnvlzZa%2B98PidHQtAQe0RoeeMHE8S7xefCHYTAKg4k7Gfpjf3LheaHn1dOANu3EO0zQaXbIKpmW30afyvUP8%2FzFVx%2FexVv5%2FWI09ef%2BuLyardPihj8Ft6nZsFdk%2FwthraYr8AQAAA%3D%3D)
[Template 2: example.com, host feedback](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEFeoWoC%2F%2B1UbWvbMBD%2BK0bQT40Tv%2BTVMFi3dVDKSmmzrawEo8iXRIstuZKc1A357zvFSZwlhfXr2CA4tu7uueeeu9OKGMjylBog0YrkSi54AuoqIRGZACQLaaBJ85w09rYbmqEv%2Bby1okWDWnAGmyBWaCMzN5EZ5cKVSwFKz3hee23DP278QDk2y5iyuZNLZWjqLLmZOfs4ZwGKTzijhkuBIPip7VvkN0gqp%2FKrShFsZkyuo1brkHGLZ3QKumW9No%2BmXkwRIQHNFM83eEhDCgHMOKUslMNmUoNwdDGu6DtGVoZdrSdkqUgqhmVNuWlrLQX7kEo2J9GEphqqk9tifA3lpw025q6SsIqBO4dSN48kt0F3kHCFDvuwIx%2FkbO7gqUAn1N%2BoApOhv1SJJtHjipgy3%2Bh9c%2FHlcuuOn%2B9tQyUXRg%2FlvmvI%2F5iBMahv6Hnrxh5p%2BDCscWI2cbcttyfCNhc1poai8Wyvydkh1GjdIC9SQFzTHDW2amAUPFMcSGgymdV5dsLjyVTJIo%2F5Li6nimbaDu8O4fE3iNEO47EGwbN6MtHgB2G70%2B31Xfty9LDnAzpmxNLmUyEVxBr%2FqSkU7ATPitTwmC5pfZSwGCVMS6xSoxXTnDZDVLtwUNxWuT%2F2o0HihNmi%2BWZTfRhMen7o9qEfuG2%2F57k0bLdd6A7ajPUZ67DgYINf2%2B637fBpN0DjyhhO7RpepEtaarI%2BGZZtna8MS%2FO09jc1429RYtTAGf3f%2BH%2Bw8XjHaLqAJKbWPfCCrusN8Df0wyjoRIHfDINu2O%2Bce17kebYu0KZSYoU3zeEdQ65b7OF8Tsc%2Fr%2Fvme%2Fqjd5vfi6erZy8cDwYzdfXtvOeP77kowvLyHVn%2FAvA0nzHTBwAA)
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
