### PR TITLE
add Calemander, Calemander Booking Domain

### DIFF
--- a/calemander.com.booking-domain.json
+++ b/calemander.com.booking-domain.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "calemander.com",
+  "providerName": "Calemander",
+  "serviceId": "booking-domain",
+  "serviceName": "Calemander Booking Domain",
+  "version": 1,
+  "logoUrl": "https://calemander.com/logo-120.png",
+  "description": "Serve a workspace's booking pages on a subdomain the customer owns (for example book.example.com). Adds exactly one CNAME on that subdomain pointing at Calemander's edge; the certificate is issued by HTTP validation once the CNAME resolves, so no TXT record is needed. The template takes no variables and is only ever applied with a host: it never touches the apex.",
+  "syncBlock": false,
+  "hostRequired": true,
+  "syncPubKeyDomain": "calemander.com",
+  "syncRedirectDomain": "calemander.com",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.calemander.com",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Calemander is a scheduling platform: businesses publish booking pages, and this template lets a business serve its booking page on its own hostname (for example `book.example.com`). The customer chooses the label with the `host` parameter (`hostRequired` is set), and the template writes one record:

- `CNAME` `@` → `customers.calemander.com` (ttl 3600)

Certificate validation happens over HTTP at the edge (Cloudflare for SaaS), so no ownership TXT record is needed. The signing key is in place: `syncPubKeyDomain` is `calemander.com` and the RS256 public key is published as chunked TXT at `_dc1.calemander.com` (`p=1,a=RS256,d=…` / `p=2,d=…`). `syncRedirectDomain` is `calemander.com`. Proxy preference for this CNAME at providers that ask: DNS-only.

Companion template: `calemander.com.email-sending.json` (#1821).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Note: the template contains a single CNAME with no variables and no TXT records, so the TXT, variable and `essential` rules are satisfied vacuously; `hostRequired` is set because the CNAME must sit under a customer-chosen label, never at the apex.

## Online Editor test results

**Editor test link(s):**

- Subdomain (`example.com`, host `book`; `hostRequired`, so no apex run applies): [Test calemander.com/booking-domain example.com/book](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIABpVo2oC%2F91UbW%2FaMBD%2BK5a%2FbFNJmsCAkWnS%2Bra1e%2Bm6lr1IFUIX%2BwCrSZzZDpQi%2FvvOBApVu2mfJyEh5%2B557rm7x15wh3mZgUOeLHhp9FRJNGeSJ1xAhjkUdAyFznnjPnoOOWXzo%2Fs4xSyaqRK4AqZa36hiHEidgyq2wUc4dlhnsuNN5hSNVbrgSdzgmR7rbyYjxMS50ib7%2Bw8V7fuEIG5GYVmMCSvRCqNKt8LzK6qJDNhMmxtbgsBnlq2FsRLGaJkuKGyrtJbJ3ASZqKzTOQnTs8Ky5yNtGN4CzQdX2HB98NVfhOxASuvjwmVzYkN2dH7w%2BcTzugm4HepSq8L5wvR12z0JQjnG13VlNE6NlKBFMGXpZyuULJ2z037%2Fgk0hUxJ8Z8QucIWoixm0OpuibTCrWaFZ%2F2efvgltpKcpECXKkPUpf7Nn5uCGuqfcKRgFaUYH0uPTdUGNIO2AQVlmigTMlJvQlCbauoQpR4Q%2B6nQlJgTzMqDE29DveF6Iw0yLG56MILPY4B50ib8qZZBc4UyFddZFlX7E%2BXrlT9jM51yiJJhwf86qm7Q8uV5wNy9XxvIT4XVhOr71lvWTt33tGda7teEjLufIZa1OFC0Hywa%2Fo1UOt%2FQDctZGxc7%2Bt3W8M%2Bg0Nroqh2qDKcFAbv2l2qCvH8AHG%2Fx1TeArq3GhDQ4t%2FYOrDG6mlleZU0OYwfaTFEO%2FozkJtRQlmsdzKOr7ttZH%2FoF%2FHEODD6Xw0tXqHUh7AiLoBmmrK4KXnXYr6MWjKJDtFGUTuq9arfbO6%2FD02%2FHX9%2BHhINFapOsC%2FuYfZDOYW75cDho01P%2B8RbKEhSnKIfjUZtTsBFEviON%2BFCdxlLSjsPcybkW9vShKosh3g9bVPS%2FIPbu%2B4djuvJ%2Bddr%2B2jWpCLr6bD92ubn759O7Owmn7x8ne2VV8vNcZH9qTN3z5G93p27oGBgAA)

