### PR TITLE
dnsdoctor.dev.domainverify: v2 — declare syncRedirectDomain, add logoUrl

### DIFF
--- a/dnsdoctor.dev.domainverify.json
+++ b/dnsdoctor.dev.domainverify.json
@@ -3,8 +3,10 @@
   "providerName": "DNS Doctor",
   "serviceId": "domainverify",
   "serviceName": "DNS Doctor Domain Verification",
-  "version": 1,
+  "logoUrl": "https://dnsdoctor.dev/icon.png",
+  "version": 2,
   "syncPubKeyDomain": "dnsdoctor.dev",
+  "syncRedirectDomain": "dnsdoctor.dev",
   "description": "Proves domain ownership for DNS Doctor monitoring by adding a single TXT record.",
   "variableDescription": "token is the per-domain ownership verification code DNS Doctor issues when you add a domain. Documentation only — never shown to the user.",
   "records": [


### PR DESCRIPTION
# Description

Updates `dnsdoctor.dev.domainverify.json` (merged in #1368) to **version 2**. No record changes: the
template still adds the single ownership-verification TXT (`_dnsdoctor-challenge` =
`dnsdoctor-verify=%token%`). Two metadata additions:

- `syncRedirectDomain: "dnsdoctor.dev"` — our signed synchronous apply URL carries a `redirect_uri`
  back to the add-domain wizard on dnsdoctor.dev, and the template never declared the domain that
  redirect may point to. Cloudflare tolerated the omission; a strictly validating provider would not.
- `logoUrl: "https://dnsdoctor.dev/icon.png"` — served (200, `image/png`, square mark).

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit) — "Check template" clean; apex and subdomain apply tests linked below
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` — unchanged, `dnsdoctor.dev.domainverify.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver — `https://dnsdoctor.dev/icon.png`, 200, `image/png`

Also validated against `template.schema` (passes) and with `dc-template-linter` (info-level only:
`DCTL1021` on the custom `_dnsdoctor-challenge` label as in #1368; under `-cloudflare`, `DCTL5003`
noting Cloudflare ignores `syncRedirectDomain` and `DCTL5008` on the conflict-matching keys — informational,
the fields are kept for providers that honor them).

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — `dnsdoctor.dev`; the public key TXT is live at `_dck1.dnsdoctor.dev`, every apply URL carries `sig` + `key=_dck1`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — correct, only `syncPubKeyDomain` is set
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — this PR adds it: `dnsdoctor.dev`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — the only TXT is the verification token
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — `Prefix` with `txtConflictMatchingPrefix: "dnsdoctor-verify="`
- [x] no variable is used as a bare full record value — the value is `dnsdoctor-verify=%token%`, fixed prefix
- [x] no bare variable is used as the full `host` label — the host is the fixed label `_dnsdoctor-challenge`
- [x] no variable is used in the `host` field to create a subdomain — none; the `host` parameter is used for subdomains (see the subdomain test)
- [x] `%host%` does not appear explicitly in any `host` attribute — it does not
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template — not set on purpose: the record is an inert proof token the user may delete after verification, and nothing in the template depends on it staying; the same as in v1 (#1368)

## Online Editor test results

**Editor test link(s):**
- [Test dnsdoctor.dev/domainverify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANq4oWoC%2F%2BVUXW%2FaMBT9K5alPZWPNKV8RNpDB9U0IVjLoGrXocjEF%2BI1sSPbATLEf981aQusbNOe92Qn91yfc%2B699oZaSLOEWaDBhmZaLQUH%2FYnTgHJpuIqs0jUOS1p5DQ5ZimDaG34hvV0cYwb0UkRQ5qmUCbkELebFPvQmCxeHI3cOKCJmhZIIT9RCTXSC0NjazAT1%2BpGOuoiUrGVygVCkMC4p8JGlkNFNPutDUR57Qr%2BDjIALDZH9LYiDibTIdmICeoOWwZDSEVEriYyxyMjcyd87SZUUuAq5ILOCMM7djhGDSwJkfD8myKk0rznRTAs2S6B3RGTVE0giDLExkAx09Q3l8qBMJFIcDgUIY3LUuYrxkELlTgLyl2fUHChPQdoyV8mkIN9y3ztvEAl4LDEx0hCrduQ59svpLBUbGjxuqC0y1zs0goFYGYsf4WvlqlHMkgTkAlz9mGWHZa2Wc%2FD%2B3c7hO0RYi829aHoebte2q%2BQ8EZEdMBvFWK8BOtsVHuZiTU9CnmMnSOh2uq3QH0pCuJc%2FrTxPJGbAmuGwQy1S6d4J7hZa5VkoXvAZ0yw17kK8ZD4epU5fch%2Bp2%2B%2BsuY%2FR4GPDv8iH%2FfZTq90aeHotBp9nvVE%2FVd3vMympkycWUmkIDa7M5hrdWp1DhaZ5YkXIVmz%2Fi0chy7KkQDcGo0jxazNkeav%2BsRl%2F1XnUpZBHrhTC3e0WzBoe9zrVGWNRtcH8VpX5zK%2FOvE6TX%2FAm8AgOnoqT78gf3op9R8AYnFjB3ENwlaxYYeh2O61gd%2F7zEuC8GbYEHjIH8z2%2FWUUtXmd83gkuz4PLRu2y0fZa7TPPCzzP2QBjyypscPoO544qO%2BzKsepn%2Bnq1%2FuDfXaXd3m02uao%2FFLdP997110KI67PJxB894N36CfvycrErBgAA)
- [Test dnsdoctor.dev/domainverify example.com/sub](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB25oWoC%2F%2B1U7W7aMBR9FcvSfo1ASPiMtB9bkaa1o%2B26rp3aocixDXFJ7Mx2gAzx7rsmbYGVbi8wCckx91yfc%2B699hpbnhcZsRxHa1xotRCM608MR5hJwxS1SjcZX%2BDGc%2FCc5ADGo%2FOvaLSNQ8xwvRCU13kqJ0IuuBbTahd6kQWLw6EbBxSUWKEkwDM1U990BtDU2sJErdaBjpagSjYLOQMoUBiXFAXAUkl6WSZnvKqPPaLfQa44E5pT%2ByqIcUO1KLZiInwJlrlBtSOklhIYU1GgqZO%2Fc5IrKWAVcoaSChHG3BdBBpaMo%2Bvv1wg4lWZNJ5poQZKMjw6IrJpziYRBNuWo4Np7QbnYKxOiivF9AcKYEnQuUzikUqWTAPz1GU0HKnMubZ2rZFahH2XgtztIcjgWmRRokFVb8hL65XTWig2O7tfYVoXrHRiBQKqMhU38XDmPpiTLuJxxVz9iyX5ZvXoO3r3ZOnwDCGuhuWHP9%2BFzZU%2BUnGaC2jGxNIV6jcHZtvB8Klb4KOQxdoQEbyabBv6lJI938ieNx4mEDL4iMOy8SVW%2Bc2LKBDYzrcoiFk8pBdEkN%2B5OPCXfH2RPntLvt%2Fmw3Rp0%2B6vxx04Qludng3l%2F0B%2F7eiXGF8no6ixXJw%2BJlNiJFDOpNI8NrMSWGjxbXfIGzsvMipgsye4vRmNSFFkFngxEgeLPlsj6bh1rSbN291pb%2Fqn1oF8xo64iwt3y9iAIet1%2B1%2Bv1CfM6vTD0Bt1h4E1Z0un2OyHtsnDv0Tj6ovzl1TjoDTcGxlcQ9yq8z5akMnizmTSgT%2F8r4SoB02fIgrOYOGTgBz3PH8Lvuj2MumHkt5thJwyG3be%2BH%2Fm%2Bc8KNrQuxhlncn0K8pGbOW%2BOHn%2Bd3We90WSW0d3F7o%2Ft3p6PxbLr6skjp7efiQy67c7hvvwHttKTPPwYAAA%3D%3D)
