### PR TITLE
Add WorkSync inbound-mail template (worksync.works.inbound.json)

### DIFF
--- a/worksync.works.inbound.json
+++ b/worksync.works.inbound.json
@@ -1,0 +1,22 @@
+{
+	"providerId": "worksync.works",
+	"providerName": "WorkSync",
+	"serviceId": "inbound",
+	"serviceName": "WorkSync inbound mail",
+	"version": 1,
+	"logoUrl": "https://fallback.worksync.works/icon.svg",
+	"description": "Routes mail sent to one WorkSync mail name (for example mail.example.com) into the shop's Intake queue and Shop Inbox, by adding the single MX record the mail provider receives on. Applied to that mail name only (hostRequired): the record is an MX at the applied name, never at the domain itself, so an existing mailbox provider at the apex is left exactly as it is.",
+	"variableDescription": "None — the MX target and priority are fixed values of the WorkSync mail provider.",
+	"syncPubKeyDomain": "worksync.works",
+	"syncRedirectDomain": "worksync.works",
+	"hostRequired": true,
+	"records": [
+		{
+			"type": "MX",
+			"host": "@",
+			"pointsTo": "inbound.postmarkapp.com",
+			"priority": 10,
+			"ttl": 3600
+		}
+	]
+}


### PR DESCRIPTION
# Description

Third template for the WorkSync service provider (`worksync.works`): the single MX record inbound mail arrives on (`MX 10 inbound.postmarkapp.com`), applied to the mail name only. `hostRequired: true` — the record is written at the applied host, never at the apex, so an existing mailbox provider at the domain is left untouched. The hostname and email-sending templates landed in #1759; this is the third and last of the set.

## Type of change

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json` (`worksync.works.inbound.json`)
- [x] resource URL provided with `logoUrl` is actually served by a webserver (`https://fallback.worksync.works/icon.svg` → 200, `image/svg+xml`)

# Checklist of common problems

- [x] `syncPubKeyDomain` is set (`worksync.works`)
- [x] `warnPhishing` is **not** set alongside `syncPubKeyDomain`
- [x] `syncRedirectDomain` is set (`worksync.works`)
- [x] no TXT record contains SPF content — the template has no TXT record at all (one MX record)
- [x] `txtConflictMatchingMode` — not applicable, no TXT record
- [x] no variable is used as a bare full record value — the template has no variables; the MX target and priority are fixed values of the mail provider
- [x] no bare variable is used as the full `host` label — host is the fixed `@` (relative to the applied host)
- [x] no variable is used in the `host` field to create a subdomain — the subdomain comes from the `host` parameter (`hostRequired: true`)
- [x] `%host%` does not appear explicitly in any `host` attribute
- [x] `essential` is set to `OnApply` on records the end user may need to modify — not applicable: the single MX record is the service itself; removing it removes the service, which is the intended way to disconnect

## Online Editor test results

**Editor test link(s):**
 - [Test worksync.works/inbound example.com/mail](https://domainconnect.paulonet.eu/dc/free/templateedit?token=H4sIANEKpmoC%2F91Ua2%2FaMBT9K5a%2FrNUCBEqhiTRpSK3Wamo1tZ1K1SF0iW%2FAItjBdngM8d93Hd5Vtx%2BwT0nu49xzT4694g4neQYOebziudEzKdDcCR7zuTZju1RJtXzhwT77ABOq5i8UfqI8ZSyamUywbJNqoAslDtF35WxbwCYgM6qaobFSKx7XA57pof5pMqoeOZfbuFZLIcsGkIyrp2xqMtGqamdDAhBoEyNzV4LwR104tCU4s6gcc5pphWw%2Fvswo4sTOUm0YLoD2xzJc3X5UEz05J57U6kbI7Ejnnyy7Uw7GyKYFFsiAFniiOEUHehGwwZKBEFINNx30Qpj3XWYw0UaUwXLwTkOfQDkjprQH6%2BR5JlGwciC4I45aZUt2NtLWPeK0kAbFeVyibYGlJSp%2BEHX5MGyRfHPAFJK6u5TQBKuYdBazNGBW%2B05cSOs8bT%2BSNjkQ3APiwk%2FJMHVerMQRIbAEQ9Gq%2F39gJAwyvD75DQ9e819FI6w3Sxhi6MAM0ZXK5UZqIx0BGWSpXBDhGWSFVyMty0%2F%2F1o6TH%2Bc98KMYfMfldbnPR0b1H48oSK3E%2Fb3qWFQeO1NgwDeqWh6%2Frbhb5t63991tLb1%2F9adAkzHssz5YvZpTdgJmTOJ765RHZbMguToMuHNk6YtWGK5764D%2FJmn6h0E9cvCO45H%2FDkO352RodJH35a4nBwMT6w%2FtrvvtpL2363%2FbAPjJcqi0wb6lJ7jC4G7rSZE52Yc5HEIi6XsrLYmopSzBvFNEbU71lpwAB%2F8UZC%2FBe236IvFLSH91hK1mSzQu0wrUo6tKU0CzchVetivQiKJBFEX1CNKje%2BjjW%2Brju%2BhUS7T%2BapDgb5pONoel5et1LyBd%2F%2F8tyRgWZij64EsbYaNVCaNK%2FeI5bMQXYdysV9v19kW99TkM4zD0S6F1m81X5KFj9%2FDiUrVfb2qv0I3My3R6G97eSHGfwnNDDr%2BNX7rtAr%2BraadzdTP%2Fwtd%2FAGNJJk5sBgAA) — subdomain run (`example.com`, host `mail`); apex run not required because `hostRequired: true`