### PR TITLE
Add waybornusa.com mail-delegation and email-records templates

### DIFF
--- a/waybornusa.com.email-records.json
+++ b/waybornusa.com.email-records.json
@@ -1,0 +1,56 @@
+{
+    "providerId": "waybornusa.com",
+    "providerName": "Wayborn",
+    "serviceId": "email-records",
+    "serviceName": "Wayborn Email Authentication",
+    "version": 1,
+    "logoUrl": "https://waybornusa.com/wayborn_white.svg",
+    "description": "Adds the DKIM, SPF and DMARC records that authenticate marketing email Wayborn sends from your send subdomain. Every record is created under send.<your domain>; no record on your root domain, your website or your existing mail is touched.",
+    "variableDescription": "%dkim1%, %dkim2% and %dkim3% are the three Amazon SES Easy DKIM selector tokens issued for this domain. Wayborn fills them in; the domain owner never types them.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "domainconnect.waybornusa.com",
+    "syncRedirectDomain": "waybornusa.com",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "%dkim1%._domainkey.send",
+            "pointsTo": "%dkim1%.dkim.amazonses.com",
+            "ttl": 3600,
+            "groupId": "dkim",
+            "essential": "OnApply"
+        },
+        {
+            "type": "CNAME",
+            "host": "%dkim2%._domainkey.send",
+            "pointsTo": "%dkim2%.dkim.amazonses.com",
+            "ttl": 3600,
+            "groupId": "dkim",
+            "essential": "OnApply"
+        },
+        {
+            "type": "CNAME",
+            "host": "%dkim3%._domainkey.send",
+            "pointsTo": "%dkim3%.dkim.amazonses.com",
+            "ttl": 3600,
+            "groupId": "dkim",
+            "essential": "OnApply"
+        },
+        {
+            "type": "SPFM",
+            "host": "send",
+            "spfRules": "include:amazonses.com",
+            "groupId": "spf",
+            "essential": "OnApply"
+        },
+        {
+            "type": "TXT",
+            "host": "_dmarc.send",
+            "data": "v=DMARC1; p=none;",
+            "ttl": 3600,
+            "groupId": "dmarc",
+            "essential": "OnApply",
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1"
+        }
+    ]
+}

--- a/waybornusa.com.mail-delegation.json
+++ b/waybornusa.com.mail-delegation.json
@@ -1,0 +1,39 @@
+{
+    "providerId": "waybornusa.com",
+    "providerName": "Wayborn",
+    "serviceId": "mail-delegation",
+    "serviceName": "Wayborn Managed Sending Subdomain",
+    "version": 1,
+    "logoUrl": "https://waybornusa.com/wayborn_white.svg",
+    "description": "Delegates the send subdomain of your domain to Wayborn's nameservers so Wayborn can create and rotate the SPF, DKIM and DMARC records for your marketing sending subdomain automatically. Only send.<your domain> is delegated; no record on your root domain, your website or your existing mail is touched.",
+    "variableDescription": "No variables. The four nameservers are fixed values from a single Amazon Route 53 reusable delegation set shared by every Wayborn customer, so the applied records are identical for every domain.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "domainconnect.waybornusa.com",
+    "syncRedirectDomain": "waybornusa.com",
+    "records": [
+        {
+            "type": "NS",
+            "host": "send",
+            "pointsTo": "ns-944.awsdns-54.net.",
+            "ttl": 3600
+        },
+        {
+            "type": "NS",
+            "host": "send",
+            "pointsTo": "ns-165.awsdns-20.com.",
+            "ttl": 3600
+        },
+        {
+            "type": "NS",
+            "host": "send",
+            "pointsTo": "ns-1831.awsdns-36.co.uk.",
+            "ttl": 3600
+        },
+        {
+            "type": "NS",
+            "host": "send",
+            "pointsTo": "ns-1275.awsdns-31.org.",
+            "ttl": 3600
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Add two templates for Wayborn (<https://waybornusa.com>), a marketing-email service for
home-services small businesses. Wayborn sends on behalf of each owner from that owner's
own domain, and both templates are scoped to a single `send` subdomain — neither writes a
record at the apex, and neither touches the owner's website or existing mailboxes.

**`waybornusa.com.mail-delegation`** delegates `send.<domain>` to an Amazon Route 53
reusable delegation set with four NS records at host `send`. Once delegated, SPF, DKIM,
DMARC and every later key rotation happen on our side, so the domain owner approves
exactly once. This is the same shape as the already-merged
[`realtimecdp.io.email-setup`](https://github.com/Domain-Connect/Templates/blob/master/realtimecdp.io.email-setup.json)
(NS at host `mail`) and [`fraudmarc.com.mail`](https://github.com/Domain-Connect/Templates/blob/master/fraudmarc.com.mail.json).
Subdomain NS only — we are explicitly **not** asking for apex NS.

The label is `send`, deliberately, not `mail`: the spec's conflict rule ("NS records
conflict with all other records … and for any record ending with the NS host") means an
apply at `mail` would delete an existing `mail.<domain>` webmail A record or MX target.
`send` collides far less, and our client pre-flights the label against live DNS and
refuses to offer this template if anything already exists at `send.<domain>`.

**`waybornusa.com.email-records`** is the fallback for DNS providers that do not apply NS
records: three Amazon SES Easy DKIM CNAMEs, one SPF merge and one DMARC TXT, all under
`send`. The three variables are the SES selector tokens; Wayborn fills them in from the
`CreateEmailIdentity` response, the owner never types them.

No MX and no custom MAIL FROM in either template. Custom MAIL FROM would forfeit SPF
alignment; DMARC still passes on DKIM alignment, which is what the SES DKIM CNAMEs give
us.

Every apply is RSA-SHA256 signed — `syncPubKeyDomain: domainconnect.waybornusa.com`, key
host `_dck1`, already published and resolving.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`logoUrl` is `https://waybornusa.com/wayborn_white.svg` → `200 image/svg+xml`.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](https://github.com/Domain-Connect/Templates#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on three of the above:

- **SPFM host.** Guideline 4 gives the apex as its example. Our `SPFM` is at host `send`,
  because that is the domain SES signs and envelope-sends from; an apex SPF include would
  be both wrong and a needless change to the owner's root domain. The merge semantics are
  unaffected — the merge is per host.
- **Variables in `host`.** `%dkim1%._domainkey.send` keeps the fixed `._domainkey.send`
  suffix, so the variable can only ever name a DKIM selector under our own subdomain. The
  `send` label is a literal, not a variable, so guideline 8 is not engaged.
- **`mail-delegation` has no variables at all.** The four nameservers come from one Route 53
  reusable delegation set and are byte-identical for every Wayborn customer.

## Online Editor test results

**Editor test link(s):**

`waybornusa.com.mail-delegation`

- [Test waybornusa.com/mail-delegation example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALWfoGoC%2F%2B1V30%2FbSBD%2BV1b70gcc49gJDW7vJNpcVYSgFKj6gFA09k6cFbbXt7tOcBH%2Fe2djmyTtHa0qnXSVeEBsdna%2B%2BeabH77nFosqB4s8vueVVkspUB8LHvMVNInSZW3AT1XBvUfrGRT0mn9u7WQwqJcyxbVXATIfCMwxAyvVlnXXi51CCRkKdomlkGXGLutEKHJ2HkvUxvnGQ4%2FnKlOfdE6eC2srE%2B%2Fv7%2FLqf85WC2nRN8uMAASaVMtqTSDm05YNGmYXyAwFZKaPxtScNarWrPtpFesYvjCsJMqOPdFh5tHAUqA%2FjYTIgLC0su7osC%2FP33lsenJ8ujZMT48u3jKNqdLCsLnSbaQC9C1al7Ppct%2BwgdrSwcoU8rzx2Ycyb9av%2FNdbJP9k0rBOYhSvWKm6IEyVbQitlO0ee%2B3NChND%2BrCeBN5Js%2Bbg6uXwrKrTBQrfyQ9aQpLjdEfFM8V6g%2FHZFWU7d0DbGoGmS3lHVV1CXpPec60KBsxQoBzZUQFfiOGFqonIOCLSVEOCY5t2oWQtMwsCEixpGBJss9G9NqQOas8Vw8kNVZVLetlL7OJTg5Zr%2FdaCtwCtEi4105Tpm1yltzyeQ26wvTmvkxNspm37xbx9nqqyxNT6342B87hAISmqffT57lXHicfX99w2lWv9s0u6Xyhj6eyK6kZKydKaK0U3pRkcjkY%2BrIyg43jkl2gdZWup%2BaODIHjwfh5peDDukcLAMfp1pEk07KGiA4Ly69tfBwtfPvIiWKWzXaibB49Ti%2BBso96N19WDEPAOaFdhp3AXiE6ZVnU1k%2F37CjQUxu2z3vN6x%2FWm973m3EWUWak0zgz9B1trysTqmlqjqHMrZ7CCzZVIZ67pGiJoyEoQ35S3bLdcl70ACz9TWo%2FPROoIS7dCo%2BTlMBGYDiZpMh6MwiRy7pPB4SSC8eQwSYaQbq3jf17WT%2B%2FkjXZojBsYcBv2KCcYwx%2B%2BLem%2FJfV0l%2F2uSf2o4X%2FXvJ6evf9bVjcejfLzcD0P1%2FNw%2FQfDRZ9AA0sUM3DPwiA8GASHg2ByFUbxOIzDoR%2BOglE02guCOAhcKmhsm%2B49fTG3v5X87%2Brjntj7cBzuTefm9t37%2BXBSN%2Bfw5stxLk%2FeUjZX4d2%2ByMKLT3%2F9wR%2B%2BAiAgX7xxDAAA)
- [Test waybornusa.com/mail-delegation example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADmgoGoC%2F%2B1V32%2FbNhD%2BVwi97KGyqli2Y6vbAK9GMK9N2sbZMiAIjJN4lolQokBSdrQg%2F%2FuOlhTb7ZAVfdkK5MGwxON99913P%2FTgWcxLCRa9%2BMErtdoIjnrOvdjbQp0oXVQGglTlnv9kvYCcbnvXjZ0MBvVGpLjzykHIHkeJGVihDqzHXuwcCsiQswUWXBQZW1QJV%2BTsPDaojfONT3xPqkz9riV5rq0tTfz69TGv7nW5XQuLgdlkBMDRpFqUOwKxN2vYoGF2jcxQQGa6aEytWK0qzdpXq1jL8AfDCqLs2BMdZp4MLAX6aSREBoSllXWPDnvx8cxns3fz851hdj69fMs0pkpzw1ZKN5Fy0HdoXc6mzX3PBipLD1akIGUdsA%2BFrHe3gh8PSP7MhGGtxMjfsEK1QZgqmhBaKdte9puTLSaG9GEdCbwXZsfB1cvhWVWla%2BSBkx%2B0gETi7EjFC8U6gwnYFWW7ckCHGoGmQ3FPVd2ArEjvlVY5A2YokEQ2zeEvYnipKiIyjIg01ZDg2L5dKFnLzJqAOEtqhgRb73WvDKmD2nfFcHJDWUpBNzuJXXxq0GKn307wBqBRwqVm6iL9Rar0zotXIA02Jx%2Br5B3Ws6b9Yq%2B5nqqiwNQGX4yB87hELiiqffL54lbLyYtvHjxbl671LxZ0vlbG0rMrqhspJQprrhSdFKY3GQwC2BpOj8NBUKB1lK2l5o9GYfjofz3SyWjYIfVDx%2BjbkcbRSQcVjQgqqO6%2BHax%2F%2BsSLYJXOjqFuH32PWgSXe%2FVu%2FbYehID3QLsKW4W7QGtV0lumVVUuRedTgobcuJ3Wed8cud92%2FjcNgIssskJpXBr6B1tpysjqilokr6QVS9jC%2FoinS9d8NRE1ZCWYz8pcNNtuN7stQw4WvqbOvrfkqWMu3D5NojANYch7I%2BSj3uB0mPbGmIQ9vkomHCYngBAd7OZ%2F3tzPL%2BhjIdEYN0HgVu5UEpTxHj%2Bv8bPZPd973312%2FzYP332Cz8%2Fo%2FzG9W59G%2FmUAXwbwZQD%2FowGkz6mBDfIluKv9sD%2FqhZNeOL7qR%2FFwEEdRMAj7w9PJqzCMw9Clg8Y2KT%2FQl%2Ffwm%2Bttw%2Bpa1q%2FG5R%2FX7%2Bfz8Tj89e2M63m2mP42uRuefXgvz8Tg05%2BjVTj9yXv8G5%2Beju7BDAAA)

`waybornusa.com.email-records`

- [Test waybornusa.com/email-records example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIigoGoC%2F%2B1WbW%2FbNhD%2BK4SAfKrtylLerDQDvMQd2sBZkLhdgSAwKPJsE5ZIgaTsuEH223ekpDpO3DYohqEd8kkk7473PA%2BPR90FFvIioxaC5C4otFoIDvodD5JgSVep0rI0tMNUHrS%2BWM9pjt7BX5UdDQb0QjDwUZBTkbU1MKW5Wds2Y8jAeZF%2BaWcgrWDUCuU2WoA2bpR0W0GmpuqDzjBoZm1hktevNwE10%2FFyJix0zGKKG3AwTIvCb5cEfc4NwRTk9OzdsEWuLt4SKjk5HfYvT0gNEe3UErpGAiSneg5WyCnxZEgD2oBE%2F4lWOVmpUvs5MWXKFbrJDhkg%2FFW9LxGGMA24HSelRNG8d%2BeND6wCfjsiUjXuSlZ7aqVsbW9VK0tIDRIkSldzuBXGg%2FPYMI1VJZsB7zj9qBY0zeB0Q4YdPhd5d6dF%2FCDa8SL4cYxjDV4iO9MApJ%2FTzwjlanBFBtSsvHCIPANmMb9Vc5AGc5oSaU3cygwBNPwbnSYiy7zuORHyyO9euRC1lKiEBBSK2FUBlZdDblaS%2FZ4pNg%2BSCc0MVCsXZXoGq1MfjESqXZiSEvF0ntSni7gELlBS%2ByXmiVdTmsn1XeAwoM%2FJeX84QNNMGbvWqzOu8s1h1XGH526AEtKakXrg5D4d6mUzYOoc1mLdxvth2AqmWpWFvxnOE21gjKs06ir7T9kvimwV3Le%2BiSV6Dpbov8ESPwdL%2FO9jwcs7XEOp85picllmgIcZYF1kJYfkccp1HnT%2BfprRp9E6y5hjK2ANSU4txcXFse8f3SNSHEsl4eirvFzwVzJiyK09UXKSCWaH1LIZ3uih4g7ChYaJuN3uUtvWKIL7m%2FtWgIxhvC7sm1Z9VVw%2FvqXY36FWoybW6DIWjX9BNc2NewOayOuN0Jsm9jpwY1%2F8bkJT1o1i3xi6jSF6ZIgaQ%2FzIEAcOvJhKpWFs8EttqVECq0tsAHmZWTGmS7pe4mxMnX7I1aAVt3t6iWX10jwEtqVi68Pc8PpeyY45cwIJd7iH6WE6iRhvRxCF7d3wIG2nITtsp1GvF8d8d5%2Bx8MGTuf1B%2Fda7uT6prRW75ZY%2BJR49i3j0%2FyMeP4t4%2FKsSr5pUTftxd8I21yVbuyH5m2ZZQxD5%2FSIEf6QL%2F1S8blrYYV8a1UujemlUL43qp25U%2BJ9m6AL4mDq%2FKIz222GvHR6OojjZ20v2os7BwW502H0VhknosFgwtiJ6h39yD%2F%2FhAlbmZ9ko%2FgjLnuq%2FFR9OXoWLT2fsc%2B8jZ%2Fo8fb86%2B2MYmT0ZvlfHwf0%2F3GLChogQAAA%3D)
- [Test waybornusa.com/email-records example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALKgoGoC%2F%2B1WW2%2FbNhT%2BK4SAPM1WZcmOE2UZ4MUu1nbOcnG2rEFgUOKxzUUiNZKy4wXZb9%2BhLrUdu2kehmEt8iSJ5%2FZ9Hw8P9eAYSLOEGnDCBydTcs4ZqHfMCZ0FXUZSiVxTN5ap0%2FhkPaUpeju%2FlXY0aFBzHkMRBSnlSVNBLBXTK9tmDBlYL9LLzQyE4TE1XNpEc1DavoWthpPIqbxSCQbNjMl0%2BObNJqD6c7yYcQOunk8xAQMdK54V6UKnx5gmWIL0P7wbNsjl2VtCBSP9Ye%2FihFQQ0U4NoSskQFKq7sBwMSUFGVKD1iDQf6JkSpYyV8U30XnEJLoJlwwQ%2FrLKS7gmsQJMx0guULTC2%2F2%2BCCwDfjgiQtbuUpQ5lZSmsjfKlQVEGgkSqcpvuOe6AFdgwzJG5vEMmGv1o4rTKIH%2Bhgx77I6nrb0GKV78vUKE4j3AdwWFRGamAEgvpX8hlMvBJRlQvSyEQ%2BQJxAbrG3kHQmNNnSOtiV2ZIYCaf63ThCdJoXtKuDgqspcuRC4EKiEAhSJmmUHpZZHrpYh%2FTGR854QTmmgoV87y6AMs%2B0UwEimzxFIIxONu9aeNuADGUVLzKWbLq27N8ObBsRjQ5%2BS0NxygaSa1Wenljst6d7B07ebZEyC5MHok15zsw6WFbBp0VcMY7Ntg3%2FMazlTJPCtOhvVEG2htO43azv5F9LIsWTqPjWex%2BC%2FB4v83WIKXYAn%2BfSx4eIcrKFVdnU0u8gRwMx3siyRnED4tuaqDzl8uM7oeraqMGY6CuCbJqKG4OD8u5kfriGTHQgo4%2BiwvG%2FyZihhyb06kmCQ8NkNq4hme6KFkFsKZggm%2F3%2B1S2VYonMfbx4aDjGG8auzbRnVU7Dy%2BpzjfoVKjlm8ms1qbMa9jMqpoqu09UEffbITf1vE3ZQJbxh4Cu0CjuOUHxYBo1Qb%2FicGvDcETQ%2BBYEnwqpIKxxic1uUIpjMpxEKR5YviYLuhqicVjanVEzhqtmG77MIvyxlkH9rRz3UqHamc3XL%2FUv2MWW6W43el2dOgdTFqt5uGk7TfbB9Fh88Db7zQ73XbEaNRhHUbX7s%2Fdt%2Btzl%2Bjmtu1s4R3HdlsB%2F%2BUK%2BN%2BmAsHLFQi%2BZgXKOVbx38FzfozjsEV2Tk3yN02SmikS%2FYqYrk3sLcLPju3%2FHcHbBo7k16n2OtVep9rrVPt2phr%2BAWo6Bzam1tf3%2FP2md9j0DkZ%2BEHb2w6Dtdruddjv4zvNCz7NsQJuS7AP%2BI67%2FHTrxx4%2BX7%2Bfe1c959%2FpidNr9FU6X5%2B0%2Ffuon4nwgfv%2Fz%2FDrf77%2F1B1H%2F6th5%2FAfjV3Yo6hAAAA%3D%3D)

All four tests apply cleanly with no errors or warnings reported by the editor.
`mail-delegation` expands to the four NS records at `send.<domain>`; `email-records`
expands to the three SES DKIM CNAMEs, the merged SPF TXT at `send.<domain>`
(`v=spf1 include:amazonses.com ~all`) and the DMARC TXT at `_dmarc.send.<domain>`.
The `host=shop` runs place every record under `send.shop.example.com`, confirming the
templates never write at the apex.
