### PR TITLE
Add optional second certificate validation record

### DIFF
--- a/customdomainkit.com.custom-domain.json
+++ b/customdomainkit.com.custom-domain.json
@@ -3,10 +3,10 @@
   "providerName": "Custom Domain Kit",
   "serviceId": "custom-domain",
   "serviceName": "Custom domain",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://customdomainkit.com/custom-domain-kit-logo.png",
   "description": "Connects a custom hostname to a SaaS application using Custom Domain Kit, verifies hostname ownership, and provisions its TLS certificate.",
-  "variableDescription": "CNAME_TARGET: the Custom Domain Kit routing target; HOSTNAME_OWNERSHIP: the Cloudflare for SaaS hostname ownership token; CERTIFICATE_VALIDATION: the Cloudflare for SaaS certificate validation token; REPLACEMENT_OWNERSHIP: the Custom Domain Kit replacement verification token",
+  "variableDescription": "CNAME_TARGET: the Custom Domain Kit routing target; HOSTNAME_OWNERSHIP: the Cloudflare for SaaS hostname ownership token; CERTIFICATE_VALIDATION: the first Cloudflare for SaaS certificate validation token; CERTIFICATE_VALIDATION_SECONDARY: the optional second Cloudflare for SaaS certificate validation token; REPLACEMENT_OWNERSHIP: the Custom Domain Kit replacement verification token",
   "syncBlock": false,
   "syncPubKeyDomain": "customdomainkit.com",
   "syncRedirectDomain": "customdomainkit.com,www.customdomainkit.com,test.customdomainkit.com",
@@ -32,6 +32,14 @@
       "type": "TXT",
       "host": "_acme-challenge",
       "data": "%CERTIFICATE_VALIDATION%",
+      "txtConflictMatchingMode": "All",
+      "ttl": 300
+    },
+    {
+      "groupId": "certificate-validation-secondary",
+      "type": "TXT",
+      "host": "_acme-challenge",
+      "data": "%CERTIFICATE_VALIDATION_SECONDARY%",
       "txtConflictMatchingMode": "All",
       "ttl": 300
     },


### PR DESCRIPTION
## Description

Adds the optional certificate-validation-secondary group for Cloudflare for SaaS hostnames that require two concurrent _acme-challenge TXT values. The template version is increased to 2 so the published automation can fetch the change.

Bare TXT variables remain necessary because Cloudflare supplies opaque ownership and certificate validation tokens.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern <providerId>.<serviceId>.json
- [x] resource URL provided with logoUrl is actually served by a webserver

# Checklist of common problems

- [x] syncPubKeyDomain is set
- [x] warnPhishing is not set alongside syncPubKeyDomain
- [x] syncRedirectDomain is set whenever the template uses redirect_uri in the synchronous flow
- [x] no TXT record contains SPF content
- [x] txtConflictMatchingMode is set on every TXT record that must be unique per label or content prefix
- [x] no variable is used as a bare full record value unless necessary — see justification above
- [x] no bare variable is used as the full host label
- [x] no variable is used in the host field to create a subdomain
- [x] %host% does not appear explicitly in any host attribute
- [x] essential is set to OnApply on records the end user may need to modify or remove without breaking the template

## Online Editor test results

**Editor test link(s):** https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMFmomoC%2F%2B1WYW%2FiOBD9K1ak%2FbQE0tItNKuTjqXpFW2hFeSuhyoUGduAryFObQeOq%2Frfd5xAE5rQuz2tTqqunyCO582b8XsTP1qaLeMQa2a5j1YsxYpTJnvUci2SKC2WVCwxj%2B65rhOxtGrPWwZ4CSFWN92EztNd6CvXsEUxueKEFUDsDCV%2Ftx%2F9%2FHbFpOIistzjmhWKufhVhrBroXWs3EajglBjD9%2BGVdvE1eNoDnCUKSJ5rFNIqyuiiBGtEEZZFFoIpSNggrSAxRHGI4TjOOQEmxCUKB7NUanCGgKafMaZygHEOgLqCx7XEI4oSptkKlGIQ0L%2FaoQIkxqCAJrVTaVYcjwN2fk%2BxUGn7wV%2BZ%2FiL57tIL1g5O5Ii0YaXxnLO9Gd0eT3y07Dr24E3HF32braRoUjoLMSSoZmQWXVlvlD6PYs%2Bo6439HsXvW7H94LfOle9847fux5kSDMula7EKxSFVjjkNGvcq5jByOteD847w3GGLtLicYgUIwJ69%2F15ht7NVafr9b2BX2pCuX0M1E7YkkV6e46kAGYUuonIl1CQe8ud4VCxbOUmmX5lmwznoDfMxiGjXILMXttaW6%2FX9ap1zZSuV2OboxuyhwTAwVdaJkAM8ghJleXePVpz0EWcWm5rMYjRm5jtVLWFgMefjYsFj7TyBTx%2BKIrug4nSYLqm4zzViqg76djP0skT%2BL%2F7OXxAZvbWlbsYY0WssUlWVmua8k8N7pyB83Qfa7IAffcFNdCdMDxIqaAKO1fFIVqYAHmywGHIonmRUrVMfzQtO5M3lpsfRDD30b%2BnWjDDwdPcV2OBVqXtvovL5Klm%2FSUiFuRCngD%2BzjkKRxr%2BLTcLkShW8IFpMr23jVtgJS0n4Gl4QfyVgj0omX9waMVmAc0YS7xU5qu5I3xXxXiyo3yXc55sSf%2B3hIs%2BN5kNla1TmaycOhBU9qsJfaaaDU0DXqnRtOoC0XS7DSd%2BOCSXdXWwXgsTXCk%2BE1EoescOVMbnkZAsUPCLdSLZboIuk1DzAK9xvkRJYC4BGxClgreACdP1xSSNsutLQYRbU%2Fx9T3P516yAEqMfbqzYJO0pPcGf7NYRJfYJJdRut04cm1DanLZnzdMWOStcv165ob12%2FSq7hykFreI4TO25xhtlPZkhsTcMtvVWjPZ6uQcvxPGmC96fyRXFVqv7%2F1azMeXbFvbLhKWiy3PlTRQ8qcEn9X2AvQ%2Bw9wH2PsDe5ACDy57CK0YDbLYfO8entnNmHzm%2B03aPmu6nZv3otNVsH390HNdxTFGAltX8CDe%2F4p3Pml7cfnnoN%2F6YtRZDb6QaY5%2BNb7vdRq95M7oQ8%2FFl2%2FNuz6Lxw1D9ZD19A8ttZ6kcEwAA