### PR TITLE
Add Trustholm Bridge signed-sync hostname templates (US/AU/EU)

### DIFF
--- a/trustholm.com.bridge-hostname-au.json
+++ b/trustholm.com.bridge-hostname-au.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "trustholm.com",
+  "providerName": "Trustholm Bridge",
+  "serviceId": "bridge-hostname-au",
+  "serviceName": "Trustholm Bridge hostname (AU)",
+  "version": 1,
+  "logoUrl": "https://bridge.trustholm.com/logo-trustholm.png",
+  "description": "Point a guest hostname at Trustholm Bridge (CNAME, DNS only) and publish the ownership TXT. Do not proxy the CNAME if the zone is on Cloudflare.",
+  "variableDescription": "%txt% is the Bridge-minted ownership token (sx-verify-…). It is signed in the apply URL and is not user-supplied.",
+  "syncPubKeyDomain": "trustholm.com",
+  "syncRedirectDomain": "us.bridge.trustholm.com,au.bridge.trustholm.com,eu.bridge.trustholm.com,bridge.trustholm.com",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.au.bridge.trustholm.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_trustholm-bridge-verify",
+      "data": "%txt%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "sx-verify-"
+    }
+  ]
+}

--- a/trustholm.com.bridge-hostname-eu.json
+++ b/trustholm.com.bridge-hostname-eu.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "trustholm.com",
+  "providerName": "Trustholm Bridge",
+  "serviceId": "bridge-hostname-eu",
+  "serviceName": "Trustholm Bridge hostname (EU)",
+  "version": 1,
+  "logoUrl": "https://bridge.trustholm.com/logo-trustholm.png",
+  "description": "Point a guest hostname at Trustholm Bridge (CNAME, DNS only) and publish the ownership TXT. Do not proxy the CNAME if the zone is on Cloudflare.",
+  "variableDescription": "%txt% is the Bridge-minted ownership token (sx-verify-…). It is signed in the apply URL and is not user-supplied.",
+  "syncPubKeyDomain": "trustholm.com",
+  "syncRedirectDomain": "us.bridge.trustholm.com,au.bridge.trustholm.com,eu.bridge.trustholm.com,bridge.trustholm.com",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.eu.bridge.trustholm.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_trustholm-bridge-verify",
+      "data": "%txt%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "sx-verify-"
+    }
+  ]
+}

--- a/trustholm.com.bridge-hostname-us.json
+++ b/trustholm.com.bridge-hostname-us.json
@@ -1,0 +1,30 @@
+{
+  "providerId": "trustholm.com",
+  "providerName": "Trustholm Bridge",
+  "serviceId": "bridge-hostname-us",
+  "serviceName": "Trustholm Bridge hostname (US)",
+  "version": 1,
+  "logoUrl": "https://bridge.trustholm.com/logo-trustholm.png",
+  "description": "Point a guest hostname at Trustholm Bridge (CNAME, DNS only) and publish the ownership TXT. Do not proxy the CNAME if the zone is on Cloudflare.",
+  "variableDescription": "%txt% is the Bridge-minted ownership token (sx-verify-…). It is signed in the apply URL and is not user-supplied.",
+  "syncPubKeyDomain": "trustholm.com",
+  "syncRedirectDomain": "us.bridge.trustholm.com,au.bridge.trustholm.com,eu.bridge.trustholm.com,bridge.trustholm.com",
+  "syncBlock": false,
+  "hostRequired": true,
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "customers.bridge.trustholm.com",
+      "ttl": 3600
+    },
+    {
+      "type": "TXT",
+      "host": "_trustholm-bridge-verify",
+      "data": "%txt%",
+      "ttl": 3600,
+      "txtConflictMatchingMode": "Prefix",
+      "txtConflictMatchingPrefix": "sx-verify-"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add three signed-sync Domain Connect templates for Trustholm Bridge vanity hostnames.

Trustholm Bridge is a file-transfer control plane. Customers point a **subdomain** (e.g. `securefiles.example.com`) at a cell-specific CNAME and publish a Bridge-minted ownership TXT. We ship one template per cell so the CNAME target is fixed in the template and cannot be chosen in the browser:

| File | CNAME `pointsTo` |
|------|------------------|
| `trustholm.com.bridge-hostname-us.json` | `customers.bridge.trustholm.com` |
| `trustholm.com.bridge-hostname-au.json` | `customers.au.bridge.trustholm.com` |
| `trustholm.com.bridge-hostname-eu.json` | `customers.eu.bridge.trustholm.com` |

`hostRequired: true` — apply `host` is the guest subdomain. Apex is not in scope.

Apply URLs are RSA-SHA256 signed (`syncPubKeyDomain` TXT at `_dcpubkeyv1.trustholm.com`). Live copies:

- https://us.bridge.trustholm.com/v1/public/domain-connect/templates/bridge-hostname-us
- https://au.bridge.trustholm.com/v1/public/domain-connect/templates/bridge-hostname-au
- https://eu.bridge.trustholm.com/v1/public/domain-connect/templates/bridge-hostname-eu

**Bare `%txt%`:** the Worker mints `sx-verify-…` and puts it in the signed apply URL. It is not user free-text. `txtConflictMatchingMode: Prefix` / `txtConflictMatchingPrefix: sx-verify-`.

Please onboard Cloudflare with **proxy off** for these CNAMEs (a proxied CNAME onto `customers.{,au.,eu.}bridge.trustholm.com` returns Error 522). Logo: https://bridge.trustholm.com/logo-trustholm.png

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `providerId.serviceId.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC)
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [ ] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC)

`essential` omitted: both records are required for the product (CNAME + ownership TXT). Users should not drop either while the hostname is in use.

Bare `%txt%` justification is in the Description.

## Online Editor test results

Subdomain apply (`host=www`, `domain=example.com`, `txt=sx-verify-exampletoken1234567890ab`). Apex not required (`hostRequired: true`).

**Editor test link(s):**

- [Test trustholm.com/bridge-hostname-us example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAKHJpGoC%2F%2B1Va2%2FaMBT9K5alSq2WhJBCgUiT1te6qo%2F1QbWpHYqc2IDVxM5sB8gQ%2F33X4VVUqvXjpO0b9j333nN9DjdTbFiWp8QwHE5xruSIU6bOKQ6xUYU2Q5lmXiIz7KyC1yQDMO4uw%2BhIcTpggNBMjXjCquy4unSHUhsBCW6h14A3KqAlGO0%2B3O8BfMSU5lLgsO7gVA7kg0ohbWhMrsNabd7B26BZszB3fZWLAdShTCeK56aqhW8kFwYRNCiYNuuexKBXhHaPrw%2BvTh10cn2PpEjLPUQERXkRp1wPkRkyJMcCSA55jrrfux46kUhIg%2BCpJmUVrwog3q8Ov6RgiGsohY5TWdB%2BShTz7KBEcRKn7GSD6I6ZmB2Lt7lzRm4G3Bl90dbIZybQrp648Fq8X7o%2FisAPDvY8dG5sruYDAQlcVFVInqcleri7rAaBsGVbgCyuLiDEGbV0dCmSmyK%2BYOWJzAgXW8xgIXeMcsUSswIV2tsmikOK7ffsjfttl4ueR6lMnnHYJ6lmDrbi3bGfBdAAzwEe7oCRVFTj8GmKTZlbo1Ui4Dkcjp%2Bsma0JdFfCMYEuMoPn9N7oawzYbv%2FA92fOqiSovS4YrTLche3nWljrEUOWUr4sBT8n5liKfsoTc0VMMuRicCWprX2jWJ9P8FbIIhbiteB41ps52HorWs%2Feg9ZLWdiEwF%2BcLaZZcB6Px3AYKFnkEV%2Bm5ESRTNtNsEx%2B2sjuLdOfqvxeRdGe1mwW8MqW9WC%2F0TxotTs%2BibElCV6UikXWk8QUii01y4rU8IiMyfqKJlFlVphJQxSavNZTzPfIfJTFS79fTQdHNLGzcruv%2Bp0mbTYpcevU991GM47ddicO3IDu1%2F0koaQTt18swa0b8o%2F7b%2BPtmdZMGE7sTjtMx6TUePbKYYsR33KYtzH7O1T42%2BfvOeDD%2F0r%2FC0rD9tBkxGhELNJ%2BtFy%2F49aDrr8fNvyw3vKaQbsVdD74fuj7dh74Xs%2Fnn8IueblF8MNpo372Jb0YfNOPpyPVuOxM9GFwdCtM62utSz7ftx6bxUFXnyW3H%2FHsN8P2E1%2F1CAAA)
- [Test trustholm.com/bridge-hostname-au example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAOzJpGoC%2F%2B1V2W7bMBD8FYJAgQSRFMlOfAgoUOd4SJukSewAKVLDoCVKZiORKg8fNfzvXcqHYsRG27cC7Zu5O7uc5YxXc6xpXmREUxzOcSHFmMVUXsU4xFoapUciy71I5NjZJG9JDmDcW6fRmWRxSgGhqByziJbVwzLojoTSHApcYirAng5oDUYHncdDgI%2BpVExwHAYOzkQqHmUGZSOtCxUeHy9v8LZoHluYW4UKnkKfmKpIskKXvfCdYFwjglJDla7uJBq9IXRwftu5uXTQxW0XCZ7NDhHhMSrMMGNqhPSIIjHhQHLECtR76nnoQiAuNIKnms7KfNkAsaQ8%2FBCcIqagFTrPhImTjEjq2UGJZGSY0Ystou%2F0VL%2BzeFu7ZOTmwJ3Gr67V4oVydKCmLrwWS2buV1Pza41DD11pW6tYyqGA8bILKYpshh4frstBIG3ZGpDFVQZSjMaWjprx6M4MP9HZhcgJ4zvMYCEPNGaSRnoDMsrbJYpDzO443RPfFVzdeZaJ6AWHCckUdbAV74F%2BN0ADPAd4iAEjIWOFw%2Bc51rPCGq0UAS%2FhcPxgzWxNoHoCjhHcInJ4Tm8PT4BrDc6rN3x%2F4Wy6guBVz8Gmwl05fymHdR%2FRZK3m61bwc6rPBU8yFukboqMR4%2BmNiG3vO0kTNsU7IatciCvN8aK%2FcLC116Aavw9Xr5WhUwL%2FcrqaZsV5MpnAIZXCFAO2LimIJLmyy2Bd%2FLxV3V%2BXP5f1%2FZKiPVVsVvDSmUGtfnLaaLbaPhliSxLsKCQdWFsSbSRdy5abTLMBmZAqFEeD0q8wk4IsXPJWUr5cJctRVi%2F9R4I6eBBHdlxmt1bQbvlJRAK3mSSn7skwid1WI2q7fj1ImsOgQYifvFqFO%2FfkL7fg1vNTpSjXjNjN1skmZKbw4o3JVlPuM5m3Nf5vCPG3z993wIr%2Fxf5HxIYdosiYxgNikfbr5fptN6j1%2FHp4EoT1mldvwUTtI98Pfd%2FOAx%2Fu5fxz2CivdwkemfrH%2BKzb7RydXwftqCVaHT2uH3VV7WZyT9LLz02TNsZP9986X97jxU8CiDnp%2FggAAA%3D%3D)
- [Test trustholm.com/bridge-hostname-eu example.com/www](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANPJpGoC%2F%2B1V72%2FaMBD9VyxLk1otCQYKKZEmrS1VVRW6jlG1UoeQSRywmtiZ7RRSxP%2B%2Bc%2FhVVNC2b5O2b%2Fju3fmd3%2BMyx4alWUINw8EcZ0q%2B8Iip6wgH2Khcm4lMUi%2BUKXY2yVuaAhj312l0rng0ZoDQTL3wkJXVozLoTqQ2Agpclm8BBzqgNRgdXd4fA%2FyFKc2lwEHVwYkcy3uVQNnEmEwHlcryBm%2BHZsXC3G0oE2PoEzEdKp6Zshe%2Bk1wYRNE4Z9ps76QGvSN0dHF71r10UPv2G5IiKY4RFRHK8lHC9QSZCUNyKoDkhGeo%2F9j3UFsiIQ2Cp5oVZb5sgHhcHl6lYIhraIUuEplHcUIV8%2BygVHE6Slh7h%2BgHMzMfLN7WLhm5KXBn0ZtrjXxmAh3pmQuvxePC%2FZ7XSK157KFrY2s1Hwso4KLsQrMsKdB9r1MOAmnLNgdZXJ1DirPI0tGFCO%2Fy0Q0r2jKlXOwxg4X0WMQVC80GlGtvnygOzffH2YH4vuDqzvNEhs84iGmimYOteD32Iwca4DnAQwwYSRVpHDzNsSkya7RSBLyEw%2FGzNbM1ge5LOIZwi0zhOb0DfABuDDiv3iRk4Wy6guDbnsNNhbty%2FlIO6z5q6FrNt63g58xcSBEnPDRdasIJF%2BOujGzvO8ViPsN7IatcgLea48Vg4WBrr%2BF2%2FAFcvVaGzSj8y9lqmhXn6XQKh7GSeTbk65KMKppquwzWxU871YN1%2BVNZPygp2tOWzQpeOrNaq580mv5pi9ARtiTBjlKxobUlNblia9nSPDF8SKd0G4rCYelXmElDFi55L6lYrpLlKKuX%2FiNBHTyMQjsut1urRRt1P2Kh26w2iHtS91surcVNd9Q8JT4lsV%2BN%2FTercO%2Be%2FOUW3Hl%2BpjUThlO72c6SKS00Xrwz2WrKQybzdsb%2FDSH%2B9vkHDljxv9j%2FiNiwQzR9YdGQWqT9ermk5VZrfVIPTqoB8T1y2vIbrY%2BEBITYeeDDvZx%2FDhvl7S7BonN7Xp%2F0xMNDp9PttsevJ%2F6onWZfH4rK1X2rfX3zpX%2F1TMhjpdn9hBc%2FASy82f7%2BCAAA)

Apply output (all three):

- `www.example.com.` CNAME → cell `customers.{,au.,eu.}bridge.trustholm.com`
- `_trustholm-bridge-verify.www.example.com.` TXT → `"sx-verify-exampletoken1234567890ab"`
