### PR TITLE
aser.tr.eposta: add SMTP TLS reporting record (version 2)

### DIFF
--- a/aser.tr.eposta.json
+++ b/aser.tr.eposta.json
@@ -3,9 +3,9 @@
   "providerName": "aser.tr",
   "serviceId": "eposta",
   "serviceName": "aser.tr Business Email",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://aser.tr/statik/favicon-32.png",
-  "description": "Connects the domain to aser.tr business email: MX, SPF, DKIM, DMARC, MTA-STS and automatic client configuration.",
+  "description": "Connects the domain to aser.tr business email: MX, SPF, DKIM, DMARC, MTA-STS, SMTP TLS reporting and automatic client configuration.",
   "variableDescription": "%dkimselector1%: DKIM selector Ed25519; %dkimdata1%: DKIM key record; %dkimselector2%: DKIM selector RSA; %dkimdata2%: DKIM key record; %stsid%: MTA-STS policy id",
   "syncBlock": false,
   "syncPubKeyDomain": "aser.tr",
@@ -61,6 +61,14 @@
       "ttl": 300,
       "txtConflictMatchingMode": "Prefix",
       "txtConflictMatchingPrefix": "v=STSv1"
+    },
+    {
+      "type": "TXT",
+      "host": "_smtp._tls",
+      "data": "v=TLSRPTv1; rua=mailto:postmaster@%domain%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "v=TLSRPTv1"
     },
     {
       "type": "CNAME",


### PR DESCRIPTION
# Description

Adds the RFC 8460 SMTP TLS Reporting record to `aser.tr.eposta` and bumps the
template to version 2.

```
_smtp._tls  TXT  "v=TLSRPTv1; rua=mailto:postmaster@%domain%"
```

The service already publishes this record when a domain is configured through
the provider's DNS API. Only the Domain Connect path was missing it, so the two
setup routes produced different zones for the same product. This closes that
gap. Reports go to the domain's own postmaster mailbox, which the service hosts,
rather than to a provider-side address.

Nothing else changed: the other ten records are byte-identical to version 1.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

`logoUrl` returns `HTTP 200`, `image/png`, 1020 bytes.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [ ] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

**On the unticked box:** the two DKIM records use `%dkimdata1%` / `%dkimdata2%`
as bare values. A DKIM record is `v=DKIM1; k=...; p=<key>` in full, and the
selector, algorithm and key rotate together, so there is no fixed prefix that
could be pinned without making the record wrong on the next key roll. These two
records are unchanged from version 1, which was reviewed and merged in #1708.
The new record added here is not bare: it is pinned to `v=TLSRPTv1;` and
constrained further by `txtConflictMatchingPrefix`.

The `_smtp._tls` record uses `%domain%` in `data` (not in `host`), which the
Online Editor resolves to the applied domain — see the test output below.

## Online Editor test results

[Test aser.tr/eposta example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMiOomoC%2F%2B1Y2W7iOhh%2BlSjSXJUlCQESKqQGCB0KAQrpxqhCJnHAkDhp7LC06jz7cVgKtHQ655xK05G4AWP%2F%2FvflM088hV7gAgr5whMfhP4U2TCs2XyBBwSGKRryiZftJvDg3gFbTJEFl%2BQw8AkF2819Yq4UEYQhIZzuAeQysikMCfIxX5ASvOsP%2FavQZeQjSgNSSKfX19KMJUWTtAMYSx8nM1IqwEN224bEClFAlxz4so8xtCjh6Ahyts8kYI763Eb2YCMbxrILnHGb4LrtaoKr1GsG%2BzS0TjnBGaaW7JpddmSYbc5sdLmQ2RRShIccwDYHIso4U2RxlosgphxTyEHDKASxFqnYJBAiMHBhZU%2B5b%2FYEeQS6TEE%2FFL8VllK5zQan21I2K6qn3JLOBhS80Ezggulg%2BaG9Pt1ckt5w6XS1HQ7SQQ6EEmSzk7WhXOC7yFpwyI6DtsBWyfWtCV9wgEvgaqcdDepwUVk6dD%2Fw7LADbcR405fjAGDoprZEK8GEL%2Fx44ukiiLPBuGX7I5YobH0WZ5aPMCWmz356czG1m3LIDxFd8AVRSPCUstzICGzFoshcj0CcKy2sBYG74J8TL%2FxZVI19CSRwOpELmRY8wpYb2bDQZ3s7ojbMd9iYt%2BaWy6v4pfqrBGOujfOQeXtDs4odv6sunVOWmw7zMzUAtUYslwzfjkVorsv%2FlkTpA4nSZ0js2x4IrS33aXFZFOIpFxSxj%2BEpF0agGFcP9QtL2rO1A085xy%2BKv6lCO4QOmvMHSdZnW9n8h9EuNzVD3xrhUZBkOf6rtPoo1v0tjxdPsFKZMkcgu7iuoM81dsn%2B%2FcAQjwapPnX3VGLNqdM2Y612whL3Xw8QCsOzb6uE%2BWRNN1J%2FEYK4R67a4r%2BMwgE%2BNiKWz6bE%2F%2BO0njY7HJZz6hCP%2B%2BcE%2F8iSvb9tXPfM6Zv2BueATUqYsnxvy56thqEfBX20oQ9ACDwST9PNzR97V%2B83d3%2Fw8XqvucSbUzEJVyMhKQlSTlAy4oZu2WCWNMW4u7PwT4pwMz5GRTICUjYXl6yXccbatRmcP9CFDKA0rkROy3Ol6kIxJzlrPpbsafeyGmFNL75WQlorERJwUAHplQKMbl%2B4UauVamOtWRpOHkYTdK7OhJJ2qVc1rVXWLhUtPi8P62yta6QOnFlPyeehmf4emO2rcVa2jNlEEYdAv8rPJrqPxjeyUypL%2BjXpnls3rXmvMrFzVL0yxidlvYevukRvtF0bY%2F2ul1085oXhVNa6%2BC53%2FV2qtkS50azdTm%2Fb5eys517aYbdZK13fTQ33vCGByQUQM%2FJgHjpCYAylVqlWd04a7aFV04edu9F5OG6czMlcCRWv2itJ%2FrzXQuI5rsNeRWmA7tAD07yziMBYGU3y5NbBTtrIdzIl6ji%2BnB7lZj0LddLKQ1Zi8wx2skBoOgs%2FbJjzx5b1Herjm2b0UL%2BO5Auiqop0NZfv2lEPdx48O1fNlhdRNWPfqH4rkuQrVX2kg5vGbQ2fpEuZqnrxOL3uNLOT2U3mAgfNRqUl98BdGZ%2FPahXtUivFQVs2rDhgYk4Qcrl8TpIykiwpqpjNZPk44dEQ%2ByHsE%2FYNaBSyCqJhxMa%2FF7kU9cEMbLdsqw%2FiFszqg7BTxvbVYMcryHe2bVWHq%2FX1eO%2FbVlwvsaZ81s7nB8ogk1QFFSZly1GSg5yST8o5Ia9almXLqrUDSV8h1YOAdFuqB%2BfJm9b71oxpkUEGkTsEILifwHX3bPsj1mjuDCzI%2B8Yc6CoHYcWndpa%2FwSu7be4jjxxb3VdtdV8%2B0z4VYH%2BZfrnBWmsj34Dn99r%2F1wzRL7H%2FwQH69W36T8%2BHfaT79Ux8lXZ7j46%2FJPMOmLDz3vk7jVg%2FtdbKv%2FfM%2BtPq3yfYK%2B0IXI%2FA9Qhcj8D1CFyPwPUIXI%2FA9Qhcj8D1ywPX%2BP9cMIV2H8Rk8exPCmpSFExRLAhyQRZSGVnNK%2BKJIBQEIdYcEroy6umZab%2FzHy9Pp2I9c9Noag8Cbj7ko0dTsvULa2GU7lqO2QNEMvSJnHFqulHkn%2F8BxjHkVSYgAAA%3D)

Applied against `example.com` with no host. All eleven records render; the new
one resolves as:

```
_smtp._tls.example.com.  TXT  300  "v=TLSRPTv1; rua=mailto:postmaster@example.com"
```

[Test aser.tr/eposta example.com/ofis](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMePomoC%2F%2B1YWW%2FqOBT%2BK1Gk%2B1SWJCRsFdINaykEKEsXrirkxg4YEieNHZZWnd8%2BDktZyp12ZipNq%2BGFUvv4O%2Bf4bJ95FhlyPBswJGafRc93pxgivwrFrAgo8mPMFyOvyw3goL0N%2FmWKTbQUR55LGdgu7gsL%2BYBigigVSg7ANhebIp9il4hZJSLa7tDt%2BTYXHzHm0Ww8vj4W55AMT%2BIW4JAuiSaUmEeG%2FDRE1PSxx5YIYsElBJmMCmyEBOhyDURgrrDR%2FbDRjULdWcG4jQidVjkiFGtVg38aersQEYyuHu10O3zL6LaEbr0j%2BNwnn2EyFACBAggYR2bYFEwbI8IEbpCFh4EPQitioUvAx%2BDBRsU9437ACXYosrmBri%2F%2FyC61CpsFoQQVTZMz58JSDgIGXmUmaMFtMF0frnc3h5Q3KO2OvoOgHEWgjGLId9aOCp5rY3MhYBgGbUHMvO2aEzFrAZui1UoreKihRXF5ofuB55ttBDHHZq%2FbHiDIjm2FVoqpmP31LLKFF2aDccvXRzxR%2BPefYWa5mDDadfm%2FzlyO7aYcdn3MFmJWliIiYzw3EhL%2FxqPIrx6DMFeaRPc8eyG%2BRF7xeVSNfQ3Us9qBjbgVIiamHUCUHfC1HVUb8B2Y7m13i3IQv9hglWD8asM85Le9kVnFTtw1l80Zz02L3zMzADNHPJcMF4YqdNsWP6RReUej8hkaB9ABvrlFn%2BaWRSGfC16OuASdC34AcmH1MDe7lP25vsBzwXJz8gdNaPnIwnPxqMh6b6tbfDfahYZulLZOOAxEeY7%2FVVq9F%2BvBFuP1JnipTPlFYJhbV9DnOruE%2F31gqMO82IDZeybx5tRudUOrdsIS9l8HUIb8nz9WCfPJlm60%2FkUIwh65aot%2FMwpHcCCmpsunxL9DWk%2BbHYTlnDqGcf8SEZ94sg%2B2jeueX%2FqmvaE54JMSxUzX2cK7Fg4jM%2FTdwBvgzRkP%2BMCh4UTdnP61d%2Fx%2Bc%2F7XCiBUs9tkwo2pHEWr0RBVJCUppRPyRm7ZaJYyubDL8zSY5NBmjIxydAQULRmWrpOwxvp116s8soUKkDIuBlbTsZXyIt2dJM35WIHTzlU5IHopd2iEsjbCp%2BCoAcqBAVxuX7lRrearY72RH04eRxNcycykvH5VKut6s6BfpfVwvzCs8e8lndaANeunUynUjV943VZvrKmmMZuk5SEo9VKzScnF4xvVyheU0jXtVMyb5rxfnMAky%2FSM8Vmh1Ce9Di3VWzYkpHTX1xZPKWk4VfUOuUteXyjlpqzWG9Xb6W2roM369hX0O41q%2FvpuatiVugIml0BOqA9z35I8Y6g089WadVZvDc1qadi%2BG1X8cf1sTudpP%2B2U%2B3nFnfebWK6QGuoX03XQGTpgmrIWARinR5MUvbWIFTdS7USeWZarxkfJWd%2FE7Xj6UVP4XENtDUgNa%2BH69e78qWleoNL4phE81q4D9ZJmMmmlN1fvWkGftB8dmCxrhUVQTsCbjNsMFLWXyTyxh5v6bZWcxfOJcubyaXrdbmiT2U3ikniNerGp9sFdgVRm1aJ%2BpefDoC0bVxgwOSlJyWQqqSgJRVXSGVlLaGKY%2BHhIXB8NKP8LWODzSmJ%2BwGmAE9gMD8AMbJegOQBhK%2BZ1Qvkuhz0Y8GRF%2Fda1se5axwv3cNIPoBmWTWisKCkpS5OgHIWKiaKqKktRoKqIf8jQlJKp9EMitcNOD0jrUW66X7VHx8ubTnzUm2mOkwhZOEYphD%2BAbe%2B5%2BJ85pdszsKC%2F9%2BlIj9khG7FDlz%2Bx2XyX69ntfh%2B6mlMb%2FKpt8Fuk3IqIv02vf87Gv1RH3ZCztbdrth372KT4ukE77sfu0%2BHo3P0ezr2%2BQN64994zZJ8xf01fDzJy%2B4D5hkl5xJfNI%2Br7exOm14EXv3vJfQU%2F7iP8IXjixSdefOLFJ1584sUnXnzixSdefOLFJ178f%2BfF4a%2FRYIrgAISiIYeISpmoLHVlOSuls5oWU1Utk1LOJCkrSaH1iLKVY88v3IOdX6hFGU4eLvmIZItecJbKNJ7uHgnxALTKFRU3Mh7sPzlWrXbRa9Kc%2BPInVixPvewgAAA%3D)

Applied again with host `ofis`. Every record moves under the host as expected:

```
_smtp._tls.ofis.example.com.  TXT  300  "v=TLSRPTv1; rua=mailto:postmaster@example.com"
```

`%domain%` resolves to the domain rather than the host-qualified name, so with a
host set the reports still go to the domain's own postmaster mailbox. That is
the intended behaviour: `%domain%` is the account that owns the zone.

## Note on the linter

`dc-template-linter` currently reports two `info`-level `DCTL1021` findings on
this file, for `_smtp` and `_tls`. Both labels are in IANA's underscored-node-
names registry; the linter's local copy of that registry is behind. The
`-tolerate warn` gate this repository uses for the PR check passes (exit 0), but
`--merge-or-fail` does not, so `automerge-possible` will not be applied and this
needs a manual merge.

Domain-Connect/dc-template-linter#25 removes that check; once it lands the
findings disappear on their own. Nothing in this template needs to change either
way.
