### PR TITLE
Add looops.ai.website.json

### DIFF
--- a/looops.ai.website.json
+++ b/looops.ai.website.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "looops.ai",
+  "providerName": "Looops",
+  "serviceId": "website",
+  "serviceName": "Looops Website",
+  "version": 2,
+  "logoUrl": "https://looops.ai/logo-domainconnect.svg",
+  "description": "Connect your domain to your Looops website (www serves the site; the bare domain redirects to www)",
+  "syncPubKeyDomain": "looops.ai",
+  "syncRedirectDomain": "looops.ai, looops.app",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "connect.looops.site",
+      "ttl": 300
+    },
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "34.233.43.155",
+      "ttl": 300
+    }
+  ]
+}

--- a/looops.ai.website.json
+++ b/looops.ai.website.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://looops.ai/logo-domainconnect.svg",
   "description": "Connect your domain to your Looops website (www serves the site; the bare domain redirects to www)",
   "syncPubKeyDomain": "looops.ai",
-  "syncRedirectDomain": "looops.ai, looops.app",
+  "syncRedirectDomain": "looops.ai,looops.app",
   "records": [
     {
       "type": "CNAME",

--- a/looops.ai.website.json
+++ b/looops.ai.website.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://looops.ai/logo-domainconnect.svg",
   "description": "Connect your domain to your Looops website (www serves the site; the bare domain redirects to www)",
   "syncPubKeyDomain": "looops.ai",
-  "syncRedirectDomain": "looops.ai,looops.app",
+  "syncRedirectDomain": "looops.ai, looops.app",
   "records": [
     {
       "type": "CNAME",


### PR DESCRIPTION
# Description

New template for Looops (looops.ai), an AI website builder for small businesses. It connects a customer's domain to their Looops website: `www` points at our hosting endpoint (CNAME `connect.looops.site`), and the bare domain gets an A record to our redirect host, which answers with a permanent redirect to `www` (the site is served on `www`; the apex redirect host issues its own certificate per domain). Both hosts are fixed; the template uses no variables.

Public key for `syncPubKeyDomain` is published at `_dcpubkeyv1.looops.ai` (TXT). `logoUrl` is served from https://looops.ai/logo-domainconnect.svg.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

(The template has no TXT records and no variables, so the TXT and variable rules hold trivially.)

## Online Editor test results

**Editor test link(s):**

- Apex (no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAGQ%2Bo2oC%2F%2B1T32%2BbMBD%2BV5CfNgWIAyQlTJMatZM29YfWtVunRhEy4CTWAFPbCWNR%2FvedA4Sk2bTH7WFPmLvvvrv77m6DFM2KlCiKgg0qBF%2BzhIoPCQpQyjkvpE0YMveOW5IBEF3vXGCXVKxZTHf4kkaSAc%2FeegQ2HvfuNRWS8RwFjglJFvyzSAG2VKqQQb%2B%2FT9vXPivhGWF5zPOcxsqW6wUQJFTGghVqR4Iuap9R8ZUwariheP3b5G5KM16VZWno6qg01JIa2vhm94qIoG2woAkTwCg1DUS81i1VefxxFV3R6nIHeqGPdn9qwk4BptE%2BiwLAAOIikSiYbpCqCq3Rxe3k5h24llwqLWVZatE5y5V84GBo%2B294GiGVAuFcjLfmnmjSkZwfU7ie7biu7bn2YDg8DJ5tTfSD5zTs6pqBxm0XkmQxB8VtxjtueC0EXxUha%2FEFESSTeonayOlR6KyNnSKkM7JFzgUNJXyJWgmoXYkVNVG2ShULSUk6UxKHIFxaQYESvEBxKlxe71otXEIU%2BaNoJgqTWNfL9PImPhlHkR9Z0XjgW96cYss%2FO4stPJp7iT8ezPHYP7iDkwP59SF0alEpaa4Y0Zs%2BSUtSSbR9MbamhfOugd%2BN7B8ofWbC0P%2BP4a%2BPAc5KkjVNQqJhDnZGFh5bA%2FzguIHrBsORPRgNsT%2FqYRxgrIunUtV9beAKD%2B8PXT%2FfPcX3j%2FOeeMomksUce9%2FYndP78nyP82riXa6vrr9%2BJ8v30eIt2v4EjS2HoToGAAA%3D
- With host "test": https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAPs%2Fo2oC%2F%2B1Ty27bMBD8FYGnFpZk6uXEKgrUSYoiaBKkRZq0DgyBktY2UVsUSNqCavjfu7QlP%2BIWvebQk6jd2eHOcHdFNMzLGdNA4hUppVjyHOR1TmIyE0KUymWc2LvEHZsjkNxsUhhXIJc8gw2%2BglRx5NlFj8DW0y69BKm4KEjs23jJRHyTM4RNtS5V3O3uru2anJOLOeNFJooCMu2q5QQJclCZ5KXekJDLbc6qxUJaW7ilxfa3ubtpzXpTVZVlugNl6SlYJvhuc0qZhLZYQs4lMipDgxVvjaS6yO4X6WeorzagF%2F6Y9Nem7BRgW%2B2xLBGMICFzReLnFdF1aTy6vBvcfsTUVChtrKwqY7rghVYPAgOt%2FoanMVJrNC6gdG3viAZ7kg%2FHFEHo%2BkHghoHrRdFh8Whtk1%2BigGTf1wg9blUoNs8EOu5ysefWgB%2BbTKRYlAlva0om2VyZQWqrn4%2FKR23985bA3MwnhZCQKPwyvZCoQcsF2GS%2BmGmesIrtQ3mWoIGzGhtVmEWaUwOL7cyhgW7TY840%2B6eDNknyzDTOzST3ziGM%2Bmzs0NQbO6EP507aT88cP%2FQgg8hP%2FV5%2BsBQn2%2FLnrTi2DpSCQnNmRn8wq1ityPrFOzZajnX87RlfiYKRjYPw%2F1le3bPg6im2hDxhBupTv%2BfQvuPRBz%2BIQxpj3%2FQsikKvQ2lMqRGAbFttK9zSw%2F0kw%2FH36aeLm2rI687j8DqiT5fDH9XgUXnRxX3ZYWHw82rY7X7xrm7fk%2FVvjpuOsmIGAAA%3D
