### PR TITLE
add Speech Oak, Speech Oak practice website

### DIFF
--- a/speechoak.com.practice-sites.json
+++ b/speechoak.com.practice-sites.json
@@ -1,0 +1,22 @@
+{
+  "providerId": "speechoak.com",
+  "providerName": "Speech Oak",
+  "serviceId": "practice-sites",
+  "serviceName": "Speech Oak practice website",
+  "version": 1,
+  "logoUrl": "https://www.speechoak.com/assets/speechoak-mark.png",
+  "description": "Points a hostname at your Speech Oak practice website.",
+  "variableDescription": "host is the hostname label the site answers on, usually www.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "speechoak.com",
+  "syncRedirectDomain": "app.speechoak.com",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "connect.speechoak.com",
+      "ttl": 600
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Speech Oak (speechoak.com), a website builder for speech-language pathology practices. The template points one hostname of the practice's own domain (the `host` the user chooses, usually `www`) at `connect.speechoak.com` with a single CNAME. `hostRequired` is set because a CNAME cannot sit at the apex; the Speech Oak dashboard sends apex users to an ALIAS or ANAME record at their registrar. `syncPubKeyDomain` is `speechoak.com` (key published at `_dck1.speechoak.com`) and `syncRedirectDomain` is `app.speechoak.com`, the host that runs the synchronous flow.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

The template has one CNAME record and no TXT, SPF or DMARC records, so the TXT, `txtConflictMatchingMode` and `essential` items have nothing to apply to.

## Online Editor test results

<!-- 
  Required. Follow these steps in the Online Editor (https://domainconnect.paulonet.eu/dc/free/templateedit):
    1. Load your template and use "Check template" to perform extended schema and consistency check
    2. Fill in domain/host as well as variable values
    3. Click "Test apply template"
    4. Click "Copy Markdown" and paste the link below
    5. If necessary repeat steps 2-4 with different group setups and/or domain/host configuration
-->

**Editor test link(s):** 
<!-- paste the links from "Copy Markdown" here -->
<!-- REQUIRED: at last one test with domain apex and one test with subdomain (host set). EXCEPTION: if hostRequired=true, apex test is not required.
<!-- paste multiple links if more test conducted. At least 1 per template file included in the PR -->
[Test speechoak.com/practice-sites example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAH8ypGoC%2F91T227aQBD9FWtfg8FADMFSpaZNk0ZVyaVJkypC1nh3gBVm19ld47qIf%2B8slBCaKOpzn6yZOef4zGWXzOG8yMEhS5asMHohBZpzwRJmC0Q%2B1TBrcj1njafiEOYEZt%2FW5eACZlSzaBaS45pXGOCOgtBKh3ZXfMELtsigwsyDCbtAY6VWLGk3WK4n%2BtbkxJk6V9ik1aqqqrlnqwXWorOtp2Q4BzNrFmpCWgItN7Jwaz12qaVyNoBgqq1T5CUAF9S6NMEbjpreEhgJWY4ne3JeJZA2cFPcKeaQYb5OeXIAylbUT6BVIyhtCXleB74FP5Na8Q%2B55jOWjCG3uMlcltkXrE%2F0HKR6ZQMeco1CGuTuCQRF0fwb6A1d42NJSNqIMyXpE0kbYVnysGSuLvwqPg6Pv376A6fwvV%2Fyeko3mkKulaIfvRB3jlbSi6LVaNVgv7TCdCc9oqlvjeFPoMvCZ5YoSe1TMDG6LFK5pRRgYG79AW7JD3vs0Zb%2BsOb7%2F8qJ0gZTS19wpcFtl%2FMydzKFCnYpwVOaUV6TTUtVUnk5AbW5zY07AQ7%2Bof8GSwX3pqW%2Fej4YIMLROBTdbhwexrEIj%2FpZFIqsyw%2FHWU%2F0hXj2iF59YW%2B%2Bor0BIp29chL84zjOK6gtW61GDRrm%2F9ob3YCFBYoUPLITdXphNAjb7Zt2L4njpNNvRnHU7nYOoiiJIt8KWrfpdkn38vxSWPf07uJscHBvcGiOx%2F3689Vd3L44%2Bq7PHluH0y7cXy3OM56d3v64fcdWvwHI%2FlxXIwUAAA%3D%3D)

[Test speechoak.com/practice-sites example.com/portal](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAP4ypGoC%2F91TbW%2FaMBD%2BK5a%2FlkCgFGikSeubprYapaxTtVUoOpwDPBzbsx2yDPHfZ9MF%2BqZqn%2FcpOt9zT5577m5NHeZagEOarKk2asUzNJcZTajViGyhYNlkKqeNXXIIuQfTL9s0uYGlz1k0K85wW6cNMOeDyHKHdp98VUdqJClxGsAeu0JjuZI0aTeoUHP11Qhfs3BO26TVKsuy%2BUxWC6xFZ1u7xygHs2xqOfdcGVpmuHZbPjpSXDpLgCyUddJrIeBIpQpD3lHUDJLAcJgKPH9GF1gIt8QtcM8oYIpi%2BxSKCUhb%2Bn6Ikg1S2AKEqEhoIXhSSXYqFFvSZAbC4uPLqJheY3WucuDyjQkEyBgzbpC5HQi0br4EBkFj%2FFl4pJ%2BIM4Xn90XKZJYmD2vqKh1GcTY8%2BXzxF%2B7Dj2HIW5fulA%2BZktL%2F6BW5c34kvTjeTDYN%2BltJTPfUE%2B96LQx%2Fgd8sfCIpLIcyDoSP50YVOuV1lQYDuQ07WNc%2FPCOY1AwPNUX4O59LZTC1%2FguuMFj3mhfC8RRK2D9lLPVOicqLtT7riV77IB83dKcxAwf%2FYESDphkL0nlY%2F6w3O2Y9wAiwg1F3yrrRgB3Oon48ayPDTrvTHzy5pjdP7d1zeukk%2BhOQjkM4lBNRQmXpZjNpeFf%2F7w79SlhYYZZCAHfiTi%2BKj6N2%2B67dS476yWG3OegeHcX9gzhO4jh0g9Y9Nrz2u%2FN0a2hLn9%2FfDn4Mq4vubdH51hrL%2B%2FGof3Bzjaff43h4f8KuINOXn86uLj7QzR9trtzeNQUAAA%3D%3D)

Apex is not tested: `hostRequired` is true, and the editor answers "Template requires a host name" for an empty host.
