### PR TITLE
add Pointer, Connect your website

### DIFF
--- a/pointer.ojieame.design.public-website.json
+++ b/pointer.ojieame.design.public-website.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "pointer.ojieame.design",
+  "providerName": "Pointer",
+  "serviceId": "public-website",
+  "serviceName": "Connect your website",
+  "version": 1,
+  "logoUrl": "https://pointer.ojieame.design/favicon.svg",
+  "description": "Connect a verified public website to your chosen subdomain with Pointer.",
+  "variableDescription": "%target%: operator-selected Pointer delivery hostname; %proof%: 32-character hexadecimal Pointer ownership code without its fixed prefix; %ownership%: Cloudflare-issued hostname ownership token; %certificate%: Cloudflare-issued certificate validation token",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.pointer.ojieame.design",
+  "syncRedirectDomain": "pointer.ojieame.design",
+  "hostRequired": true,
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "%target%", "ttl": 300 },
+    { "type": "TXT", "host": "_pointer", "data": "pointer-%proof%", "ttl": 300, "txtConflictMatchingMode": "Prefix", "txtConflictMatchingPrefix": "pointer-" },
+    { "type": "TXT", "host": "_cf-custom-hostname", "data": "%ownership%", "ttl": 300, "txtConflictMatchingMode": "All" },
+    { "type": "TXT", "host": "_acme-challenge", "data": "%certificate%", "ttl": 300, "txtConflictMatchingMode": "None", "essential": "OnApply" }
+  ]
+}


### PR DESCRIPTION
# Description

Add Pointer's signed synchronous template for connecting a verified public website to a customer-selected subdomain. It applies one CNAME and three verification TXT records under the protocol `host` parameter; it does not change nameservers, apex records or email records.

Pointer uses Cloudflare for SaaS for delivery. The application signs each immutable record set with RS256, validates the selected subdomain, and independently verifies source and destination ownership before activating delivery. `syncPubKeyDomain` and a fixed callback domain are configured. The public signing key is published at `_dcpubkeyv1.domainconnect.pointer.ojieame.design` and its three TXT fragments were verified against the prepared RSA key. Cloudflare onboarding remains pending; this PR is template review, not a claim of live provider approval.

Bare-value exceptions: `%ownership%` and `%certificate%` are complete Cloudflare-issued validation values and cannot be prefixed. `%target%` is an operator-configured delivery hostname selected by Pointer's server from its delivery configuration, not customer input; separate delivery pools can have different zone roots. All three values are inside the signed request. Pointer's own TXT uses the fixed `pointer-` prefix and a 32-character hexadecimal `%proof%` suffix.

Conflict handling: `_pointer` replaces only matching `pointer-` values (`Prefix`); `_cf-custom-hostname` is unique at its label (`All`); `_acme-challenge` permits multiple concurrent challenges (`None`) and is `OnApply` so a completed challenge can be removed. The CNAME and ownership records remain required. Cloudflare currently ignores these conflict/essential properties and `hostRequired`; Pointer enforces the nonempty host itself. Actual Cloudflare consent and conflict behavior will be tested during restricted provider onboarding, not inferred from editor output.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver


Validation: the official `dc-template-linter` at commit `e91773489dfd7aae37afe3fc4e2bba7e3e8d27b8` passed with `-loglevel error -tolerate info -logos -cloudflare` (exit 0). The public SVG returned HTTP 200 with `image/svg+xml`. The Online Editor's Check template and Test apply template actions were run with synthetic data for `www.example.com` and `docs.team.example.com`; both generated the four intended labels and values at TTL 300. The links below were produced by the editor's Copy Markdown action. No DNS was changed, and the editor tests do not validate signatures or live provider consent. Apex testing is exempt because `hostRequired` is true.

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 

[Test pointer.ojieame.design/public-website example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMJeomoC%2F%2B1WXW%2FbNhT9K4KAPNVy5I%2BqtYoCc9MuG7ZkbeG0BQLDoMkrmStFqiRlxw3833cpyZKcOF0fGyBv5uU59%2FNcyre%2BhSwXxIIf3%2Fq5VmvOQP%2FJ%2FNjPFZcWdF%2F9y4Fk0GdgeCr9XoO6RCvi3lc4vDCg15xCxS6WgtNgA0vD0XlzWZPOlJRArbdVhfZa0Bq04Ur68aDnC5WqKy0QvLI2N%2FHp6fGMThOCjpXsm3WKLtBINc9t6aaJQzx0zRMOzKsy2wf1rKqSoCtlQHqmWDKVES69Dbcrry6u73IjmpOlgLcHAU4s0SnYk9hTOWhilQ4MCAyJkWqyx0BwDL%2F1MISVmPkr7wSbqBJkjYYBXRFNqAOu4IYwoDwjoiGrjcSmrHjuUcWgzEoV1uPWeAm%2FcfVowB%2FoskGi2zOhCpYIoiHgxhQI28fuOLTqK0gkUtAWe0NRBUepnXtvTQRnxBVf0d1kt5K%2BEYp%2B9eOECAOV5X2x%2FAu2b8teYp%2BqptJqHP0HteWYH4FxjaiG%2ByDa1fQRvhUIR81ZXWBsZCrNjB9f3%2Fp2m5diu5xevKvhePzNadi5NDPVmSBarUW5jcJw12u4sy%2BzlrnIG61jD0ibWlDPs%2BMDf91YlF%2BCYrMXxNIVl%2BkFjtCtTDky%2Fyikvmtd%2Bw9mQ5OAFsaqLNgPt02so4afTGoqxMOhCM3ACVUIkGk3TFc7PxnoUknnAQzum%2BXEbfg%2FcprnYuvv5rue%2Fx3vF%2B0Y571aPIjD%2FcDXCvpUZW1ym80GD6lWRb7ge0qOO5UZ96jtydcH7Pmefl3y8VjJwBn2na8sd2U3L19AlThkOBiOxs%2BjFy8nZEkZJHfPDtwMwhFwZM05wDnbQoMDddpYwzqWFojdwRSUhoVLhZTGWvdZISxfkA1pTYwuiGsrNtPgLTq%2BvxOyeo%2BrHt4R9fH6u0NeMOpazN2LHyZswJLJ82AYDcfBeBCNgpcDMgjGaE%2FYcBIlYdj5evz4G%2FPDT8nB3LsymooN2Rp%2Fd0%2FGdZX7%2Fe0fLfd%2Fh%2FmYK7%2F%2FVhw24agwH3PBhy%2FWvWKPrdcvXG7zQO7mPXzenvb4aY%2Bf9vhx7zF%2B9Q1ZA1sQBx2GwygIJ8EgnIUv4tEkHkf90SSaDKJnYRiXeVkwtir8Fv8HdP8B%2BH9cfp4tp7DWV39%2F%2FyDPkzClUZou%2BSd29Yzn7z5MzsXvn5Q8Ox%2BHr%2F3df%2BHAIoP1DQAA)

[Test pointer.ojieame.design/public-website example.com/docs.team](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOleomoC%2F%2B1W227jNhD9FYFAnmo58mXjWEWBupsCze4mDVIvUCAwDIoc2WwoUiEpO27gf%2B%2FQkiUlsdN97KJ5k4ZnztzOUHoiDrJcUgckfiK50SvBwVxyEpNcC%2BXAdPVfAmgGXQ5WLBTp1KhrtCLupsThgQWzEgxK7yKRgoVrSKxA8vqwcvqolQLmgo0uTNCAVmCs0IrEvQ6ReqG%2FGongpXO5jU9PD2d0mlIk1qprVwukQCMzInc7mjoODZBapAJ4UGa2Dxo4XSbBltqCCmyRcJ1RoYK1cMugKq7rc6NG0ETCxbMAJ46aBbiTONA5GOq0CS1IDImRKueAgxQYfhNgCKcw8x%2BDE2yiTtFr0A%2FZkhrKPHAJj5QDExmVtbNeK2zKUuQB0xx2WenCBcLZIBWPvh4D%2BICUNRJpP0pd8FRSA6GwtkDYPnaL0Ol7UOjIwDjsDUMVHHRtnQcrKgWnvvjS3U92o9gvUrN7EqdUWigtN0XyGTYXu15in8qmsnIc3aPa8p63wIVBVO17FO1ruoWHAuGoOWcKjI2e2nBL4rsn4jb5TmzXk6tfKzi%2B%2Fuw17CntVLcmiFbnUG6DKNp2at%2Fpn9PGc57XWsce0Ca1sJpniwOfHh3KL0WxuSvq2FKoxRWO0K%2FMbmTkIKQ6a6jJ0WxYGrLCOp2F%2B%2BE2ibXU8I1JTaQ8HoqyDLxQpQS1aIdpa%2BcbA11r5RnA4r45Qf2G%2F64meS43ZDvbdsjfeD5vxjjrVOJBHO4H3lbQZTprkuOa2a5DZaBpYXSRz8XeMcfNyqy%2F2vYUd884ZnuSuxYLGktJePN%2BCqXlpQRnu9tQpx4Z9fqD4Yez0fmYJoxD%2BvLdg%2BuheAccX%2F0e4sxdYcCDWi2tYC1LA8ROYQrawNynQnfGageyQjoxp2vamDibU99ibKzFUyR%2BvR%2BqvJvb%2FXwh88NdaI99zplvt%2FDfgGRMRz0OvTAZwnk4TMejcAzng5AnPDpP6Rnr9Yet78nbX503Py4HlNCW10Su6caS7St5VxXv97r7Run%2FOt7vvwuv75NDDTko2%2B%2B%2F%2BOc33JHCDy3if770%2BnLdzjp4Kb7v%2Ffvev%2B%2F9%2F2vv8a%2FC0hXwOfUO%2Fah%2FFkbjsBdNo1E8jOL%2Bh%2B5oNDobD36IojiKfGlgXVn%2BE%2F5ntP8wyJfN5OaPe%2FY5lxefqDTZ5c2nh3GWJKdf5eXj%2FcNq9SWZit%2BmC3U7%2BYls%2FwGwYQR0YQ4AAA%3D%3D)
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
