### PR TITLE
AI-CMYK, 2 templates

### DIFF
--- a/ai-cmyk.com.portal.json
+++ b/ai-cmyk.com.portal.json
@@ -1,0 +1,20 @@
+{
+    "providerId": "ai-cmyk.com",
+    "providerName": "AI-CMYK",
+    "serviceId": "portal",
+    "serviceName": "AI-CMYK Customer Portal",
+    "version": 1,
+    "description": "Connects the selected address to an AI-CMYK Customer Portal.",
+    "syncBlock": false,
+    "hostRequired": true,
+    "syncPubKeyDomain": "domainconnect.ai-cmyk.com",
+    "syncRedirectDomain": "app.ai-cmyk.com",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "sites.ai-cmyk.com",
+            "ttl": 300
+        }
+    ]
+}

--- a/ai-cmyk.com.website.json
+++ b/ai-cmyk.com.website.json
@@ -1,0 +1,20 @@
+{
+    "providerId": "ai-cmyk.com",
+    "providerName": "AI-CMYK",
+    "serviceId": "website",
+    "serviceName": "AI-CMYK Website",
+    "version": 1,
+    "description": "Connects the selected address to an AI-CMYK Website.",
+    "syncBlock": false,
+    "hostRequired": true,
+    "syncPubKeyDomain": "domainconnect.ai-cmyk.com",
+    "syncRedirectDomain": "app.ai-cmyk.com",
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "sites.ai-cmyk.com",
+            "ttl": 300
+        }
+    ]
+}


### PR DESCRIPTION
# Description

AI-CMYK provides Website and Customer Portal hosting for Australian Printers. These two synchronous templates let a domain owner approve one CNAME for a selected subdomain, pointing to the fixed target `sites.ai-cmyk.com`.

Both templates use `hostRequired: true` and the standard request `host` parameter with record host `@`. No variable destination, companion name, mail record or redirect is included. Root domains remain on our manual setup path. The application also rejects empty host scope before signing; Cloudflare does not enforce `hostRequired`.

Requests use RSA SHA-256 signatures with the public key at `_dcpubkeyv1.domainconnect.ai-cmyk.com` and callbacks at `app.ai-cmyk.com`. The two public TXT chunks were published and verified against the signing public key through both authoritative nameservers, 1.1.1.1 and 8.8.8.8 on 10 September 2026. Cloudflare onboarding will be requested after merge.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Both templates pass the official linter (version 120) with `-loglevel error -tolerate info -logos`, and also pass `-cloudflare -tolerate info` (only informational provider notes). The actual Online Editor schema and apply tests below produce the expected single CNAME for each selected subdomain.

The `logoUrl` check is not applicable: neither template declares a logo URL; the approved logo will be attached to Cloudflare’s onboarding email.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

TXT/SPF uniqueness rules are not applicable because neither template includes those records. `essential: OnApply` is not applicable: the sole routing CNAME must remain for the service to work. There are no template variables.

## Online Editor test results

Apex tests are not applicable because both templates require a non-empty `host`. These links were copied from the Online Editor after checking and applying the exact submitted templates.

**Editor test link(s):** 

[Test ai-cmyk.com/website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALYEomoC%2F91S72%2FaMBD9VyJ%2FbYJMIAQiTRpjnVRVVANV6iaEoiM%2BwCOJM9tJGhD%2F%2B2x%2BtbBK%2B75Pyfnuvbt393ZEY1akoJFEO1JIUXGG8oGRiAD3kqzZtBKREfeSeoLMlJLhgzca%2F3w0CYWy4gkeIDUuFDdUl9frauflkq9QKi5yErVdwlAlkhf6EJORyHNMtHL0Gh2FqflH5gBjEpV5FA7kzg1fyzZs8uRLKpINiZaQKnTJWig9xd8ll2hm07LEY9X3cvGIzVeRAbf92OEnOXZtXYu25VNkhiHRFwAUxU2ZSQvJFIlmO6KbwioePQ3H9%2BQ4hAk%2F2w0Knmv1LExoh1Y3JFqnJOpQup%2FvXbIVOcZvtHP3NKbB4iuYg%2BEJdeKv69oEKynKIuZnSAESMmXvegbPrtDzM3x2wNu%2BfJULibEyX9ClxPPesjLVPIYa3p5YEptNpI0ZU5msYflbfX48%2F3E6Bhr%2Bod0lMUvswNy6KQDo%2B36v4y2CReB1O%2B2B1%2Fcp87ohQrjswaIfDN458wPTfuzNq50ZU2GuOaTWpmkNjSL7%2Fdw1%2B%2FuP5JhLK6iQxWArfer3PDrw2vSZtqN2EHW6LdoOQ5%2FeURpRahWg0keBO%2BOK934gnbtR8yuk%2Fno1UcHydfqjut%2FUbLsdf8vD7loNq6KaTOqXsViLT2T%2FB5om3pVgBAAA)

[Test ai-cmyk.com/portal example.com/orders](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALwEomoC%2F91SXW%2FaMBT9K5Ffl1ATwlekSSt02jpEoVUnNCEUufYt9UjizHagAfHfdwMECuu09z3Z1%2Ffc4%2BPjsyEWkixmFki4IZlWSylA3woSEiY9nhSLGlcJcY%2BtO5YglFzfev3hjwE2DOil5LAbyZS2LD4dnoOdfm6sSkA74wq3BG2kSklYd4kAw7XM7K4mfZWmwK1x7As4BmLcg3CYEBoMHiqHpc5feGulgCLlvVjxBQmfWWzAJS%2FK2Af4lUsNKNXqHPaocf40gOJGJUyW94rdhu9vr517UMIfQCADt8cBlmUXMGwrLQwJpxtii6x0oH93PfxM9iKw%2FFQaqmRqzaPC0kgL5oLE2piEDUq3s61L1iqF6EQ7cw8ycRZeGf4fHKYO%2FIhDY7Gea5VnkaymMqZZYsqfruanZwSzimFaUZS3y3mqNEQGV2ZzDZV7SR5bGbEVOx0JHqEfcYFiDXaR6E8P0n0ojhoFs%2BwfJrgkEryULcuUPdNAiDZreA3fBy%2FocOoxv930Gi0eQKcLrPXkv0nsO2F%2BN7OX3mHOILUSe5jgeMUKQ7bbmYs%2B%2Fm9vwm83bAkiYiXYp37Lo12vTh9pPaw3w4DWfL%2FdaNMPlIaUlm8AY%2FdP3GA%2B3iaDLNsjPfr6czKsj1K9fu1cNSdfJvffBkGzJ29W4858fdXr6%2BB7Vy0%2Bku1vxT1icH8EAAA%3D)
