### PR TITLE
Add FadeHost templates: minecraft-server (SRV) and community-website (CNAME)

### DIFF
--- a/fadehost.com.community-website.json
+++ b/fadehost.com.community-website.json
@@ -1,0 +1,22 @@
+{
+    "providerId": "fadehost.com",
+    "providerName": "FadeHost",
+    "serviceId": "community-website",
+    "serviceName": "FadeHost community website",
+    "version": 1,
+    "logoUrl": "https://fadehost.com/logo.svg",
+    "description": "Serves a FadeHost community website (server join page, live map, player leaderboard) on a subdomain of the customer's own domain, for example play.example.com: one CNAME to join.fadehost.net; FadeHost issues the certificate at its edge. A host is required because the Domain Connect standard does not place CNAME records on the apex. No variables.",
+    "syncPubKeyDomain": "fadehost.com",
+    "syncRedirectDomain": "laplace.fadehost.com",
+    "syncBlock": false,
+    "hostRequired": true,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "@",
+            "pointsTo": "join.fadehost.net",
+            "ttl": 3600,
+            "essential": "Always"
+        }
+    ]
+}

--- a/fadehost.com.minecraft-server.json
+++ b/fadehost.com.minecraft-server.json
@@ -1,0 +1,27 @@
+{
+    "providerId": "fadehost.com",
+    "providerName": "FadeHost",
+    "serviceId": "minecraft-server",
+    "serviceName": "FadeHost Minecraft server",
+    "version": 1,
+    "logoUrl": "https://fadehost.com/logo.svg",
+    "description": "Lets players join a Minecraft Java Edition server hosted on FadeHost through the customer's own domain. One SRV record points the domain (apex, or a subdomain via the host parameter) at the FadeHost node the server runs on and the server's port.",
+    "variableDescription": "%node%: the FadeHost node the server runs on, always a label under fadehost.net (e.g. eu1); %port%: the server's port",
+    "syncPubKeyDomain": "fadehost.com",
+    "syncRedirectDomain": "laplace.fadehost.com",
+    "syncBlock": false,
+    "records": [
+        {
+            "type": "SRV",
+            "name": "@",
+            "service": "_minecraft",
+            "protocol": "_tcp",
+            "priority": 1,
+            "weight": 5,
+            "port": "%port%",
+            "target": "%node%.fadehost.net.",
+            "ttl": 3600,
+            "essential": "Always"
+        }
+    ]
+}

--- a/fadehost.com.minecraft-server.json
+++ b/fadehost.com.minecraft-server.json
@@ -5,11 +5,12 @@
     "serviceName": "FadeHost Minecraft server",
     "version": 1,
     "logoUrl": "https://fadehost.com/logo.svg",
-    "description": "Lets players join a Minecraft Java Edition server hosted on FadeHost through the customer's own domain. One SRV record points the domain (apex, or a subdomain via the host parameter) at the FadeHost node the server runs on and the server's port.",
+    "description": "Lets players join a Minecraft Java Edition server hosted on FadeHost through a subdomain of the customer's own domain, for example play.example.com: one SRV record pointing at the FadeHost node the server runs on and the server's port. A host is required; the apex keeps its manual setup.",
     "variableDescription": "%node%: the FadeHost node the server runs on, always a label under fadehost.net (e.g. eu1); %port%: the server's port",
     "syncPubKeyDomain": "fadehost.com",
     "syncRedirectDomain": "laplace.fadehost.com",
     "syncBlock": false,
+    "hostRequired": true,
     "records": [
         {
             "type": "SRV",


### PR DESCRIPTION
# Description

Two new templates for FadeHost (fadehost.com), a Minecraft server host:

- `fadehost.com.minecraft-server.json`: one SRV record so players can join a Minecraft Java Edition server through a subdomain of the customer's own domain (`_minecraft._tcp.<host>.<domain>` → `%node%.fadehost.net.` on `%port%`). The target variable can only fill the node label; the `.fadehost.net.` suffix is fixed in the template.
- `fadehost.com.community-website.json`: one CNAME so a FadeHost community website (join page, live map, leaderboard) is served on a subdomain of the customer's domain (`<host>.<domain>` CNAME `join.fadehost.net`). No variables.

Both templates are `hostRequired` (subdomain only), signed (`syncPubKeyDomain`: fadehost.com, key published at `_dcpubkeyv1.fadehost.com`) and return the browser to `laplace.fadehost.com` (`syncRedirectDomain`). The logo at `https://fadehost.com/logo.svg` is live.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Notes on the checklist: no TXT records in either template. `%port%` is the whole `port` value of the SRV record, which the specification requires for numeric fields; `%node%` sits inside the fixed `%node%.fadehost.net.` target. Both records are `essential: Always` because each template is exactly the one record the service needs.

## Online Editor test results

**Editor test link(s):** 
[Test fadehost.com/minecraft-server example.com/play](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAD5pomoC%2F%2B1U627TMBR%2BFcvSBIg0S0PXSxASYxviMmAMhoSmKTq1T1OzJM5sp1037d05Ttqugw14AP60OvfvfOeLr7nDosrBIU%2BueWX0TEk0byVP%2BAQkTrV1odAFD9axj1BQLn9N0TcUpYhFM1MCm6JClSgMTFzHe9Hchn%2BpYx9WmWydSb9W6ZIn3YDnOtMnJqeKqXOVTba3N%2FFs%2B3BoZxlVSbTCqMo1lfwQnWW00IJ6sR9alQw2Rr2DGbADqXzyci7zPVEycqyxuanRdTalUluPpS6A2ugJuZGJ2jpdoHlkmZ6XrA0GbKINw0sgKrGZHi4NDzah3si%2BHH9jBoU2klUEy6kyY%2BCanuu5pZbYeJbQTF1aDwxKueGm0ZU2LmS7DXamLDW%2BqJVB%2BbxJgwov2TliZZkiNgooa8ip2NVV6GkGo2Cc4%2F4d4rb88K3knwAFDPI5LCwRlMMYc1aXpAy2vlCJjj3GMAsZ1t0nz9mWx7vsfWcHL49FKY7q8Xtc7Ddc%2Fq48n3GMkvYTbp2TA9EsMLwn91WuxTlPJpBbDLgPHi%2Fp4YkzNfnaO1ienF5zt6i8Luk8VF62In15K1uy0rWo28%2FAaaG9MFMnqsajtFFu0ch2jiqbOp7skN%2FvR7w2u1OeA5OhWzMdbrLlz%2BIcNX3Wj6KAo7VICgE%2FZbdhmt%2Bc3QT8ioSU3oI%2FI%2FGv%2BNjQG2%2BXJqdXIlkZqblK1aqmAgOF9d%2F7qvr0TvnZqv60bUC2R9yk1V1vtqud8rgfDchByFRWaoOppX9wtcEV00WdO5XCHG5dUqRQVfmCFrEUpT4PXGGJXoIDv2Dd%2FRNlG3dpz%2FLg%2Ff50rWahgKdSeHpU8wwOUOBOt9fpgYw7vXgy6IwGvbgjIoiwN4mGo1huPI%2F3PZ1%2FeSDvHuu%2B29%2BcBXS4%2FzT9lSbSpoUZyhR8ahzF%2FU406nSjr9EwiXvJsyiMe%2F1%2BPHoaRUkUeWrQupa5a1Lxpn751acv7%2FNvF4Nc7gzrYrx3Mfz%2B7nN3LqIjped7h4cnxdHuwZvyUl6JF%2FzmJ62vp1ZJBwAA)
[Test fadehost.com/community-website example.com/play](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH1pomoC%2F91Ua0%2FbMBT9K5a%2FbNPSkLbQ0kyTVhhorBogHpo2VFW38W3rLYmD7aSEqv9910lfDCa%2B71PknHPuPfdhL7jFJIvBIg8XPNOqkAL1meAhn4DAmTLWj1TCvQ12Dglx%2BSmhXwglxKAuZISViLhJnkpbNuY4NpLCbvC%2FhGxDZVtqgdpIlfKw6fFYTdWtjkkyszYz4d7erqM9B%2FummJJKoIm0zGyl5NeUDg0D9u9M7K3zhJr9UjJlGUzRY7EskCWQeYzaURIWI%2Bn1WIEW75hKKaDJx0IlQBI1YXaGLMqNVQnqN4apecpq0GMTpRk%2BAPUVq2D%2B6uB8hxQK2fF5%2F9sJs6oy4G%2FqStF%2B2NqWxuRUSJUItZUTGdGcGBBiDUMxRZ%2F12aymMo33udQo2BgjyA1Wus%2B13WOVphhZZiykguohpxQ4VdbZi9Z2NEZKC%2BNqdVrI8MFn54oVoCWMYzS%2BG2aZRpf5eIBlHfv5ojjGFQryEtkNJ4Yqk%2F8C9yhW0W8eTiA26HEHXq1K4aHVOf1bGePh3YLbMnNbVDnmNZ2On9yCUiutuVF0fNZVgq2lVWp3gsDjaAymVoLbrX48h9Lw5XDp8UcazWibbEibtfa%2FM8FtVjdbOk21yrORXGsy0JAYd53W6rsn8uFaf1cHcJnlNFUaR4a%2BYHON68qTPLZyBHPY%2FhLRCLIsLsmoIZTCPO9KWl%2B1lT8BFl5vykhEzrN0t7jbjoJeL%2Bg1mtjtNPYPodOA3n63cdCDbnOMwb7oNneehJeei9cehactfGkiy6FH7fxvi6M1MFCgGIGjtoJWp%2BE8BTfBYdg6CNtt%2F7DTbnWD90EQBoErB42tq13QxuzuCo%2BSov29eR2fBD9hkuG96ZePj%2FfNfGBOLwcXXy8fbi9u90%2FPBj%2BOzj7y5R89vDP89AUAAA%3D%3D)

Both templates are `hostRequired`, so the apex test does not apply (subdomain tests above).
