### PR TITLE
add Dineora, Dineora restaurant website

### DIFF
--- a/dineora.io.site.json
+++ b/dineora.io.site.json
@@ -1,0 +1,32 @@
+{
+  "providerId": "dineora.io",
+  "providerName": "Dineora",
+  "serviceId": "site",
+  "serviceName": "Dineora restaurant website",
+  "version": 1,
+  "logoUrl": "https://dineora.io/logo-domain-connect.png",
+  "description": "Points www at the restaurant's Dineora website and adds the ownership verification record. Does not touch mail records.",
+  "variableDescription": "token = ownership verification token, unique to the restaurant's Dineora account",
+  "syncPubKeyDomain": "dineora.io",
+  "syncBlock": false,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "template-7n5.pages.dev",
+      "ttl": 300,
+      "groupId": "site",
+      "essential": "OnApply"
+    },
+    {
+      "type": "TXT",
+      "host": "_dineora-verification",
+      "data": "dineora-verification=%token%",
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "dineora-verification=",
+      "ttl": 300,
+      "groupId": "site",
+      "essential": "OnApply"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for **Dineora** (`dineora.io`), a SaaS that builds and hosts websites for
restaurants. The `site` service points the customer's `www` at their Dineora website and
adds an ownership-verification TXT record. No mail records are touched.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver
      (`https://dineora.io/logo-domain-connect.png`, 512x512 PNG, HTTP 200)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — public key published as TXT at `_dcpubkeyv1.dineora.io`
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
      — not applicable, the template does not use `redirect_uri`
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix
      — `Prefix` with `dineora-verification=`, so only our own verification record is ever replaced
- [x] no variable is used as a bare full record value — the TXT value is `dineora-verification=%token%`
- [x] no bare variable is used as the full `host` label — both hosts are fixed (`www`, `_dineora-verification`)
- [x] no variable is used in the `host` field to create a subdomain
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on both records

Notes for the reviewer:

* The template deliberately contains **no apex record**. Two of the providers our customers
  use most (GoDaddy, IONOS) do not accept a CNAME at the apex, so `www` is the canonical
  hostname for this service; our own DNS instructions do the same for those providers.
* With `host` set, the template resolves to `www.<host>.<domain>`. That is expected for this
  service: it always installs the website under `www` of the zone it is applied to. A separate
  template for connecting a bare subdomain (e.g. `order.example.com`) will be submitted
  separately rather than overloading this one.
* The verification TXT proves that the domain belongs to a specific Dineora account. The token
  is random, per account and per connection, and is checked server-side before anything is
  activated.

## Online Editor test results

**Editor test link(s):**

* apex (no host): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMAypGoC%2F%2B1VW2%2BbMBT%2BK8jStIdCAiShAakPXbNJvaTtpFTtVEXoYBywSmxmm9As6n%2BfTUiTrK029WmT9pTAOf78XY7NCikyLwtQBEUrVAq%2BoCkRpymKUEoZ4QI6lCP7uXIJc92JRuuaLkgiFhSTZoWkGub51X6rJYhUUAlgyqpJ0rYuiJCUMxR5Nip4xm9EoZfkSpUy6na3DLqm6KR8DpQ5mDNGsOqULNMQKZFY0FI1MOiaU6akVde1BcpSOdnZ96O0NmRaBhaw1II0lU0nr5mmk9PS0rTojGIwoBoAc5F2rBEn0mJco%2FIK55amUrQ12TFSQFBICjLa46P4A2HW0VvYTdm2Kka%2FV0Q%2Fvc0YMOYVU8beJcPXVXJOlqPGj1%2BjMvVPBccPKJpBIYmNWpYoul8htSxNKieXx%2BPPujnnUulH7ZcJuTFvwg3vdiqcQzbolJAR2UnJQvcopRPqua6NMsGrcjd3IiVhioKJ8Iodl2WxRE%2F285aTu8l2w7il7OzaYdIEBVtBe9WjD41bHwyJR3XC2aygWI1B4ZyybMxTs8m1IDP6%2BHpLW3sD%2FR3apk82%2BsEZibcGT7WETSrkEbSJpIP5fCscteAxbfrX%2BHpVCQLm0hzCzfr7PYDpBuEemf8Nxu76xhvzwoMQfM9LkmGAQ5cM%2FF4wHPRDP5x5kMyghwxrmjEuSCz1L6hKaOeUqPSkzKtC0Rhq2L5KcQxGrhYpdVVv8XKK2Pqor6eojfAPJihOsRFMjc%2Fh0CcJ7vecJBjOnL4f9B1Ise%2BEmn0wOEwPPbe3cw%2B9vKFeuYi2lr8a34vZbGW8ZzZ%2F6%2FrfpHtq6zn9n%2BK%2FnqI%2B9RIWJI3B9PmuHzhu6HjexAuiQRD1%2FM4g7Ifu4MB1I9c13PWHZS1%2Fpe%2BA3dOPsvHdManDpBydwwG5vbg9W3zp4vyU53TJzrL8IKu%2FfR3zi5srfISefgJC%2F776NggAAA%3D%3D
* subdomain (`host=shop`): https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAMzpGoC%2F%2B1VXWvbMBT9K0ZQ9lDbteM6H4Y%2BdM3ouq1tYCmMlRCuJcUWdSRXkvOx0P8%2ByXGapE3Z2NMYezLWvTr33HOur1dI02lZgKYoWaFSihkjVF4RlCDCOBUSfCaQ%2Bxy5ganJRP11zAQUlTOGaX1DMQPzfLSf6kiqNFQSuHbmNG1SZ1QqJjhKQhcVIhN3sjBXcq1LlZycbBmc2KBHxBQY97DgnGLtlzwzEIQqLFmpaxg0EIxr5czncwe0o3O6U%2FedcjZkGgYOcOIAIarOFHNu6OSsdAwtNmEYLKgBwEIS3%2BkLqhwuDKqocO4YKkUTU75tBSSDtKD9PT5aPFDunL2FXYddp%2BLssaLm7W3GgLGouLbyLjkeVOlnuuzXery0ysbfFwI%2FoGQChaIualii5H6F9LK0rlzcnF9%2FMMm5UNq8Gr2sybV4Q2F5N1PhdXjsl5BR5RM6MzlaG4eiIHBRJkVV7vpOlaJcM7AW3vLzsiyW6Ml9Ljn8NtwWHDeUvV05rJugYdvQXvTsqFbryJJY6AvBJwXD%2Bho0zhnPrgWxRQaSTtjicEoTewP9D3obPbnoh%2BB0vBV4ZFrYuEIXYESkPhbTbeMqFyVqCoxZfWddw9wsQcJU2Q9xg3G%2FBzLaoNyvYUYNzi5GrZE9CKEHrTBM024b9wIat6J2Nz7ttXqTENIJRMiyZxkXko6VeYKupFFQy8pMzLQqNBvDHLZHBI%2FBtm2aVSZqSryeJr7%2B5M00%2BU2fjZ%2B%2FMU5jgm3nzIp%2BCqSLgUZeEJHUO407oQckoF6vCyQMaBiFYXtnKb1eVwe20r7%2BB%2F18NaxNPweH9UWHB2fqlx78bQKMXDPB%2F33993w1m0HBjJIx2NxW0Gp7Qc8Lw2HYTuJOEvX8OG6Fnfg4CJIgsPzNT2gtwcrsid0NgYYBdK%2B%2BTOPu9%2BXt3dfOPMqPP13Gj9nlgC2yz9FpeZN2P7bTfJGKM%2FT0EzqRSvpiCAAA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
