### PR TITLE
Add folita.me.domainverify template (folita custom domain verification)

### DIFF
--- a/folita.me.domainverify.json
+++ b/folita.me.domainverify.json
@@ -1,0 +1,22 @@
+{
+    "providerId": "folita.me",
+    "providerName": "folita",
+    "serviceId": "domainverify",
+    "serviceName": "folita custom domain verification",
+    "version": 1,
+    "logoUrl": "https://folita.me/assets/favicon.svg",
+    "description": "Proves ownership of a domain to connect it to a folita profile page (folita.me). Adds a single TXT record used only for verification.",
+    "syncPubKeyDomain": "folita.me",
+    "syncRedirectDomain": "accounts.folita.me",
+    "hostRequired": false,
+    "records": [
+        {
+            "type": "TXT",
+            "host": "_folita-challenge",
+            "data": "folita-verify=%token%",
+            "ttl": 3600,
+            "txtConflictMatchingMode": "Prefix",
+            "txtConflictMatchingPrefix": "folita-verify="
+        }
+    ]
+}


### PR DESCRIPTION
# Description

New template `folita.me.domainverify.json` for **folita** (https://folita.me), a free profile / link-in-bio page service.
It lets a user prove ownership of their own domain to connect it to their folita page. The template adds a single TXT record
`_folita-challenge.<domain>` with `folita-verify=%token%` used only for verification (no routing records).
Requests are signed (`syncPubKeyDomain`: `folita.me`, public key published at `_dcpubkeyv1.folita.me`) and the sync flow
returns to `accounts.folita.me` (`syncRedirectDomain`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)
  (not applicable: the only record is the verification TXT, which the user does not need to edit)

## Online Editor test results

**Editor test link(s):** 
- [Test folita.me/domainverify example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAADEo2oC%2F91TbWvbMBD%2BK0JQ2GjsKInTNoZ96NvY6AulpKNQglGksyNqS54lJ3FD%2FvtOeW26MfZ5n6zTPXd6nsd3C%2BqgKHPugMYLWlZmqiRU3yWNaWpy5XhYAG3tEvccw20K7y1UUyVghZem4EpPoVJps08dVBBRW2cKsoaSFVYJ7pTRWIGh9ae406K5ycxTlWPlxLnSxu32jk6bWwvOtlOO%2FY0O7TTDYglWVKpctYrpA%2FIFS8xMY8%2BJKolJCd8%2B6wzBOg3CEeV8xMmGHspMVQ6k5BmQT7sXP4fkXEqLOKt0hvnh85BUIEwlSW1BEqPzBntUB4pCb0KjxUM9voHmavX2B1t9%2BhGkwl5uB%2BBCmFo7G75HTox1j%2FCzRih6nfLcQouuKVgavyyoa0rvMzLboDFI1h0CMeF5DjrzjSTHH7dlEaz%2F1pcjZ15BH2HaOfS8d8IYHufu0ug0V8LdcScmKP3OSFi5C6ma0z9CNrmPL9DlaNmib0ZDsmc9am2GBuEw5ziHEApT7AXgKatMXSZqiy95xQvrZ3Vb%2BXJQOtrWvlB%2FXunyAR%2BLTrcnIY36J9RTUZk2FSQWv9zVFcpyVY2eFnXuVMJnfH8lRcLLMm%2BQucUstvvot14P%2BT%2F7fcDmwPRECi9O%2BYUaRwyYBBHAQKZB1BWnwSAaSwx7%2FTGwlHXGZ%2B9287el%2Fcty7v0FXCbtFPerdp7PeGPpcjlqodf%2FvUicD8unIBPuYV3WPQnYIOh0hmwQsyhmLDyNOoP%2B2TFjGHgJYN1a6gIn6P3s0OfZt%2BZhcnE1vLnkvdf73o80uurOr9%2FK5uv99VBdX7KLvLbHT7e3r7gLvwBydjAtdgUAAA%3D%3D)
- [Test folita.me/domainverify example.com/blog](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIADDEo2oC%2F%2BVTf0%2FbMBD9KpYlpE00adKW0kbaHww2CXUgxECbhKroal9Sj9QOtlNaqn73XfqTMrYvsL%2BS8717vvd8t%2BAeJ2UBHnmy4KU1UyXRXkqe8MwUykM4Qd7YJa6Bwm2Kzh3aqRK4wkszAaWnaFU236cOKpionDcTtoayFVYJ8MpoqqDQ1X9J3OCFyc29Lahy7H3pkmZz104TnEPvmhkQv9Ghm%2BZULNEJq8oVVcJvqF90zDxr4hyrkpmMwfZabxjVaRSeKV9HwDbtkcxMFchKyJF92N34MWRnUjrCOaVzyt%2F9vGMWhbGSVQ4lM7qYE4c9UBTWJsy1uKlGA5xfrO5%2BY2udvkWpiMvvACCEqbR34Wvk2Dh%2Fi08VQcnrDAqHDb5uwfHkYcH9vKx9ps42aArSNUMgxlAUqPOaSAI93LaLYP1an468eUR9RGnvyfN2N4rod%2BbPjc4KJfwVeDEm6VdG4spdzNSMvwvZ5N7ewJfDZYO%2FGI3pvuthYzM0BMcZ0BxiKMxkL2BEY0BRbk1VpmpbU4KFiavndVv9cFA%2B3NY%2FrAkoXumrD2Ak4lZbYtY56fK6JZVrYzF19AVfWZLnbUXeTqrCqxSeYX8kRQplWcxJgaMs0b31Xa%2BH%2FQ%2Ffw42Qd80%2FaOngBVIpapWq3i7IelHWgnbQH8Uy6MSZCEZRG4OsdRKf9DOMTwnc%2BPsG%2F2NTD81G2i7tFdS7d1Y8w9zx5XLYIOP%2FH7U0MQ6mKFOooa2o1Q2ifhDHd1E%2FiTpJpxe2%2B71%2B%2B%2FQ4ipIoqmWg82u5C5qp19PE89GxmPUGeXldnHe%2F31vx4%2BL6V%2Fdz5%2FH229ezdvPSvrgvg8GTj3s5bclvGXHqDpAFAAA%3D)

dc-template-linter (`-tolerate warn`): passes; only an info-level DCTL1021 (`_folita-challenge` is a service-specific underscore label, not in the IANA registry).
