### PR TITLE
Esmolt, 2 templates

### DIFF
--- a/esmolt.com.website-apex.json
+++ b/esmolt.com.website-apex.json
@@ -1,0 +1,19 @@
+{
+  "providerId": "esmolt.com",
+  "providerName": "Esmolt",
+  "serviceId": "website-apex",
+  "serviceName": "Esmolt Website",
+  "version": 1,
+  "description": "Connects an apex domain to an Esmolt website.",
+  "variableDescription": "%target%: exact IPv4 routing target issued by Esmolt's hosting provider",
+  "syncPubKeyDomain": "esmolt.com",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}

--- a/esmolt.com.website-cname.json
+++ b/esmolt.com.website-cname.json
@@ -1,0 +1,20 @@
+{
+  "providerId": "esmolt.com",
+  "providerName": "Esmolt",
+  "serviceId": "website-cname",
+  "serviceName": "Esmolt Website",
+  "version": 1,
+  "description": "Connects a subdomain to an Esmolt website.",
+  "variableDescription": "%target%: exact CNAME routing target issued by Esmolt's hosting provider",
+  "syncPubKeyDomain": "esmolt.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "%target%",
+      "ttl": 3600,
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two signed Domain Connect templates for Esmolt websites:

- `website-apex` connects a zone apex with the exact IPv4 target returned by
  Esmolt's hosting provider.
- `website-cname` connects the protocol `host` with the exact CNAME target
  returned by Esmolt's hosting provider.

Both templates contain one routing record, require signed synchronous requests
through `syncPubKeyDomain`, and leave ownership, mail, certificate and unrelated
DNS records outside their scope.

The `target` variable necessarily occupies the complete record value because
the authoritative target is selected dynamically by the hosting provider for
the exact customer domain. Esmolt constrains this input before signing, and its
Domain Connect runtime admits only reviewed DNS-provider IDs and exact HTTPS
origins.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template
      behavior to not be backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] Resource URL provided with `logoUrl` is actually served by a webserver —
      not applicable because neither template declares `logoUrl`

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in
      the synchronous flow — not applicable because Esmolt does not request a
      redirect URI
- [x] No TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique —
      not applicable because the templates contain no TXT records
- [x] No variable is used as a bare full record value unless necessary —
      `%target%` is necessary and justified in the description above
- [x] No bare variable is used as the full `host` label
- [x] No variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on the routing records

## Online Editor test results

Editor test links:

- [Test esmolt.com/website-apex example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE76omoC%2F9VSa2%2BbMBT9K5alah8GyBAECdKkVUundo%2B007J2bRQhY25Ta2Az25CkUf777DyaZJv2fZ8w93HuOefeFTZQNxU1gLMVbpTseAnqqsQZBl3LygRM1th7yYxobSvxxSZn4xpUxxlsGuZQaG7Apw0sDqmTDnS3rbHpDpTmUuAs9HAJminemM0%2FfieFAGY0ogI5LFTKmnKBjHSRHdBuWOCQqOK0qGB4gnJmqJqBOcsQLCgz6Oqmi5GSreFihrY5xLVuoUTFcof6SqMnqTcVe8FOyFKwm7b4CMvhhsjv3ihgUpUaZ5MVNsvGqT23YYdkn2%2Bde5ILo8fyiJaNGlPhrJcQ4lk8DcJwagP4Wpw3TbXE6%2Bnaw89SQH4YMLVevXBYULs52JHYTbOvmRXZ5Hxf31BFa%2B22u%2B%2BcnLRO970T7N5beu4vHEQBCaIgxI4InwmpINf2S02rrEijWvBw3VaG53ROD6GS5dQpsLy1zVqsU2PE9iKcMSU11D4Po05cyUvmeHN3XL0wLmOSFn6f9SM%2FLgrwB72476cQhwWBx0ERpkd3%2BucF%2F%2BNSD979dQ%2FrqWeN%2FN812N1q2kGZU1cXkSjxycAPyTjsZ3Evi5IgiZM0Sl4TkhHiRIA2W20ru%2F%2FjzeNb04w%2BpY%2Ft3efhQxx%2Fv%2B7B4uny9nL88Jyy91%2FvL%2B6bHx9m3%2BY%2FR%2FGXN3j9C9oysuFkBAAA)
- [Test esmolt.com/website-apex example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANf8omoC%2F91SYW%2BbMBD9K8hStQ8FZgiQgjRp1boP3bQtraK1UhQhg2%2BpO7CZbUiyKP99diBN2Kb9gH2Ce3f37r3z7ZCGuqmIBpTtUCNFxyjIW4oyBKoWlfZLUSP3JfOZ1KYSvT%2FkDK5AdqyEQ8MaCsU0eKSBzSk16nAe%2BhqT7kAqJjjKAhdRUKVkjT7E6J3gHEqtHMIdy%2BVQURPGHS0sMhANw3zLRCQjRQU3I5YLTeQK9EXmwIaU2rmddZEjRasZXzl9zmFKtUCdYjuwvlLOk1CHiqNha2TLy1lbfITtzUHI77uRUApJFcoWO6S3jXV7bWDLZH7f2u0JxrWaizNZBtW6Qtkkwdg1fAq4ZsQA6Au%2Fbppqi%2FbLvYt%2BCg75acDS7OpFw4aYl4NBxDBNPYnGRCtjtMnZsachktTKvvCxezFqXx77Fz2BiXuZFgnS0Md%2B6AfICmIrLiTkynyJbqUxq2ULLqrbSrOcrMkJomVOrBOjX5ms4RoviPeXMUimRBMTnaaNFpTT0spn9s7isiA0jRIvhQJ70QRPvQKS2AvSuAzCybdpEkZnJ%2FvnMf%2FjaMdr%2FOuz7Jeu2el%2FYsW8tCId0JzY2hCHiYdTL8Dz4CqLoyyI%2Fas4nITTS4wzjK0RULr3tzPXcH4HiL%2Be4VX8YR137d118JXV3x9TGn26n1%2FOn3%2BIsHzkD0HyLHRxf%2FcG7X8B%2FrGNwnoEAAA%3D)
- [Test esmolt.com/website-cname example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAB%2F6omoC%2F91S7W7aMBR9FctStR9LkEkoJZEmjRU0VSttVZVuGkKRY99SS4md2Q6FId59dgIU1moPsF%2FW%2FTjX95x7NthCWRXUAk43uNJqKTjoK45TDKZUhe0wVeLgULmhpevE46bm8gb0UjBoAC%2BQG2EhZNI3HWonEPS9bXLlJWgjlMRpN8AcDNOisk2ML5WUwKxBFJk656qkQiKrEJVoN2X3VcePoVrQvIDRyYgzS%2FUC7FmKYEWZRZc3w8kYaVVbIReoLSJhTA0c5evd2A8GPSvTdOz5ehprye7q%2FBusR80mf0vjIffwqxYanApW1xBgDUxpbnA622C7rjz%2FZoNduws%2Fe1GVkNY8qKN9XdbaAqdxn5DA%2FWNAWkFdAt%2FKYVUVa7ydbwP8W0nIXj%2BZOwUPu62oOygcLeeS5llVLlo4AapM7DEV1bQ0%2FvB79OwEPt%2FjZ%2B0AF7dr%2Bkxz5Y47IoMi5NK0CLebWEilITPupbbWsNekrAsrMvpCX1OcZdSTclSMq7qxb%2FWSrX12DDi11EXvfn4iXcaZJya8MeMoSpKkF4UxxE9h74L2w0GeszCm0VOfQMRhEB95%2FK37%2F%2BXyU4Xfvdh2Hji5%2F1NqzhSGLoFn1PdGJOqHJAm75KE7SHtRGiedOCG98%2BQjISkhngkY23LdOLcc%2BwRfnA%2FM9HFsu%2BJu%2BGU4nRQw6avpWP14XEYjstLknl%2F3Brdfr39efcLbP2nLPFC8BAAA)
