### PR TITLE
update SendBeam, SendBeam sending domain (version 2)

### DIFF
--- a/sendbeam.io.sending-domain.json
+++ b/sendbeam.io.sending-domain.json
@@ -3,15 +3,16 @@
   "providerName": "SendBeam",
   "serviceId": "sending-domain",
   "serviceName": "SendBeam sending domain",
-  "version": 1,
+  "version": 2,
   "syncBlock": false,
   "syncPubKeyDomain": "sendbeam.io",
   "syncRedirectDomain": "sendbeam.io",
   "logoUrl": "https://sendbeam.io/brand/sendbeam-wordmark.svg",
-  "description": "Authenticates a domain for sending email with SendBeam. Adds two CNAME records — the DKIM signing key and the return-path (bounce) host — that delegate to records SendBeam manages, so later key rotations never need another DNS change. Nothing is added at the apex; no existing record is changed.",
+  "description": "Authenticates a domain for sending email with SendBeam. Adds three CNAME records: the DKIM signing key and the return-path (bounce) host, which delegate to records SendBeam manages so later key rotations never need another DNS change, and the sending host the email provider checks directly. Nothing is added at the apex; no existing record is changed.",
   "variableDescription": "%token% — the hosted-record token SendBeam assigns to the domain (8–32 hex characters); both CNAME targets are fixed names around it under dom.sendbeam.io.",
   "records": [
     { "groupId": "dkim", "type": "CNAME", "host": "resend._domainkey", "pointsTo": "resend._domainkey.%token%.dom.sendbeam.io", "ttl": 3600 },
-    { "groupId": "return-path", "type": "CNAME", "host": "send", "pointsTo": "send.%token%.dom.sendbeam.io", "ttl": 3600 }
+    { "groupId": "return-path", "type": "CNAME", "host": "send", "pointsTo": "send.%token%.dom.sendbeam.io", "ttl": 3600 },
+    { "groupId": "sending-host", "type": "CNAME", "host": "rsend", "pointsTo": "send.forge.rmta.net", "ttl": 3600 }
   ]
 }


### PR DESCRIPTION
# Description

Update to the SendBeam (sendbeam.io) sending-domain template, version 1 → 2. It adds one CNAME record, `rsend` → `send.forge.rmta.net` (group `sending-host`). SendBeam's email provider now requires this record for new sending domains and verifies its target directly. It cannot be delegated through a CNAME under `dom.sendbeam.io` the way the other two records are, so its target is the provider's fixed hostname.

The DKIM and return-path records are unchanged. Nothing is added at the apex, and no existing record is changed.

## Type of change

- [ ] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [x] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`sendbeam.io`; key published at `_dcpubkeyv1.sendbeam.io`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`sendbeam.io`)
- [x] no TXT record contains SPF content: the template has no TXT records
- [x] `txtConflictMatchingMode`: not applicable, no TXT records
- [x] no variable is used as a bare full record value: the two delegated `pointsTo` values are fixed names around `%token%`, and the new record's `pointsTo` is fixed
- [x] no bare variable is used as the full `host` label: hosts are the fixed `resend._domainkey`, `send` and `rsend`
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential`: not applicable; none of the records is one the user would modify independently

## Online Editor test results

**Editor test link(s):**
- apex: [Test sendbeam.io/sending-domain acme-example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEXlo2oC%2F%2B1W227bOBD9FYJAgRaxFNmOnVTFPqSbAA2CBkXq7Us2MMbkWOJaIgWSvjXIv3coyZdk7QL7trvoiy1xbufMHI79xD2WVQEeefrEK2sWSqK9kTzlDrWcIJSxMryzNd1BSa78Kxk%2FkpEsDu1CCdzGKJ1F0pSg9M74Koq1fmzrt0DrlNE87VHMWouPhREznk6hcNicfJlPbnF91QS8Rhcc7lEqi8IfcSlMZv6wBZ3n3lcuPT3ds59OLGi5PYmWxsoS7Cx2i4xiJTphVeVrhPxy7nPUXgnqmmPQkmBTY7e8kE4KtlQ%2BZxvOMbuU0jGfW0T2%2B93l52tGaKmOS%2BkQ2dXtzWfmVKZD%2FAzXjADVBot%2BbnVUASV7OzFzLfAdy43zHbbMlciZxAIzwsK82aTcVmUlaMgIpjMsTNnWqa3xEMg4ppE6T58oqZ6hcpZd3X1lIgedYWeLYcMrlK0PGoIbUZA%2FipljzQCKdczuKFcIUNQgKUP2Jg4qXH1g2jBcKeeDR4M4ODZFZRzkAFbBpMCrF41%2F480M9Rv257yXdM%2FqfAEQyqhNUtt33MGFfrrQl%2BDbzuntRR3f7%2FdYjqtQ1YKgzrh3H9iEYLfD8WAz9ATfIpuqFVHQJOLwTiMgvJ7RF1GnrPGekgL6dgg8fXjiGblX9d2QMxWui19X4SrUReg1EKBXiyFHPG4w0ozClTNKezcyh8xx24v4VflQwJPI%2B8Mkee7sl9%2BT0VEUIdHLwnXZf1xrswbqtEcpH6lG9yjD2JYeYo3%2BRZHH5w7%2FbjSOdx1%2BpNu5ufAgSoxwBbTQMBam3NWipxrdWG2CKpp66cLS24Q%2F%2FD3%2BcZPggYfnug3hZdgX55PBVHQvJPIAimRmLI6D3IDaTGy9ndPiKueFV2NYwu5IijFUVbEmDo6slI5U8qpDulmXh0QhwcNBQexj%2BtmkOnwsReCtwqTeDwfYm8J5lEjsRmfDaS%2BaDEUS4cUAz0QCEhPY2%2F4Hfhh%2Buv537Ufnws6EsIAviyWsHX8OojnMvJVGS7am%2Br%2FiZw8QPK77fxOlxw7dnl%2BK%2FaXY%2F45iaXM7WKAcQ3DrJb1hlLyPut1Rt5v2BungPE7Oe%2FSP4CRJ0iQJNND5hucT7fb9rc7n4NT1%2FeDk%2Fvs3dzIaDUffJovkTI%2F%2BUveD5fT2U9lPrj%2FlXZ19ufmNP%2F8AR%2FIIlV4LAAA%3D)
- sub-domain (host set): [Test sendbeam.io/sending-domain acme-example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAEblo2oC%2F%2B1VW2%2FbNhT%2BK4SAAi1mKZJsObGKPbhxgRVZg%2FWGFcgCgyKPJc4SKZCULwvy33coWb6kcYG9DUVfbOhcv%2B%2Fc%2BOBZqOqSWvDSB6%2FWaiU46HfcSz0DkmdAq0Aob7BX3dIKTb1PqHyDStQY0CvBYO8jZO5zVVEhD8onXmRnR%2FZ2K9BGKOmlMfpsJXtTKrb00gUtDXSSP5rsBrazzuEpOmfwEbjQwOwZk1Ll6osuUV5YW5v04uJIf5FpKvle4q%2BV5hXVy8CscvTlYJgWtW0RetPGFiCtYFg1Q%2BiOBFkovecFKCnJWtiC9JwDMuXcEFtoAHJ9O33%2FliBazGNSFAKZ3bx7T4zIpfNfwpYgoFahwTZa%2BjXFYC8z1UgGr0ihjB2QdSFYQTiUkCMWYlUfcp%2BVVFTSHGEaRVyXdRtaK0sdGUMkYOXxFzjmU5hOk9ntJ8IKKnMY7DH0vFzaVtAR7IcC7YEtDekaUG4DcouxnIPAAnHuond%2BtIbNayIVgY0w1ll0iJ1hl5QHbhyoFjQrYXZS%2BBdWLUG%2BIH81cRiN2ngOEHB%2FF6TVH7hT4%2BppXF2c7a5PL69a%2F%2BEwJgVsXFZNGVbGvHpNMoS9a46lOgeL8DWQhdggBYlD7L6xBYjXEvxD6hg1OJokh37XBC%2B9e%2FByNK%2Fb3eBL4dbFbmu3Cm0S%2FHQE8FODixHMO4zYI7dySkhrPqvn1MGuFsGT9C6BxSEfjsPwcXCc%2FmiMzqJwgU4Tt2n%2Fc67%2BDLRhz1I%2Bkw33KIdAV5YGEuxJkvvHgfePkjA%2FVPget7NfeMoq8GFD8aBBwFR1yCVhbfCrRTgXvWONna%2BMO3x9iLtvY9z3Qe66KPjdlsMJxkN2mSULFl1x8Bw4HDelYe7GjmK5kbXVDR6wqimtmNM1PYg4m9O6LrfIxaAWw%2BG0PKmU7M7mt93f8eHU0mf1x8C%2B17aBN%2BfMFUC4tiVxkixGNPOzOBn7o9EQfMoo90fjy3gEbJGEk%2BToKXjmlfjuW3DaCzDGHVHqLvK0XNOt8R7dFD1fgpbgKetW9MMR1eeYnl%2BL%2Fxu3%2BwEu189h%2FjnMP8Qw4703dAV8Tp1pHMZjP5z4UfQ5itI4SZOrAKFF4fCXMEzD0FEBYzuuD%2FgiHL8F3t%2BTYfTbZTKT5dvp17q8NDcfrq8m4Yd1dN2oZvH1T9osr9cXevL78lfv8V%2BOjtKXnAsAAA%3D%3D)
