### PR TITLE
add Pentoggle, Pentoggle custom domain

### DIFF
--- a/pentoggle.com.customdomain.json
+++ b/pentoggle.com.customdomain.json
@@ -7,7 +7,7 @@
   "logoUrl": "https://pentoggle.com/logo-email.png",
   "description": "Points a domain at the app the user built on Pentoggle: apex A/AAAA records to the Pentoggle custom-domain proxy and www as a CNAME. No variables - the targets are fixed for all users.",
   "syncPubKeyDomain": "pentoggle.com",
-  "syncRedirectDomain": "pentoggle.com,pentoggle-web-staging.fly.dev",
+  "syncRedirectDomain": "pentoggle.com",
   "records": [
     {
       "type": "A",

--- a/pentoggle.com.customdomain.json
+++ b/pentoggle.com.customdomain.json
@@ -1,0 +1,31 @@
+{
+  "providerId": "pentoggle.com",
+  "providerName": "Pentoggle",
+  "serviceId": "customdomain",
+  "serviceName": "Pentoggle custom domain",
+  "version": 1,
+  "logoUrl": "https://pentoggle.com/logo-email.png",
+  "description": "Points a domain at the app the user built on Pentoggle: apex A/AAAA records to the Pentoggle custom-domain proxy and www as a CNAME. No variables - the targets are fixed for all users.",
+  "syncPubKeyDomain": "pentoggle.com",
+  "syncRedirectDomain": "pentoggle.com,pentoggle-web-staging.fly.dev",
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "37.16.24.142",
+      "ttl": 600
+    },
+    {
+      "type": "AAAA",
+      "host": "@",
+      "pointsTo": "2a09:8280:1::10c:4ea8:0",
+      "ttl": 600
+    },
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "custom.pentoggle.com",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Pentoggle** (https://pentoggle.com), a platform where people build web apps from a prompt. `pentoggle.com.customdomain.json` connects a user's own domain to their published app: apex `A`/`AAAA` records to Pentoggle's custom-domain proxy and `www` as a `CNAME`. The template is fully static (no variables) and signed (`syncPubKeyDomain`); the service provider implementation lives in the Pentoggle platform and uses the synchronous flow with `redirect_uri` (hence `syncRedirectDomain`).

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

Also validated with `dc-template-linter -loglevel error -tolerate info -logos` (exit 0).

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead (no TXT records in this template)
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) (not applicable: no TXT records)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description (not applicable: no variables)
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description (not applicable: no variables)
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) (not applicable: all three records must stay as applied for the domain to reach the app; the user removes the template as a whole to disconnect)

## Online Editor test results

**Editor test link(s):** 
- [Test pentoggle.com/customdomain example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOcUpGoC%2F%2B1U72%2FaMBD9Vyx%2FLQlJyoBYmjS0bl1Xraq6TqtaIXQkB3hK4sx2gAzxv%2B8SCJT%2BWD9N6ofmi5PcvfO753decYtpnoBFLlY812ouY9RnMRc8x8yq6TRBN1Ipb%2B2CF5BSMr9swhQyqOcywhoWFcaqNFYpyGwfeghimzS2y5ujNlJlXPgtnqip%2BqETyp9ZmxvRbh9waVdxBwmYuHk2JXCMJtIyt3UBfqlkZg2DbXEGltkZMsjzei2IEhsXMrFMZWzHSFACLtmgPaCHaYyUjg2zqsY85O1sS5Mmy5JBFrPFYsGg2vTjxeDbJ5ddKDYHLWGcoGFOXcSCnmJFTCObyCXGbKI0gySpKRm3UqvMostifI7lyUaYx8dQpVxhLImhfTZpS5%2BLuxW3ZV5JP6DfM2UsvX6oTrMW6VrR53HP9btu0HH9TkARa0n5ruetW3ssPc%2FCA%2FBC0Q%2F6nvCF8L1IdBD6wnu6Uq3OvhSpdlhsI6%2F7sJ9dpeG6xf%2BoDEf7Dod0%2Fo0OuARyc4PabkJvU62KfCSb%2FBw0pKZyfIO8O4AOG%2Bwd59WOcpopjSNDK9hCUyNWF9jiaZFYOYIF7H%2FF0YiMlpRE0FCUShweQbYZhErDGCw8L3%2BLj%2BKooiirqcLAG4fQ6ztB2A%2BdTtzrORCB54Q4Hgc48T2YRPdm9MkB%2FseU7pVCYwgmoZq%2BQbKA0vD1Yyc87uJlF7zOhhpDbjvaGHLb0wtmfE0NDVvk6zenvTnt%2FzuNLkcDc4xHUKUFXtB1vNDx%2FWu%2FIzqh8H3XD%2FrvusdHnie8%2BljQ2E2fK7pL79%2Bi%2FNfs90%2BZLM9Oz49PPmv%2F6%2Bz22y10dHGkTvPk%2B5fy5maSXWVHk9n12Xu%2B%2FgvLPZjorQgAAA%3D%3D)
- [Test pentoggle.com/customdomain example.com/app](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAYVpGoC%2F%2B1UXW%2BbMBT9K5ZfCwQIoWBp0qK20raqbTp1XaUqihy4Jd4AI9vkY1H%2B%2By7ka%2Bnn4%2FpQXsDce67PPffYS2qgqHJugLIlrZScihTU15QyWkFpZJbl4CSyoNYueMkLTKaDbRhDGtRUJNDCklobWaSy4KLchx6DyDqN7PKmoLSQJWWeRXOZyR8qx%2FyJMZVmnc4Bl04TtwGBuVOVGYJT0IkSlWkL0IEUpdGEb4oTboiZAOFV1b5rpETGtcgNkSXZMWKYAHPS7%2FTxIQoSqVJNjGwxj3nbm9KoyXxBeJmS2WxGeLPpyWX%2F4swhl5JMuRJ8nIMmdlvEcJVBQ0wBeRBzSMmDVITneUtJO41aizIZ1ONzWJyuhXk6hiblO6QCGZoXkzb0KbtfUrOoGun7%2BHsitcHPz800W5FuJC67x44XOn7geIGPEWNQ%2BdB1V9Yei8%2BLcJ%2B7MYv8yGUeY56bsAB4xNznK7Xq7EuhaofF1vI6j%2FvZVRquLPpHljDadzjE%2BW91gDlHN29Rm01w8LjIlKyrkdhCKq54oRvTb8H3B%2BjhFn7f4pt9RVZKBSONb25qhe0YVYNFizo3YsRnfP8rTUaIyhdIU2MUqxwOolwfhzWzlBv%2B8hgsOkqThqdoTldvHPoxxGB7D2HXDrpRYvPjwLXdMBrHvSTu9jDZev0gv3JaDxQDrREpeHMQ%2B%2FmMLzRdPTXFc628bYl329XWoJu20KDOQWtvGPSd9TW00Osf1vuw3n%2BwHt6gmk8hHfEm03f90HZj2%2FNuvIAFMQt8J%2FaCuBscuS5z2wGBNutWl3jb%2FnvP0gtYmJ8mvIomJ%2BXvu4Dfnn67CovC7d0V%2FV%2FX56dn8vZLGsmjazn7RFd%2FAZ9pXSHVCAAA)
