### PR TITLE
Add ScaleNodes web service template

### DIFF
--- a/scalenodes.com.web-service.json
+++ b/scalenodes.com.web-service.json
@@ -1,0 +1,17 @@
+{
+  "providerId": "scalenodes.com",
+  "providerName": "ScaleNodes",
+  "serviceId": "web-service",
+  "serviceName": "ScaleNodes Web Service",
+  "version": 1,
+  "logoUrl": "https://cloud.scalenodes.com/logo.svg",
+  "description": "Connect a customer hostname to its ScaleNodes web service.",
+  "variableDescription": "target is the unique service label assigned by ScaleNodes, without the .scalenodes.app suffix.",
+  "syncBlock": false,
+  "syncRedirectDomain": "scalenodes.com",
+  "syncPubKeyDomain": "domainconnect.scalenodes.com",
+  "hostRequired": true,
+  "records": [
+    { "type": "CNAME", "host": "@", "pointsTo": "%target%.scalenodes.app", "ttl": 300, "essential": "OnApply" }
+  ]
+}


### PR DESCRIPTION
# Description

Add a signed synchronous Domain Connect template for ScaleNodes customer web services. It creates a CNAME to a service-specific label beneath the fixed `scalenodes.app` suffix. Intended initial DNS provider: Cloudflare, with DNS-only records.

`hostRequired: true` satisfies the standard schema for a CNAME at `@`. Cloudflare ignores this property and supports apex flattening; apex and nested hostname behavior must still be validated during provider onboarding.

## Type of change

- [x] New template

# How Has This Been Tested?

- [x] Template functionality checked using Online Editor
- [x] Template filename follows `<providerId>.<serviceId>.json`
- [x] `logoUrl` is publicly served over HTTPS as SVG

The official linter passed with `-loglevel error -tolerate info -logos -cloudflare`, and the current upstream JSON schema validation passed. Application tests cover signature construction, nested host labels, target restrictions, and unavailable provider templates.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set
- [x] No TXT/SPF records or TXT conflict policies apply
- [x] No bare variable is used as a full record value or host label
- [x] Host scoping uses the apply request `host` parameter
- [x] `%host%` is not embedded in record attributes
- [x] `essential` is set to `OnApply`

## Online Editor test results

Online Editor check accepted the template. With `domain=example.com`, `host=shop.api`, and `target=scalenodes-domainconnect-test`, the apply preview produced `shop.api.example.com. CNAME scalenodes-domainconnect-test.scalenodes.app` with TTL 300.

[Reproduce nested-host test](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGYno2oC%2F%2BVT227aQBD9ldVKfapNbANpsFSpuVCpl9AoSZWHCFlr7wCr2LvOXiAU8e%2Bd5WoK7Q%2F0zZ45c%2FbMnJkFtVDVJbNA0wWttZoKDvoLpyk1BStBKg6mVaiKBrvsgFWIpg8%2BP%2FB5zBnQU1HAqnAGebj532eOisgT5ORhB5uCNkJJmsYBLdVY%2FdQlwifW1iY9OytK5XjrUNGZh7XMdIzVGCq0qO2KgV4rKaGwhJHCGasq0GSijJUogVhFhDWkoQPlko3IlhfCtGB5CTcHlJbpMVgiDLETIE6KVwfbKlKyHErCjBFjCZzk8wZ9QGbCTpSzq8JmC6yuiXGjkXjzz5q5LK5KVbzQdMRKA%2BvIPXChsZUbVTEhT5niUXcu%2FwbzHYavPor1EFpHFX4U9%2FDqkBjdstrhW%2FiG0tzQ9HlB7bz2Tl0PLm%2F7Gzj%2BfvILoIS05lHh77v1QN790RCCrEXj2lEUUDAGpBXMG%2FlDXtZ1OafL4TKgv5SEbP%2FkMNhIRhy8MVxHaEj1TU9UjewCI2OtXJ2JbV3NNKuMX90tw%2FMBxXDL8bwnwdha%2FCq6kx8ejC20gGVeLHqqNGTeW2adhu3IKldakbEZ24d4kTHfJfZmMIv8x%2BOU6ztotMSZZQfOnlDyrzFnvPADEP70LpI25AkkYX4et8PO%2BYiFjPN22It53sl7ozzqRo1LPn3nf7%2FlYz9OerwcBmjO%2F9o77pdhU%2BAZ8%2FgkSs7DqBfG0WMSp91u2o1a7U4Ut3vvoyiNvCLf5HoQC9y35qbRLrOyb0wnkZ%2Bvbr%2FmNxf9u9tJNIti6%2FqvH7733Ozikg1q93T98pEufwPaurPszQUAAA%3D%3D)

The generic editor rejects an empty host with `Template requires a host name`, as expected from `hostRequired: true`. Cloudflare ignores this template field; its apex flattening behavior requires validation during Cloudflare onboarding. No live customer DNS was changed.

The public signing key is published at `production-v1.domainconnect.scalenodes.com`. No private signing key is included. Production automatic connection remains disabled pending template acceptance, Cloudflare onboarding, and end-to-end verification.
