### PR TITLE
add UNIVU, UNIVU Website

### DIFF
--- a/univu.app.website.json
+++ b/univu.app.website.json
@@ -1,0 +1,35 @@
+{
+  "providerId": "univu.app",
+  "providerName": "UNIVU",
+  "serviceId": "website",
+  "serviceName": "UNIVU Website",
+  "version": 1,
+  "logoUrl": "https://univu.app/favicon.svg",
+  "description": "Connects your domain to your UNIVU website.",
+  "syncPubKeyDomain": "univu.app",
+  "syncRedirectDomain": "univu.app",
+  "syncBlock": false,
+  "records": [
+    {
+      "groupId": "apex",
+      "type": "A",
+      "host": "@",
+      "pointsTo": "169.155.56.59",
+      "ttl": 3600
+    },
+    {
+      "groupId": "apex",
+      "type": "AAAA",
+      "host": "@",
+      "pointsTo": "2a09:8280:1::12e:d42:0",
+      "ttl": 3600
+    },
+    {
+      "groupId": "www",
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "connect.univu.site",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for UNIVU (univu.app), a website builder for small brands. Connects a customer's domain to their UNIVU-hosted site. Two record groups so the service provider can apply only what the customer set up: `apex` (A/AAAA to the UNIVU apex redirector, which 301s to www) and `www` (CNAME to `connect.univu.site`, the Cloudflare for SaaS fallback origin). Synchronous flow only, every request signed, `syncPubKeyDomain` is `univu.app`.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Linted with `dc-template-linter -loglevel error -tolerate info -logos univu.app.website.json` (exit 0). With `-cloudflare` the only note is DCTL5003 (`syncRedirectDomain` unsupported by Cloudflare), kept because the guidelines require it when `redirect_uri` is used.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (no TXT records in this template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique (no TXT records in this template)
- [x] no variable is used as a bare full record value (no variables in this template)
- [x] no bare variable is used as the full `host` label (no variables in this template)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (not applicable: all three records are required for the site to resolve)

## Online Editor test results

**Editor test link(s):**

Apex, both groups:
[Test univu.app/website example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFqAo2oC%2F%2B1UXW%2FaMBT9K8ivC6mTkkAsTRptp60ao9NW1ocKRU7iUmuJndkOkCH%2B%2B64JIXRdu5c99KG8cHN97vH9ONcbZFhR5tQwRDaoVHLJM6YuM0RQJfiycmlZIudwMKUFANFsevl9Bm7N1JKnbAdfsURzoDl4j7G9m8PpkinNpUDEc1AuF3KmckDdG1NqcnJyuPTkjgKJFK5eLiAqYzpVvDS7SHQuhWCp0b1aVqqXyYJy0TOy%2BWwu3Kfj2nxqkX6pkk%2Bsvtgh%2F6jNHn9lGVfA%2BCTgLJfpD0TuaK6ZgwAqVaYRud2ghZJVuesALdka4KYubd1jMO%2BlNmC%2Bsx2UXBh9LeHTCyPXCwI3CN0gsgEGOnAaYrx1nqGD35OMPsURGfkjTDxCPJ%2BRbOAT%2FDT1arXqmM%2Bn48%2FvO%2Brm7Ig8bZrtNi3ZT7Ejnm8d9EsKFndNmcO82kayNQV9MTeVRXcHWLtkYt7iS6pooa0G28jbB6HzNvYWWZu2hq6S1kwFCO4YZNYHs1gfnFQt2N4PmfOFkIrFGv6pqRT0w6gKJlxUueExXdHOlaUx6CGvoVANp0AB0z8atmj0bkeTUUOfG7SD4iy1xXI7jVHqJ0kWJf2UDqL%2BwEuCfoQ93I%2FY6RAPhwnzhqOjHXy0nH%2Ffwq7VTGsmDKd2z8b5itYaba0eHirrcfr%2FVtWLqqPV8b6QRsf7Up7X8AsoY%2B7AFrzq6VVP%2F0tP9m2kS5bF1MJ87Id9HPU97xoPiBcQ33dPwzAI8RuMCd4NgWnTVLeBd%2FH4RUST9EYGHyY%2Fz0JWr8XFz%2Fzb5OpqMuPXYnI3%2FTjOuPTO6EyY6P7yLdr%2BBhTXvYFTCAAA)

Host set, both groups:
[Test univu.app/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAFaBo2oC%2F%2B1UXW%2FaMBT9K8ivC8GGBIilSaP70NDaaqraVVuFIpM44C3Yke0kpYj%2FvmvC59Z2T5P60Lwk8b33%2BN5zjr1Cli%2BKnFmO6AoVWlUi5XqcIopKKarSZ0WBvH3gki0gEd1cjr%2FdwLLhuhIJ36TXfGoEwOxXj3Nbt%2FtoxbURSiJKPJSrmbrROWTNrS0M7XT2m3YyBiBK%2BqaaQVXKTaJFYTeV6L2SkifWtJaq1K1ULZiQLaua32bDbTu%2B62cpk6%2Fl9Atffthk%2FjGbC1%2FxVGhAfDLhLFfJL0QzlhvuIUhVOjWI3q3QTKuy2DDACn4P6XZZuLlH8DlXxsLnO8egEtKaawW%2FpB%2F5JAz9sO%2BHkSuwwECvj%2FHaewYOnicRuwxHdNgdYkooJV1O06BL8dPQdV0fkN9fji4%2BHqCb2BF40pDtN5RsVTwAT9YeelCSxwdSJqDXjkh%2Bz8Bf3E%2FU4rCHmStH7KahWOxqCqbZwjgf7qrvTsonu%2Fq7BsDtLGZSaR4beDNbapjH6hIUWpS5FTGr2WEpTWLQM19CowaiAAPqHYklG79ue0uZZc9p5aE4TVyvwhGKI5YNyXTQDoIwaQdT0msPs3TQZuEgGkzJIIh62dEx%2But8PX6QTtnixnBpBXPHZZTXbGnQ2sl6apBHp%2Fi3P17cODtXbucBV%2FqnMz1vyxcyz8QDY7%2Fa7NVm%2F9lmcDUaVvE0Zi61i7v9No7ahFzjgJKI9gI%2FCMhgSN5gTPFGEW5sM%2BEKbtHj%2BxOR22x8PmOfRsG5%2BvyzvupcfM8vWD2s8NnDdJyFZ3MpfoRh5zzBb9H6N6rJf2JBCAAA)

Group `apex` only:
[Test univu.app/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEmCo2oC%2F%2B1TXW%2BbQBD8K9a9FsOBwTEnVWqafiiKalVN3CiNLHSGtX0p5tDdAaGW%2F3sXcIzTJulrHsoLcDs7tzuzuyUGNnnKDRC2JbmSpUhAnSeEkSITZWHzPCfWITDlGwSS2fT8%2BwyPNahSxNDCK1hogTSH02Ps4PoQLUFpITPCXIukciVnKkXU2phcM8c5XOosOZLIzNblCrMS0LESuWkzyZnMMoiNHtSyUINEbrjIBkZ2v92F%2B3Lspp46i78WiwuoP7TIP3prwt8gEQoZnwW8T2X8k7AlTzVYBKFSJZqw2y1ZKVnkrQI8h3uEmzpv%2Bj7Fz7XUBj%2FfNQpKkRl9JfHXHYe2GwR2MLaDsEkwqMBoTOnOeoEOn2cZPU5DNvEmlLmMuR6wxPcYfZ66qqqe%2BWx6%2BuVjT93FjsjjTmy7k2TvYk8831nkl8wg6kWZo18PQsI9x%2FkCO5ab%2Fg69lo2wbUGRaHO6djEz54pvdDONDxy3j0jmDyy3Hc18z9NzYEFilUkFkcY3N4XCNo0q0LhNkRoR8Yr3R0kcoc1pjfVrjCINmnrkYdaN8b7khBv%2BkoUWiZK4KV40OlNKxz6AP6TjpTv0FxNvOPGX4ZCDR0MYTegyjI%2B266%2B1e3q%2FHosIWkNmBG%2B26DSteK3JrnH78dw82cW%2Fx%2BaVtDO3cKb%2B2%2FLqbMHd07yEJOIN1KPeeEjDoeteUZ95IzY6sYPApZ73hlJG2w5Am67LLW7p8X6Swrks39ylN045Ej8u%2FKvZelI5tLi%2BE9PzzydhcRnMFsapi0%2Bzm7dk9xvcYSLfuAYAAA%3D%3D)

Group `www` only:
[Test univu.app/website example.com/shop](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIACqCo2oC%2F91TUU%2FbMBD%2BK5VflwYnaUNjadIKQxtCQ4PB0EBVdMRua0jsyHZasqr%2FfZektIWN7X15ie377ru77%2B5WxImizMEJwlakNHohuTCnnDBSKbmofChL4m0N51AgkFyfn36%2FxmcrzEJmooUvxb2VSLN93cf2brbWhTBWakVY4JFcz%2FS1yRE1d6607OBgG%2FRgCkiilW8XM%2FTiwmZGlq71JMdaKZE526t1ZXpcFyBVz%2Bnu2gXcpOM3%2BdQq%2B1rdn4n6Y4t8VVtjvhRcGmR8E3CU6%2ByRsCnkVngEodpwS9jdisyMrspWASjFE8JdXTZ1j%2FE419bh8UOjoJbK2SuN1yBO%2FGA49IexP0waB4cKRDGla%2B8vdPi9yRgCTdgoHFEWMBaEgvFByOjb1Mvlcsd8fD7%2BcrKj7mx75Fkntt9Jsunijniy9shPrUS6E2WC%2FXoWUjwBzpfwM13sYti5boRtE0pl69PGRccSDBS2GcZnirsXHJNnkruOZbKh2VJgOnKmtBGpxT%2B4ymCRzlTYtqLKnUxhCbsnnqXY5LzG7C1akQVb%2BkoY1Q0ysvubxDk4%2BKcyHkl51hQiG8kjOg3D4HDYh0E86g9ENOoDhHE%2F45AdTu9pHB1O9xbttw3886q91FNYK5ST0CzUOF9Cbcl6PfGwH%2F9dUdh2CwvBU2igIcWgNOkHwRUdsDBiNPZpOAjC6B2ljLabIKzrKlzhhOzPBknGl8nn2%2BqWw8PNO3USPH064kWUFPT4sTqzWXRRf7up5g%2FJ2Y%2BL92T9C5D5efYyBQAA)