### PR TITLE
Add hellagood.food website template

### DIFF
--- a/hellagood.food.website.json
+++ b/hellagood.food.website.json
@@ -1,0 +1,30 @@
+{
+    "providerId": "hellagood.food",
+    "providerName": "HellaGood",
+    "serviceId": "website",
+    "serviceName": "HellaGood restaurant website",
+    "version": 1,
+    "logoUrl": "https://hellagood.food/og.png",
+    "description": "Connects your own domain to your HellaGood restaurant website (www) and verifies that you own the domain.",
+    "variableDescription": "verify: the ownership token shown on the Site settings tab of your HellaGood portal.",
+    "syncBlock": false,
+    "syncPubKeyDomain": "hellagood.food",
+    "syncRedirectDomain": "app.hellagood.food",
+    "hostRequired": false,
+    "records": [
+        {
+            "type": "CNAME",
+            "host": "www",
+            "pointsTo": "connect.hellagood.food",
+            "ttl": 3600
+        },
+        {
+            "type": "TXT",
+            "host": "_hellagood",
+            "data": "hellagood-verify=%verify%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "hellagood-verify="
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template for **HellaGood** (hellagood.food), a website builder/host for small restaurants. The template connects a customer's own domain to their HellaGood site: a `www` CNAME to our Cloudflare-for-SaaS fallback origin (`connect.hellagood.food`), plus an ownership TXT record under a fixed label (`_hellagood`) carrying a per-site token so our app can bind the domain to the right customer before serving it. The apex is intentionally not touched (customers forward the bare domain to www at their registrar).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — n/a: both records are required for the service; neither is user-editable

## Online Editor test results

**Editor test link(s):** 
[Test hellagood.food/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH9%2Bo2oC%2F%2B1V227aQBD9FWulSK3KxVBigqU%2BJKFKqyooTchFiZA12GNYxew6u2uMi%2Fj3zmJuCajtYyv1BZvdc2bOzNlZz5nBSZqAQebPWarklEeovkbMZ2NMEhhJGdVi%2BmGVzW4PJoRmX%2Bz%2BRbmlUU15iEtejkPNKd5m9S3eUagNZAqEcbbgKSrNpWB%2Bo8ISOZK3KrEijEm1X6%2B%2FFlOXo1oqRsSKUIeKp2bJZOdSCAyNdgqZKUfmwonkBLhwjCyXfqXBeZfn%2BXsHROSQFh5z1I4Zg7HMZSwzxlW8mtULisMwwe4rBUtm4S%2BxxKGaxjyl9M8oHD22UWQZ6MZm1GgMFyPKA0NHxm81plIZSGwyXYjwLJHhM%2FNjSDSWK1fZ8BsW3aWkQ4ZZzDVGXFFPNihI09oeciy1ucaXjKDRJgXRpIo085%2FmzBSp9fC8d3r5eYW3Vue5PReSC6P7khbC0oD9BMaQmx89111UNsH6D%2F1tqGBDsa6Cgd2CqmVbPx2Vz6PdgPQ6M2R8nPDQXIIJx9TRSxnZDFcKYz5jByGrvQNZ2GKwqLAfUmCwbcGAVK1biDOgmcFaKCfbAuhtpGSWBnyNT0HBRNu5WjOfXlEHa%2B4Ts%2B9ldvuvkIVkVgMfCakw0PQEkykqyaiMnJlkieEB5LBdisKAnE0Kkqxpl8LsuybKQSxdW%2FX4945VWBCFtgpupzv2wO2EnluNWt5JteVBu9qBuFNtIrQbJxBh7Ho7d8Xhm%2BTwdbFtJGqNwnCwN8BpkkOh2WLv4Kyq%2BaODs%2BzoX1jToEIH5b9R%2F4BRNKAaphgFYGFNt%2BlV3U610ei7Ld9t%2B812rd057rjHH1zXd11bAn1gyirnNMm7M8zuejrv3j5%2B77Ye%2BQ14t8k9H05fcHZ2ffHwOKwPk%2Fbx%2Fbem7N1NXbqMfgJCyUGnowcAAA%3D%3D)  (apex)
[Test hellagood.food/website example.com/johnny.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACJ%2Bo2oC%2F%2B1VbWvbMBD%2BK0ZQ2FhenDenMexD15a2lIQsy9hYCUaxLrZWR%2FIkOa4X8t93ivPahO3rGPtim9Pdc%2FfcczoviYF5mlADxF%2BSVMkFZ6AeGPFJDElCIylZbYYPUtmdDugcvcm9Pb8rjzSoBQ9hHZfDVHPE21lf%2BzsKtKGZosI4e%2BcFKM2lIH6jQhIZyc8qsUUYk2q%2FXj8upi6jWioijGKgQ8VTs44k11IICI12CpkpR%2BbCYXJOuXCMLE2%2Fq8F5k%2Bf5W4cK5mAtfMZBOyamxkausUwMG7yarZcqTqcJ3BxVsI4s%2FLUvxiCnmKeY%2FhmEo2OLIkugTzajBmO4iDAPnTpy9rrGVCpDE5tMFyL8kMjwmfgzmmgoLcNs%2BgjFzbqkc4JZnxEwrrAnOy%2BaprUTz1hqM4IfGbqyXQoMk4pp4j8tiSlSq%2BH14Kp%2Fu%2FG3Uue5nQvJhdFjiYawFOA0gTGoZstz3VVlBzb%2BOt5DBbsQqyo19JBQtWzr%2B4vyfXEIiJ8vBoWfJTw0fWrCGDval8xmGCqY8Rdy1mVzdiYLWU1WFfJTCgj2LZhgVdsWwgvFOwO1UM73BL7LWIhiY4uUzNKAbyNTquhc2xu2xXg6AplsUZ4OYSaVzThZewGa2LJ4JKSCQOObmkwhS6MyFGueJYYHNKd7EwsDFDspkIXGU0Q5FVKUdxOFrB0R2CjwZz0rJGChZcbt3fda3RZtQ6vqhq12tX3JWPWy22XVRsvreF6zPWu2pgeb5PyeOb9MzrUZtAZhOLWb4irJaaHJ6mTANhT3A3aW6ckU2Ib%2F1TwnFRyt%2F4r%2BS4rijdd0ASygNqDpNr2q26s2GmO37bsdv9Ou9dpeo9t457q%2B61oy%2BBcr6S5xNxxuBfI4uhdx7755qxfm7ov78Vn3OoU7iroPYqC%2BDZuPkVcf9J%2FD6dDFjfcLxFLx6wgIAAA%3D)  (with host)
