### PR TITLE
add Calemander, Calemander Email Sending (dual provider)

### DIFF
--- a/calemander.com.email-sending-dual.json
+++ b/calemander.com.email-sending-dual.json
@@ -1,0 +1,62 @@
+{
+  "providerId": "calemander.com",
+  "providerName": "Calemander",
+  "serviceId": "email-sending-dual",
+  "serviceName": "Calemander Email Sending (redundant)",
+  "version": 1,
+  "logoUrl": "https://calemander.com/logo-120.png",
+  "description": "Send booking confirmations, reminders and cancellations from your own domain through two independent sending providers, so an outage at one does not cost you your own address. Group 'emailit' adds a return-path MX, an SPF include and a DKIM key under the fixed 'emailit' label; group 'resend' adds the same three under the fixed 'send' / 'resend._domainkey' labels. Calemander always names the group(s) to apply, matching the providers the domain was registered with. The domain's own apex MX and SPF are never touched.",
+  "variableDescription": "%dkim%: the full DKIM TXT value minted for this domain by Emailit (v=DKIM1; k=rsa; p=...), which is prescribed by the provider and cannot carry a prefix. %resend_dkim%: the base64 public key Resend mints for the same domain, written as p=... exactly as Resend's own templates do. Both are issued when the domain is added in Calemander and cannot be pre-filled.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "calemander.com",
+  "syncRedirectDomain": "calemander.com",
+  "records": [
+    {
+      "groupId": "emailit",
+      "type": "MX",
+      "host": "emailit",
+      "pointsTo": "feedback-smtp.ffdc-1.emailit.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "emailit",
+      "type": "SPFM",
+      "host": "emailit",
+      "spfRules": "include:_spf.emailit.com"
+    },
+    {
+      "groupId": "emailit",
+      "type": "TXT",
+      "host": "emailit._domainkey",
+      "data": "%dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "All",
+      "essential": "OnApply"
+    },
+    {
+      "groupId": "resend",
+      "type": "MX",
+      "host": "send",
+      "pointsTo": "feedback-smtp.us-east-1.amazonses.com",
+      "priority": 10,
+      "ttl": 3600
+    },
+    {
+      "groupId": "resend",
+      "type": "SPFM",
+      "host": "send",
+      "spfRules": "include:amazonses.com"
+    },
+    {
+      "groupId": "resend",
+      "type": "TXT",
+      "host": "resend._domainkey",
+      "data": "p=%resend_dkim%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "p=",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Calemander is a scheduling platform: businesses publish booking pages, and the platform sends the booking confirmations, reminders and cancellation notices that result. This template verifies a business's sending domain with two email providers at once so the business's own from-address keeps working if one provider is unavailable. It is a separate serviceId from `calemander.com.email-sending.json` (#1821), which stays the single-provider template.

Records, in two groups (the apply URL always names `groupId`; the app never applies without one):

- group `emailit`: `MX` `emailit` → `feedback-smtp.ffdc-1.emailit.com`
- group `emailit`: `SPFM` `emailit` → `include:_spf.emailit.com`
- group `emailit`: `TXT` `emailit._domainkey` → `%dkim%`
- group `resend`: `MX` `send` → `feedback-smtp.us-east-1.amazonses.com`
- group `resend`: `SPFM` `send` → `include:amazonses.com`
- group `resend`: `TXT` `resend._domainkey` → `p=%resend_dkim%`

All records sit under fixed labels (`emailit`, `emailit._domainkey`, `send`, `resend._domainkey`); the domain's apex MX and SPF are never touched. Both SPF records are `SPFM`. The two DKIM TXT records use different conflict modes on purpose: Emailit's value is the whole record (`All`), Resend's carries a fixed `p=` prefix (`Prefix`), matching Resend's own merged templates. The Resend record shape was verified today against a live Resend-issued record set.

`syncPubKeyDomain` is `calemander.com` with the RS256 public key published as chunked TXT at `_dc1.calemander.com`; `syncRedirectDomain` is `calemander.com`. Proxy preference: none of these records should be proxied.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

Note on the bare-variable rule: `%dkim%` is the full value of the `emailit._domainkey` TXT record, as in #1821, because a DKIM record's content is prescribed by RFC 6376 and carries no service prefix; the Resend record uses the `p=` prefix form.

## Online Editor test results

**Editor test link(s):**

- Subdomain (`example.com`, host `booking`), both groups: [Test calemander.com/email-sending-dual example.com/booking](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAxWo2oC%2F%2B1YbW%2FaSBD%2BKytLVVsVOyblEiDKBwhcDqWkeaFSqihCa3vAe1l7fbtrCBflfvvN2gbsQprct2tEvgR2Zp6ZeXZeVjxaGqKEUw1W%2B9FKpJixAOQgsNqWTzlENMavji8iq7aSntMIta2TlRxlCuSM%2BZAZ4injtoI4YPHUDlLK1wobtqRvtMl1rk0%2BSAjSOKCx%2FohGM5CKidhq12sWF1PxTXI0DrVOVHtvrxrgnlGw6%2Fuuk8RTtA1A%2BZIlOrO3DD7xhLg3TnwRT5iMqJGpGpEQMYOiCIIRn8Y%2BcJ4LyUSKiCxEKomYxyQQGGxMdChFOg2JngtiLBMEh1iTImWyJAqxlUBQIlJNp0CoJiIGRAFFYqExDqUN%2BNoBDQIJSjnkFD0k5H1GJdPvjQDDw1B1KmM7oTokw5uawb6%2B%2BB2D8HkaQBY%2FJb2zwZDcw4KkGcE6BDJhDxCU4Dj1gB%2BRae4FXWLkhROjrvCWTJYAmxi56t7SyhnnpKC%2FAhajL10v5XO6wHQRMcfOfH5QH4lGapKEL2oEb8IPDXFGviIv%2B1YwPqcKc58ypQELhMyZDh0yWsnfq5y9BB6QlowGQwuVQGKYmfhF6ocQOKamqGTU49Cr1Me74J5F79p5oinnOYmjmxGZUZ4CwQrR6HgiDBdMLePyFnn9Mk0%2BzI6NTf2I3B9LRY9Icuw4zscamYfMDwnaJDJz6SEO2pVzXRZeVhRUygXeImoj4w55l%2FM8LgXoUQUHDZKkHmd%2BdtNXmU4WpSqCLG4xDxSjkExrQI5UHhiBB%2BprvjAHuXVB4nIemBwd0hVYaYZHplRqmA8hLl8MpoVVgwL8XL71dT6eSRPsCeM8vwC1iP0uF%2F691Z5QriA%2FuUi9M1j0MtRtw8foXEHAJPj6eS2UChkoq337aGWFth5ITKNcLxIzfoY3%2BDnE7qsIE2HoGwk8nAAEHvXvbRXpxJlMAt%2BuO4XmahoygZwucDi5CKxxMn0%2BcN2n2k89Y1kOt%2FlWyeQq5YCRW0Uzt8d4VvH5AjQW6wZyqTvNSKSarmrdKgWNHx%2F0CU5FrCc9LLpxKAID2%2BFmfONQwgnHqJm%2FX%2BOO6dsf4snLdDvHheRZglNlA1UaOaYR%2FRvnLqj%2FwvKPrqskF7ItDFed%2FRyzwu7G6FuTmxxXGva1LF9k3W5tVSlkBvu5m7h7qlmYCozXDXCHIS37BHsdmxoKToskim2IB1nWY5aZleqqoACBEipppMwLYQl5W8G8W4LerlDvCtjnIA07RrY5NYeD08mw456eXP91ej3wPvcu%2B93O5bdOp3F63umddNnlWXd6eXLYv%2BkML770%2B8PO4MtgdNb%2F7r6Nv8tBr3PZ6RqSSpVkuHodM72r%2FnX%2FvFfQ82Z4WdGCpc6msZAwVvif4oMIG0jLFBdJlHLNxnRO10eBP85eGdgZCqVII66G8oiK8xfpcmCuu6Jo6FesglKHV%2BfVOPBN0zAzUJpe0DhstjwbPM%2BzG9D4bDe9%2BoHdaKGANlv1VrNeemRvf4K%2F%2BMze6O3yuOhkbzHryUy6ylh7iYPZMU7POnluM5F%2FaLYkMh6Qhl838%2FVE30bCblJtb8lKB%2FzPbn61IktXX%2B77bJG%2F0PTPP0%2FeSudvZ%2BGHtq8k%2F%2Bv3%2FMYjbpOA17b4G1%2B5v0Z%2F39Xwzbtb7rvlvlvuu%2BW%2BW%2B675b5b7m9oud8hFp1BMKZGfd%2FdP7Ddll2vj9x6u95o%2F7bv7Deah63WJ9dtu67JCpTOb%2FrxCRMr%2FVZg7T1Evf3u4OxTeD0Y%2Ba1kpM%2F%2FPPnePQuah1dTmfh%2FBOdYMv3WV%2BEfW0%2F%2FAn5eUCMjGwAA)
- Subdomain, group `emailit` only: [Test, emailit group](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAC9Wo2oC%2F%2B1WbW%2FiOBD%2BK1akVVsdSQN9p%2BoHKFwPdekW6J56qirkJBPw4sQ524GyVe%2B33zgJEFq67X2722v5UPCMn5l5PPPYj5aGKOFUg1V%2FtBIppiwA2QmsuuVTDhGN8afji8iqLK1XNEJv63xpR5sCOWU%2BZBtxlXFbQRyweGQHKeUrhxd7Sdt4k0HuTbYlBGkc0Fjv4KYpSMVEbNWrFYuLkfgqOW4ea52o%2Bu7ueoK7xsGu1lwniUe4NwDlS5bobL9l8IknxMQE8UUcMhlRY1MVIiFiBkURBCM%2BjX3gPDeSUIqIzEUqiZjFJBCYbEz0WIp0NCZ6JojZmSA4xJoUJZMFUYitBIISkWo6AkI1ETEgCigSC415KG3AVwFoEEhQyiEXGCEhWxmVTG8ZA6aHqepUxnZC9Zh0bysGe3D9Kybh8zSALH9KWpedLpnAnKQZwXoMJGQPEJTgOPWAn5JRHgVDYuZFEOOu8JRMlQAvMXLX3cUuZ5iTgvEKWMy%2BdLyUz%2Bgcy0XEHDuLua12iEZqkoTPKwRPwh8b4ox9SV72q2B8RhXWPmJKAzYImTE9dsjN0r6lcvYSeEBaMhoMLVQCiWFq8hepP4bAMT1FJaMeh9Zaf3wKJiz6VM8LTTnPSby5vSFTylMg2CEaA4fCcMHUIi9vnvcv02R7emb2VE%2FJ5EwqekqSM8dxdipkNmb%2BmOCeRGYhPcTBfeVaF42XNQWVco6niN7IuEM%2B5TwPSwl6VMHhPklSjzM%2FO%2Bl%2B5pNlqYoki1PME8UsJNMakCOVJ0bggfqaz81CvrsgcaEHpkaHNAV2muGRKZUa5scQlw8Gy8KuQQN%2BL5%2F6qh7PlAl2yDjPD0DNY7%2FJhT%2Bx6iHlCvKV69S7hHkrQ90kPsanDwGT4OvXvdAqZKCs%2Bt2jlTXaSpCYRrueJ0Z%2Burf4fYzTt2ZMhKHvRuBiCBB41J%2FYKtKJE4aBb1edwnOphkwgp3MUJxeBNSrT3qHrPlV%2BGBnbsrsptkrCfsoBM7eKYa4PcW0t5hvQ2KwvkEvTaSSRarrsdauUNH590OeoithPultMY1cEBrbBjXyjKKHCMWr090vcMHP7LJ%2B8TTdzXFheJThVNlClkWMa0e%2Bou6D%2BCcvPQ6%2BTXNg2MLwe7MeYa%2By%2BkL4VucnZ2sC%2Bl%2BXrbNqtjS6FzWC%2FdhL3TxULS4HhagDuMaXFnOCs41BDwWlRRHEb4kJW9ZBl25Z9hfsTKmmkzMNggXS3BnW%2FwLpbgt0XaM%2BQDBdm6aVGdjsXYbfhXpwP%2FrwYdLy9Vq%2FdbPS%2BNhr7F1eN1nmT9S6bo975Ufu20b3%2B3G53G53PnZvL9h%2Fuz%2FHX67QavUbTkFTqG8PV%2B5hp9duD9lWroOen4WVJCzY2G8VCwlDhf4rPHxwXLVO8NqKUazakM7paCvxh9qbAOVBoRRrxIigLUpy%2FPxfyuJqBYnzfIfyleV5Xp2Hgm1lhRj7c4xBvxb2a7YZ%2B1d6v%2Bp7tuZ5nQ3hwcrDnHR66xyelJ%2FXmB%2Febj%2BoXk1wWh0b28rKejK6tidhbHEzPUCur5LV7iPxFsysh4wFp%2BO9WvtLvTSR8KNXmkVybgH%2FZyS8vxKf7Ct6AH8P%2FMfwfw%2F8%2FHH58TSk6hWBIjXvNrR3a7oldrd641Xr1oF47co5q5vOL69Zd11QFSueH%2F4gvjvJbwzrs9135W7TXvPUH8%2Bme%2B216yX%2FvT74dtAM6%2Bq4n4vw4%2FLJfYyPpnllPfwOPhX7MURMAAA%3D%3D)
- Apex (`example.com`, no host), both groups: [Test, apex](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAE9Wo2oC%2F%2B1XbW%2FaSBD%2BKytLVVMdduyGpC1VPjiBRiglFxJyzamK0Noew4rF6%2B6uITTK%2FfabtQ3YCbS9L6e2gi8Yz%2BwzM8%2B8LQ%2BWhmnKqQar9WClUsxYBLIbWS0rpBymNMGfTiimVmMlvaBT1LZOV3KUKZAzFkJ%2BEN8ybitIIpaM7CijfK3w7CzpGG1yXWiTPQlRlkQ00a%2Fw0AykYiKxWl7D4mIkbiTHw2OtU9Xa3687uG8UbO%2B166TJCM9GoELJUp2ftww%2BCYSYGCOhSGImp9TIVINImDKDogiCkZAmIXBeCEksxZQsRCaJmCckEuhsQvRYimw0JnouiDmZIjgkmpQhkyVRiK0EghKRaToCQjURCSAKKJIIjX4obcDXBmgUSVDKIWdoISUvcyqZfmkE6B66qjOZ2CnVY9K7bRjs68sP6ETIswhy%2Fylpn3d7ZAILkuUE6zGQmN1DVIHjNAD%2BnowKK2gSPS%2BNGHWFWTJRAjzHKFT3l6ecYUEK2ith0ftKeimf0wWGi4gFdm5zT70iGqlJU75oEMxEODbEGfmKvPxXyficKox9xJQGLBAyZ3rskMFK%2FlIV7KVwj7TkNBhaqASSwMz4L7JwDJFjaopKRgMO7Vp9vIgmbPqiVQSacV6QOLgdkBnlGRCsEI2GY2G4YGrpV7Ao6pdpsjc7Nme892RyLBV9T9Jjx3FeNch8zMIxwTOpzE0GiIPnqrEuCy8vCirlArOI2si4Q14UPA8rDgZUwVGTpFnAWZhn%2BirXyb1UpZNlFgtH0QvJtAbkSBWOEbinoeYL86I4XZK4nAcmRoecCKw0wyNTKjPMjyGpJgbDwqpBAT5Xs76OJzBhgh0zzosEqEUSnnARTqxWTLmC4s1lFpzDop2jbho%2BRucKIiYh1Nu1UCpkpKzW5wcrL7T1QGIa5XqRmvHTu8XnMXZfTZgKQ99A4MsYIApoOLHVVKdOHEeh7Tml5moaMoGcLnA4uQiscTIdHLnuY%2BOblrEse5tsqzS%2Byjig51bZzK0hvqvZ%2FA40Fusz5Ep3mpFINV3VulVxGh%2Fv9SlORawn3Su7sSciA%2BtzM75xKOGEY9TM3z8T3%2FTtE3%2BKMt3McSnZSnCmbKBKI8d0Sr%2Fi3AX1X1h%2BarpOcinbwHDd2Lcxa%2Bw%2BG31rctPjWsP%2BKMuXebdbG1VKmcHelom7x4aFocBw3QB36NKyT7DXsamh5LQMAp%2FycIcs168UVBk7IqRU0qkyV4Ml1uca2N0S7bNlnnO8bViGDyN7Pid73bO457tnp9dfzq67wUG73znx%2Bze%2B3zy78NunJ6x%2FfjLqn77p3Pq9y4%2BdTs%2FvfuwOzjt%2Fu7%2FHp99t%2B33%2FxJBUqR3D1Y8x077qXHcu2iU9vw0vK1qwuNkoERKGCr8pXoGwZbTMcHVMM67ZkM7p%2BlUUDvN7BfaCQinSiMugOpSS4g66rtGydX9g6Fd6uT6ZhlFouoSZ0REd0jg4Cj2bNt%2BA3Qzdpk3feQf224geuhRo02vSynV682X7uxfqdRdXJ4KfX7esRzPMapNrW9CzYxyMHtm2dMg%2FNJ%2F%2FeeAY968X6sYpvZtB25qtVuM%2FS6pXe66S62orl6t6Yx9vv1v88s1cD%2FtJJ9ei%2FYXb%2BJt3rd1%2B%2FPlb9q6Bd9HdCt6t4N0K3q3g3QrereDdCv7fV%2FAdgtAZRENq9F67r49s953teQPXa3mHrcN3ztvD5puDgz9ct%2BW6JhxQukjxA%2F77rv7vtr7eT27mg7jzKZz4fc29GwXN4Lz79aZ%2FyC%2FkjatGo7%2F6n64%2BRNP5sfX4Lx%2BSBLphGgAA)
