### PR TITLE
Add SparkOS, SparkOS website (sparkos.site.json)

### DIFF
--- a/sparkos.site.json
+++ b/sparkos.site.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "sparkos",
+  "providerName": "SparkOS",
+  "serviceId": "site",
+  "serviceName": "SparkOS website",
+  "version": 1,
+  "hostRequired": true,
+  "syncPubKeyDomain": "thesparkos.io",
+  "syncRedirectDomain": "sparkhostapp.com",
+  "logoUrl": "https://sparkhostapp.com/logo.png",
+  "description": "Point a subdomain of your domain (for example www.yourdomain.com or stay.yourdomain.com) at the website SparkOS publishes for you: one CNAME to SparkOS's edge, plus one TXT that proves you own the hostname so the SSL certificate is issued automatically. Nothing is added at the apex and no other record is changed.",
+  "variableDescription": "%ownership% - the hostname ownership token issued when the website is connected in SparkOS (published as the _cf-custom-hostname TXT under the chosen subdomain; one token per hostname).",
+  "records": [
+    {
+      "groupId": "routing",
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "sites.connectsparkos.com",
+      "ttl": 3600
+    },
+    {
+      "groupId": "ownership",
+      "type": "TXT",
+      "host": "_cf-custom-hostname",
+      "data": "%ownership%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template `sparkos.site.json`: points a subdomain of the customer's domain at the website SparkOS publishes for them. Two records under the chosen host (`www`, `stay`, ...): a CNAME to the SparkOS edge (`sites.connectsparkos.com`) and a TXT (`_cf-custom-hostname`) carrying the hostname-ownership token, so the TLS certificate is issued automatically. Nothing is added at the apex and no existing record is changed.

`hostRequired: true`: the template is always applied with a `host` parameter. Apex domains are deliberately out of scope (they would need a CNAME at the apex); SparkOS keeps those on a manual path.

Companion to the already merged `sparkos.email.json` (#1774): same provider, same `syncPubKeyDomain` and `syncRedirectDomain`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`thesparkos.io`; the public key is published at `_dck1.thesparkos.io`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`sparkhostapp.com`; the synchronous flow uses `redirect_uri`)
- [x] no TXT record contains SPF content
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label (`_cf-custom-hostname` uses `All`: exactly one ownership token per hostname)
- [x] no variable is used as a bare full record value unless necessary. **Justification:** the `_cf-custom-hostname` TXT is read by the CDN that terminates TLS for the hostname, and it compares the record value against the token it issued, byte for byte. A fixed prefix would break verification, so `%ownership%` has to be the whole value.
- [x] no bare variable is used as the full `host` label (both hosts are fixed: `@` and `_cf-custom-hostname`)
- [x] no variable is used in the `host` field to create a subdomain (the subdomain comes from the `host` parameter)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` / `OnApply`: not applicable. Both records are required for the service to work, and removing either takes the website offline.

## Online Editor test results

**Editor test link(s):**

[Test sparkos/site example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAJ8xo2oC%2F%2B1UbW%2FbNhD%2BKwSBYi1iKbLsOJOKAivSdus6p0GcFQWCwKDIk01EJjWSiqME%2Fu876sWOggDbxw4YYMAi77mX5547PlIHm7JgDmj6SEuj76QA81nQlNqSmVtt6Wh%2Ffc42CKMLb%2Fi6QIMFcyc5tHCJMfZXQyjZQtbZ78BYqRVNxyO61tZdwl%2BVNIARnKkA%2FWvFL6rsC9Qf9IZJBFK3hq6WUGraQi5BoBd3e1CD8AFZWYZcbxBX6JX%2B0xRoXDtX2vT4%2BDno2EPCUq0QLcByI0vXFEcvtFSOMGKrTDQpiM5JrStDuuPrXBsC9wybB2S73Ybe2Np8ZIJWTFM%2Fu35DmCPIp28I6RtUVlkhLRIlPi46pUQrIGfn7%2BcfidM97idLQKxgRMqisg3i6vsVBsSoXiR0R1eit6pJ4pkqFIJY3ZwXiz8IB%2BNkLjkqTqTFn61AEFY5rNHhdVHUITnXbi3VygOYEN7eVs1KuCdMCaI0QQgYghpoIzyQr5lagQi9xsxIlhXwYdDSV1gWir%2BW5SsSDOvbW5DqLai%2Bqu0a1KBbPo1WCnVHK4rQd%2B913z6s1DYeS54HvLLIKthn8a2qFM5xg%2BB4j%2BH3Ar9t2tnmLxHTu73xjFqalqbXj3RldFU2I48fTjbD4%2BrSj3sjF20HG4%2B%2F%2BN3xg2SvdLchNuwI9BPdjqpzOKaTWRTtRk8T7PtySIEkDgleYOknmTk27PfTDPh57860ygvJ3Zw57pWea%2BGDvy8KurvZjegD9mJ5IH2DQftF62a%2BK7wrBBcAD03hS9m7IEO2sf5d6Z2vB943vft144%2FHA1%2B8G7M4m%2FCpOIFZfsp%2BzhIeiTHE%2BYRNsxM%2BE9QXKldKG1ha%2FGeuMtA%2FI5uqcHLJtuxwJfgS176okZdFK6ZAMZ8Jp9pnq6XT9fHfyDaiS8E9U%2BllE5DNEpZPAzYRSTBNplGQRUkWnOYcTSJh01g8eVafvbYvPKqDLoPFuXWSFY1gW1ZbuvNjMxiQjsgLAxIOyP1jk38kkjcjHKv%2FRfuPiYZ7bdkdiCXzyDiKZ0GUBOPoKo7TSZLGp%2BH49GQ8PjmKojSKfO1gXcv0ETf86W7T5PPD9DLT0RGyPDbf54uzb0fq0xeZfBWmin%2F%2FmE%2Fq6cWn219%2Fe5i%2Fo7u%2FAUXfVzvdCAAA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
