### PR TITLE
storeoncloud.com.email: version 2 (Stoily rebrand: ownership TXT, CNAME DKIM, stoily redirect domains)

### DIFF
--- a/storeoncloud.com.email.json
+++ b/storeoncloud.com.email.json
@@ -1,38 +1,44 @@
 {
-  "providerId": "storeoncloud.com",
-  "providerName": "StoreOnCloud",
-  "serviceId": "email",
-  "serviceName": "Email Verification Records",
-  "version": 1,
-  "logoUrl": "https://www.storeoncloud.com/img/logo.svg",
-  "description": "Configure SPF, DKIM, and DMARC records for email verification with StoreOnCloud managed Magento hosting.",
-  "variableDescription": "DKIM_SELECTOR: The DKIM selector (e.g., storeoncloud), DKIM_VALUE: The DKIM public key value",
-  "syncBlock": false,
-  "syncPubKeyDomain": "storeoncloud.com",
-  "syncRedirectDomain": "storeoncloud.com,admin.storeoncloud.com",
-  "warnPhishing": false,
-  "hostRequired": false,
-  "records": [
-    {
-      "type": "SPFM",
-      "host": "@",
-      "spfRules": "include:_spf.storeoncloud.com"
-    },
-    {
-      "type": "TXT",
-      "host": "%DKIM_SELECTOR%._domainkey",
-      "data": "v=DKIM1; k=rsa; p=%DKIM_VALUE%",
-      "ttl": 3600,
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=DKIM1"
-    },
-    {
-      "type": "TXT",
-      "host": "_dmarc",
-      "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@%domain%",
-      "ttl": 3600,
-      "txtConflictMatchingMode": "Prefix",
-      "txtConflictMatchingPrefix": "v=DMARC1"
-    }
-  ]
+    "providerId": "storeoncloud.com",
+    "providerName": "Stoily",
+    "serviceId": "email",
+    "serviceName": "Email Verification Records",
+    "version": 2,
+    "logoUrl": "https://www.stoily.com/img/logo.svg",
+    "description": "Configure ownership, SPF, DKIM (CNAME) and DMARC records for email with Stoily managed Magento hosting.",
+    "variableDescription": "OWNERSHIP: the tenant's platform UUID for the _stoily ownership TXT (derived server-side). DKIM is a fixed CNAME to the shared platform key — no per-tenant variable.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "storeoncloud.com",
+    "syncRedirectDomain": "stoily.com,admin.stoily.com,storeoncloud.com,admin.storeoncloud.com",
+    "hostRequired": false,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_stoily",
+            "data": "stoily-verify=%OWNERSHIP%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "stoily-verify="
+        },
+        {
+            "type": "SPFM",
+            "host": "@",
+            "spfRules": "include:mail.stoily.com"
+        },
+        {
+            "type": "CNAME",
+            "host": "stoily._domainkey",
+            "pointsTo": "stoily._domainkey.stoily.com",
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_dmarc",
+            "data": "v=DMARC1; p=quarantine; rua=mailto:dmarc@%domain%; pct=100",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "v=DMARC1",
+            "essential": "OnApply"
+        }
+    ]
 }


### PR DESCRIPTION
# Description

This updates `storeoncloud.com` / `email` (first merged in #754) from version 1 to version 2. The provider has rebranded to Stoily, and the records we ask customers to create changed along with it.

- **Ownership:** a new `_stoily` TXT record `stoily-verify=%OWNERSHIP%`. It uses conflict matching on the `stoily-verify=` prefix, and `%OWNERSHIP%` is the customer's platform ID, which our backend derives and signs.
- **DKIM:** now a fixed CNAME, `stoily._domainkey` → `stoily._domainkey.stoily.com`. This replaces the v1 TXT record, which needed the `%DKIM_SELECTOR%` / `%DKIM_VALUE%` variables. The platform signs with one shared key, so no per-customer value or variable host remains.
- **SPF:** `include:mail.stoily.com`, replacing `include:_spf.storeoncloud.com`.
- **DMARC:** adds `pct=100` and `essential: OnApply`.
- **Settings:** `syncRedirectDomain` adds `stoily.com,admin.stoily.com` and keeps the old domains during the transition. `logoUrl` moves to `https://www.stoily.com/img/logo.svg`, because the old URL returns 404. `warnPhishing` is removed, since it must not appear alongside `syncPubKeyDomain`.
- `providerId`, `serviceId` and `syncPubKeyDomain` are unchanged, so the existing `_dcpubkeyv1.storeoncloud.com` key still applies.

All targets resolve publicly: `stoily._domainkey.stoily.com` serves a `v=DKIM1` key, `mail.stoily.com` has an SPF record, and `_dcpubkeyv1.storeoncloud.com` serves the key. `dc-template-linter -cloudflare -logos` passes with info-level notes only.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [x] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — uses `SPFM`
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (ownership, DMARC)
- [x] no variable is used as a bare full record value (`stoily-verify=%OWNERSHIP%`)
- [x] no bare variable is used as the full `host` label (all hosts are fixed)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove (DMARC)

## Online Editor test results

**Editor test link(s):**
- apex (no host): [Test storeoncloud.com/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAK%2FiomoC%2F%2B1W%2B2%2FiOBD%2BVyxL1e1qE5oQyiMrpHZLT1dVUI6We2yvQsYxYDWxs7YDpRX3t9844RF6VHs6nXT9oRKCMJ7XN%2FPNOM%2FYsCSNiWE4fMapknMeMXUZ4RBrIxWTgsYyiypUJtjZnvdIAvr4xkgeL0GumZpzynIzlhAe72Rr1QsrRb8wxSecEsOlQANGpYo0qM6Z0iDBYdXBsZzKoYrBZGZMqsPj48ViUdF5JJvFMU%2Bmx1apoudTsI2YpoqnJrfH51JM%2BDRTDMmFAK8znjropv%2BjgzpXl1304bx31r34iIiIUKd7NjhHqkgCTaRCeeZowc0MFchQQgSZsgh14VsYiWZSGy6mFZszUZyMY9bZi3%2F9a%2B9icPPTZT9EZsaQYYII84NGtsIQIkHD4WUnD2aPRwWsXa7o9rdb9AEKzOcQ1VaQKVdDxT9WCgBcI4Im%2FBFOcygIkrKe9IwokG3DPLAl%2BiOren4NCYlS8FKkgjZpWwh6KeiXWNIHHE5IrFkh6WfjK7bsSCiGOMwCqzVgEYfambLeukMOiRIuSi1zXvrYabx0bQs8YN8y8B1ts1r3CId3z9gsU0snqNNaG%2F6sy2jJQAzZ5uLOLduW7aNtU45AxRjgVlD3PHh8NJYvMaemSwydQWe7MrLu%2B4pBkfFBlfXZyyh45WyzA8J1d%2Bmd2pKlk0EWM8CAOQDOIhZaspWKVLbPW7tzsFYaRXmtobV2EiUXRt%2FKQ8dlryXApQD75YsSouiuevN2Phr%2BZ5S2v2VEAW24YJ%2BRykjbJm1kmFucHhURj0CRmrbvef9peTdpgBrTGsaPE7sVrsVZmkKzV%2FcrBz9JwUY7etwDhg0f2SOBvcZKvAIhPE2VzNIR3%2BingC%2FRdvdtLO%2F2TO83tnfYPm%2BpZAWe32KUnRCX1FvEbQT1ptukge%2F6Tb%2FhMdpsnowptmnyqQCmjzT8EgPLCYdGZUDsJIsNH5EF2YkiOiIWH6DScAphXpJeFAv1O6T%2FR7nttWsUUVsGbne4z%2Br1GnzccUAbbm1SY24zqtXdeoMFrBE0Wk3WKF0Hr10Xh66FXSfKXT2LF2Sp8epvHF2jPS3TE4bJR6%2BMEfqTxPEGGOB6g8A2072Gdmi691r6%2Fcl%2B48371wumNIiv7Jj%2FFfd2Fa3uHdgl74P6Pqjvg%2FrGBxXucE3g5XpErF7Vq9Zdr%2BX63q3fCL1qGLQqIKsGJ588LywwMG2KcjzDTV6%2Bw7G34I3g5%2F7TrPoUdRe%2Fq%2FHwyzC4%2Fko%2BqYerTA9rvV61HnylIgqa8Hr4F%2BYWOIpqDQAA)
- subdomain (host=shop): [Test storeoncloud.com/email example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALHiomoC%2F%2B1Wa2%2FaSBT9K6ORom1VTGxweLhCahrSNo1IIkK6XaURGsYDjGrPuDNjHhuxv33v2AYMJdp%2BWKmtlC8hnrmvc%2B65137EhsVJRAzDwSNOlJzxkKmLEAdYG6mYFDSSaVilMsaVzf0VicEe3xrJoyWca6ZmnLLMjcWER9uzwvTcnqJPTPExp8RwKVCfUalCDaYzpjSc4KBWwZGcyDsVgcvUmEQHx8fz%2Bbyqs0y2imMeT46tUVXPJuAbMk0VT0zmj8%2BkGPNJqhiScwFRpzypoNubdxXUvbzooRdnV6e985eIiBB1e6f9M6TyItBYKpRVjubcTFGODMVEkAkLUQ%2F%2BCiPRVGrDxaRqayaKk1HEujv5r%2F%2B8Ou%2Fffri4CZCZMmSYIML8oZFlGFLE6O7uopsls9fDHNa2VjT4PEAvgGA%2Bg6yWQaYcDYy%2FrOYAuEYEjfkCbjMoCIqykfSUKDjbpPnKluhLWnM9HwmJEoiSl4LWZVsIeino20jSrzgYk0iz%2FOQmHV2yZVcCGeKwCqxVn4UcuDNlu6JDFRLGXJRaVtmPsbXYD20J7rNvKcQON1UVPcLB%2FSM2y8TKCXgqrOGhoNGKgRiyqcWZWbUtO0ebphyBiTGgrXrDdeHfhbF6iTg1PWLoFDrbk6ENf6MYkIwPmhR3%2B1nwqrKpDgTX25b3xlKWjPtpxAAD5gA4DVlgxVYiqeyftXYboDAahhnX0Fo7iZILowfy0HU5aglwKcEufWFMFN2yN%2Btko%2BG9RknnW0oUyIYL9hqplHRs0UYGmcebozzjERhS0%2FFc93%2Bld10GmDGtYfw4sVvhWpwmCTR79bCq4L%2BlYMOtPB4Aw1qPbEFgr7GSrixVU5nA00TJNBnytU8CGGNt99%2Fa%2B37H%2FWHtf58HgOeNpOyh67UZZSfEIY02cZr1Rstp0brneC2v6TLaap2MKLbl8okAxQ81%2FBIDSwoHRqUg8DiNDB%2BSOdkehXRILE5Ap%2BEW0uyLX%2BSLtRB%2FtYB2cAJ%2BqMCd3g1DavngdqE3aLNRa9WIUyfthuP77bpDvFHNaTdcf%2BSPm%2F5JzSu9G556dxx6R%2By2pdzm02hOlhqvvhNtAXsX7qwDA%2BahJ0YL%2FUOiaI0P4P2i%2BNZTv0b4%2FVgfaPF%2Fj%2F1v0Mx8A1X3e%2FqDa6g0qk9sop9OwGZprR4qsHGeR%2Fl5lJ9H%2BbcfZfgO0AQ%2B1IfE2tbcWsNx247nDrxm4NYC36t69XbLbb1y3SDHwbTJKXmEr4HydwAezRexRydEh%2B8Xg7vL961b76P%2FLnoVff6kw4%2FX09gz%2FvzaH7j6L%2FjU%2FBcA%2Bywrtg0AAA%3D%3D)
