### PR TITLE
add Calemander, Calemander Email Sending

### DIFF
--- a/calemander.com.email-sending.json
+++ b/calemander.com.email-sending.json
@@ -1,0 +1,35 @@
+{
+  "providerId": "calemander.com",
+  "providerName": "Calemander",
+  "serviceId": "email-sending",
+  "serviceName": "Calemander Email Sending",
+  "version": 1,
+  "logoUrl": "https://calemander.com/logo-120.png",
+  "description": "Send booking confirmations, reminders and cancellations from your own domain. Adds a return-path MX, an SPF include and a DKIM key under a fixed 'emailit' label, leaving the domain's own mail records untouched.",
+  "variableDescription": "%dkim%: the full DKIM TXT value minted per domain by the sending provider (v=DKIM1; k=rsa; p=...). It is issued when the domain is added in Calemander and cannot be pre-filled.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "calemander.com",
+  "syncRedirectDomain": "calemander.com",
+  "records": [
+    {
+      "type": "MX",
+      "host": "emailit",
+      "pointsTo": "feedback-smtp.ffdc-1.emailit.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "type": "SPFM",
+      "host": "emailit",
+      "spfRules": "include:_spf.emailit.com"
+    },
+    {
+      "type": "TXT",
+      "host": "emailit._domainkey",
+      "data": "%dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Calemander is a scheduling platform: businesses publish booking pages, and the platform sends the booking confirmations, reminders and cancellation notices that follow. This template sets up a customer's own domain as the sending domain for that mail, so those messages arrive from the customer's brand rather than ours. It writes three records under a fixed `emailit` label — a return-path MX, an SPF include and a DKIM key — and deliberately does not touch the domain's apex MX or SPF, so applying it cannot disturb the customer's existing mail. The DKIM value is the template's only variable; it is minted per domain by the sending provider when the domain is added, so it cannot be pre-filled.

The signing key is in place: `syncPubKeyDomain` is `calemander.com` and the RS256 public key is published as chunked TXT at `_dc1.calemander.com` (`p=1,a=RS256,d=…` / `p=2,d=…`). The template also passes `dc-template-linter -loglevel error -tolerate info -logos` with no findings.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Note on the bare-variable rule: `%dkim%` is the full value of the `emailit._domainkey` TXT record, with no fixed prefix. A DKIM record's content is prescribed by RFC 6376 — it begins `v=DKIM1;` and the key material follows — so a service-specific prefix cannot be added without making the record invalid. The label it sits under is fixed (`emailit._domainkey`, no variable), and `txtConflictMatchingMode: "All"` means a key rotation replaces the record rather than accumulating alongside it.

Note on `essential`: it is set on the DKIM TXT, which is the record most likely to be edited or replaced over the life of the domain. The MX and SPFM sit under the same fixed label and are not intended to be user-modified, so they are left without it.

## Online Editor test results

**Editor test link(s):**

- Apex (`example.com`, no host): [Test calemander.com/email-sending example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOVIo2oC%2F%2B1VW2%2FiOBT%2BK5alUXe1JA3XFkZ9CIUyTAsthXbpVBVyYge8OHEmdrhMxf72PQ6XwrZd7ctKO1IlJByf%2B3e%2Bc%2FyMNQtjQTTDtWccJ3LGKUvaFNewTwQLSQSfti9DnNtJuyQEbXy%2Bk4NMsWTGfZYZwi0XlmIR5dH4RfbKDDWNIurvFGcsUVxGuJbPYSHH8i4RYDDROla14%2BPDfI6NgpUvOHac2VKm%2FITHOrPHxifypJyCY%2BTLKOBJSIxM5VDCQm68KATOkE8inwmxFqIgkSFayjRBch4hKiHByEYupaAMhjpNIismeoI6wxyYo%2F7NBeKRL1LKMm8ENS7bHTRlS5RmJRIU8AWj6CgDhesjJIjHRA4JRmYmOT1hmzhHKguaYZIwXyYQNI20TP0Jo7aBhySceII1Dkr9RKc8%2FFTLHAWpEOsMBsMBmhGRMgTFakgghmTWcZC3zJQ3DULbtqJfZmfGNv8ZTc8SRT6j%2BMy27V9t1NaIK%2FipFBzNJyzay9pICKUggPNebzfYRlIjj0EMZgVciHUhahn5dSH9Ka4FRCi2vrlJvUu2bGRe36Kf0blllAM2%2Bn2tDXK49viM9TI2jOsM4X4ild5yk2vDZgnAqIGEy4Ax6hF%2FaqlQx3YQUN%2FK2xvNHfe5TLheAjedHNYaiFmsOM4qt4sCVOi8FUfFwW0qGGSEN0ypjeDuwP%2BeG2jcKy%2F2aI010MownWiy6zveSwaOC30OZBfc1x2i%2FQm0tyOpcesKAapMQdM1J2asriM3jsUSr55WOfxDRmz0At0TRNkizBYEFgTb4LBJDE7jRKbxiG%2F1Y5KQUJklsrV8PDB92to%2BYnM2yZvza8p12q2g4zqt8%2F73Vr%2FtFRu9Zt3t3bluqdV1G%2Bd13rusj3uN5tDt3Fw1L5sP9%2B7VXfPi%2BnbQ7A%2Fa3dZ19%2BohXyiWypWT06pDPJ%2ByYDzhf0xFGMn4e6J0Opsvlj%2Fc%2BnmjedH60v56edXpXt%2F0bvuDu%2Fvfhw%2FfnOrpSaVcKhbymwIO%2F3rthttz69jgxseRTNhIwT%2BB5QBI6yQFPoep0HxE5uTlivojYgAHmBVIofi%2FMTRa78cX5mwa%2FS%2FYuUeBQ6KOqG9aws1a9kiF%2BUVWtrzqCbVKrFi2Tk88xwpOysV8ADUXvMreln%2F7DfinPf%2FCjX2euWJOlgqvXnH8vXpnZzAeefTesKA%2FScblrGYo%2Baeq8s1J%2Foln4IB6%2F4M27Jba6ikHW%2Bljwj4m7GPC%2FqsJg2dckRmjI2L0Ck6hYjlVK58fOE4tf1orle1ytVh2Cr%2FBt%2BOYSpjS6448w9u5%2F2ri7rAf1ZtfSTFouaUwvnHJolKPSnetOPh2nwIH%2B2LRaxWr1dn8DK%2F%2BAjd17f62DAAA)
- Subdomain (`example.com`, host `booking`): [Test calemander.com/email-sending example.com/booking](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABJJo2oC%2F%2B1WW2%2FaSBT%2BKyNLVXZV7NhAuFV5MIFQSkwgkG4uitDYM4ZZxh7XMyYhEfvb94y5BDbp7j62UiUk8Lmf73znmBdD0SjhWFGj8WIkqVgwQtMuMRpGgDmNcAyPViAio7DT9nEE1sbZTg86SdMFC2juCFLGTUljwuLpq%2B6NG2prQzTaGS5oKpmIjYZTMLiYiuuUg8NMqUQ2jo8P6znWBqZTtK0k9yVUBilLVO5v6JjIF2IOgVEg4pClEdY6WUApjZiOIhEEQwGOA8r5WonCVERoKbIUiccYEQEFxhZyCQFjcFRZGpsJVjPk3RTAHY0G54jFAc8IzaNh1Op1PTSnS5TlLWIUsidK0FEOClNHiGOf8gLiFC90cWpGN3mOZJ40xySlgUghaRYrkQUzSiwND04Z9jltHbT6gcxZ9KGRBwozztcVjG%2FGaIF5RhE0q6CABIpZ50H%2BMjfeDAhtx4p%2BW5xqX%2BcTmp%2BmEn9CyallWb9bqKsQk%2FCRGQR6nNF4r2qtwYSAAn7vzXaDbSwU8inkoGbIOF83Ipdx0OQimBuNEHNJ15JB5vfospVHfY9%2B2uaKEgbYqO9bbZAzGvcvhlommnHeDchnQqotN5nSbBYAjBwLEIaUEh8Hc1NGKrHCkASmY20sd9xnImVqCdy0C4ZSQMxSxbZXhV0WoIL3Xh6ZhFcZp1CRsWFKYwKyg%2Fh7YWBwb6JYkzXWQCvNdKzwbu7GXjHw80mdAdk5C5SHVTCD8XqC6LAu52BKJQxdMazX6jJ2k4QvjdXDqmA8i5hOXqF7gCxbhOkThgNBNzhsCtusFgimqciSCdu6JTjFkdS3ZBvg%2FiDCwzbE%2FS6GTgataNFbAnrdTui5duds9K0z6vql1rDddIfXrlvu9N3WWZMNe83psNW%2Bcb3BRbvXvv3qXly3zy%2Bvxu3RuNvvXPYvbp1iqXxSqdbqNvYDQsPpjP0551Eskm%2BpVNni8Wn57DbPWu3zzuful96F178cDK9G4%2Buvf9zc3tn1WrVyUi4VnU0fh1%2FDbssduk1Do8imsUjpRMI3hlMBuKs0A3ZHGVdsgh%2Fxq4gEE6zhB9AlaKH5f%2FA1Xl%2FLLQNeAd%2BM%2F39wdo8Yh%2FSdkEBPiOljXS%2BR8kn1BJvVoIbNcuA7Zt2pFc2wXi0SQI0Ua%2Fbe7X%2F%2FzfBv1%2F8NY%2FZJ6PJHvJTG6s0C%2FFf7i1PYIQd9b6PQXzgnfA4BIPBTNv269e%2F1%2F9NuygExf5yp7O7h6qEAl%2BzXOv5ax1%2Fr%2BEOsI%2FxBkHhByQRr86JdrJh23XScsW03nHqjZFulWsU%2BqXyEZ1uXpKhU68G8wFt5%2F31sPNvjZrnTvvvcHwzk8Lpb88udXu%2B5c35Znn5kdx276vbLMCrb906N1d81AEf7Hg0AAA%3D%3D)

