### PR TITLE
Template for wondeya conversational landing pages (wondeya.com/connect)

### DIFF
--- a/wondeya.com.connect.json
+++ b/wondeya.com.connect.json
@@ -1,0 +1,28 @@
+{
+  "providerId": "wondeya.com",
+  "providerName": "wondeya",
+  "serviceId": "connect",
+  "serviceName": "wondeya landing page",
+  "version": 1,
+  "description": "Connect your domain to your wondeya conversational landing page.",
+  "variableDescription": "No template variables: the routing target and the certificate DCV delegation are fixed for wondeya's Cloudflare-for-SaaS zone.",
+  "syncPubKeyDomain": "domainconnect.wondeya.app",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "groupId": "routing",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "cname.wondeya.app",
+      "ttl": 3600
+    },
+    {
+      "groupId": "certificate",
+      "type": "CNAME",
+      "host": "_acme-challenge",
+      "pointsTo": "%fqdn%.3d36317d5c29f8d5.dcv.cloudflare.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New Domain Connect template for **wondeya** (`providerId: wondeya.com`, `serviceId: connect`). It connects a customer's subdomain to their wondeya conversational landing page, hosted on Cloudflare for SaaS: a routing `CNAME` to our fallback origin (`cname.wondeya.app`) plus an `_acme-challenge` DCV‑delegation `CNAME` so Cloudflare issues and renews the certificate. Signed via `syncPubKeyDomain` (`domainconnect.wondeya.app`). Subdomain‑only (`hostRequired: true`) because Cloudflare's Domain Connect does not support an apex CNAME.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`wondeya.com.connect.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver — N/A: this template sets no `logoUrl` (optional field, omitted).

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set (`domainconnect.wondeya.app`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow — N/A: this template does not use `redirect_uri`.
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — N/A: the template has no TXT records (both records are CNAMEs).
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix — N/A: no TXT records.
- [x] no variable is used as a bare full record value — `pointsTo` is a fixed target (`cname.wondeya.app`) or the built‑in `%fqdn%` embedded in a fixed suffix (`%fqdn%.3d36317d5c29f8d5.dcv.cloudflare.com`); no bare request variables.
- [x] no bare variable is used as the full `host` label — hosts are fixed (`@`, `_acme-challenge`).
- [x] no variable is used in the `host` field to create a subdomain — uses the standard `host` parameter with `hostRequired: true`.
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove — N/A: neither the routing CNAME nor the DCV‑delegation CNAME is a user‑editable record (not a DMARC‑like case).

## Online Editor test results

**Editor test link(s):**
[Test wondeya.com/connect example.com/chat](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACUfomoC%2F%2B1UYWvbMBD9K0JQ9qG2cWIndQyDtckYY1spa9etK8Eo0jkRtSVXktOmIf99smM3Tug29m2MfRLS3T3de%2B%2BkNTaQFxkxgOM1LpRccgbqPcMxfpCCwYp4VObYeQ6dkxx2QRvQoJacQl1CpRBAze50PxtlRDAu5qggc7BJS1CaS4HjnoMZaKp4Yeo9Hm%2BB0EqWCjGZEy6QkdttC2YvqwBIVUKyPWyvAieKk1kGkz3gc4lawqjN0DEyC0BKlqYCMETNwSALVx9TUIannFYVk%2FE1YpDBvL4UEQUo5Y%2FAUCqf%2B3ql0TiTJUszG3ZtwL0k5BI9SVG3pVeCXpSzD7Ca1LRsT1t%2BjXZeKzspiib9LJP0DscpyTQ4eCG1%2BQz3JVdgJTeqtGcKqFRM4%2Fh2jeeWR1G70RCyKGZVVDaMz08%2FvcVbCLt9U9kquTD6SlbmCWvWwfXGZDgOhr6%2FcbrIHU1%2Bip4QmoNLFyTLQNR2d%2B46Su%2BZOPICFgyD3gkb0P4ojdjAY3Tp0Wf1mtHbNTHdOLgSMtkRnjqNfhYVHom1ti1r%2BrAdVANZN5%2FwuqajTJeJhSqIIrmunkILeruHOm1hb7e40wb4F6C2ZT4XUkGi7UpMqaC1LS8zwxPyQHZHjCZW%2BWxlGWobtbjW0gOBxfZRNcQYMeR37jk4YbRixSv3Bn7IWDQauEEYnbjhjPbc2WAWukEUBemIMqBs2HnxL3wGL7%2F5fcFBaxCGE9sCPs0eyErjTTVFL5M5mBbvgJzdeR0f%2FnRw%2Fhr%2BU8cO7H9H%2FyVH7RegyRJYQqrUvt8fuv7I7flXfhD7Udzveb0wDMLw2Pdj3684gDZbFdb2b%2Bj%2BCnhyUS7J96evQSSXZTQa3x1%2F%2BxKW7%2FKPl4s0y9nN2TWd%2Bf7JzdWj%2FxpvfgDLwMc3vAcAAA%3D%3D)

Note: `hostRequired` is `true`, so per the template guidance an apex test is not required; the subdomain test above (`example.com` / `chat`) exercises both record groups and yields `chat.example.com CNAME cname.wondeya.app` and `_acme-challenge.chat.example.com CNAME chat.example.com.3d36317d5c29f8d5.dcv.cloudflare.com`.