### PR TITLE
Add Domainee custom domain templates (apex and subdomain)

### DIFF
--- a/domainee.dev.edge-apex.json
+++ b/domainee.dev.edge-apex.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "domainee.dev",
+  "providerName": "Domainee",
+  "serviceId": "edge-apex",
+  "serviceName": "Domainee Custom Domain (root)",
+  "version": 1,
+  "logoUrl": "https://domainee.dev/logo.png",
+  "description": "Point a root domain at Domainee's edge. Publishes anycast A records at the apex and a CNAME for www. Domainee issues and renews the TLS certificate automatically.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainee.dev",
+  "syncRedirectDomain": "domainee.dev",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip1%",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%ip2%",
+      "ttl": 300
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "%cname%",
+      "ttl": 300
+    }
+  ]
+}

--- a/domainee.dev.edge-subdomain.json
+++ b/domainee.dev.edge-subdomain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "domainee.dev",
+  "providerName": "Domainee",
+  "serviceId": "edge-subdomain",
+  "serviceName": "Domainee Custom Domain (subdomain)",
+  "version": 1,
+  "logoUrl": "https://domainee.dev/logo.png",
+  "description": "Point a subdomain at Domainee's edge with a single CNAME. Domainee issues and renews the TLS certificate automatically.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainee.dev",
+  "syncRedirectDomain": "domainee.dev",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%cname%",
+      "ttl": 300
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Two new templates for **Domainee**, a custom domains API for SaaS platforms. They let a platform's end user point their domain at Domainee's edge from their own DNS provider instead of copying records into a registrar panel by hand.

Two files because the record shapes genuinely differ and a template is static:

- `domainee.dev.edge-apex` publishes two anycast A records at the root plus a `www` CNAME
- `domainee.dev.edge-subdomain` publishes a single CNAME (`hostRequired: true`)

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — `domainee.dev` on both. Public key is live at `_dck1.domainee.dev`.
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — absent from both.
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` — `domainee.dev` on both.
- [x] no TXT record contains SPF content — neither template publishes any TXT record.
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique — not applicable, no TXT records.
- [ ] no variable is used as a bare full record value — **see justification below.**
- [x] no bare variable is used as the full `host` label — hosts are the literals `@` and `www`.
- [x] no variable is used in the `host` field to create a subdomain — the subdomain template uses the protocol's `host` parameter.
- [x] `%host%` does not appear explicitly in any `host` attribute.
- [x] `essential` is set to `OnApply` on records the end user may need to modify — not applicable, neither template publishes a policy record of that kind.

### Justification for bare variables in `pointsTo`

`%ip1%`, `%ip2%` and `%cname%` are used as complete record values. The rule's stated exception applies: an A record's value is an IPv4 address and a CNAME's value is a hostname, and neither can carry a service-specific prefix without becoming invalid. The variables are constrained by their record type rather than by a prefix.

They are variables rather than literals deliberately. The addresses are deployment configuration, and hardcoding them would require a new PR here and a fresh provider sync every time the edge moves.

## Online Editor test results

Both templates passed **Check template** with no errors or warnings.

**Editor test link(s):**

[Test domainee.dev/edge-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMZoomoC%2F%2B1UXW%2FaMBT9K5alapsKIR%2FQNJEmjbVTV%2FVD1Uo1TRVCJr6A2yTObAdKEf991wkUaFdpD3voQ59i33vPzT3Hx15QA1mRMgM0XtBCyangoE45jSmXGRM5gMNhShtPuUuWYS09XmUxo0FNRQIVCPgYmqyAh038GYAcldrIjNR78lFJaT5h9RSUFjKnsdegqRzLG5UiamJMoeNWa3uYlk07RT5GFAedKFGYCkmvpMgNYcT2JDWEMEPWv%2F6giZ3PIVflMBV6ApqwfJ4wbUiXKEik4trWmwkQywGzHLsdXXYvvpGRVGQ2mzlP3YjQuqxacATnMNMVsHd%2BTRJQRoxEgrISViJbZnCTpnPHyjLPk6%2BpTO5pPGKphjqCI53BvO79Unxb8QO4wCHNazUrAjS%2BXVAzL6zmXQxPpDa4%2FGKP0MqjexK3e6Lw9jBkDKocuO6y8W8g%2FxVQpdEGiEI9gyY52mAH3F826KPMYbAZvN9YkbJOemBoTHASmW364mqsZFkMxLq%2BYIpl2pp3jbzdgfbX2Ftq10jbLsOO4zsd3%2FGisI76Nho4QeD4nY7jtds2XM1cNbSu2ZHbDi%2FGuVQw0PhlplRYaVSJx5mVqREDNmObEE8GrCjSOXLVmMWeu4dU%2F6jSmzPDcLk94Ua0Bh3wxJIV1WWDMPAOR14zOmhHzTbwsBkFHJp%2BNAz9MEi8kI%2B2bu7fbvVrd3ejN2gNuRHM3sZuOmNzTZfP3PJy%2Bh0l3%2FL4a9%2BuKNS%2BXZF4eepvj0m%2FgZfg3UvvXvofXsInT7Mp8AGzZb7rHzTdqOm5Pfcw9n0cFU3khu7hvuvGrmsZgDY1wQW%2Bh9svIb30s%2BOf0c2v9G74%2B%2BZAXO%2BfXZy07sL9NGpdwDD5Pr0%2F7z0GaXByNftMl38ANe1XjYcIAAA%3D)

[Test domainee.dev/edge-apex example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB1pomoC%2F%2B1UXU%2FbMBT9K5YltE00IR%2F9jDRpBaat0DHGGDygqnJttzVL4sx2GkLV%2F77rtKUtH9JeJvHAU3uv77m55%2Fhcz7HhSRYTw3E0x5mSM8G46jEcYSYTIlLOXcZnuPZwdkYSqMXHq1M40VzNBOUViLMJd0jG7zb5RwB0lGsjE7SM0XslpfkA1TOutJApjvwajuVE%2FlIxoKbGZDo6ONge5sAeu1k6ARTjmiqRmQqJz6VIDSLI9kRLCCIGrT%2F9TiM7n4vO81Es9JRrRNKSEm1QFylOpWLa1pspR5YDnDLodnTW%2FfYZjaVCRVG4D92Q0DqvWjAAp7zQFfCy%2FxNRrowYCwqyIpIDW2IgiOPStbKUKT2MJf2NozGJNV9mYKRTXi57PxXfVlxwJmBI81LNigCObubYlJnVvAvpqdQG%2Fn6yV2jl0ZcSwj2R%2BXuQMgZUDj1vUfs3UPACqNJoAwShHkFpCjbYAQ8WNXwvUz7cDD6orUhZJ90RMCZ3qUw2fUmWQTBRMs%2BGYg3JiCKJtv5dg2920IM1%2FKbCQwjkbdRquIHbCFy%2F01pmA5sN3TB0g0bD9et1m64mr3pa7%2ByIbimISSoVH2r4JSZXUGlUDpea5LERQ1KQTYrRIQwQl8BYwyn03L2q5YdWJBkxBILtGTfi1fCQUctYVJvabLV9Wg%2BcDm21nDpphA7x6iOHjcio6Qe0Uw%2Fp1gY%2Ft90v7fCO7lxrnhpB7GJ244KUGi8eGec5CjuCvnIOax%2BveNiF3%2BHy1AOvktCgBovxZq43c%2F0Xc8GjqMmMsyGxlYEXNB2v4%2FjepdeOgjBqtNx2xwubzX3PizzPkuDaLDnO4cXcfivxj%2F2v19e9L9%2Fbqd%2FrF%2FfH5qpzUo%2BT4PBifNIrT3sXV7fEy%2Ft%2Fbu%2B6H%2FHiL7Mx%2BBivCAAA)

[Test domainee.dev/edge-subdomain example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHtpomoC%2F91Tf2%2FTMBD9KpalCRBN5mZt10RCYoNOINgPusKYpipy42trlsTBdtqVqt%2Bdc9O03QZ8AP6yzvfe%2Bd6785JayIqUW6DRkhZazaQA%2FVHQiAqVcZkD%2BAJmtLHNXfAMsfT9JosZA3omE1iTQEzAM%2BWoIu%2BST1jkXWmsykgVk5dbxiukzEAbqXIaNRs0VRP1VadInVpbmOjwcL%2BtQ5f2i3yCLAEm0bKwaya9UjK3hJNtYcItqV9%2FYYjrk8ylnTqMzCcptnRxct7ztyAijSnBEJ4LoiGHuSF2CmTw%2BZokoK0cywRdI7xEHdxikKYL3wle5MlpqpJ7Go15aqC6uSpHn2BR1X7urUP0QUgNif0bZqqM7cPPEkFotNUlVka80sLQ6G5J7aJwDq9VbOAYvnWTc16YgcLwIMlxEAd4aS2aesTYarhq0F8qh3hXbNjYPO4G%2BsBxP8BPVLaraqaqwGiiVVnEsuYUXPPMuD2q2XeP6MOaf1cVwHjdzhqH8%2FAfKXZ9yUmuNMQGT25LDbXurEytjPmc765EEvOiSBcow2AWaz73pHqs7l5wyzcb6z%2FxujanQWOROEHS7XbYEU0IROgFITS91ug48MJWZ%2ByFYxEmxx3GRNDe%2Byh%2F%2BkT%2F%2FCqPzQVjILeSu90%2FSed8YehqNWyg0f%2BlMFwGw2cgYu6gAQs6Hgu9JhuwbhS0o6Omz7pBq9t5zVjEmJMCxlZKl7gp%2BztCz5vXZ%2Br2PoDe5fT7UfDlQ69f3t%2FctNvm9Pa82xtcnl3Bt4fR4Mf85A1d%2FQYG7mq%2FAwUAAA%3D%3D)

Coverage, matching the CI requirement of an apex test and a host test per template:

| Template | Case | Result |
|---|---|---|
| `edge-apex` | apex, host empty | `example.com` A ×2, `www.example.com` CNAME |
| `edge-apex` | `host=app` | `app.example.com` A ×2, `www.app.example.com` CNAME |
| `edge-subdomain` | `host=shop` | `shop.example.com` CNAME |

`edge-subdomain` sets `hostRequired: true`, so per the PR template's note an apex test is not required for it.

<sub>Apologies for the earlier revision: one pasted link was truncated in transit and failed to decode, and the `edge-apex` host case was missing. All three links above were regenerated and verified to decompress correctly before posting.</sub>
