### PR TITLE
Pointer, 2 templates

### DIFF
--- a/pointer.ojieame.design.public-website-apex.json
+++ b/pointer.ojieame.design.public-website-apex.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "pointer.ojieame.design",
+  "providerName": "Pointer",
+  "version": 1,
+  "logoUrl": "https://pointer.ojieame.design/favicon.svg",
+  "variableDescription": "%proof%: 32-character hexadecimal Pointer ownership code, without its fixed pointer- prefix",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.pointer.ojieame.design",
+  "syncRedirectDomain": "pointer.ojieame.design",
+  "serviceId": "public-website-apex",
+  "serviceName": "Connect your root domain",
+  "description": "Connect a public website to your root domain with Pointer.",
+  "hostRequired": false,
+  "records": [
+    {
+      "type": "A",
+      "host": "@",
+      "pointsTo": "165.227.255.44",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_pointer",
+      "data": "pointer-%proof%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "pointer-"
+    }
+  ]
+}

--- a/pointer.ojieame.design.public-website-cname.json
+++ b/pointer.ojieame.design.public-website-cname.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "pointer.ojieame.design",
+  "providerName": "Pointer",
+  "version": 1,
+  "logoUrl": "https://pointer.ojieame.design/favicon.svg",
+  "variableDescription": "%proof%: 32-character hexadecimal Pointer ownership code, without its fixed pointer- prefix",
+  "syncBlock": false,
+  "syncPubKeyDomain": "domainconnect.pointer.ojieame.design",
+  "syncRedirectDomain": "pointer.ojieame.design",
+  "serviceId": "public-website-cname",
+  "serviceName": "Connect your website address",
+  "description": "Connect a public website to your chosen subdomain with Pointer.",
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "connect.livetyped.com",
+      "ttl": 300
+    },
+    {
+      "type": "TXT",
+      "host": "_pointer",
+      "data": "pointer-%proof%",
+      "ttl": 300,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "pointer-"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds two signed Pointer templates for the live Caddy delivery route. `public-website-cname` connects a subdomain to the fixed Pointer-controlled name `connect.livetyped.com`; `public-website-apex` connects a root domain to Pointer's reserved address `165.227.255.44`. Both add one narrowly prefixed ownership TXT record. The existing `public-website` template remains unchanged for the Cloudflare for SaaS route.

The application selects the root template only for an apex domain and the CNAME template for subdomains. HTTPS certificates are obtained through Caddy after DNS ownership and routing checks; no certificate-authority validation TXT values are part of these contracts. The only template variable is a 32-character hexadecimal Pointer proof, preceded by the fixed `pointer-` prefix. Routing targets cannot be supplied by the caller. Requests are signed, use the existing published key, and return only to `pointer.ojieame.design`. The application keeps these service IDs disabled until provider availability is verified. This PR requests catalogue review, not confirmation of DNS-provider activation.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using the Online Editor
- [x] Template file name follows `<providerId>.<serviceId>.json`
- [x] The logo URL is served by a webserver

Both files pass the official `dc-template-linter -loglevel error -tolerate info -logos` check. Application integration tests cover exact record expansion, fixed destinations, signed requests, separate rollout gates, and callbacks that do not themselves activate delivery. A controlled root-domain connection is live with the same A-plus-TXT contract and valid public HTTPS. Editor tests below verify DNS expansion; they do not claim provider onboarding has completed.

# Checklist of common problems

- [x] `syncPubKeyDomain` is set
- [x] `warnPhishing` is not set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set for the synchronous redirect
- [x] No TXT record contains SPF content
- [x] Every ownership TXT uses `txtConflictMatchingMode: Prefix` and the fixed `pointer-` prefix
- [x] No variable is used as a bare full record value
- [x] No bare variable is used as the full host label
- [x] Subdomain selection uses the standard `host` parameter
- [x] No explicit `%host%` appears in a record host
- [x] `essential: OnApply` is not needed: both routing and ownership records are required for this connection; neither is an independently configurable mail/policy record

## Online Editor test results

[CNAME template: www.example.com](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAIyBpGoC%2F%2B1UXU%2FbMBT9K5GlPS0p6Re0kSaNjW2dpgKCgiahKnLsm8aQxsF2Grqq%2F33XTdLSAWOv0%2Fbmj3Ov7zn3%2BK6IgXmeUgMkWJFcyYXgoL5yEpBcisyAaslbAXQOLQ5azDLiblGneIq48wqHFwtQWsiMBG2XpHImr1SK94kxuQ4ODp7PdxDThWAya%2BnFzKagStAohRPQTIncbNKRN%2FikjN8ETrfjsYQqyjCRk8AD5cDEnKZOXYQjywyLSETuMMnBdUphElkYRxjtxOIBuFOX4Tm5AjzBN%2FUyYx9Sye5IENNUQ3VyXkTfYHki51TYEvhmgYVmwEzrRW1s5AVwoRC1jX0ZDQrJQyV3EaWCeSVEWhjwWGbV3UJqrT9W7ztLWSinhjqUcwVaI5jvqdaAqVPl3gYYWSVgidSQObqIKnYbtRopW5gP780F3BdIB0s0qkBtkJlUXJPgZkXMMt9UdXo8%2FlTDcfveesQm0ROJ20azVCzABvAWk3OEGIPu6Pr%2B2t0mmnyf7NKE%2BdZYnBq609Gr7fAoB64eDPKNkaYZU8MSkc3G6ADrz6bPz0Dqu11qsp6uXfJDZhDuiE7duv0IRM%2Fhf4GaQ11qWZa4mSlZ5KFoQnL06Vzbb9UE3%2BxFT5vwm038dPOxZGz3frvT7fUPjwZDGjEO8a97YotEC0kFobUSNYWCpkHzIjUipCXdHXEW0jxPl8hJ4y0%2B8bR5WeWwikot%2BGutc0nImWUorIMj%2F9BnWKs3ZMOu1xt2wRv2%2Btxjgz4bHAGnfkQfjY%2FfD5k%2F%2BBp74uMHgMwIaifOcVrSpSbrJ86qOTbOau2RbSzwqvh%2FD%2F%2Bpi0b83%2Bp%2FotU4PzRdAA%2BpRXb8zqHnD712e9LpBN1O0Ou1Bu1Bv3341vcD37fMQJtKjxVOk8dzhNxd61LdDi97I%2F9Mj0b38f3x6ehL%2F07Es3HRTpKzz5fz0lwNJteDd2T9E%2FznZYVECAAA)

[A template: example.com apex](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMyBpGoC%2F%2B1Uy27bMBD8FYFATpVkWbISW0CBvHoomhRp4KApgkCgyLXNRBYVkvKjhv%2B9S0u2kiZuzi1642N2uTM73BUxMC1zaoAkK1IqORMc1GdOElJKURhQvnwQQKfgc9BiXBB3h%2FqKp4i7qnF4MQOlhSxI0nVJLsfyRuV4PzGm1Emn83a%2BzojOBJOFr2djm4IqQbMczkEzJUqzSUcO8Ek5OkicKPTYhCrKMJEzgQXlwMSU5k5ThCPnBRYxEaXDJAfXmQszkZVxhNHOSCyAO00ZnlMqwBN8Uy8LdppL9kiSEc011CdXVfYFludySoUtgW8WWGgBzPh7tbGR18CFQtQudj8aFJKHWu4qywXz5pBpYcCjJSxaRCP1Wf28s5SVclAS49RlIZC%2FEGwLpE6d1mnSOka%2BCt5otBXQx1QTqc01PFVIgu8kQUJScU2SuxUxy9JWc9JgcXlsbWEz6KHEbfcw9sPwyA%2Fj2O%2F18M4YdEIUBGt3Fz28HbbxabkzEaeGtpp5Teuf5cDVwiDBEfIyl9SwiSjGl9ht68VtT9%2BANHdtarK%2BX7vkpywgbdndu02rEYj%2Bwr8BPpPTtlRcjZWsylRs8SUacqrt%2F9lG3r0Ivd%2FG3hG73hCym6AbRr348Kg%2FoBnjMPp9T2x5aBSpILWGoaZSSNKoCvsxrXIjUjqn7RFnKS3LfIlsNN7iEy97VdQmOm5F3tsnl6ScWUbCWnMQDOKAQeRFEPe9XhiDNwgY93iQ0TiMMzii%2FWdz4c%2FT433Pt0KD1lAYQe0YOcnndKnJ%2BpWFGlr7LfSuzn8H73sXzfa%2Fo%2F9SR3EaaDoDnlILC4Pw0AsGXrc7DMMkipJe34%2BibhTGH4IgCQLLCrSptVjhbHg%2BFchF7%2BmhPy70bfEobx%2Bzzmn%2FaqDDG7ioPokfi0wOYk3j6dn3xbfgI1n%2FAgG84mr4BwAA)

[A template: www.example.com subdomain expansion](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIALKBpGoC%2F%2B1U2W7bMBD8FYFAnmIpsuRTQIE6dQukiQMncA80MAyaXFlMZVEhKR8x%2FO9dWZIdN0nz3KJvPGaXO7PD3RAD8zSmBkiwIamSC8FBXXASkFSKxIBy5L0AOgeHgxazhNT2qGs8RdywwOHFApQWMiFBvUZiOZNfVIz3kTGpDs7OXs53FtKFYDJx9GKWp6BK0GkMfdBMidTs0pETfFKGJ4HlezaLqKIME1kRrCgHJuY0tsoiLLlMsIhIpBaTHGrWUphIZsYSRluhWAG3yjJsK1WAJ%2FimXifsPJbsJwlCGmsoTobZ9BLWfTmnIi%2BB7xZYaALMOK9qk0feAhcKUfvY19GgkDwUcmfTWDB7CVMtDNg0hdUBUUr9oXjeWstMWSiJsYqyEMiPBKuA1CrSWmVay8hnwTuNKgEdTBVJbW7hIUMSfC8JEpKKaxLcbYhZp3k1vRKLy%2Fe5LfIMeiRxW281Hc9rO16z6TQaeGcMOsF33W1tHz36PjrET9K9iTg19KCZXbb%2BSQ5crQwSDJGXGVDDIpHMBtjt3ItVT1%2BAlHeH1GQ73tbIo0xgcmA3rpWtRiD6C%2F8GOEzOD6Uul0vczJTM0omoQlL05FznX6gKvjuKHlfhd7v48e4TyTDfu3XPbzRb7U6XThmH8Pc9yYtEu0gFk9w21GQKqRqVYVfmWWzEhC7p4YizCU3TeI2cNN7iE8cdSworFTRKsV%2FtV41MOMtpidyizPO7NOx27a5Xb9mNRpvZnQ5Qm4esHXZ8r9Fosifz4c9T5G3vHwkOWkNiBM0nSi9e0rUm22duKrlVbnKOSFZtf1Pwv4b%2BuIbe%2B9%2Fdf7W7OCU0XQCf0BzpuV7Ldrt2vT7yvMD3A89zsKpWt3HquoHr5sRAm0KODc6Mp9OC3Aw%2F%2BbHsX09v3Mv%2B59OvvavB%2FWn0se9d8Ycf3x7Ph%2FqiPlDDxeVV7x3Z%2FgKnDUDEFggAAA%3D%3D)
