### PR TITLE
Add Adway career site template

### DIFF
--- a/adway.ai.career-site.json
+++ b/adway.ai.career-site.json
@@ -1,0 +1,14 @@
+{
+  "providerId": "adway.ai",
+  "providerName": "Adway",
+  "serviceId": "career-site",
+  "serviceName": "Adway career site",
+  "version": 1,
+  "logoUrl": "https://app-dev.adway.ai/adway-icon-light.svg",
+  "description": "Connect a subdomain to your Adway career site.",
+  "syncPubKeyDomain": "domainconnect-keys.adway.ai",
+  "hostRequired": true,
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "ssl.adway.ai", "ttl": 300 }
+  ]
+}


### PR DESCRIPTION
# Description

Add Adway career sites. The domain owner selects a subdomain (for example careers.example.com), which receives one CNAME pointing to ssl.adway.ai. Connecting DNS does not publish the site. Our synchronous integration signs requests with RSA-SHA256 and does not collect customer DNS credentials or use a redirect URI.

Public verification key: `kdev20260910.domainconnect-keys.adway.ai` (two TXT fragments, RS256). Public DNS reconstruction and signature verification passed. Cloudflare onboarding will follow template review; a real-provider consent flow has not yet been enabled or tested.

## Type of change

- [x] New template
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit): Check template and Test apply template.
- [x] Template file name follows `<providerId>.<serviceId>.json`.
- [x] `logoUrl` is served by a webserver: HTTP 200, image/svg+xml.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set.
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`.
- [x] `syncRedirectDomain` is set whenever `redirect_uri` is used: not applicable, no redirect URI.
- [x] No TXT record contains SPF content: no TXT records in this template.
- [x] `txtConflictMatchingMode` for unique TXT records: not applicable, no TXT records.
- [x] No variable is used as a bare full record value.
- [x] No bare variable is used as the full host label.
- [x] No variable is used in the host field to create a subdomain; the standard host parameter is used.
- [x] `%host%` does not appear explicitly in any host attribute.
- [x] `essential: OnApply` for records the end user can modify without breaking the service: not applicable, the sole CNAME is required for routing.

## Online Editor test results

The subdomain test produces `careers.example.com. CNAME ssl.adway.ai`, TTL 300. Apex test is not applicable because `hostRequired` is true.

[Test adway.ai/career-site example.com/careers](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAHoOo2oC%2F91S2W7bMBD8FYGv0eUjsi2gQF33cpsGTuIERQ1DoMmNTUQiVZKSqxr%2B964sX62RH%2BiTxN3hcGZ3NsRClqfUAok3JNeqFBz0mJOYUL6mlU8FcY%2F1W5ohjgzrDpYN6FIw2KEZ1QDaMwKZjp1zvNMgnD2iBG2EkiRuuSRVS%2FWoU0SurM1NHAQ0zz0OpX%2FQEOx%2BPMGU9FKxXFnflEtk4WCYFrndMZGRkhKYdahjigVXGRXSscqpVKGdCw1%2BLbOSbFIsvkL1fodGjuYaa5i8F6iMfzaIlTL2Hn4WQgOatroAl2hgSnND4tmG2CqvDY9uh98%2B7OF4fFuPUAlpzVTh0Zj0nNNadN4Jw%2B1865LfSkJyYpy7e0F4DX5R3BT4TGUn6saQwcJSqyJPxOFaTjXNTL3UA8HsL4b5gWJ25KjfF0upNCQGv9QWGg4msyK1IqFreipxluCa0grlGuwi0%2BUAZBOAk0pOLX19BC5JOKs1izpSXQhbUWdBvef%2BM%2FO6i961RzudyBvwfitqsV6PL%2BhZOP8N7evpvJgdGAPSClpHcJgigyHb7dzFOf5nlnDrhpbAE1qj22E78sKB1wqn7TAOB6jX73Sjbv%2F6KsRzWNsAYxuDG0zHeS7I8Kk3Cu7uVvYmmkwnTy%2FvuIxGV58D0P2bj5NP7e54%2FPDje6C%2FPK7fkO0f22y0gWkEAAA%3D)
