### PR TITLE
update Loot OS storefront: DKIM CNAMEs move under mail. (version 2)

### DIFF
--- a/lootos.com.storefront.json
+++ b/lootos.com.storefront.json
@@ -3,10 +3,10 @@
   "providerName": "Loot OS",
   "serviceId": "storefront",
   "serviceName": "Loot OS storefront",
-  "version": 1,
+  "version": 2,
   "logoUrl": "https://lootos.com/domain-connect/logo.svg",
-  "description": "Points a hostname at your Loot OS hosted storefront and lets its sign-in emails come from no-reply@ that hostname. The certificate is issued and renewed automatically once the records resolve.",
-  "variableDescription": "%target% is the storefront edge hostname the CNAME points at (cdn.lootos.com in production). %endpoint% is the CloudFront routing endpoint behind it, which the _cf-challenge record names so CloudFront can confirm the hostname is meant for this storefront. %dkim1%, %dkim2% and %dkim3% are the Amazon SES Easy DKIM tokens issued for the hostname; the three CNAMEs let sign-in emails be signed as no-reply@ the hostname. Every request is signed; the DNS provider verifies the signature against _dck1.lootos.com.",
+  "description": "Points a hostname at your Loot OS hosted storefront and lets its sign-in emails come from no-reply@mail. that hostname. The certificate is issued and renewed automatically once the records resolve.",
+  "variableDescription": "%target% is the storefront edge hostname the CNAME points at (cdn.lootos.com in production). %endpoint% is the CloudFront routing endpoint behind it, which the _cf-challenge record names so CloudFront can confirm the hostname is meant for this storefront. %dkim1%, %dkim2% and %dkim3% are the Amazon SES Easy DKIM tokens issued for mail. the hostname; the three CNAMEs, under that mail. subdomain, let sign-in emails be signed as no-reply@mail. the hostname and leave any mail already on the hostname untouched. Every request is signed; the DNS provider verifies the signature against _dck1.lootos.com.",
   "syncBlock": false,
   "syncPubKeyDomain": "lootos.com",
   "syncRedirectDomain": "lootos.com,lootmonsters.com",
@@ -27,19 +27,19 @@
     },
     {
       "type": "CNAME",
-      "host": "%dkim1%._domainkey",
+      "host": "%dkim1%._domainkey.mail",
       "pointsTo": "%dkim1%.dkim.amazonses.com",
       "ttl": 300
     },
     {
       "type": "CNAME",
-      "host": "%dkim2%._domainkey",
+      "host": "%dkim2%._domainkey.mail",
       "pointsTo": "%dkim2%.dkim.amazonses.com",
       "ttl": 300
     },
     {
       "type": "CNAME",
-      "host": "%dkim3%._domainkey",
+      "host": "%dkim3%._domainkey.mail",
       "pointsTo": "%dkim3%.dkim.amazonses.com",
       "ttl": 300
     }


### PR DESCRIPTION
# Description

Updates `lootos.com.storefront.json` to version 2. The three Amazon SES Easy DKIM CNAMEs move from `%dkimN%._domainkey` (on the storefront hostname itself) to `%dkimN%._domainkey.mail`, and the storefront's sign-in emails now come from `no-reply@mail.<hostname>` instead of `no-reply@<hostname>`. The description and variable description say so; nothing else changes (records for the storefront CNAME and the `_cf-challenge` TXT are identical to version 1).

Reason: version 1 put the DKIM selectors under the hostname's own `_domainkey`, which is where a customer's existing mail on that hostname keeps its selectors. Scoping the sender to the `mail.` subdomain keeps Loot OS records away from whatever mail the customer already runs. Records applied from version 1 are plain CNAMEs to `*.dkim.amazonses.com` and stay harmless; the version bump makes providers refetch the template.

## Type of change

Please mark options that are relevant.

- [ ] New template
- [x] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Comments (unchanged from #1749):
- Bare variable value: the `_cf-challenge` TXT carries `%endpoint%` on its own because CloudFront prescribes the exact record content (the distribution's routing endpoint) for its hostname ownership check; a prefix would make the check fail. It is scoped by its fixed `_cf-challenge` label and `txtConflictMatchingMode: All`, so a stale value from an earlier attempt is replaced rather than accumulated.
- `essential`: not set on any record on purpose. All five records are required as-is for the storefront and its sender to work; there is none a user would need to edit independently.
- The DKIM `host` values keep their fixed `._domainkey.mail` suffix; the variable is still only the selector.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->

[Test lootos.com/storefront example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPsCo2oC%2F%2B1XbW%2FbNhD%2BK4SAABtmK3rx%2BzCgWeK2QZe0a9JhaBAYNHm2GEukIlJO1CD%2FfUfJsmUnqwvsywLkg2FK98Z77rkj9eAYSNKYGnBGD06aqaXgkJ1yZ%2BTEShmlXaYSp7WWnNMENZ0%2FUEY%2BXqBAQ7YUDEoLbVQGs0xJsxFsG5AtlSVkWijpjIIWRpurL1mMqpExqR4dHm7iH3KVUCHbTEkJzBxaXVcv5%2BiCg2aZSE3pxvmkhDSaUBIpbSRGJtSQQuUZqeNbAfDGNgiVnMSAVgJ%2FWsxlW0gCGC%2FWBGMDQbWESNXOII2LN1bgEhOh4zqISy4jIAwyI2aCIZREoDetcwxkvWcg4c6uc4N5GFSJ44IoyQD9AIqZyrjGf63iJbgWGJoJOo3hZCu7A0OzOZgD694aNpIAPodN0lZ4fH50NibpChBDfmJcuhtICSaJNeU5s85%2FdskBSF5qr90fxyrnb0v3mcqNkHNS65ApRAIzE6ZF7iLBotJgwmZtFmFyIOd1WsRuCHFVTXeMSoRWzkSWlIbrjWPkBChqzFSGEnzc5Ihb5AuR%2BAetahEclOCW6xDXWZX3UUK%2FKUkuxhdkTHVBTj6cnhGjFiDXNbHO6zJugv9aPpkogxV4ukVyiZSvil0Z6HxacbFlObNLlymUb2yp9VPGNPKsOEeXdlWUrgmNM6Dc0mJbNZdG5SwC7pIx9kuBuN7moI3FqgpWbfzk%2FILUTUpQEakIK5qgFjU54kPnuHM0nXC28BtksJTThWS%2Fx4otnNGMxhqqN5%2Fy6QcoTsqUd0eClX8GLrDQ5hmNll0mCuNhl69MbFafcf9og%2FPCZDmGWdHfGV09OKZI7bAo4V%2Bp4%2BMbO39KIl%2BqRhvgW2NwYISe99ha217%2Bfbmx3GKknRbUUOthzfWGD1zdm2NkZSyYOaOGIcPnZ4pbp0dx7DRi7OxvxUt3UlFjAYVrS7qz65WS%2FXNpSVINNS7P5PFcjOBHYgT%2FLUb4IzHCfTGuH1sOSmCyqe41wl%2BzBO4pHjrQYIU9PSKV4tMch006EbVNSjOaaHs41dZXW%2BbXtf1V5QCfK37YN9szz8rqylsp92kwDVmHd6E367vMDqhq1Eg0t%2Fu1JbOa1J8GLOQd6M568340EMMbb%2BHHQRLKjuqmvVo5sMq3%2FWygh8bL%2FWVwF953iu63Hu1PB2zIPfBnQa0cWuV5GHVE96a36MeDZCg95afBbZh1dNf08v5y4FgksYFxCk7WjVy3TpLHRkzoHd284mxCU5w6CLxGKYZ42layOpJXeK96YgeqZl%2FguLD4C3vE%2Bz1%2FxsOZ14aO3213go7fpl0%2FaHdDj1HeHfRo2G9cF55eJP71vrDNAtAapBE0LrvvjhbaeXzS5atEtrrc3U7r%2BzX%2Bn2e5U7B9LNxt3B0o9pp%2Ft6VfAkD7Om8PQHvNXzxA%2B6bNHoD2mr8UgK5beLS8DsbXwfg6GF8H4%2BtgbAxGvJtq%2FC7lE2pVAy%2Fotb1h2%2Fcu%2FeEo8EZB3%2FX7g2G%2F%2B4vnjTzPJoHfohUKD3hTbd5RnVyeDiPvY3FWXCyi8dfx19vTm%2BLdW310JMb9L3%2Bem%2F674jx%2Br%2F8aLH5zHv8BCqU2zIoSAAA%3D)
