### PR TITLE
Add waymail.app.email: Waymail email sending (DKIM CNAMEs, MAIL FROM MX + SPFM)

### DIFF
--- a/waymail.app.email.json
+++ b/waymail.app.email.json
@@ -1,0 +1,51 @@
+{
+  "providerId": "waymail.app",
+  "providerName": "Waymail",
+  "serviceId": "email",
+  "serviceName": "Email sending",
+  "version": 1,
+  "logoUrl": "https://waymail.app/icon-192.png",
+  "description": "Lets Waymail send email from this domain: DKIM signing keys, and a MAIL FROM domain with its SPF record.",
+  "syncBlock": false,
+  "syncPubKeyDomain": "waymail.app",
+  "syncRedirectDomain": "console.waymail.app",
+  "hostRequired": false,
+  "variableDescription": "%dkim1%, %dkim2%, %dkim3%: the three DKIM selectors Amazon SES issued for this domain. %sesRegion%: the AWS region Waymail sends from, e.g. eu-central-1.",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "%dkim1%._domainkey",
+      "pointsTo": "%dkim1%.dkim.amazonses.com",
+      "ttl": 1800,
+      "groupId": "dkim"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim2%._domainkey",
+      "pointsTo": "%dkim2%.dkim.amazonses.com",
+      "ttl": 1800,
+      "groupId": "dkim"
+    },
+    {
+      "type": "CNAME",
+      "host": "%dkim3%._domainkey",
+      "pointsTo": "%dkim3%.dkim.amazonses.com",
+      "ttl": 1800,
+      "groupId": "dkim"
+    },
+    {
+      "type": "MX",
+      "host": "mail",
+      "pointsTo": "feedback-smtp.%sesRegion%.amazonses.com",
+      "priority": 10,
+      "ttl": 1800,
+      "groupId": "mail_from"
+    },
+    {
+      "type": "SPFM",
+      "host": "mail",
+      "spfRules": "include:amazonses.com",
+      "groupId": "mail_from"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

New template for Waymail (waymail.app), an email sending service on Amazon SES. Lets Waymail send from a customer's domain: the three DKIM CNAMEs SES issues for the domain (group `dkim`), and a MAIL FROM subdomain `mail` with its MX and SPF via SPFM (group `mail_from`). No DMARC record on purpose: a DMARC policy is the domain owner's, and a second record would disable DMARC, so Waymail suggests one on its own screen only while none is published.

Variables are kept to the smallest part of each record: `%dkim1%`–`%dkim3%` are the DKIM selectors (host `%dkimN%._domainkey`, fixed suffix), `%sesRegion%` the SES region in the MX target. Everything else is fixed in the template.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`
- [x] resource URL provided with `logoUrl` is actually served by a webserver

# Checklist of common problems

Mark all the checkboxes after conducting the check. Comment on any point which is not fulfilled.
See [Template Quality Guidelines](../README.md#template-quality-guidelines) for details and rationale on each rule.

- [x] `syncPubKeyDomain` is set — **this is mandatory**; omitting it requires explicit justification in the PR description or the PR will be rejected
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain` — the two must not appear together
- [x] `syncRedirectDomain` is set whenever the template uses `redirect_uri` in the synchronous flow
- [x] no TXT record contains SPF content (`"v=spf1 ..."`) — use the `SPFM` record type instead
- [x] `txtConflictMatchingMode` is set on every TXT record that must be unique per label or content prefix (e.g. DMARC) — no TXT records in this template
- [x] no variable is used as a bare full record value (e.g. `@ TXT "%foo%"`) unless necessary — prefer `@ TXT "service-foo=%foo%"`; if bare, justify in the PR description
- [x] no bare variable is used as the full `host` label — the non-variable parts are fixed to limit misuse (e.g. `%dkimkey%._domainkey`, not `%dkimhost%`); if bare, justify in the PR description
- [x] no variable is used in the `host` field to create a subdomain — use the `host` parameter or `multiInstance` instead
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify or remove without breaking the template (e.g. DMARC) — no such records; the SPF result of SPFM is non-essential by the spec

## Online Editor test results

**Editor test link(s):** 

- Apex: [Test waymail.app/email example.com/@](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAMgApWoC%2F%2B1WXU%2FbShD9K6uVeGps%2FBFiYqkPaaEValNQwhX0IhRtvJNki%2B11d9ehAdHffmcdm8SXtDy0D63EQxRnvs6e2ZkT31MDWZEyAzS%2Bp4WSS8FBnXAa01u2yphIXVYUtPPo%2BsQyDKUXayc6NKilSKBKgbatjj22VqIh5yKfo3cJSguZ09jv0FTO5T8qxaiFMYWO9%2Fe3YPdFInPH7wduUSVy0IkShamS6UcwmtTnqKqTCp7MlMyIWQhNuERDHpOjDydDosU8R3xyAyvdIQzDGRkOTj6Sd6PTYR1KboVZEIF1x2fviIJEKu5aPqs8eZPK5IbGM5ZqWFvOyukHWB1VmU%2F6ZQNGwAUWMY8hSEfLFNx26EJqM4KvJcbyR4AlU4JNUzhqcd7jNyLz9zqkegiah3AvRsaAHwVQ04UUkaXSZJCxO5mT8fGYCK1L4GQm1XaDXLKnQY9gjhh1ocHFGOlbQ6vDumpuh4A7dwmUTgK5USx1fNukdbs0ja%2FuqVkV9ubffhoMj2uGm9O7kzUu3oQdLClyo8%2Fllt9%2Buaw6Nh7MTWSGccbglPiHntehcyXLoho4G0kfOj8FDJ4BDH43YPgMYPgrgMPLDVq9bVv1ZwB8ypIbR2emcLeu9QlYoYRUwqwQ0fsBtC0%2FsRe%2BjY%2BLMXxyAl3MRmUKePdU5Elacoj%2Fj7ez7PVDh2IUTDazc41r3qwLfGOoTVBXqCGbWhPRxBdMsUxb%2FWoyr1qp103uFbXP1ZDZH2ya%2BEHYmAJr4jDrHvQaU2hN84WIDvvW9NjNCmBr%2BqnlgfIiFUyszDBTKuyVUSUuclamRkzYLduYeDLBzU9XSFujF8s9XZl8rZ3rM7bniTPDNq7nRmnCE9saYVs%2F87o%2BHHJwIggDpztlfWfa7%2FnONAqjBHiXdxO2pfU7%2FgZ2qf3mYkCjShjBrJ4PUszU9GHHstTc1s3eya12%2Fb3c1lOzk1vt%2Bou4VZpTE6tzay5tvWn9I%2FyEWlt7%2FiCi55fnP2K6fI0i55Od8ka%2BszRtKPa8P%2BL2rjsojS%2By8iIrL7LyIiu%2FUVbsexBbAp8wGxZ4Qc%2Fx%2Bo4fnHtRHB7EYc%2BNIi86OHjlebHn2dODNmuy9%2FiWtP1%2BRKP8sv9lHM4OL%2FbFv%2Bzt%2B8%2Bn2u%2F2Bu%2FPwtUXdWpeFXdf5edicWfC4Wv68B%2BnMoCBqw4AAA%3D%3D)
- Subdomain (host `news`): [Test waymail.app/email example.com/news](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIAAsCpWoC%2F%2B1WXW%2BbSBT9K6OR8rRAANuxjdQHb5OoSetu5ThqtVFkjeFiTw0MnRmcOlH2t%2B8dwDFsnORhK7WV8mAZ3a8z5947B%2B6ohjRPmAYa3NFcijWPQJ5FNKA3bJMynjgsz6n14PrIUgylnysnOhTINQ%2BhTIG2rY49MVaiIIt4tkDvGqTiIqOBZ9FELMSlTDBqqXWugsPDBuwhD0Vme0PfycvECFQoea7LZPoBtCL1OcrqpIQnsRQp0UuuSCTQkAXk%2BP3ZmCi%2ByBCfrGCjLMIwnJHx6OwDOZ38Na5DyQ3XS8Kx7sWnUyIhFDJyDJ9NFv6ZiHBFg5glCirLp2L%2BHjbHZeajfpmACUQci%2BiHEKSjRAJOO3QplJ7AtwJjoweANZOczRM4bnE%2BiFY89Q4sUj7424fOQYCMAX8SoKYLCSILqcgoZbciIxcnF4QrVUBEYiGbDXLIgQI1gQVi1IVGny%2BQvjG0OqzK5loEnIVDoLBDyLRkie2ZJlXtUjS4uqN6k5vJv%2F04Gp%2FUDHend2YVLk7CLJbgmVZT0fCbP4eVx8aDOaFIMU5r3BJv4LoWXUhR5OXCmUh6bz0L6L8A6P9owM4LgJ3%2FAzj%2BskOrb1ujfgwQzVm4slWqc6cx1kdgueRCcr1BRPcJaFN%2BZgbexMeLMX50ApXHkyIBnD3lWZgUEQT%2Fxdtb9vreohgFs93uXOM1314X%2BM5Qm6CuUENmcKO29WZ8m5MzyVJlNGybfdVKv97mX1UFDIxZNmNg89DzO1uTb0wRxN3e0dbUMabFkvcHQ2N66GoJ0rgF1PBBmRESZkZumC4k9kzLAi90WiSaz9gN25micIYKkGyQvkIvlnt8dbJKQ6szNvbKqfsQMc12%2Fpf2ahaFpkfczKEX9ods3ontHsDA7s7drj1kcWj3vDjuD0LwPXAbwr%2FnnbBP%2BttTAoWyoTkzAj9KMFvR%2Bz23pyZZdf1pkrX%2F9yZZ7dHTJGv%2Fb0aylKWaYVm3TaqtS603xzMc2xr1izGefpk%2BS3n9BlXRI3v1kPzDkmTL9cj9ZeZ5baGWvmrQqwa9atCrBv0sDTJfWGwN0YyZUN%2F1j2x3aHv%2B1O0HXTfoDZ1h76gzGPzhuoFrzqBB6YrwHX5%2FNb%2B86Cr7%2B%2Fy8ELdv8zCfXp5%2B63cL8TU%2FH35PbzvzsRjJd5ebdOrJ48PRG3r%2FL66PcqYNDwAA)
